### PR TITLE
Feature/ability to delete connection

### DIFF
--- a/Moda.Common/src/Moda.Common.Domain/Data/BaseEntity.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Data/BaseEntity.cs
@@ -9,7 +9,7 @@ public abstract class BaseEntity<TId> : IEntity<TId>
     /// </summary>
     public TId Id { get; protected set; } = default!;
 
-    private readonly List<DomainEvent> _domainEvents = new();
+    private readonly List<DomainEvent> _domainEvents = [];
 
     [NotMapped]
     public IReadOnlyCollection<DomainEvent> DomainEvents => _domainEvents.AsReadOnly();

--- a/Moda.Common/src/Moda.Common.Domain/Models/IntegrationRegistration.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Models/IntegrationRegistration.cs
@@ -1,0 +1,10 @@
+﻿namespace Moda.Common.Domain.Models;
+
+/// <summary>
+/// Represents the registration of an external id with the internal object's id and state.
+/// </summary>
+/// <typeparam name="TE">Type of the ExternalId</typeparam>
+/// <typeparam name="TI">Type of the InternalId</typeparam>
+/// <param name="ExternalId"></param>
+/// <param name="IntegrationState"></param>
+public sealed record IntegrationRegistration<TE,TI>(TE ExternalId, IntegrationState<TI> IntegrationState);

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Commands/DeleteAzureDevOpsBoardsConnectionCommand.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Commands/DeleteAzureDevOpsBoardsConnectionCommand.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Moda.AppIntegration.Application.Connections.Commands;
+
+public sealed record DeleteAzureDevOpsBoardsConnectionCommand(Guid Id) : ICommand;
+
+internal sealed class DeleteAzureDevOpsBoardsConnectionCommandHandler : ICommandHandler<DeleteAzureDevOpsBoardsConnectionCommand>
+{
+    private readonly IAppIntegrationDbContext _appIntegrationDbContext;
+    private readonly ILogger<DeleteAzureDevOpsBoardsConnectionCommandHandler> _logger;
+
+    public DeleteAzureDevOpsBoardsConnectionCommandHandler(IAppIntegrationDbContext appIntegrationDbContext, ILogger<DeleteAzureDevOpsBoardsConnectionCommandHandler> logger)
+    {
+        _appIntegrationDbContext = appIntegrationDbContext;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(DeleteAzureDevOpsBoardsConnectionCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connection = await _appIntegrationDbContext.AzureDevOpsBoardsConnections
+                .FirstOrDefaultAsync(c => c.Id == request.Id, cancellationToken);
+            if (connection is null)
+            {
+                _logger.LogError("Azure DevOps Boards Connection {ConnectionId} not found.", request.Id);
+                return Result.Failure($"Azure DevOps Boards Connection {request.Id} not found.");
+            }
+
+            _appIntegrationDbContext.AzureDevOpsBoardsConnections.Remove(connection);
+            await _appIntegrationDbContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error deleting Azure DevOps Boards Connection {ConnectionId}.", request.Id);
+            return Result.Failure($"Error deleting Azure DevOps Boards Connection {request.Id}. {ex.Message}");
+        }
+    }
+}

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Commands/UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommand.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Commands/UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommand.cs
@@ -1,10 +1,8 @@
-﻿using CSharpFunctionalExtensions;
-using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
+﻿using Microsoft.EntityFrameworkCore;
 using Moda.Common.Domain.Models;
 
 namespace Moda.AppIntegration.Application.Connections.Commands;
-public sealed record UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommand(Guid ConnectionId, Guid WorkProcessExternalId, IntegrationState<Guid> IntegrationState) : ICommand;
+public sealed record UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommand(Guid ConnectionId, IntegrationRegistration<Guid,Guid> IntegrationRegistration) : ICommand;
 
 internal sealed class UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommandHandler : ICommandHandler<UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommand>
 {
@@ -30,7 +28,7 @@ internal sealed class UpdateAzureDevOpsBoardsWorkProcessIntegrationStateCommandH
             return Result.Failure($"Unable to find Azure DevOps Boards connection with id {request.ConnectionId}.");
         }
 
