### PR TITLE
Missing Serilog Enricher Libraries

### DIFF
--- a/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Moda.Infrastructure.csproj
@@ -35,9 +35,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NodaTime" Version="3.1.9" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.20.0" />
+    <PackageReference Include="Serilog.Enrichers.AssemblyName" Version="1.0.9" />
     <PackageReference Include="Serilog.Enrichers.Process" Version="2.0.2" />
     <PackageReference Include="Serilog.Enrichers.Span" Version="3.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="Serilog.Exceptions" Version="8.4.0" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.3.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="7.0.0" />

--- a/Moda.Web/src/Moda.Web.Api/Program.cs
+++ b/Moda.Web/src/Moda.Web.Api/Program.cs
@@ -30,6 +30,10 @@ try
     {
         config.ReadFrom.Configuration(context.Configuration);
     });
+    if(builder.Environment.IsDevelopment())
+    {
+        Serilog.Debugging.SelfLog.Enable(Console.Error);
+    }
 
     builder.Services.AddControllers()
         .AddJsonOptions(options => options.JsonSerializerOptions.ConfigureForNodaTime(DateTimeZoneProviders.Tzdb));


### PR DESCRIPTION
While troubleshooting something else, I had turned on the serilog self-logging and noticed we were missing a few libraries that we were adding enrichers for in config. This should square that up.