### PR TITLE
bug/Update the create and edit objective forms to have a maxLength of 256.

### DIFF
--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/create-program-increment-objective-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/create-program-increment-objective-form.tsx
@@ -262,9 +262,9 @@ const CreateProgramIncrementObjectiveForm = ({
           </Form.Item>
           <Form.Item label="Name" name="name" rules={[{ required: true }]}>
             <Input.TextArea
-              autoSize={{ minRows: 1, maxRows: 2 }}
+              autoSize={{ minRows: 2, maxRows: 4 }}
               showCount
-              maxLength={128}
+              maxLength={256}
             />
           </Form.Item>
           <Form.Item

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/edit-program-increment-objective-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/program-increments/[key]/edit-program-increment-objective-form.tsx
@@ -261,9 +261,9 @@ const EditProgramIncrementObjectiveForm = ({
           </Form.Item>
           <Form.Item label="Name" name="name" rules={[{ required: true }]}>
             <Input.TextArea
-              autoSize={{ minRows: 1, maxRows: 2 }}
+              autoSize={{ minRows: 2, maxRows: 4 }}
               showCount
-              maxLength={128}
+              maxLength={256}
               disabled={programIncrementData?.objectivesLocked}
             />
           </Form.Item>


### PR DESCRIPTION
- Update the create and edit objective forms to have a maxLength of 256.