-        var importWorkProcessesResult = connection.UpdateWorkProcessIntegrationState(request.WorkProcessExternalId, request.IntegrationState, _dateTimeProvider.Now);
+        var importWorkProcessesResult = connection.UpdateWorkProcessIntegrationState(request.IntegrationRegistration, _dateTimeProvider.Now);
         if (importWorkProcessesResult.IsFailure)
         {
             _logger.LogError("Errors occurred while processing {AppRequestName}. {Error}", AppRequestName, importWorkProcessesResult.Error);

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/GlobalUsings.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/GlobalUsings.cs
@@ -1,4 +1,6 @@
-﻿global using Moda.AppIntegration.Application.Connections.Dtos;
+﻿global using CSharpFunctionalExtensions;
+global using Microsoft.Extensions.Logging;
+global using Moda.AppIntegration.Application.Connections.Dtos;
 global using Moda.AppIntegration.Application.Connectors.Dtos;
 global using Moda.AppIntegration.Application.Persistence;
 global using Moda.AppIntegration.Domain.Enums;

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/IntegrationObject.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/IntegrationObject.cs
@@ -11,19 +11,23 @@ public abstract class IntegrationObject<TId>
 
     public bool IntegrationIsActive => IntegrationState?.IsActive ?? false;
 
-    public void UpdateIntegrationState(bool isActive)
+    public Result UpdateIntegrationState(bool isActive)
     {
         if (IntegrationState is null)
-            throw new InvalidOperationException("Integration state is not set.");
+            Result.Failure("Integration state is not set.");
 
-        IntegrationState?.SetIsActive(isActive);
+        IntegrationState!.SetIsActive(isActive);
+
+        return Result.Success();
     }
 
-    public void AddIntegrationState(IntegrationState<TId> integrationState)
+    public Result AddIntegrationState(IntegrationState<TId> integrationState)
     {
         if (IntegrationState is not null)
-            throw new InvalidOperationException("Integration state is already set.");
+            Result.Failure("Integration state is already set.");
 
         IntegrationState = integrationState;
+
+        return Result.Success();
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetIntegrationRegistrationsForWorkProcessesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetIntegrationRegistrationsForWorkProcessesQuery.cs
@@ -1,0 +1,18 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Moda.Common.Domain.Models;
+
+namespace Moda.Work.Application.WorkProcesses.Queries;
+public sealed record GetIntegrationRegistrationsForWorkProcessesQuery : IQuery<List<IntegrationRegistration<Guid,Guid>>>;
+
+internal sealed class GetIntegrationRegistrationsForWorkProcessesQueryHandler(IWorkDbContext workDbContext) : IQueryHandler<GetIntegrationRegistrationsForWorkProcessesQuery, List<IntegrationRegistration<Guid, Guid>>>
+{
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+
+    public async Task<List<IntegrationRegistration<Guid, Guid>>> Handle(GetIntegrationRegistrationsForWorkProcessesQuery request, CancellationToken cancellationToken)
+    {
+        return await _workDbContext.WorkProcesses
+            .Where(w => w.ExternalId.HasValue)
+            .Select(w => new IntegrationRegistration<Guid, Guid>(w.ExternalId!.Value, IntegrationState<Guid>.Create(w.Id, w.IsActive)))
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -6105,6 +6105,45 @@
             "Bearer": []
           }
         ]
+      },
+      "delete": {
+        "tags": [
+          "AzureDevOpsBoardsConnections"
+        ],
+        "summary": "Delete an Azure DevOps Boards connection.",
+        "operationId": "AzureDevOpsBoardsConnections_Delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
       }
     },
     "/api/app-integrations/azure-devops-boards-connections/test": {
@@ -6148,13 +6187,13 @@
         ]
       }
     },
