### PR TITLE
Feature/upgrade mapster and mediatr

### DIFF
--- a/Moda.Common/src/Moda.Common.Application/Behaviors/ValidationBehavior.cs
+++ b/Moda.Common/src/Moda.Common.Application/Behaviors/ValidationBehavior.cs
@@ -1,6 +1,4 @@
-﻿using CSharpFunctionalExtensions;
-using FluentValidation;
-using MediatR;
+﻿using MediatR;
 using ValidationException = Moda.Common.Application.Exceptions.ValidationException;
 
 namespace Moda.Common.Application.Behaviors;

--- a/Moda.Common/src/Moda.Common.Application/ConfigureServices.cs
+++ b/Moda.Common/src/Moda.Common.Application/ConfigureServices.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Mapster;
+using Mapster.Utils;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -17,6 +18,7 @@ public static class ConfigureServices
         services.AddTransient(typeof(IPipelineBehavior<,>), typeof(PerformanceBehavior<,>));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Common/src/Moda.Common.Application/Employees/Dtos/EmployeeDetailsDto.cs
+++ b/Moda.Common/src/Moda.Common.Application/Employees/Dtos/EmployeeDetailsDto.cs
@@ -82,7 +82,7 @@ public sealed record EmployeeDetailsDto : IMapFrom<Employee>
     /// </summary>
     public bool IsActive { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Employee, EmployeeDetailsDto>()
             .Map(dest => dest.DisplayName, src => $"{StringHelpers.Concat(src.Name.FirstName, src.Name.LastName)}")

--- a/Moda.Common/src/Moda.Common.Application/Employees/Dtos/EmployeeListDto.cs
+++ b/Moda.Common/src/Moda.Common.Application/Employees/Dtos/EmployeeListDto.cs
@@ -74,7 +74,7 @@ public sealed record EmployeeListDto : IMapFrom<Employee>
     /// </summary>
     public bool IsActive { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Employee, EmployeeListDto>()
             .Map(dest => dest.DisplayName, src => $"{StringHelpers.Concat(src.Name.FirstName, src.Name.LastName)}")

--- a/Moda.Common/src/Moda.Common.Application/Interfaces/IMapFrom.cs
+++ b/Moda.Common/src/Moda.Common.Application/Interfaces/IMapFrom.cs
@@ -1,7 +1,0 @@
-﻿using Mapster;
-
-namespace Moda.Common.Application.Interfaces;
-public interface IMapFrom<T> : IRegister
-{
-    void IRegister.Register(TypeAdapterConfig config) => config.NewConfig(typeof(T), GetType());
-}

--- a/Moda.Common/src/Moda.Common.Application/Moda.Common.Application.csproj
+++ b/Moda.Common/src/Moda.Common.Application/Moda.Common.Application.csproj
@@ -8,9 +8,9 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
-        <PackageReference Include="FluentValidation" Version="11.7.1" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation" Version="11.8.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />

--- a/Moda.Common/src/Moda.Common.Application/Moda.Common.Application.csproj
+++ b/Moda.Common/src/Moda.Common.Application/Moda.Common.Application.csproj
@@ -11,7 +11,7 @@
         <PackageReference Include="FluentValidation" Version="11.8.0" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="7.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />

--- a/Moda.Common/src/Moda.Common.Domain/Moda.Common.Domain.csproj
+++ b/Moda.Common/src/Moda.Common.Domain/Moda.Common.Domain.csproj
@@ -8,7 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
-        <PackageReference Include="FluentValidation" Version="11.7.1" />
+        <PackageReference Include="FluentValidation" Version="11.8.0" />
         <PackageReference Include="MediatR.Contracts" Version="2.0.1" />
         <PackageReference Include="NodaTime" Version="3.1.9" />
     </ItemGroup>

--- a/Moda.Infrastructure/src/Moda.Infrastructure/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/ConfigureServices.cs
@@ -1,9 +1,9 @@
 ﻿using System.Reflection;
+using Asp.Versioning;
 using Mapster;
 using Mapster.Utils;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,7 +50,7 @@ public static class ConfigureServices
             config.DefaultApiVersion = new ApiVersion(1, 0);
             config.AssumeDefaultVersionWhenUnspecified = true;
             config.ReportApiVersions = true;
-        });
+        }).Services;
 
     private static IServiceCollection AddHealthCheck(this IServiceCollection services) =>
         services.AddHealthChecks().Services;

