### PR TITLE
allow for CORS origins like "https://*.example.com" in CorsSettings__WebClient

### DIFF
--- a/Moda.Infrastructure/src/Moda.Infrastructure/Cors/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Cors/ConfigureServices.cs
@@ -21,7 +21,8 @@ internal static class ConfigureServices
                 policy.AllowAnyHeader()
                     .AllowAnyMethod()
                     .AllowCredentials()
-                    .WithOrigins(origins.ToArray()))
+                    .WithOrigins(origins.ToArray())
+                    .SetIsOriginAllowedToAllowWildcardSubdomains())
         );
             
     }


### PR DESCRIPTION
Will help break a cycle that would arise in TF where 

```mermaid
flowchart TD
  A[moda.api] -- provides base url to client  --> B[moda.client]
  B -- provides base url to API for CORS --> A
```

By allowing wildcards in the cors settings we can just allow ourselves (and other users) to just put `https://*.yourdomain.com` for the CORS settings on the API and then observe a simpler dependency flow in IaC where the API gets spun up and then the client pulls the API url during its own provisioning.