-    "/api/app-integrations/azure-devops-boards-connections/{id}/import-organization-configuration": {
+    "/api/app-integrations/azure-devops-boards-connections/{id}/sync-organization-configuration": {
       "post": {
         "tags": [
           "AzureDevOpsBoardsConnections"
         ],
-        "summary": "Import Azure DevOps processes and projects.",
-        "operationId": "AzureDevOpsBoardsConnections_ImportOrganizationConfiguration",
+        "summary": "Sync Azure DevOps processes and projects.",
+        "operationId": "AzureDevOpsBoardsConnections_SyncOrganizationConfiguration",
         "parameters": [
           {
             "name": "id",
@@ -7045,7 +7084,7 @@
           "description": {
             "type": "string",
             "description": "Gets the team description.",
-            "maxLength": 1024,
+            "maxLength": 2048,
             "minLength": 0,
             "nullable": true
           },
@@ -7097,7 +7136,7 @@
           "description": {
             "type": "string",
             "description": "Gets the team description.",
-            "maxLength": 1024,
+            "maxLength": 2048,
             "minLength": 0,
             "nullable": true
           },

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/index.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/index.ts
@@ -1,6 +1,8 @@
 export { default as PageTitle } from './page-title'
 export { default as AppBreadcrumb } from './app-breadcrumb'
 export { default as AppHeader } from './app-header'
+export { default as LoadingAccount } from './loading-account'
+export { default as ModaDateRange } from './moda-date-range'
 export { default as ModaEmpty } from './moda-empty'
 export { default as ModaGrid } from './moda-grid'
 export { default as NotAuthorized } from './not-authorized'

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/moda-grid-cell-renderers.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/moda-grid-cell-renderers.tsx
@@ -6,9 +6,7 @@ import './moda-grid-cell-renderers.css'
 import HealthCheckTag from './health-check/health-check-tag'
 import {
   NavigationDto,
-  PlanningTeamNavigationDto,
   PlanningIntervalObjectiveListDto,
-  TeamNavigationDto,
   SimpleNavigationDto,
 } from '@/src/services/moda-api'
 import Link from 'next/link'

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/components/delete-azdo-boards-connection-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/components/delete-azdo-boards-connection-form.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import useAuth from '@/src/app/components/contexts/auth'
+import { AzureDevOpsBoardsConnectionDetailsDto } from '@/src/services/moda-api'
+import { useDeleteAzdoBoardsConnectionMutation } from '@/src/services/queries/app-integration-queries'
+import { Descriptions, Modal, message } from 'antd'
+import { useCallback, useEffect, useState } from 'react'
+
+interface DeleteAzdoBoardsConnectionFormProps {
+  showForm: boolean
+  connection: AzureDevOpsBoardsConnectionDetailsDto
+  onFormSave: () => void
+  onFormCancel: () => void
+}
+
+const DeleteAzdoBoardsConnectionForm = (
+  props: DeleteAzdoBoardsConnectionFormProps,
+) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [messageApi, contextHolder] = message.useMessage()
+
+  const deleteConnectionMutation = useDeleteAzdoBoardsConnectionMutation()
+
+  const { hasClaim } = useAuth()
+  const canManageTeamMemberships = hasClaim(
+    'Permission',
+    'Permissions.Connections.Delete',
+  )
+
+  const deleteConnection = async (
+    connection: AzureDevOpsBoardsConnectionDetailsDto,
+  ) => {
+    try {
+      await deleteConnectionMutation.mutateAsync(connection.id)
+      return true
+    } catch (error) {
+      messageApi.error(
+        'An unexpected error occurred while deleting the Azure DevOps Boards connection.',
+      )
+      console.log(error)
+      return false
+    }
+  }
+
+  const handleOk = async () => {
+    setIsSaving(true)
+    try {
+      if (await deleteConnection(props.connection)) {
+        setIsOpen(false)
+        props.onFormSave()
+        messageApi.success(
+          'Successfully deleted Azure DevOps Boards connection.',
+        )
+      }
+    } catch (errorInfo) {
+      console.log('handleOk error', errorInfo)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleCancel = useCallback(() => {
+    setIsOpen(false)
+    props.onFormCancel()
+  }, [props])
+
+  useEffect(() => {
+    if (!props.connection) return
+    if (canManageTeamMemberships) {
+      setIsOpen(props.showForm)
+    } else {
+      handleCancel()
+      messageApi.error(
+        'You do not have permission to deleted Azure DevOps Boards connections.',
+      )
+    }
+  }, [
+    canManageTeamMemberships,
+    handleCancel,
+    messageApi,
+    props.connection,
+    props.showForm,
+  ])
+
+  return (
+    <>
+      {contextHolder}
+      <Modal
+        title="Are you sure you want to delete this Azure DevOps Boards connection?"
+        open={isOpen}
+        onOk={handleOk}
+        okText="Delete"
+        okType="danger"
+        confirmLoading={isSaving}
+        onCancel={handleCancel}
+        maskClosable={false}
+        keyboard={false} // disable esc key to close modal
+        destroyOnClose={true}
+      >
+        <Descriptions size="small" column={1}>
+          <Descriptions.Item label="Name">
+            {props.connection?.name}
+          </Descriptions.Item>
+        </Descriptions>
+      </Modal>
+    </>
+  )
+}
+
+export default DeleteAzdoBoardsConnectionForm

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -7382,6 +7382,63 @@ export class AzureDevOpsBoardsConnectionsClient {
     }
 
     /**
+     * Delete an Azure DevOps Boards connection.
+     */
+    delete(id: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDelete(_response);
+        });
+    }
+
+    protected processDelete(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Test Azure DevOps Boards connection configuration.
      */
     testConfig(request: TestAzureDevOpsBoardConnectionRequest, cancelToken?: CancelToken): Promise<void> {
@@ -7440,10 +7497,10 @@ export class AzureDevOpsBoardsConnectionsClient {
     }
 
     /**
-     * Import Azure DevOps processes and projects.
+     * Sync Azure DevOps processes and projects.
      */
-    importOrganizationConfiguration(id: string, cancelToken?: CancelToken): Promise<void> {
-        let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}/import-organization-configuration";
+    syncOrganizationConfiguration(id: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}/sync-organization-configuration";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
         url_ = url_.replace("{id}", encodeURIComponent("" + id));
@@ -7464,11 +7521,11 @@ export class AzureDevOpsBoardsConnectionsClient {
                 throw _error;
             }
         }).then((_response: AxiosResponse) => {
-            return this.processImportOrganizationConfiguration(_response);
+            return this.processSyncOrganizationConfiguration(_response);
         });
     }
 
-    protected processImportOrganizationConfiguration(response: AxiosResponse): Promise<void> {
+    protected processSyncOrganizationConfiguration(response: AxiosResponse): Promise<void> {
         const status = response.status;
         let _headers: any = {};
         if (response.headers && typeof response.headers === "object") {

--- a/Moda.Web/src/moda.web.reactclient/src/services/queries/app-integration-queries.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/queries/app-integration-queries.ts
@@ -60,13 +60,24 @@ export const useUpdateAzdoBoardsConnectionMutation = () => {
   })
 }
 
-export const useImportAzdoBoardsConnectionOrganizationMutation = () => {
+export const useDeleteAzdoBoardsConnectionMutation = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (connectionId: string) =>
+      (await getAzureDevOpsBoardsConnectionsClient()).delete(connectionId),
+    onSuccess: (data, connectionId) => {
+      queryClient.invalidateQueries([QK.AZDO_BOARDS_CONNECTIONS, connectionId])
+    },
+  })
+}
+
+export const useSyncAzdoBoardsConnectionOrganizationMutation = () => {
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (connectionId: string) =>
       (
         await getAzureDevOpsBoardsConnectionsClient()
-      ).importOrganizationConfiguration(connectionId),
+      ).syncOrganizationConfiguration(connectionId),
     onSuccess: (data, connectionId) => {
       queryClient.invalidateQueries([QK.AZDO_BOARDS_CONNECTIONS, connectionId])
     },


### PR DESCRIPTION
- Added an API endpoint to delete an Azdo Boards Connection.
- Added a form to the UI to delete an Azdo Boards Connection.
- Updated the SyncOrganizationConfiguration process to add existing integrations if they exist. This can happen if a connection is deleted and a new connection is created for the same type and context.