### PR TITLE
Bug/Updated the get PI predictability queries to ignore team of teams data

### DIFF
--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/ProgramIncrements/Queries/GetProgramIncrementPredictabilityQuery.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/ProgramIncrements/Queries/GetProgramIncrementPredictabilityQuery.cs
@@ -1,4 +1,6 @@
-﻿using Moda.Planning.Application.Models;
+﻿using Moda.Organization.Domain.Enums;
+using Moda.Planning.Application.Models;
+using Moda.Planning.Domain.Enums;
 
 namespace Moda.Planning.Application.ProgramIncrements.Queries;
 public sealed record GetProgramIncrementPredictabilityQuery(Guid Id) : IQuery<ProgramIncrementPredictabilityDto?>;
@@ -20,9 +22,9 @@ internal sealed class GetProgramIncrementPredictabilityQueryHandler : IQueryHand
     {
         // TODO: filter by teams only.  Don't include teams or objective data for team of teams.
         var programIncrement = await _planningDbContext.ProgramIncrements
-            .Include(p => p.Teams)
+            .Include(p => p.Teams.Where(t => t.Team.Type == TeamType.Team))
                 .ThenInclude(t => t.Team)
-            .Include(p => p.Objectives)
+            .Include(p => p.Objectives.Where(o => o.Type == ProgramIncrementObjectiveType.Team))
             .AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/ProgramIncrements/Queries/GetTeamProgramIncrementPredictabilityQuery.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/ProgramIncrements/Queries/GetTeamProgramIncrementPredictabilityQuery.cs
@@ -1,4 +1,7 @@
-﻿namespace Moda.Planning.Application.ProgramIncrements.Queries;
+﻿using Moda.Organization.Domain.Enums;
+using Moda.Planning.Domain.Enums;
+
+namespace Moda.Planning.Application.ProgramIncrements.Queries;
 public sealed record GetTeamProgramIncrementPredictabilityQuery(Guid Id, Guid TeamId) : IQuery<double?>;
 
 internal sealed class GetTeamProgramIncrementPredictabilityQueryHandler : IQueryHandler<GetTeamProgramIncrementPredictabilityQuery, double?>
@@ -18,8 +21,8 @@ internal sealed class GetTeamProgramIncrementPredictabilityQueryHandler : IQuery
     {
         // TODO: filter by team on teams and objectives
         var programIncrement = await _planningDbContext.ProgramIncrements
-            .Include(p => p.Teams.Where(t => t.TeamId == request.TeamId))
-            .Include(p => p.Objectives.Where(o => o.TeamId == request.TeamId))
+            .Include(p => p.Teams.Where(t => t.TeamId == request.TeamId && t.Team.Type == TeamType.Team))
+            .Include(p => p.Objectives.Where(o => o.TeamId == request.TeamId && o.Type == ProgramIncrementObjectiveType.Team))
             .AsNoTracking()
             .FirstOrDefaultAsync(p => p.Id == request.Id, cancellationToken);
         if (programIncrement is null || !programIncrement.Teams.Any())


### PR DESCRIPTION
- Updated the get PI predictability queries to ignore teams that have a type of TeamOfTeams and objectives that are not type of Team.