### PR TITLE
Feature/add connection details page

### DIFF
--- a/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
+++ b/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
@@ -7,6 +7,7 @@ public sealed class AzureDevOpsBoardsConnection : Connection<AzureDevOpsBoardsCo
         Name = name;
         Description = description;
         Connector = Connector.AzureDevOpsBoards;
+        Configuration = new AzureDevOpsBoardsConnectionConfiguration(null, null);
     }
 
     public Result Update(string name, string? description, Instant timestamp)

--- a/Moda.Web/src/Moda.Web.Api/Controllers/AppIntegrations/AzureDevOpsBoardsConnectionsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/AppIntegrations/AzureDevOpsBoardsConnectionsController.cs
@@ -34,7 +34,7 @@ public class AzureDevOpsBoardsConnectionsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
-    public async Task<ActionResult<IReadOnlyList<ConnectionListDto>>> GetById(Guid id, CancellationToken cancellationToken)
+    public async Task<ActionResult<ConnectionDetailsDto>> GetById(Guid id, CancellationToken cancellationToken)
     {
         var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
 
@@ -45,7 +45,7 @@ public class AzureDevOpsBoardsConnectionsController : ControllerBase
 
     [HttpGet("{id}/config")]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Connections)]
-    [OpenApiOperation("Get Azure DevOps Boards connection based on id.", "")]
+    [OpenApiOperation("Get Azure DevOps Boards connection configuration based on id.", "")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -91,7 +91,7 @@ public class AzureDevOpsBoardsConnectionsController : ControllerBase
 
     [HttpPut("{id}/config")]
     [MustHavePermission(ApplicationAction.Update, ApplicationResource.Connections)]
-    [OpenApiOperation("Update an Azure DevOps Boards connection.", "")]
+    [OpenApiOperation("Update an Azure DevOps Boards connection configuration.", "")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -5067,10 +5067,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ConnectionListDto"
-                  }
+                  "$ref": "#/components/schemas/ConnectionDetailsDto"
                 }
               }
             }
@@ -5169,7 +5166,7 @@
         "tags": [
           "AzureDevOpsBoardsConnections"
         ],