--- a/Moda.Infrastructure/src/Moda.Infrastructure/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/ConfigureServices.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Mapster;
+using Mapster.Utils;
 using Microsoft.ApplicationInsights.DependencyCollector;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Mvc;
@@ -18,6 +19,7 @@ public static class ConfigureServices
     {
         var assembly = Assembly.GetExecutingAssembly();
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         services.AddSingleton<IClock>(SystemClock.Instance);
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="Hangfire.Console.Extensions" Version="1.1.0" />
     <PackageReference Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />
-    <PackageReference Include="Mapster" Version="7.3.0" />
+    <PackageReference Include="Mapster" Version="7.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.12" />

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="7.1.0" />
     <PackageReference Include="Hangfire" Version="1.8.6" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
     <PackageReference Include="Hangfire.Console.Extensions" Version="1.1.0" />
@@ -16,8 +17,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="7.0.12" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="7.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="5.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.12">
       <PrivateAssets>all</PrivateAssets>

--- a/Moda.Infrastructure/src/Moda.Infrastructure/OpenApi/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/OpenApi/ConfigureServices.cs
@@ -1,3 +1,4 @@
+using Asp.Versioning;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -18,7 +19,6 @@ internal static class ConfigureServices
         var settings = config.GetSection(nameof(SwaggerSettings)).Get<SwaggerSettings>()!;
         if (settings.Enable)
         {
-            services.AddVersionedApiExplorer(o => o.SubstituteApiVersionInUrl = true);
             services.AddEndpointsApiExplorer();
             services.AddOpenApiDocument((document, serviceProvider) =>
             {

--- a/Moda.Integrations/src/Moda.Integrations.MicrosoftGraph/Moda.Integrations.MicrosoftGraph.csproj
+++ b/Moda.Integrations/src/Moda.Integrations.MicrosoftGraph/Moda.Integrations.MicrosoftGraph.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Graph" Version="5.30.0" />
+    <PackageReference Include="Microsoft.Graph" Version="5.31.0" />
     <PackageReference Include="Microsoft.Identity.Web.MicrosoftGraph" Version="2.15.2" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
   </ItemGroup>

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/ConfigureServices.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/ConfigureServices.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using FluentValidation;
 using Mapster;
+using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Moda.AppIntegration.Application;
@@ -14,6 +15,7 @@ public static class ConfigureServices
         services.AddMediatR(options => options.RegisterServicesFromAssembly(assembly));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsConnectionConfigurationDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsConnectionConfigurationDto.cs
@@ -27,7 +27,7 @@ public sealed record AzureDevOpsBoardsConnectionConfigurationDto : IMapFrom<Azur
             PersonalAccessToken = string.Concat(PersonalAccessToken.AsSpan(0, 4), new string('*', PersonalAccessToken.Length - 4));
     }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<AzureDevOpsBoardsConnectionConfiguration, AzureDevOpsBoardsConnectionDetailsDto>();
     }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsConnectionDetailsDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsConnectionDetailsDto.cs
@@ -37,7 +37,7 @@ public sealed record AzureDevOpsBoardsConnectionDetailsDto : IMapFrom<AzureDevOp
     /// </value>
     public bool IsValidConfiguration { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<AzureDevOpsBoardsConnection, AzureDevOpsBoardsConnectionDetailsDto>()
             .Map(dest => dest.Connector, src => src.Connector.GetDisplayName());

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsWorkProcessDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsWorkProcessDto.cs
@@ -7,7 +7,7 @@ public sealed record AzureDevOpsBoardsWorkProcessDto : IMapFrom<AzureDevOpsBoard
     public required string Name { get; set; }
     public string? Description { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<AzureDevOpsBoardsWorkProcess, AzureDevOpsBoardsWorkProcessDto>();
     }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsWorkspaceDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsWorkspaceDto.cs
@@ -9,7 +9,7 @@ public sealed record AzureDevOpsBoardsWorkspaceDto : IMapFrom<AzureDevOpsBoardsW
     public Guid? WorkProcessId { get; set; }
     public bool Sync { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<AzureDevOpsBoardsWorkspace, AzureDevOpsBoardsWorkspaceDto>();
     }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/ConnectionListDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/ConnectionListDto.cs
@@ -29,7 +29,7 @@ public sealed record ConnectionListDto : IMapFrom<Connection>
     /// </value>
     public bool IsValidConfiguration { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Connection, ConnectionListDto>()
             .Map(dest => dest.Connector, src => src.Connector.GetDisplayName());

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Moda.AppIntegration.Application.csproj
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Moda.AppIntegration.Application.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     </ItemGroup>
 

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Moda.AppIntegration.Application.csproj
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Moda.AppIntegration.Application.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     </ItemGroup>

--- a/Moda.Services/Moda.Goals/src/Moda.Goals.Application/ConfigureServices.cs
+++ b/Moda.Services/Moda.Goals/src/Moda.Goals.Application/ConfigureServices.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Moda.Goals.Application;
@@ -12,6 +13,7 @@ public static class ConfigureServices
         services.AddMediatR(options => options.RegisterServicesFromAssembly(assembly));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Moda.Goals.Application.csproj
+++ b/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Moda.Goals.Application.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />
     </ItemGroup>

--- a/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Moda.Goals.Application.csproj
+++ b/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Moda.Goals.Application.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />

--- a/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Objectives/Dtos/ObjectiveDetailsDto.cs
+++ b/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Objectives/Dtos/ObjectiveDetailsDto.cs
@@ -54,7 +54,7 @@ public sealed record ObjectiveDetailsDto : IMapFrom<Objective>
     /// <value>The closed date.</value>
     public Instant? ClosedDate { get; private set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Objective, ObjectiveDetailsDto>()
             .Map(dest => dest.Status, src => SimpleNavigationDto.FromEnum(src.Status))

--- a/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Objectives/Dtos/ObjectiveListDto.cs
+++ b/Moda.Services/Moda.Goals/src/Moda.Goals.Application/Objectives/Dtos/ObjectiveListDto.cs
@@ -45,7 +45,7 @@ public sealed record ObjectiveListDto : IMapFrom<Objective>
     /// <value>The target date.</value>
     public LocalDate? TargetDate { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Objective, ObjectiveListDto>()
             .Map(dest => dest.Status, src => SimpleNavigationDto.FromEnum(src.Status))

--- a/Moda.Services/Moda.Links/src/Moda.Links/ConfigureServices.cs
+++ b/Moda.Services/Moda.Links/src/Moda.Links/ConfigureServices.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using FluentValidation;
 using Mapster;
+using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Moda.Links;
@@ -14,6 +15,7 @@ public static class ConfigureServices
         services.AddMediatR(options => options.RegisterServicesFromAssembly(assembly));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Services/Moda.Links/src/Moda.Links/Moda.Links.csproj
+++ b/Moda.Services/Moda.Links/src/Moda.Links/Moda.Links.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />
     </ItemGroup>

--- a/Moda.Services/Moda.Links/src/Moda.Links/Moda.Links.csproj
+++ b/Moda.Services/Moda.Links/src/Moda.Links/Moda.Links.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />

--- a/Moda.Services/Moda.Links/src/Moda.Links/Models/LinkDto.cs
+++ b/Moda.Services/Moda.Links/src/Moda.Links/Models/LinkDto.cs
@@ -9,7 +9,7 @@ public sealed record LinkDto : IMapFrom<Link>
     public required string Name { get; set; }
     public required string Url { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Link, LinkDto>();
     }

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/ConfigureServices.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/ConfigureServices.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Mapster;
+using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Moda.Organization.Application;
@@ -13,6 +14,7 @@ public static class ConfigureServices
         services.AddMediatR(options => options.RegisterServicesFromAssembly(assembly));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Moda.Organization.Application.csproj
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Moda.Organization.Application.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     </ItemGroup>
 

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Moda.Organization.Application.csproj
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Moda.Organization.Application.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     </ItemGroup>

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Models/TeamNavigationDto.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Models/TeamNavigationDto.cs
@@ -6,7 +6,7 @@ public record TeamNavigationDto : NavigationDto, IMapFrom<BaseTeam>
 {
     public required string Type { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<BaseTeam, TeamNavigationDto>()
             .Map(dest => dest.Type, src => src.Type.GetDisplayName());

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Teams/Dtos/TeamDetailsDto.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Teams/Dtos/TeamDetailsDto.cs
@@ -37,7 +37,7 @@ public sealed record TeamDetailsDto : IMapFrom<BaseTeam>
 
     public TeamNavigationDto? TeamOfTeams { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<BaseTeam, TeamDetailsDto>()
             .Map(dest => dest.Code, src => src.Code.Value)

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Teams/Dtos/TeamListDto.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/Teams/Dtos/TeamListDto.cs
@@ -32,7 +32,7 @@ public sealed record TeamListDto : IMapFrom<BaseTeam>
 
     public TeamNavigationDto? TeamOfTeams { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<BaseTeam, TeamListDto>()
             .Map(dest => dest.Code, src => src.Code.Value)

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/TeamsOfTeams/Dtos/TeamOfTeamsDetailsDto.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/TeamsOfTeams/Dtos/TeamOfTeamsDetailsDto.cs
@@ -37,7 +37,7 @@ public class TeamOfTeamsDetailsDto : IMapFrom<BaseTeam>
 
     public TeamNavigationDto? TeamOfTeams { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<BaseTeam, TeamOfTeamsDetailsDto>()
             .Map(dest => dest.Code, src => src.Code.Value)

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Application/TeamsOfTeams/Dtos/TeamOfTeamsListDto.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Application/TeamsOfTeams/Dtos/TeamOfTeamsListDto.cs
@@ -32,7 +32,7 @@ public class TeamOfTeamsListDto : IMapFrom<BaseTeam>
 
     public TeamNavigationDto? TeamOfTeams { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<BaseTeam, TeamOfTeamsListDto>()
             .Map(dest => dest.Code, src => src.Code.Value)

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/ConfigureServices.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/ConfigureServices.cs
@@ -1,4 +1,5 @@
 ﻿using System.Reflection;
+using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Moda.Planning.Application;
@@ -12,6 +13,7 @@ public static class ConfigureServices
         services.AddMediatR(options => options.RegisterServicesFromAssembly(assembly));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Moda.Planning.Application.csproj
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Moda.Planning.Application.csproj
@@ -10,7 +10,7 @@
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />
     </ItemGroup>

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Moda.Planning.Application.csproj
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Moda.Planning.Application.csproj
@@ -8,8 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.40.3" />
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
         <PackageReference Include="NodaTime" Version="3.1.9" />

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Models/PlanningTeamNavigationDto.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Models/PlanningTeamNavigationDto.cs
@@ -6,7 +6,7 @@ public record PlanningTeamNavigationDto : NavigationDto, IMapFrom<PlanningTeam>
 {
     public required string Type { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<PlanningTeam, PlanningTeamNavigationDto>()
             .Map(dest => dest.Type, src => src.Type.GetDisplayName());

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Risks/Dtos/RiskDetailsDto.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Risks/Dtos/RiskDetailsDto.cs
@@ -21,7 +21,7 @@ public class RiskDetailsDto : IMapFrom<Risk>
     public string? Response { get; set; }
     public Instant? ClosedDate { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Risk, RiskDetailsDto>()
             .Map(dest => dest.ReportedBy, src => NavigationDto.Create(src.ReportedBy.Id, src.ReportedBy.Key, src.ReportedBy.Name.FullName))

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Risks/Dtos/RiskListDto.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Risks/Dtos/RiskListDto.cs
@@ -16,7 +16,7 @@ public class RiskListDto : IMapFrom<Risk>
     public NavigationDto? Assignee { get; set; }
     public LocalDate? FollowUpDate { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Risk, RiskListDto>()
             .Map(dest => dest.Status, src => src.Status.GetDisplayName())

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/BacklogLevels/Dtos/BacklogLevelDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/BacklogLevels/Dtos/BacklogLevelDto.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.BacklogLevels.Dtos;
+﻿using Mapster;
+
+namespace Moda.Work.Application.BacklogLevels.Dtos;
 public sealed record BacklogLevelDto : IMapFrom<BacklogLevel>
 {
     public int Id { get; set; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/ConfigureServices.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/ConfigureServices.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using FluentValidation;
 using Mapster;
+using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Moda.Work.Application;
@@ -14,6 +15,7 @@ public static class ConfigureServices
         services.AddMediatR(options => options.RegisterServicesFromAssembly(assembly));
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
+        TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
         return services;
     }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Moda.Work.Application.csproj
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Moda.Work.Application.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
         <PackageReference Include="Mapster" Version="7.4.0" />
-        <PackageReference Include="MediatR" Version="12.0.1" />
+        <PackageReference Include="MediatR" Version="12.1.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     </ItemGroup>
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Moda.Work.Application.csproj
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Moda.Work.Application.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.7.1" />
-        <PackageReference Include="Mapster" Version="7.3.0" />
+        <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.8.0" />
+        <PackageReference Include="Mapster" Version="7.4.0" />
         <PackageReference Include="MediatR" Version="12.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.12" />
     </ItemGroup>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStates/Dtos/WorkStateDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStates/Dtos/WorkStateDto.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkStates.Dtos;
+﻿using Mapster;
+
+namespace Moda.Work.Application.WorkStates.Dtos;
 public sealed record WorkStateDto : IMapFrom<WorkState>
 {
     public int Id { get; set; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Dtos/WorkTypeDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Dtos/WorkTypeDto.cs
@@ -1,4 +1,5 @@
-﻿namespace Moda.Work.Application.WorkTypes.Dtos;
+﻿using Mapster;
+namespace Moda.Work.Application.WorkTypes.Dtos;
 public sealed record WorkTypeDto : IMapFrom<WorkType>
 {
     public int Id { get; set; }

--- a/Moda.Web/src/Moda.Web.Api/GlobalUsings.cs
+++ b/Moda.Web/src/Moda.Web.Api/GlobalUsings.cs
@@ -1,4 +1,5 @@
-﻿global using FluentValidation;
+﻿global using Asp.Versioning;
+global using FluentValidation;
 global using MediatR;
 global using Microsoft.AspNetCore.Mvc;
 global using Moda.AppIntegration.Application.Connections.Commands;

--- a/Moda.Web/src/Moda.Web.Api/Models/Planning/ProgramIncrements/ProgramIncrementTeamResponse.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Planning/ProgramIncrements/ProgramIncrementTeamResponse.cs
@@ -36,7 +36,7 @@ public class ProgramIncrementTeamResponse : IMapFrom<TeamListDto>, IMapFrom<Team
 
     public TeamNavigationDto? TeamOfTeams { get; set; }
 
-    public void Register(TypeAdapterConfig config)
+    public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<TeamListDto, ProgramIncrementTeamResponse>();
         config.NewConfig<TeamOfTeamsListDto, ProgramIncrementTeamResponse>();


### PR DESCRIPTION
- Updated to Mapster 7.4.0. This version added a new IMapFrom interface which allowed us to remove our custom IMapFrom interface.
- Replaced the deprecated Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer with Asp.Versioning.Mvc.ApiExplorer.
- Updated Mediatr to 12.1.1.