### PR TITLE
Bug/fix menu collapse state

### DIFF
--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/menu/menu-helper.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/menu/menu-helper.tsx
@@ -60,6 +60,7 @@ function getItem(
     children,
     label: route ? <Link href={route}>{label}</Link> : label,
     type,
+    title: null,
   } as MenuItem
 }
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/hooks/use-local-storage-state.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/hooks/use-local-storage-state.ts
@@ -2,18 +2,20 @@ import { useEffect, useState } from 'react'
 
 export const useLocalStorageState = <T = any>(
   key: string,
-  defaultValue: T
+  defaultValue: T,
 ): [T, (value: T) => void] => {
   const [value, setValue] = useState<T>(() => {
     // If window is undefined, we are on the server and localStorage is not available
     if (typeof window !== 'undefined') {
       const storedValue = window.localStorage.getItem(key)
-      return storedValue && storedValue !== 'undefined' ? JSON.parse(storedValue) : defaultValue
+      return storedValue && storedValue !== 'undefined'
+        ? JSON.parse(storedValue)
+        : defaultValue
     }
   })
 
   useEffect(() => {
-    window.localStorage.setItem(key, value ? JSON.stringify(value) : undefined)
+    window.localStorage.setItem(key, JSON.stringify(value))
   }, [key, value])
 
   return [value, setValue]


### PR DESCRIPTION
- Fix the issue where setting a value as false is stored as undefined.
- Update the main app menu so that collapsed menu items without children don't show a tooltip. This confusing alongside menu items that do have children.