-        "summary": "Get Azure DevOps Boards connection based on id.",
+        "summary": "Get Azure DevOps Boards connection configuration based on id.",
         "operationId": "AzureDevOpsBoardsConnections_GetConfig",
         "parameters": [
           {
@@ -5225,7 +5222,7 @@
         "tags": [
           "AzureDevOpsBoardsConnections"
         ],
-        "summary": "Update an Azure DevOps Boards connection.",
+        "summary": "Update an Azure DevOps Boards connection configuration.",
         "operationId": "AzureDevOpsBoardsConnections_UpdateConfig",
         "parameters": [
           {
@@ -7971,6 +7968,32 @@
           },
           "name": {
             "type": "string"
+          },
+          "connector": {
+            "type": "string"
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "isValidConfiguration": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ConnectionDetailsDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
           },
           "connector": {
             "type": "string"

--- a/Moda.Web/src/moda.web.reactclient/package-lock.json
+++ b/Moda.Web/src/moda.web.reactclient/package-lock.json
@@ -43,7 +43,7 @@
         "jest": "^29.6.4",
         "jest-environment-jsdom": "^29.6.4",
         "prettier": "^3.0.2",
-        "typescript": "5.2.2"
+        "typescript": "5.1.6"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -9371,9 +9371,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
-      "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/Moda.Web/src/moda.web.reactclient/package.json
+++ b/Moda.Web/src/moda.web.reactclient/package.json
@@ -24,7 +24,7 @@
     "jest": "^29.6.4",
     "jest-environment-jsdom": "^29.6.4",
     "prettier": "^3.0.2",
-    "typescript": "5.2.2"
+    "typescript": "5.1.6"
   },
   "dependencies": {
     "@ant-design/cssinjs": "^1.16.2",

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/app-breadcrumb.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/app-breadcrumb.tsx
@@ -11,7 +11,7 @@ export interface AppBreadcrumbProps {}
 const AppBreadcrumb = () => {
   const [pathItems, setPathItems] = useState<ItemType[]>([])
   const pathname = usePathname()
-  const { breadcrumbRoute } = useBreadcrumbs()
+  const { breadcrumbRoute, isVisible } = useBreadcrumbs()
 
   useEffect(() => {
     if (breadcrumbRoute?.route) {
@@ -28,6 +28,8 @@ const AppBreadcrumb = () => {
     const last = routes.indexOf(route) === routes.length - 1
     return <BreadcrumbSegment route={route} paths={paths} last={last} />
   }
+
+  if (!isVisible) return null
 
   return (
     <Breadcrumb

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/breadcrumbs-context.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/breadcrumbs-context.tsx
@@ -5,49 +5,71 @@ import { usePathname } from 'next/navigation'
 import { routes } from '.'
 
 export const BreadcrumbsContext = createContext<BreadcrumbContextType | null>(
-  null
+  null,
 )
 
 export const BreadcrumbsProvider = ({ children }) => {
-  const [ breadcrumbRoute, setBreadcrumbRoute ] = useState<{pathname: string, title?: string, route?: ItemType[]}>(null)
+  const [breadcrumbRoute, setBreadcrumbRoute] = useState<{
+    pathname: string
+    title?: string
+    route?: ItemType[]
+  }>(null)
+  const [isVisible, setIsVisible] = useState(true)
   const pathname = usePathname()
 
-  const setRoute = useCallback((route: ItemType[]) => {
-    setBreadcrumbRoute({pathname, route})
-  }, [pathname])
+  const setRoute = useCallback(
+    (route: ItemType[]) => {
+      setBreadcrumbRoute({ pathname, route })
+    },
+    [pathname],
+  )
 
-  const generateRoute = useCallback((pathname: string, lastItemTitleOverride?: string): ItemType[] => {
-    const pathSegments = pathname.split('/').filter((item) => item !== '')
-    return pathSegments.map((item, index) => {
-      // Set the title of the last path segment to the title passed in from the page
-      let titleOverride = {}
-      if (lastItemTitleOverride && index === pathSegments.length - 1) {
-        titleOverride = { title: lastItemTitleOverride }
-      }
+  const generateRoute = useCallback(
+    (pathname: string, lastItemTitleOverride?: string): ItemType[] => {
+      const pathSegments = pathname.split('/').filter((item) => item !== '')
+      return pathSegments.map((item, index) => {
+        // Set the title of the last path segment to the title passed in from the page
+        let titleOverride = {}
+        if (lastItemTitleOverride && index === pathSegments.length - 1) {
+          titleOverride = { title: lastItemTitleOverride }
+        }
 
-      return {
-        path: item,
-        href: '/' + pathSegments.slice(0, index + 1).join('/'),
-        ...routes[item],
-        ...titleOverride
-      }
-    })
-  }, [])
+        return {
+          path: item,
+          href: '/' + pathSegments.slice(0, index + 1).join('/'),
+          ...routes[item],
+          ...titleOverride,
+        }
+      })
+    },
+    [],
+  )
 
-  const setTitle = useCallback((title: string) => {
-    const route = generateRoute(pathname, title)
-    setBreadcrumbRoute({pathname, route})
-  }, [pathname, generateRoute])
+  const setTitle = useCallback(
+    (title: string) => {
+      const route = generateRoute(pathname, title)
+      setBreadcrumbRoute({ pathname, route })
+    },
+    [pathname, generateRoute],
+  )
 
   useEffect(() => {
     // Only set the default route if it hasn't been set already
     if (breadcrumbRoute?.pathname !== pathname) {
-      setBreadcrumbRoute({pathname, route: generateRoute(pathname)})
+      setBreadcrumbRoute({ pathname, route: generateRoute(pathname) })
     }
   }, [pathname, generateRoute, breadcrumbRoute])
 
   return (
-    <BreadcrumbsContext.Provider value={{ breadcrumbRoute, setBreadcrumbTitle: setTitle, setBreadcrumbRoute: setRoute }}>
+    <BreadcrumbsContext.Provider
+      value={{
+        breadcrumbRoute,
+        isVisible: isVisible,
+        setBreadcrumbIsVisible: setIsVisible,
+        setBreadcrumbTitle: setTitle,
+        setBreadcrumbRoute: setRoute,
+      }}
+    >
       {children}
     </BreadcrumbsContext.Provider>
   )

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/breadcrumbs-context.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/breadcrumbs-context.tsx
@@ -54,6 +54,7 @@ export const BreadcrumbsProvider = ({ children }) => {
   )
 
   useEffect(() => {
+    setIsVisible(true)
     // Only set the default route if it hasn't been set already
     if (breadcrumbRoute?.pathname !== pathname) {
       setBreadcrumbRoute({ pathname, route: generateRoute(pathname) })

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/types.d.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/types.d.ts
@@ -5,10 +5,17 @@ export interface BreadcrumbContextType {
     pathname: string
     route?: ItemType[]
   }
+  isVisible: boolean
+  /**
+   * Sets the value to make the breadcrumb visible or not
+   * @param isVisible
+   * @returns
+   */
+  setBreadcrumbIsVisible: (isVisible: boolean) => void
   /**
    * Sets the title displayed for the last item in the page breadcrumb
-   * @param title 
-   * @returns 
+   * @param title
+   * @returns
    */
   setBreadcrumbTitle: (title: string) => void
   /**
@@ -16,6 +23,6 @@ export interface BreadcrumbContextType {
    * @param route
    * @returns
    * @example setBreadcrumbRoute([{ title: 'Org' }, { title: 'Teams', href: '/orgs/teams' }, { title: ${team.name} }])
-  */
+   */
   setBreadcrumbRoute: (route: ItemType[]) => void
 }

--- a/Moda.Web/src/moda.web.reactclient/src/app/not-found.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/not-found.tsx
@@ -2,11 +2,15 @@
 
 import { Result } from 'antd'
 import useBreadcrumbs from './components/contexts/breadcrumbs'
+import { useEffect } from 'react'
 
 export default function NotFound() {
   const { setBreadcrumbIsVisible } = useBreadcrumbs()
 
-  setBreadcrumbIsVisible(false)
+  useEffect(() => {
+    setBreadcrumbIsVisible(false)
+  }, [setBreadcrumbIsVisible])
+
   return (
     <Result status="404" title="404" subTitle="Resource not found"></Result>
   )

--- a/Moda.Web/src/moda.web.reactclient/src/app/not-found.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/not-found.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import { Result } from 'antd'
+import useBreadcrumbs from './components/contexts/breadcrumbs'
+
+export default function NotFound() {
+  const { setBreadcrumbIsVisible } = useBreadcrumbs()
+
+  setBreadcrumbIsVisible(false)
+  return (
+    <Result status="404" title="404" subTitle="Resource not found"></Result>
+  )
+}

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/employees/[key]/employee-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/employees/[key]/employee-details.tsx
@@ -5,7 +5,13 @@ import Link from 'next/link'
 
 const { Item } = Descriptions
 
-const EmployeeDetails = (employee: EmployeeDetailsDto) => {
+interface EmployeeDetailsProps {
+  employee: EmployeeDetailsDto
+}
+
+const EmployeeDetails = ({ employee }: EmployeeDetailsProps) => {
+  if (!employee) return null
+
   return (
     <>
       <Descriptions>
@@ -17,7 +23,9 @@ const EmployeeDetails = (employee: EmployeeDetailsDto) => {
           </Link>
         </Item>
         <Item label="Office Location">{employee.officeLocation}</Item>
-        <Item label="Hire Date">{employee.hireDate && dayjs(employee.hireDate).format('M/D/YYYY')}</Item>
+        <Item label="Hire Date">
+          {employee.hireDate && dayjs(employee.hireDate).format('M/D/YYYY')}
+        </Item>
         <Item label="Is Active?">{employee.isActive?.toString()}</Item>
       </Descriptions>
     </>

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/employees/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/employees/[key]/page.tsx
@@ -2,12 +2,13 @@
 
 import PageTitle from '@/src/app/components/common/page-title'
 import { EmployeeDetailsDto } from '@/src/services/moda-api'
-import { createElement, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import EmployeeDetails from './employee-details'
 import { getEmployeesClient } from '@/src/services/clients'
 import { Card } from 'antd'
 import { useDocumentTitle } from '@/src/app/hooks/use-document-title'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
+import { authorizePage } from '@/src/app/components/hoc'
 
 const EmployeeDetailsPage = ({ params }) => {
   useDocumentTitle('Employee Details')
@@ -20,7 +21,7 @@ const EmployeeDetailsPage = ({ params }) => {
     {
       key: 'details',
       tab: 'Details',
-      content: createElement(EmployeeDetails, employee),
+      content: <EmployeeDetails employee={employee} />,
     },
   ]
 
@@ -50,4 +51,10 @@ const EmployeeDetailsPage = ({ params }) => {
   )
 }
 
-export default EmployeeDetailsPage
+const EmployeeDetailsPageWithAuthorization = authorizePage(
+  EmployeeDetailsPage,
+  'Permission',
+  'Permissions.Employees.View',
+)
+
+export default EmployeeDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/employees/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/employees/[key]/page.tsx
@@ -9,6 +9,7 @@ import { Card } from 'antd'
 import { useDocumentTitle } from '@/src/app/hooks/use-document-title'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { authorizePage } from '@/src/app/components/hoc'
+import { notFound } from 'next/navigation'
 
 const EmployeeDetailsPage = ({ params }) => {
   useDocumentTitle('Employee Details')
@@ -16,6 +17,7 @@ const EmployeeDetailsPage = ({ params }) => {
   const [employee, setEmployee] = useState<EmployeeDetailsDto | null>(null)
   const { key } = params
   const { setBreadcrumbTitle } = useBreadcrumbs()
+  const [notEmployeeFound, setEmployeeNotFound] = useState<boolean>(false)
 
   const tabs = [
     {
@@ -33,8 +35,17 @@ const EmployeeDetailsPage = ({ params }) => {
       setBreadcrumbTitle(employeeDto.displayName)
     }
 
-    getEmployee()
+    getEmployee().catch((error) => {
+      if (error.status === 404) {
+        setEmployeeNotFound(true)
+      }
+      console.error('getEmployee error', error)
+    })
   }, [key, setBreadcrumbTitle])
+
+  if (notEmployeeFound) {
+    return notFound()
+  }
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -16,6 +16,7 @@ import useAuth from '@/src/app/components/contexts/auth'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { useGetTeamOfTeamsRisks } from '@/src/services/queries/organization-queries'
 import { authorizePage } from '@/src/app/components/hoc'
+import { notFound } from 'next/navigation'
 
 enum TeamOfTeamsTabs {
   Details = 'details',
@@ -33,6 +34,7 @@ const TeamOfTeamsDetailsPage = ({ params }) => {
   const { setBreadcrumbTitle } = useBreadcrumbs()
   const [risksQueryEnabled, setRisksQueryEnabled] = useState<boolean>(false)
   const [includeClosedRisks, setIncludeClosedRisks] = useState<boolean>(false)
+  const [notTeamFound, setTeamNotFound] = useState<boolean>(false)
 
   const { hasClaim } = useAuth()
   const canUpdateTeam = hasClaim('Permission', 'Permissions.Teams.Update')
@@ -98,7 +100,12 @@ const TeamOfTeamsDetailsPage = ({ params }) => {
       setBreadcrumbTitle(teamDto.name)
     }
 
-    getTeam()
+    getTeam().catch((error) => {
+      if (error.status === 404) {
+        setTeamNotFound(true)
+      }
+      console.error('getTeam error', error)
+    })
   }, [key, setBreadcrumbTitle, lastRefresh])
 
   const onUpdateTeamFormClosed = (wasUpdated: boolean) => {
@@ -120,6 +127,10 @@ const TeamOfTeamsDetailsPage = ({ params }) => {
     },
     [risksQueryEnabled],
   )
+
+  if (notTeamFound) {
+    return notFound()
+  }
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -15,6 +15,7 @@ import { EditTeamForm } from '../../components'
 import useAuth from '@/src/app/components/contexts/auth'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { useGetTeamOfTeamsRisks } from '@/src/services/queries/organization-queries'
+import { authorizePage } from '@/src/app/components/hoc'
 
 enum TeamOfTeamsTabs {
   Details = 'details',
@@ -66,7 +67,7 @@ const TeamOfTeamsDetailsPage = ({ params }) => {
     {
       key: TeamOfTeamsTabs.Details,
       tab: 'Details',
-      content: createElement(TeamOfTeamsDetails, team),
+      content: <TeamOfTeamsDetails team={team} />,
     },
     {
       key: TeamOfTeamsTabs.RiskManagement,
@@ -148,4 +149,10 @@ const TeamOfTeamsDetailsPage = ({ params }) => {
   )
 }
 
-export default TeamOfTeamsDetailsPage
+const TeamOfTeamsDetailsPageWithAuthorization = authorizePage(
+  TeamOfTeamsDetailsPage,
+  'Permission',
+  'Permissions.Teams.View',
+)
+
+export default TeamOfTeamsDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/team-of-teams/[key]/team-of-teams-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/team-of-teams/[key]/team-of-teams-details.tsx
@@ -5,7 +5,12 @@ import ReactMarkdown from 'react-markdown'
 
 const { Item } = Descriptions
 
-const TeamOfTeamsDetails = (team: TeamOfTeamsDetailsDto) => {
+interface TeamOfTeamsDetailsProps {
+  team: TeamOfTeamsDetailsDto
+}
+
+const TeamOfTeamsDetails = ({ team }: TeamOfTeamsDetailsProps) => {
+  if (!team) return null
   return (
     <>
       <Row>

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import PageTitle from '@/src/app/components/common/page-title'
-import { TeamDetailsDto, TeamMembershipsDto } from '@/src/services/moda-api'
+import { TeamDetailsDto } from '@/src/services/moda-api'
 import { Button, Card } from 'antd'
 import { createElement, useCallback, useEffect, useState } from 'react'
 import TeamDetails from './team-details'
@@ -16,6 +16,7 @@ import useAuth from '@/src/app/components/contexts/auth'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { useGetTeamRisks } from '@/src/services/queries/organization-queries'
 import { authorizePage } from '@/src/app/components/hoc'
+import { notFound } from 'next/navigation'
 
 enum TeamTabs {
   Details = 'details',
@@ -32,6 +33,7 @@ const TeamDetailsPage = ({ params }) => {
   const { setBreadcrumbTitle } = useBreadcrumbs()
   const [risksQueryEnabled, setRisksQueryEnabled] = useState<boolean>(false)
   const [includeClosedRisks, setIncludeClosedRisks] = useState<boolean>(false)
+  const [notTeamFound, setTeamNotFound] = useState<boolean>(false)
 
   const { hasClaim } = useAuth()
   const canUpdateTeam = hasClaim('Permission', 'Permissions.Teams.Update')
@@ -98,7 +100,12 @@ const TeamDetailsPage = ({ params }) => {
       setBreadcrumbTitle(teamDto.name)
     }
 
-    getTeam()
+    getTeam().catch((error) => {
+      if (error.status === 404) {
+        setTeamNotFound(true)
+      }
+      console.error('getTeam error', error)
+    })
   }, [params.key, setBreadcrumbTitle, lastRefresh])
 
   const onUpdateTeamFormClosed = (wasUpdated: boolean) => {
@@ -120,6 +127,10 @@ const TeamDetailsPage = ({ params }) => {
     },
     [risksQueryEnabled],
   )
+
+  if (notTeamFound) {
+    return notFound()
+  }
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -15,6 +15,7 @@ import { EditTeamForm } from '../../components'
 import useAuth from '@/src/app/components/contexts/auth'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { useGetTeamRisks } from '@/src/services/queries/organization-queries'
+import { authorizePage } from '@/src/app/components/hoc'
 
 enum TeamTabs {
   Details = 'details',
@@ -65,7 +66,7 @@ const TeamDetailsPage = ({ params }) => {
     {
       key: TeamTabs.Details,
       tab: 'Details',
-      content: createElement(TeamDetails, team),
+      content: <TeamDetails team={team} />,
     },
     {
       key: TeamTabs.RiskManagement,
@@ -148,4 +149,10 @@ const TeamDetailsPage = ({ params }) => {
   )
 }
 
-export default TeamDetailsPage
+const TeamDetailsPageWithAuthorization = authorizePage(
+  TeamDetailsPage,
+  'Permission',
+  'Permissions.Teams.View',
+)
+
+export default TeamDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/team-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/team-details.tsx
@@ -5,7 +5,12 @@ import ReactMarkdown from 'react-markdown'
 
 const { Item } = Descriptions
 
-const TeamDetails = (team: TeamDetailsDto) => {
+interface TeamDetailsProps {
+  team: TeamDetailsDto
+}
+
+const TeamDetails = ({ team }: TeamDetailsProps) => {
+  if (!team) return null
   return (
     <>
       <Row>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/objectives/[objectiveKey]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/objectives/[objectiveKey]/page.tsx
@@ -4,7 +4,7 @@ import PageTitle from '@/src/app/components/common/page-title'
 import { getProgramIncrementsClient } from '@/src/services/clients'
 import { ProgramIncrementObjectiveDetailsDto } from '@/src/services/moda-api'
 import { Button, Card, Dropdown, MenuProps, Space } from 'antd'
-import { createElement, useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import ProgramIncrementObjectiveDetails from './program-increment-objective-details'
 import { useDocumentTitle } from '@/src/app/hooks/use-document-title'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
@@ -14,6 +14,7 @@ import { DownOutlined } from '@ant-design/icons'
 import { ItemType } from 'antd/es/menu/hooks/useItems'
 import { BreadcrumbItemType } from 'antd/es/breadcrumb/Breadcrumb'
 import DeleteProgramIncrementObjectiveForm from './delete-program-increment-objective-form'
+import { authorizePage } from '@/src/app/components/hoc'
 
 const ObjectiveDetailsPage = ({ params }) => {
   useDocumentTitle('PI Objective Details')
@@ -38,7 +39,7 @@ const ObjectiveDetailsPage = ({ params }) => {
     {
       key: 'details',
       tab: 'Details',
-      content: createElement(ProgramIncrementObjectiveDetails, objective),
+      content: <ProgramIncrementObjectiveDetails objective={objective} />,
     },
   ]
 
@@ -165,4 +166,10 @@ const ObjectiveDetailsPage = ({ params }) => {
   )
 }
 
-export default ObjectiveDetailsPage
+const ObjectiveDetailsPageWithAuthorization = authorizePage(
+  ObjectiveDetailsPage,
+  'Permission',
+  'Permissions.ProgramIncrements.View',
+)
+
+export default ObjectiveDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/objectives/[objectiveKey]/program-increment-objective-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/objectives/[objectiveKey]/program-increment-objective-details.tsx
@@ -6,9 +6,15 @@ import { ReactMarkdown } from 'react-markdown/lib/react-markdown'
 
 const { Item } = Descriptions
 
-const ProgramIncrementObjectiveDetails = (
+interface ProgramIncrementObjectiveDetailsProps {
   objective: ProgramIncrementObjectiveDetailsDto
-) => {
+}
+
+const ProgramIncrementObjectiveDetails = ({
+  objective,
+}: ProgramIncrementObjectiveDetailsProps) => {
+  if (!objective) return null
+
   const progressStatus =
     objective.status?.name === 'Canceled' ? 'exception' : undefined
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/page.tsx
@@ -27,6 +27,7 @@ import {
   useGetProgramIncrementRisks,
   useGetProgramIncrementTeams,
 } from '@/src/services/queries/planning-queries'
+import { authorizePage } from '@/src/app/components/hoc'
 
 enum ProgramIncrementTabs {
   Details = 'details',
@@ -122,7 +123,9 @@ const ProgramIncrementDetailsPage = ({ params }) => {
     {
       key: ProgramIncrementTabs.Details,
       tab: 'Details',
-      content: createElement(ProgramIncrementDetails, programIncrementData),
+      content: (
+        <ProgramIncrementDetails programIncrement={programIncrementData} />
+      ),
     },
     {
       key: ProgramIncrementTabs.Teams,
@@ -232,4 +235,10 @@ const ProgramIncrementDetailsPage = ({ params }) => {
   )
 }
 
-export default ProgramIncrementDetailsPage
+const ProgramIncrementDetailsPageWithAuthorization = authorizePage(
+  ProgramIncrementDetailsPage,
+  'Permission',
+  'Permissions.ProgramIncrements.View',
+)
+
+export default ProgramIncrementDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/page.tsx
@@ -28,6 +28,7 @@ import {
   useGetProgramIncrementTeams,
 } from '@/src/services/queries/planning-queries'
 import { authorizePage } from '@/src/app/components/hoc'
+import { notFound } from 'next/navigation'
 
 enum ProgramIncrementTabs {
   Details = 'details',
@@ -55,8 +56,12 @@ const ProgramIncrementDetailsPage = ({ params }) => {
     'Permissions.ProgramIncrements.Update',
   )
 
-  const { data: programIncrementData, refetch: refetchProgramIncrement } =
-    useGetProgramIncrementByKey(params.key)
+  const {
+    data: programIncrementData,
+    isLoading,
+    isFetching,
+    refetch: refetchProgramIncrement,
+  } = useGetProgramIncrementByKey(params.key)
 
   const teamsQuery = useGetProgramIncrementTeams(
     programIncrementData?.id,
@@ -199,6 +204,10 @@ const ProgramIncrementDetailsPage = ({ params }) => {
     },
     [objectivesQueryEnabled, risksQueryEnabled, teamsQueryEnabled],
   )
+
+  if (!isLoading && !isFetching && !programIncrementData) {
+    notFound()
+  }
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/plan-review/team-objectives-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/plan-review/team-objectives-list-card.tsx
@@ -18,6 +18,8 @@ export interface TeamObjectivesListCardProps {
   newObjectivesAllowed?: boolean
 }
 
+const statusOrder = ['Not Started', 'In Progress', 'Closed', 'Canceled']
+
 const TeamObjectivesListCard = ({
   objectivesQuery,
   programIncrementId,
@@ -55,25 +57,27 @@ const TeamObjectivesListCard = ({
     if (!objectivesQuery?.data || objectivesQuery?.data.length === 0) {
       return <ModaEmpty message="No objectives" />
     }
+
     const sortedObjectives = objectivesQuery?.data.sort((a, b) => {
       if (a.isStretch && !b.isStretch) {
         return 1
       } else if (!a.isStretch && b.isStretch) {
         return -1
       } else {
-        const statusOrder = ['Not Started', 'In Progress', 'Closed', 'Canceled']
         const aStatusIndex = statusOrder.indexOf(a.status.name)
         const bStatusIndex = statusOrder.indexOf(b.status.name)
         if (aStatusIndex === bStatusIndex) {
           if (a.targetDate && b.targetDate) {
-            return dayjs(a.targetDate).isAfter(dayjs(b.targetDate)) ? 1 : -1
+            const targetDateDiff = dayjs(a.targetDate).diff(dayjs(b.targetDate))
+            if (targetDateDiff !== 0) {
+              return targetDateDiff
+            }
           } else if (a.targetDate) {
             return -1
           } else if (b.targetDate) {
             return 1
-          } else {
-            return a.key - b.key
           }
+          return a.key - b.key
         } else {
           return aStatusIndex - bStatusIndex
         }

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/program-increment-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/program-increment-details.tsx
@@ -5,9 +5,15 @@ import { ReactMarkdown } from 'react-markdown/lib/react-markdown'
 
 const { Item } = Descriptions
 
-const ProgramIncrementDetails = (
+interface ProgramIncrementDetailsProps {
   programIncrement: ProgramIncrementDetailsDto
-) => {
+}
+
+const ProgramIncrementDetails = ({
+  programIncrement,
+}: ProgramIncrementDetailsProps) => {
+  if (!programIncrement) return null
+
   return (
     <>
       <Row>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/risks/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/risks/[key]/page.tsx
@@ -3,7 +3,7 @@
 import PageTitle from '@/src/app/components/common/page-title'
 import { getRisksClient } from '@/src/services/clients'
 import { RiskDetailsDto } from '@/src/services/moda-api'
-import { createElement, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import RiskDetails from './risk-details'
 import { Button, Card } from 'antd'
 import { useDocumentTitle } from '@/src/app/hooks/use-document-title'
@@ -11,6 +11,7 @@ import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import useAuth from '@/src/app/components/contexts/auth'
 import UpdateRiskForm from '@/src/app/components/common/planning/edit-risk-form'
 import { ItemType } from 'antd/es/breadcrumb/Breadcrumb'
+import { authorizePage } from '@/src/app/components/hoc'
 
 const RiskDetailsPage = ({ params }) => {
   useDocumentTitle('Risk Details')
@@ -29,7 +30,7 @@ const RiskDetailsPage = ({ params }) => {
     {
       key: 'details',
       tab: 'Details',
-      content: createElement(RiskDetails, risk),
+      content: <RiskDetails risk={risk} />,
     },
   ]
 
@@ -59,7 +60,7 @@ const RiskDetailsPage = ({ params }) => {
         },
         {
           title: riskDto.summary,
-        }
+        },
       )
       // TODO: for a split second, the breadcrumb shows the default path route, then the new one.
       setBreadcrumbRoute(breadcrumbRoute)
@@ -112,4 +113,10 @@ const RiskDetailsPage = ({ params }) => {
   )
 }
 
-export default RiskDetailsPage
+const RiskDetailsPageWithAuthorization = authorizePage(
+  RiskDetailsPage,
+  'Permission',
+  'Permissions.Risks.View',
+)
+
+export default RiskDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/risks/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/risks/[key]/page.tsx
@@ -1,8 +1,6 @@
 'use client'
 
 import PageTitle from '@/src/app/components/common/page-title'
-import { getRisksClient } from '@/src/services/clients'
-import { RiskDetailsDto } from '@/src/services/moda-api'
 import { useEffect, useState } from 'react'
 import RiskDetails from './risk-details'
 import { Button, Card } from 'antd'
@@ -12,15 +10,20 @@ import useAuth from '@/src/app/components/contexts/auth'
 import UpdateRiskForm from '@/src/app/components/common/planning/edit-risk-form'
 import { ItemType } from 'antd/es/breadcrumb/Breadcrumb'
 import { authorizePage } from '@/src/app/components/hoc'
+import { notFound } from 'next/navigation'
+import { useGetRiskByKey } from '@/src/services/queries/planning-queries'
 
 const RiskDetailsPage = ({ params }) => {
   useDocumentTitle('Risk Details')
+  const {
+    data: riskData,
+    isLoading,
+    isFetching,
+    refetch,
+  } = useGetRiskByKey(params.key)
   const [activeTab, setActiveTab] = useState('details')
-  const [risk, setRisk] = useState<RiskDetailsDto | null>(null)
-  const { key } = params
   const { setBreadcrumbRoute } = useBreadcrumbs()
   const [openUpdateRiskForm, setOpenUpdateRiskForm] = useState<boolean>(false)
-  const [lastRefresh, setLastRefresh] = useState<number>(Date.now())
 
   const { hasClaim } = useAuth()
   const canUpdateRisks = hasClaim('Permission', 'Permissions.Risks.Update')
@@ -30,11 +33,13 @@ const RiskDetailsPage = ({ params }) => {
     {
       key: 'details',
       tab: 'Details',
-      content: <RiskDetails risk={risk} />,
+      content: <RiskDetails risk={riskData} />,
     },
   ]
 
   useEffect(() => {
+    if (!riskData) return
+
     const breadcrumbRoute: ItemType[] = [
       {
         title: 'Organizations',
@@ -45,35 +50,30 @@ const RiskDetailsPage = ({ params }) => {
       },
     ]
 
-    const getRisk = async () => {
-      const risksClient = await getRisksClient()
-      const riskDto = await risksClient.getByKey(key)
-      setRisk(riskDto)
+    const teamRoute = riskData.team?.type === 'Team' ? 'teams' : 'team-of-teams'
 
-      const teamRoute =
-        riskDto.team?.type === 'Team' ? 'teams' : 'team-of-teams'
-
-      breadcrumbRoute.push(
-        {
-          href: `/organizations/${teamRoute}/${riskDto.team?.key}`,
-          title: riskDto.team?.name,
-        },
-        {
-          title: riskDto.summary,
-        },
-      )
-      // TODO: for a split second, the breadcrumb shows the default path route, then the new one.
-      setBreadcrumbRoute(breadcrumbRoute)
-    }
-
-    getRisk()
-  }, [key, lastRefresh, setBreadcrumbRoute])
+    breadcrumbRoute.push(
+      {
+        href: `/organizations/${teamRoute}/${riskData.team?.key}`,
+        title: riskData.team?.name,
+      },
+      {
+        title: riskData.summary,
+      },
+    )
+    // TODO: for a split second, the breadcrumb shows the default path route, then the new one.
+    setBreadcrumbRoute(breadcrumbRoute)
+  }, [riskData, setBreadcrumbRoute])
 
   const onUpdateRiskFormClosed = (wasSaved: boolean) => {
     setOpenUpdateRiskForm(false)
     if (wasSaved) {
-      setLastRefresh(Date.now())
+      refetch()
     }
+  }
+
+  if (!isLoading && !isFetching && !riskData) {
+    notFound()
   }
 
   const Actions = () => {
@@ -89,7 +89,7 @@ const RiskDetailsPage = ({ params }) => {
   return (
     <>
       <PageTitle
-        title={`${risk?.key} - ${risk?.summary}`}
+        title={`${riskData?.key} - ${riskData?.summary}`}
         subtitle="Risk Details"
         actions={showActions && <Actions />}
       />
@@ -101,10 +101,10 @@ const RiskDetailsPage = ({ params }) => {
       >
         {tabs.find((t) => t.key === activeTab)?.content}
       </Card>
-      {canUpdateRisks && (
+      {openUpdateRiskForm && (
         <UpdateRiskForm
           showForm={openUpdateRiskForm}
-          riskId={risk?.id}
+          riskId={riskData?.id}
           onFormSave={() => onUpdateRiskFormClosed(true)}
           onFormCancel={() => onUpdateRiskFormClosed(false)}
         />

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/risks/[key]/risk-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/risks/[key]/risk-details.tsx
@@ -6,7 +6,13 @@ import { ReactMarkdown } from 'react-markdown/lib/react-markdown'
 
 const { Item } = Descriptions
 
-const RiskDetails = (risk: RiskDetailsDto) => {
+interface RiskDetailsProps {
+  risk: RiskDetailsDto
+}
+
+const RiskDetails = ({ risk }: RiskDetailsProps) => {
+  if (!risk) return null
+
   const teamLink =
     risk.team?.type === 'Team'
       ? `/organizations/teams/${risk.team?.key}`
@@ -31,7 +37,7 @@ const RiskDetails = (risk: RiskDetailsDto) => {
           </Descriptions>
         </Col>
         <Col xs={24} md={14}>
-          <Descriptions>
+          <Descriptions column={2}>
             <Item label="Status">{risk.status?.name}</Item>
             <Item label="Team">
               <Link href={teamLink}>{risk.team?.name}</Link>

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/connection-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/connection-details.tsx
@@ -1,0 +1,39 @@
+import { ConnectionDetailsDto } from '@/src/services/moda-api'
+import { Col, Descriptions, Row, Space } from 'antd'
+import { ReactMarkdown } from 'react-markdown/lib/react-markdown'
+
+const { Item } = Descriptions
+
+interface ConnectionDetailsProps {
+  connection: ConnectionDetailsDto
+}
+
+const ConnectionDetails = ({ connection }: ConnectionDetailsProps) => {
+  if (!connection) return null
+  return (
+    <>
+      <Row>
+        <Col xs={24} md={12}>
+          <Descriptions column={2}>
+            <Item label="Connector">{connection.connector}</Item>
+            <Item label="Is Active?">{connection.isActive ? 'Yes' : 'No'}</Item>
+            <Item label="Is Valid Configuration?">
+              {connection.isValidConfiguration ? 'Yes' : 'No'}
+            </Item>
+          </Descriptions>
+        </Col>
+        <Col xs={24} md={12}>
+          <Descriptions layout="vertical">
+            <Item label="Description">
+              <Space direction="vertical">
+                <ReactMarkdown>{connection.description}</ReactMarkdown>
+              </Space>
+            </Item>
+          </Descriptions>
+        </Col>
+      </Row>
+    </>
+  )
+}
+
+export default ConnectionDetails

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/loading.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/loading.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import PageTitle from '@/src/app/components/common/page-title'
+import { Skeleton } from 'antd'
+
+export default function Loading() {
+  return (
+    <>
+      <PageTitle title="Risk Details" />
+      <Skeleton />
+    </>
+  )
+}

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/page.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import PageTitle from '@/src/app/components/common/page-title'
+import { useEffect, useState } from 'react'
+import ConnectionDetails from './connection-details'
+import { Button, Card } from 'antd'
+import { useDocumentTitle } from '@/src/app/hooks/use-document-title'
+import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
+import useAuth from '@/src/app/components/contexts/auth'
+import { ItemType } from 'antd/es/breadcrumb/Breadcrumb'
+import { authorizePage } from '@/src/app/components/hoc'
+import { useGetConnectionById } from '@/src/services/queries/app-integration-queries'
+
+const ConnectionDetailsPage = ({ params }) => {
+  useDocumentTitle('Connection Details')
+  const { data: connectionData, refetch } = useGetConnectionById(params.id)
+  const { setBreadcrumbRoute } = useBreadcrumbs()
+  const [activeTab, setActiveTab] = useState('details')
+  const [openUpdateConnectionForm, setOpenUpdateConnectionForm] =
+    useState<boolean>(false)
+  const [lastRefresh, setLastRefresh] = useState<number>(Date.now())
+
+  const { hasClaim } = useAuth()
+  const canUpdateConnections = hasClaim(
+    'Permission',
+    'Permissions.Connections.Update',
+  )
+  const showActions = canUpdateConnections
+
+  const tabs = [
+    {
+      key: 'details',
+      tab: 'Details',
+      content: <ConnectionDetails connection={connectionData} />,
+    },
+  ]
+
+  useEffect(() => {
+    if (!connectionData) return
+
+    const breadcrumbRoute: ItemType[] = [
+      {
+        title: 'Settings',
+      },
+      {
+        href: `/settings/connections`,
+        title: 'Connections',
+      },
+      {
+        title: connectionData.name,
+      },
+    ]
+    // TODO: for a split second, the breadcrumb shows the default path route, then the new one.
+    setBreadcrumbRoute(breadcrumbRoute)
+  }, [connectionData, lastRefresh, setBreadcrumbRoute])
+
+  // const onUpdateConnectionFormClosed = (wasSaved: boolean) => {
+  //   setOpenUpdateConnectionForm(false)
+  //   if (wasSaved) {
+  //     setLastRefresh(Date.now())
+  //   }
+  // }
+
+  // const Actions = () => {
+  //   return (
+  //     <>
+  //       {canUpdateConnections && (
+  //         <Button onClick={() => setOpenUpdateConnectionForm(true)}>
+  //           Edit
+  //         </Button>
+  //       )}
+  //     </>
+  //   )
+  // }
+
+  return (
+    <>
+      <PageTitle
+        title={connectionData?.name}
+        subtitle="Connection Details"
+        //actions={showActions && <Actions />}
+      />
+      <Card
+        style={{ width: '100%' }}
+        tabList={tabs}
+        activeTabKey={activeTab}
+        onTabChange={(key) => setActiveTab(key)}
+      >
+        {tabs.find((t) => t.key === activeTab)?.content}
+      </Card>
+    </>
+  )
+}
+
+const PageWithAuthorization = authorizePage(
+  ConnectionDetailsPage,
+  'Permission',
+  'Permissions.Connections.View',
+)
+
+export default PageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/page.tsx
@@ -10,15 +10,20 @@ import useAuth from '@/src/app/components/contexts/auth'
 import { ItemType } from 'antd/es/breadcrumb/Breadcrumb'
 import { authorizePage } from '@/src/app/components/hoc'
 import { useGetConnectionById } from '@/src/services/queries/app-integration-queries'
+import { notFound } from 'next/navigation'
 
 const ConnectionDetailsPage = ({ params }) => {
   useDocumentTitle('Connection Details')
-  const { data: connectionData, refetch } = useGetConnectionById(params.id)
+  const {
+    data: connectionData,
+    isLoading,
+    isFetching,
+    refetch,
+  } = useGetConnectionById(params.id)
   const { setBreadcrumbRoute } = useBreadcrumbs()
   const [activeTab, setActiveTab] = useState('details')
   const [openUpdateConnectionForm, setOpenUpdateConnectionForm] =
     useState<boolean>(false)
-  const [lastRefresh, setLastRefresh] = useState<number>(Date.now())
 
   const { hasClaim } = useAuth()
   const canUpdateConnections = hasClaim(
@@ -52,7 +57,7 @@ const ConnectionDetailsPage = ({ params }) => {
     ]
     // TODO: for a split second, the breadcrumb shows the default path route, then the new one.
     setBreadcrumbRoute(breadcrumbRoute)
-  }, [connectionData, lastRefresh, setBreadcrumbRoute])
+  }, [connectionData, setBreadcrumbRoute])
 
   // const onUpdateConnectionFormClosed = (wasSaved: boolean) => {
   //   setOpenUpdateConnectionForm(false)
@@ -72,6 +77,10 @@ const ConnectionDetailsPage = ({ params }) => {
   //     </>
   //   )
   // }
+
+  if (!isLoading && !isFetching && !connectionData) {
+    notFound()
+  }
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/page.tsx
@@ -6,9 +6,13 @@ import { authorizePage } from '../../components/hoc'
 import { useDocumentTitle } from '../../hooks'
 import useAuth from '../../components/contexts/auth'
 import { useGetConnections } from '@/src/services/queries/app-integration-queries'
-import { ItemType } from 'antd/es/menu/hooks/useItems'
 import { Button, Space, Switch } from 'antd'
 import CreateConnectionForm from './components/create-connection-form'
+import Link from 'next/link'
+
+const ConnectionLinkCellRenderer = ({ value, data }) => {
+  return <Link href={`/settings/connections/${data.id}`}>{value}</Link>
+}
 
 const ConnectionsPage = () => {
   useDocumentTitle('Connections')
@@ -27,7 +31,7 @@ const ConnectionsPage = () => {
   const columnDefs = useMemo(
     () => [
       { field: 'id', hide: true },
-      { field: 'name' },
+      { field: 'name', cellRenderer: ConnectionLinkCellRenderer },
       { field: 'connector' },
       { field: 'isActive' },
       { field: 'isValidConfiguration' },
@@ -56,7 +60,7 @@ const ConnectionsPage = () => {
     setIncludeDisabled(checked)
   }
 
-  const controlItems: ItemType[] = [
+  const controlItems = [
     {
       label: (
         <Space>

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/roles/[id]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/roles/[id]/page.tsx
@@ -1,17 +1,18 @@
 'use client'
 
 import PageTitle from '@/src/app/components/common/page-title'
-import { Card } from 'antd'
-import { createElement, useEffect, useState } from 'react'
+import { Card, Result } from 'antd'
+import { useEffect, useState } from 'react'
 import RoleDetails from './components/role-details'
 import Permissions from './components/permissions'
 import useAuth from '@/src/app/components/contexts/auth'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { useGetRoleById } from '@/src/services/queries/user-management-queries'
 import { authorizePage } from '@/src/app/components/hoc'
+import { notFound } from 'next/navigation'
 
 const RoleDetailsPage = ({ params }) => {
-  const { data: roleData } = useGetRoleById(params.id)
+  const { data: roleData, isLoading, isFetching } = useGetRoleById(params.id)
 
   const [activeTab, setActiveTab] = useState('details')
   const { hasClaim } = useAuth()
@@ -25,8 +26,8 @@ const RoleDetailsPage = ({ params }) => {
   const { setBreadcrumbTitle } = useBreadcrumbs()
 
   useEffect(() => {
-    setBreadcrumbTitle(roleData?.name ?? 'New Role')
-  }, [roleData, setBreadcrumbTitle])
+    setBreadcrumbTitle(roleData?.name)
+  }, [roleData?.name, setBreadcrumbTitle])
 
   const tabs = [
     {
@@ -45,6 +46,10 @@ const RoleDetailsPage = ({ params }) => {
       ),
     },
   ]
+
+  if (!isLoading && !isFetching && !roleData) {
+    notFound()
+  }
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/roles/[id]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/roles/[id]/page.tsx
@@ -8,6 +8,7 @@ import Permissions from './components/permissions'
 import useAuth from '@/src/app/components/contexts/auth'
 import useBreadcrumbs from '@/src/app/components/contexts/breadcrumbs'
 import { useGetRoleById } from '@/src/services/queries/user-management-queries'
+import { authorizePage } from '@/src/app/components/hoc'
 
 const RoleDetailsPage = ({ params }) => {
   const { data: roleData } = useGetRoleById(params.id)
@@ -31,17 +32,17 @@ const RoleDetailsPage = ({ params }) => {
     {
       key: 'details',
       tab: 'Details',
-      content: createElement(RoleDetails, {
-        role: roleData,
-      }),
+      content: <RoleDetails role={roleData} />,
     },
     canViewPermissions && {
       key: 'permissions',
       tab: 'Permissions',
-      content: createElement(Permissions, {
-        roleId: roleData?.id,
-        permissions: roleData?.permissions,
-      }),
+      content: (
+        <Permissions
+          roleId={roleData?.id}
+          permissions={roleData?.permissions}
+        />
+      ),
     },
   ]
 
@@ -59,4 +60,10 @@ const RoleDetailsPage = ({ params }) => {
   )
 }
 
-export default RoleDetailsPage
+const RoleDetailsPageWithAuthorization = authorizePage(
+  RoleDetailsPage,
+  'Permission',
+  'Permissions.Roles.View',
+)
+
+export default RoleDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/users/[id]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/users/[id]/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import PageTitle from '@/src/app/components/common/page-title'
+import { authorizePage } from '@/src/app/components/hoc'
 import { UserDetailsDto } from '@/src/services/moda-api'
 import { useState } from 'react'
 
-const Page = ({ params }) => {
+const UserDetailsPage = ({ params }) => {
   const [user, setUser] = useState<UserDetailsDto | null>(null)
 
   return (
@@ -17,4 +18,10 @@ const Page = ({ params }) => {
   )
 }
 
-export default Page
+const UserDetailsPageWithAuthorization = authorizePage(
+  UserDetailsPage,
+  'Permission',
+  'Permissions.Users.View',
+)
+
+export default UserDetailsPageWithAuthorization

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -6074,7 +6074,7 @@ export class AzureDevOpsBoardsConnectionsClient {
     /**
      * Get Azure DevOps Boards connection based on id.
      */
-    getById(id: string, cancelToken?: CancelToken | undefined): Promise<ConnectionListDto[]> {
+    getById(id: string, cancelToken?: CancelToken | undefined): Promise<ConnectionDetailsDto> {
         let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -6101,7 +6101,7 @@ export class AzureDevOpsBoardsConnectionsClient {
         });
     }
 
-    protected processGetById(response: AxiosResponse): Promise<ConnectionListDto[]> {
+    protected processGetById(response: AxiosResponse): Promise<ConnectionDetailsDto> {
         const status = response.status;
         let _headers: any = {};
         if (response.headers && typeof response.headers === "object") {
@@ -6116,7 +6116,7 @@ export class AzureDevOpsBoardsConnectionsClient {
             let result200: any = null;
             let resultData200  = _responseText;
             result200 = JSON.parse(resultData200);
-            return Promise.resolve<ConnectionListDto[]>(result200);
+            return Promise.resolve<ConnectionDetailsDto>(result200);
 
         } else if (status === 400) {
             const _responseText = response.data;
@@ -6136,7 +6136,7 @@ export class AzureDevOpsBoardsConnectionsClient {
             const _responseText = response.data;
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
-        return Promise.resolve<ConnectionListDto[]>(null as any);
+        return Promise.resolve<ConnectionDetailsDto>(null as any);
     }
 
     /**
@@ -6208,7 +6208,7 @@ export class AzureDevOpsBoardsConnectionsClient {
     }
 
     /**
-     * Get Azure DevOps Boards connection based on id.
+     * Get Azure DevOps Boards connection configuration based on id.
      */
     getConfig(id: string, cancelToken?: CancelToken | undefined): Promise<AzureDevOpsBoardsConnectionConfigurationDto> {
         let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}/config";
@@ -6276,7 +6276,7 @@ export class AzureDevOpsBoardsConnectionsClient {
     }
 
     /**
-     * Update an Azure DevOps Boards connection.
+     * Update an Azure DevOps Boards connection configuration.
      */
     updateConfig(id: string, request: UpdateAzureDevOpsBoardConnectionConfigurationRequest, cancelToken?: CancelToken | undefined): Promise<void> {
         let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}/config";
@@ -7328,6 +7328,15 @@ export interface UpdateTeamOfTeamsRequest {
 export interface ConnectionListDto {
     id?: string;
     name?: string;
+    connector?: string;
+    isActive?: boolean;
+    isValidConfiguration?: boolean;
+}
+
+export interface ConnectionDetailsDto {
+    id?: string;
+    name?: string;
+    description?: string | undefined;
     connector?: string;
     isActive?: boolean;
     isValidConfiguration?: boolean;

--- a/Moda.Web/src/moda.web.reactclient/src/services/queries/app-integration-queries.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/queries/app-integration-queries.ts
@@ -13,6 +13,15 @@ export const useGetConnections = (includeDisabled: boolean = false) => {
   })
 }
 
+export const useGetConnectionById = (id: string) => {
+  return useQuery({
+    queryKey: [QK.CONNECTIONS, id],
+    queryFn: async () =>
+      (await getAzureDevOpsBoardsConnectionsClient()).getById(id),
+    staleTime: 60000,
+  })
+}
+
 export const useCreateConnectionMutation = () => {
   const queryClient = useQueryClient()
   return useMutation({

--- a/Moda.Web/src/moda.web.reactclient/src/services/queries/planning-queries.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/queries/planning-queries.ts
@@ -124,18 +124,15 @@ export const useGetProgramIncrementObjectiveById = (
 }
 
 export const useGetProgramIncrementObjectiveByKey = (
-  id: number,
-  objectiveId: number,
+  key: number,
+  objectiveKey: number,
 ) => {
   return useQuery({
-    queryKey: [QK.PROGRAM_INCREMENT_OBJECTIVES, id, objectiveId],
+    queryKey: [QK.PROGRAM_INCREMENT_OBJECTIVES, key, objectiveKey],
     queryFn: async () =>
-      (await getProgramIncrementsClient()).getObjectiveByKey(
-        id,
-        objectiveId,
-      ),
+      (await getProgramIncrementsClient()).getObjectiveByKey(key, objectiveKey),
     staleTime: 10000,
-    enabled: !!id && !!objectiveId,
+    enabled: !!key && !!objectiveKey,
   })
 }
 
@@ -252,6 +249,15 @@ export const useGetRiskById = (id: string) => {
     queryFn: async () => (await getRisksClient()).getById(id),
     staleTime: 10000,
     enabled: !!id,
+  })
+}
+
+export const useGetRiskByKey = (key: number) => {
+  return useQuery({
+    queryKey: [QK.RISKS, key],
+    queryFn: async () => (await getRisksClient()).getByKey(key),
+    staleTime: 10000,
+    enabled: !!key,
   })
 }
 


### PR DESCRIPTION
- Cleaned up the Connections Api and added Connections details page.
- Added claims checks to the detail's pages.
- Added the ability to control the breadcrumb visibility.
- Updated the global not found page.
- Hooked up the not found page when a details page does not find its target.
- Fixed the Plan Review Objectives list re-sort issue.
- Reverted back to typescript 5.1.6.

