### PR TITLE
Fixed breadcrumb title bug reverting to default on subsequent loads of page

### DIFF
--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/app-breadcrumb.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/app-breadcrumb.tsx
@@ -4,20 +4,18 @@ import { Breadcrumb } from 'antd'
 import { ItemType } from 'antd/es/breadcrumb/Breadcrumb'
 import { useEffect, useState } from 'react'
 import useBreadcrumbs, { BreadcrumbSegment } from '../contexts/breadcrumbs'
-import { usePathname } from 'next/navigation'
 
 export interface AppBreadcrumbProps {}
 
 const AppBreadcrumb = () => {
   const [pathItems, setPathItems] = useState<ItemType[]>([])
-  const pathname = usePathname()
   const { breadcrumbRoute, isVisible } = useBreadcrumbs()
 
   useEffect(() => {
-    if (breadcrumbRoute?.route) {
+    if (breadcrumbRoute?.route !== undefined) {
       setPathItems(breadcrumbRoute.route)
     }
-  }, [pathname, breadcrumbRoute])
+  }, [breadcrumbRoute])
 
   const itemRender = (
     route: ItemType,

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/breadcrumbs-context.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/contexts/breadcrumbs/breadcrumbs-context.tsx
@@ -11,10 +11,11 @@ export const BreadcrumbsContext = createContext<BreadcrumbContextType | null>(
 export const BreadcrumbsProvider = ({ children }) => {
   const [breadcrumbRoute, setBreadcrumbRoute] = useState<{
     pathname: string
-    title?: string
     route?: ItemType[]
+    defaultRoute?: ItemType[]
   }>(null)
   const [isVisible, setIsVisible] = useState(true)
+  const [overrideForPath, setOverrideForPath] = useState<string>('')
   const pathname = usePathname()
 
   const setRoute = useCallback(
@@ -49,6 +50,7 @@ export const BreadcrumbsProvider = ({ children }) => {
     (title: string) => {
       const route = generateRoute(pathname, title)
       setBreadcrumbRoute({ pathname, route })
+      setOverrideForPath(pathname)
     },
     [pathname, generateRoute],
   )
@@ -56,10 +58,12 @@ export const BreadcrumbsProvider = ({ children }) => {
   useEffect(() => {
     setIsVisible(true)
     // Only set the default route if it hasn't been set already
-    if (breadcrumbRoute?.pathname !== pathname) {
-      setBreadcrumbRoute({ pathname, route: generateRoute(pathname) })
+
+    if (breadcrumbRoute?.pathname !== pathname && overrideForPath !== pathname) {
+      const defaultRoute = generateRoute(pathname)
+      setBreadcrumbRoute({ pathname, route: defaultRoute })
     }
-  }, [pathname, generateRoute, breadcrumbRoute])
+  }, [pathname, generateRoute, breadcrumbRoute, overrideForPath])
 
   return (
     <BreadcrumbsContext.Provider

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/page.tsx
@@ -163,8 +163,8 @@ const ProgramIncrementDetailsPage = ({ params }) => {
   ]
 
   useEffect(() => {
-    setBreadcrumbTitle(programIncrementData?.name)
-  }, [setBreadcrumbTitle, programIncrementData?.name])
+    programIncrementData && setBreadcrumbTitle(programIncrementData.name)
+  }, [setBreadcrumbTitle, programIncrementData])
 
   const onEditFormClosed = useCallback((wasSaved: boolean) => {
     setOpenEditProgramIncrementForm(false)


### PR DESCRIPTION
useEffect for pathname was triggering after setTitle on a page was called, but the breadcrumbRoute wasn't updated when useEffect actually ran, causing the default route to override the explicit setTitle from a page
Added state to indicate if an override had been set on the page to prevent the default from overriding an explicit set.