### PR TITLE
Add some more sink options, force config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -350,3 +350,5 @@ MigrationBackup/
 .ionide/
 docker_access_token
 .env
+.seq/*
+!.seq/.gitkeep

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
@@ -49,6 +49,7 @@
     <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="6.3.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="6.0.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />
     <PackageReference Include="ZymLabs.NSwag.FluentValidation.AspNetCore" Version="0.6.2" />
   </ItemGroup>

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
@@ -46,6 +46,7 @@
     <PackageReference Include="Serilog.Sinks.ApplicationInsights" Version="4.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="5.0.0" />
+    <PackageReference Include="Serilog.Sinks.Datadog.Logs" Version="0.5.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.MSSqlServer" Version="6.3.0" />
     <PackageReference Include="SimplerSoftware.EntityFrameworkCore.SqlServer.NodaTime" Version="7.1.0" />

--- a/Moda.Web/src/Moda.Web.Api/Configurations/logger.json
+++ b/Moda.Web/src/Moda.Web.Api/Configurations/logger.json
@@ -2,8 +2,7 @@
     "Serilog": {
         "Using": [
             "Serilog.Sinks.Console",
-            "Serilog.Sinks.File",
-            "Serilog.Sinks.ApplicationInsights"
+            "Serilog.Sinks.File"
         ],
         "Enrich": [
             "FromLogContext",
@@ -40,12 +39,6 @@
         },
         "WriteTo": [
             { "Name": "Console" },
-            {
-                "Name": "ApplicationInsights",
-                "Args": {
-                    "telemetryConverter": "Serilog.Sinks.ApplicationInsights.TelemetryConverters.TraceTelemetryConverter, Serilog.Sinks.ApplicationInsights"
-                }
-            },
             {
                 "Name": "File",
                 "Args": {

--- a/Moda.Web/src/Moda.Web.Api/Configurations/logger.json
+++ b/Moda.Web/src/Moda.Web.Api/Configurations/logger.json
@@ -1,8 +1,7 @@
 {
     "Serilog": {
         "Using": [
-            "Serilog.Sinks.Console",
-            "Serilog.Sinks.File"
+            "Serilog.Sinks.Console"
         ],
         "Enrich": [
             "FromLogContext",
@@ -38,17 +37,7 @@
             "Application": "Moda"
         },
         "WriteTo": [
-            { "Name": "Console" },
-            {
-                "Name": "File",
-                "Args": {
-                    "path": "Logs/logs.json",
-                    "formatter": "Serilog.Formatting.Json.JsonFormatter, Serilog",
-                    "rollingInterval": "Day",
-                    "restrictedToMinimumLevel": "Information",
-                    "retainedFileCountLimit": 5
-                }
-            }
+            { "Name": "Console" }
         ]
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Moda
+
 Moda is a work management system used to plan, manage, and create associations across work items, projects, teams, planning and products.  It helps track, align, and deliver work across organizations.
 
 [Moda Docs](https://destacey.github.io/Moda)
 
 ## Local Debugging
+
 The easiest way to debug locally is to run the `Compound: Launch Moda with Compose` launch configuration. In order for this to work, you need to create the following file in the root of the project:
 a `.env` file with the following contents:
-```
+
+```env
 AAD_CLIENT_ID='{your AAD client ID}'
 AAD_TENANT_ID='{your AAD tenant ID}'
 AAD_LOGON_AUTHORITY='https://login.microsoftonline.com/{your AAD tenant ID}'
@@ -19,7 +22,8 @@ These values will be used during the `docker compose up` command to set environm
 ## Deployment
 
 If you plan to use the client container, the following environment variables must be set:
-```
+
+```env
 NEXT_PUBLIC_AZURE_AD_CLIENT_ID='{your client ID}'
 NEXT_PUBLIC_AZURE_AD_TENANT_ID='{your tenant ID}'
 NEXT_PUBLIC_MICROSOFT_LOGON_AUTHORITY='{your login authority}'
@@ -28,7 +32,8 @@ NEXT_PUBLIC_API_BASE_URL='{Your API URL}'
 ```
 
 The API container needs the following:
-```
+
+```env
 CorsSettings__WebClient={your client URL}
 DatabaseSettings__ConnectionString={connection string to your database}
 HangfireSettings__Storage__ConnectionString={connection string to your database}
@@ -39,7 +44,45 @@ SecuritySettings__AzureAd__RootIssuer={your root issuer/sts url for AAD}
 SecuritySettings__AzureAd__TenantId={your tenant ID}
 ```
 
+Additionally, by default Moda logs to the console via Serilog. If you wish to configure any of the other supported sinks (currently Seq, Datadog and Application Insights), provide the appropriate Serilog__Using__1 and Serilog__WriteTo__1 settings as env vars for your moda-api container. An example with DataDog (taken from some TF for the `azurerm_container_app` resource type):
+
+```terraform
+      env {
+        name  = "Serilog__Using__1"
+        value = "Serilog.Sinks.Datadog.Logs"
+      }
+
+      env {
+        name  = "Serilog__WriteTo__1__Name"
+        value = "DatadogLogs"
+      }
+
+      env {
+        name  = "Serilog__WriteTo__1__Args__apiKey"
+        value = var.dd_api_key
+      }
+
+      env {
+        name  = "Serilog__WriteTo__1__Args__source"
+        value = "csharp"
+      }
+
+      env {
+        name  = "Serilog__WriteTo__1__Args__host"
+        value = "moda-api"
+      }
+
+      env {
+        name  = "Serilog__WriteTo__1__Args__tags__0"
+        value = "product:moda"
+      }
+
+      env {
+        name  = "Serilog__WriteTo__1__Args__tags__1"
+        value = "service:moda-api"
+      }
+```
+
 ## License
 
 See [LICENSE](LICENSE.md)
-

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ SecuritySettings__AzureAd__RootIssuer={your root issuer/sts url for AAD}
 SecuritySettings__AzureAd__TenantId={your tenant ID}
 ```
 
-Additionally, by default Moda logs to the console via Serilog. If you wish to configure any of the other supported sinks (currently Seq, Datadog and Application Insights), provide the appropriate Serilog__Using__1 and Serilog__WriteTo__1 settings as env vars for your moda-api container. An example with DataDog (taken from some TF for the `azurerm_container_app` resource type):
+Additionally, by default Moda logs to the console via Serilog. If you wish to configure any of the other supported sinks (currently Seq, Datadog and Application Insights), provide the appropriate Serilog__Using__x and Serilog__WriteTo__x settings as env vars for your moda-api container. An example with DataDog (taken from some TF for the `azurerm_container_app` resource type):
 
 ```terraform
       env {
@@ -83,7 +83,7 @@ Additionally, by default Moda logs to the console via Serilog. If you wish to co
       }
 ```
 
-> Note, you must use `__1` or greater; `__0` is reserved for the console sink.
+> Note, if you use `__0` for the WriteTo and Using values, you will override the default console logging
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Additionally, by default Moda logs to the console via Serilog. If you wish to co
       }
 ```
 
+> Note, you must use `__1` or greater; `__0` is reserved for the console sink.
+
 ## License
 
 See [LICENSE](LICENSE.md)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       - ASPNETCORE_ENVIRONMENT=Development
       - ASPNETCORE_URLS=https://+:443;http://+:80
       - CorsSettings__WebClient=http://localhost:5002
+      - Serilog__Using__1=Serilog.Sinks.Seq
+      - Serilog__WriteTo__1__Name=Seq
+      - Serilog__WriteTo__1__Args__serverUrl=http://seq:5341
     volumes:
       - ~/.vsdbg:/remote_debugger:rw
       - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
@@ -34,3 +37,15 @@ services:
       - NEXT_PUBLIC_MICROSOFT_LOGON_AUTHORITY=${AAD_LOGON_AUTHORITY}
       - NEXT_PUBLIC_API_SCOPE=${API_SCOPE}
       - NEXT_PUBLIC_API_BASE_URL=${API_BASE_URL}
+
+  seq:
+    image: datalust/seq
+    ports:
+      - 8081:80
+      - 5341:5341
+    environment:
+      - ACCEPT_EULA=Y
+      - SEQ_FIRSTRUN_ADMINPASSWORDHASH=QBqA9On29LzcZaqOq81gGMi4dk8bQGZ+nmqSeawEFb4WdYdicKjAIWMW11eYZtKnLmYdkNlPSFxc+BiuizTu2p84njCv6jI48fle9iZ4BWin
+    volumes:
+      - ./.seq:/data
+   

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - 5341:5341
     environment:
       - ACCEPT_EULA=Y
-      - SEQ_FIRSTRUN_ADMINPASSWORDHASH=QBqA9On29LzcZaqOq81gGMi4dk8bQGZ+nmqSeawEFb4WdYdicKjAIWMW11eYZtKnLmYdkNlPSFxc+BiuizTu2p84njCv6jI48fle9iZ4BWin
+      - SEQ_FIRSTRUN_ADMINPASSWORDHASH=QBqA9On29LzcZaqOq81gGMi4dk8bQGZ+nmqSeawEFb4WdYdicKjAIWMW11eYZtKnLmYdkNlPSFxc+BiuizTu2p84njCv6jI48fle9iZ4BWin # Test1234!
     volumes:
       - ./.seq:/data
    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,6 @@ services:
       - 5341:5341
     environment:
       - ACCEPT_EULA=Y
-      - SEQ_FIRSTRUN_ADMINPASSWORDHASH=QBqA9On29LzcZaqOq81gGMi4dk8bQGZ+nmqSeawEFb4WdYdicKjAIWMW11eYZtKnLmYdkNlPSFxc+BiuizTu2p84njCv6jI48fle9iZ4BWin # Test1234!
     volumes:
       - ./.seq:/data
    


### PR DESCRIPTION
We were shipping the App Insights sink by default, but really we only want a sane default and have users provide their own config within the realm of the sink libraries we want to install. To that end, this PR includes the DD and Seq sinks (Seq for local, DD for our use case) and an update to the compose file to show how to do the Serilog `ReadFrom.Configuration` stuff in env vars. 

> Note, this is for API logs only; we're gonna have to figure something out for how we want to handle (if at all) getting logs from the react app into a particular sink somewhere)