### PR TITLE
Feature/add option to sync connection

### DIFF
--- a/Moda.Common/src/Moda.Common.Application/BackgroundJobs/BackgroundJobType.cs
+++ b/Moda.Common/src/Moda.Common.Application/BackgroundJobs/BackgroundJobType.cs
@@ -4,5 +4,8 @@ namespace Moda.Common.Application.BackgroundJobs;
 public enum BackgroundJobType
 {
     [Display(Name = "Employee Sync", Description = "Synchronize employees from external directory service.", Order = 1)]
-    EmployeeImport = 0
+    EmployeeSync = 0,
+
+    [Display(Name = "Azure DevOps Boards Sync", Description = "Synchronize active connectors for Azure DevOps Boards.", Order = 2)]
+    AzdoBoardsSync = 1,
 }

--- a/Moda.Common/src/Moda.Common.Application/BackgroundJobs/IJobService.cs
+++ b/Moda.Common/src/Moda.Common.Application/BackgroundJobs/IJobService.cs
@@ -2,7 +2,7 @@ using System.Linq.Expressions;
 
 namespace Moda.Common.Application.BackgroundJobs;
 
-public interface IJobService : ITransientService
+public interface IJobService : IScopedService
 {
     IEnumerable<BackgroundJobDto> GetRunningJobs();
 

--- a/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/UpdateExternalWorkspaceCommand.cs
+++ b/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/UpdateExternalWorkspaceCommand.cs
@@ -1,0 +1,4 @@
+﻿using Moda.Common.Application.Interfaces.ExternalWork;
+
+namespace Moda.Common.Application.Requests.WorkManagement;
+public sealed record UpdateExternalWorkspaceCommand(IExternalWorkspaceConfiguration ExternalWorkspace) : ICommand;

--- a/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/ConfigureServices.cs
@@ -33,7 +33,6 @@ internal static class ConfigureServices
             .UseDatabase(storageSettings.StorageProvider, storageSettings.ConnectionString, config)
             .UseFilter(new ModaJobFilter(provider))
             .UseFilter(new LogJobFilter())
-            .UseFilter(new AutomaticRetryAttribute { Attempts = 3, DelaysInSeconds = [30, 60, 120] })
             .UseConsole());
 
         return services;

--- a/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/ConfigureServices.cs
@@ -24,8 +24,7 @@ internal static class ConfigureServices
 
         if (string.IsNullOrEmpty(storageSettings.StorageProvider)) throw new Exception("Hangfire Storage Provider is not configured.");
         if (string.IsNullOrEmpty(storageSettings.ConnectionString)) throw new Exception("Hangfire Storage Provider ConnectionString is not configured.");
-        _logger.Information($"Hangfire: Current Storage Provider : {storageSettings.StorageProvider}");
-        _logger.Information("For more Hangfire storage, visit https://www.hangfire.io/extensions.html");
+        _logger.Information("Hangfire: Current Storage Provider : {StorageProvider}", storageSettings.StorageProvider);
 
         services.AddSingleton<JobActivator, ModaJobActivator>();
 
@@ -34,6 +33,7 @@ internal static class ConfigureServices
             .UseDatabase(storageSettings.StorageProvider, storageSettings.ConnectionString, config)
             .UseFilter(new ModaJobFilter(provider))
             .UseFilter(new LogJobFilter())
+            .UseFilter(new AutomaticRetryAttribute { Attempts = 3, DelaysInSeconds = [30, 60, 120] })
             .UseConsole());
 
         return services;

--- a/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/HangfireService.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/HangfireService.cs
@@ -9,7 +9,7 @@ public class HangfireService : IJobService
 {
     public IEnumerable<BackgroundJobDto> GetRunningJobs()
     {
-        List<BackgroundJobDto> backgroundJobs = new();
+        List<BackgroundJobDto> backgroundJobs = [];
 
         var jobs = JobStorage.Current.GetMonitoringApi().ProcessingJobs(0, 1000);
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/LogJobFilter.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/BackgroundJobs/LogJobFilter.cs
@@ -11,26 +11,26 @@ public class LogJobFilter : IClientFilter, IServerFilter, IElectStateFilter, IAp
     private static readonly ILog _logger = LogProvider.GetCurrentClassLogger();
 
     public void OnCreating(CreatingContext context) =>
-        _logger.InfoFormat("Creating a job based on method {0}...", context.Job.Method.Name);
+        _logger.InfoFormat("Job Service: Creating a job based on method {0}...", context.Job.Method.Name);
 
     public void OnCreated(CreatedContext context) =>
         _logger.InfoFormat(
-            "Job that is based on method {0} has been created with id {1}",
+            "Job Service: Job that is based on method {0} has been created with id {1}",
             context.Job.Method.Name,
             context.BackgroundJob?.Id);
 
     public void OnPerforming(PerformingContext context) =>
-        _logger.InfoFormat("Starting to perform job {0}", context.BackgroundJob.Id);
+        _logger.InfoFormat("Job Service: Starting to perform job {0}", context.BackgroundJob.Id);
 
     public void OnPerformed(PerformedContext context) =>
-        _logger.InfoFormat("Job {0} has been performed", context.BackgroundJob.Id);
+        _logger.InfoFormat("Job Service: Job {0} has been performed", context.BackgroundJob.Id);
 
     public void OnStateElection(ElectStateContext context)
     {
         if (context.CandidateState is FailedState failedState)
         {
             _logger.WarnFormat(
-                "Job '{0}' has been failed due to an exception {1}",
+                "Job Service: Job '{0}' has been failed due to an exception {1}",
                 context.BackgroundJob.Id,
                 failedState.Exception);
         }
@@ -38,14 +38,14 @@ public class LogJobFilter : IClientFilter, IServerFilter, IElectStateFilter, IAp
 
     public void OnStateApplied(ApplyStateContext context, IWriteOnlyTransaction transaction) =>
         _logger.InfoFormat(
-            "Job {0} state was changed from {1} to {2}",
+            "Job Service: Job {0} state was changed from {1} to {2}",
             context.BackgroundJob.Id,
             context.OldStateName,
             context.NewState.Name);
 
     public void OnStateUnapplied(ApplyStateContext context, IWriteOnlyTransaction transaction) =>
         _logger.InfoFormat(
-            "Job {0} state {1} was unapplied.",
+            "Job Service: Job {0} state {1} was unapplied.",
             context.BackgroundJob.Id,
             context.OldStateName);
 }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Commands/UpdateAzureDevOpsBoardsConnectionSyncStateCommand.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Commands/UpdateAzureDevOpsBoardsConnectionSyncStateCommand.cs
@@ -1,0 +1,52 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Moda.AppIntegration.Application.Connections.Commands;
+public sealed record UpdateAzureDevOpsBoardsConnectionSyncStateCommand(Guid Id, bool IsSyncEnabled) : ICommand;
+
+internal sealed class UpdateAzureDevOpsBoardsConnectionSyncStateCommandHandler : ICommandHandler<UpdateAzureDevOpsBoardsConnectionSyncStateCommand>
+{
+    private const string AppRequestName = nameof(UpdateAzureDevOpsBoardsWorkspaceIntegrationStateCommand);
+
+    private readonly ILogger<UpdateAzureDevOpsBoardsConnectionSyncStateCommandHandler> _logger;
+    private readonly IAppIntegrationDbContext _appIntegrationDbContext;
+    private readonly IDateTimeProvider _dateTimeProvider;
+
+    public UpdateAzureDevOpsBoardsConnectionSyncStateCommandHandler(ILogger<UpdateAzureDevOpsBoardsConnectionSyncStateCommandHandler> logger, IAppIntegrationDbContext appIntegrationDbContext, IDateTimeProvider dateTimeProvider)
+    {
+        _logger = logger;
+        _appIntegrationDbContext = appIntegrationDbContext;
+        _dateTimeProvider = dateTimeProvider;
+    }
+
+    public async Task<Result> Handle(UpdateAzureDevOpsBoardsConnectionSyncStateCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var connection = await _appIntegrationDbContext.AzureDevOpsBoardsConnections
+                .FirstOrDefaultAsync(c => c.Id == request.Id, cancellationToken);
+            if (connection is null)
+                return Result.Failure<Guid>("Azure DevOps Boards connection not found.");
+
+            var updateResult = connection.SetSyncState(request.IsSyncEnabled, _dateTimeProvider.Now);
+            if (updateResult.IsFailure)
+            {
+                // Reset the entity
+                await _appIntegrationDbContext.Entry(connection).ReloadAsync(cancellationToken);
+                connection.ClearDomainEvents();
+
+                _logger.LogError("Moda Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                return Result.Failure<Guid>(updateResult.Error);
+            }
+
+            await _appIntegrationDbContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Success(connection.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Moda Request: Exception for Request {Name} {@Request}", AppRequestName, request);
+
+            return Result.Failure($"Moda Request: Exception for Request AppRequestName {request}");
+        }
+    }
+}

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/ConnectionListDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/ConnectionListDto.cs
@@ -29,6 +29,11 @@ public sealed record ConnectionListDto : IMapFrom<Connection>
     /// </value>
     public bool IsValidConfiguration { get; set; }
 
+    /// <summary>
+    /// The indicator for whether the connection is enabled for synchronization.
+    /// </summary>
+    public bool IsSyncEnabled { get; set; }
+
     public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Connection, ConnectionListDto>()

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsInitManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsInitManager.cs
@@ -108,7 +108,7 @@ public sealed class AzureDevOpsBoardsInitManager(ILogger<AzureDevOpsBoardsInitMa
             if (processResult.IsFailure)
                 return processResult.ConvertFailure<Guid>();
 
-            // create types
+            // create new types
             if (processResult.Value.WorkTypes.Any())
             {
                 var syncWorkTypesResult = await _sender.Send(new SyncExternalWorkTypesCommand(processResult.Value.WorkTypes), cancellationToken);
@@ -116,7 +116,7 @@ public sealed class AzureDevOpsBoardsInitManager(ILogger<AzureDevOpsBoardsInitMa
                     return syncWorkTypesResult.ConvertFailure<Guid>();
             }
 
-            // create statuses
+            // create new statuses
             if (processResult.Value.WorkStatuses.Any())
             {
                 var syncWorkStatusesResult = await _sender.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
@@ -26,6 +26,12 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
 
         foreach (var connection in connections.Where(c => c.IsValidConfiguration && c.IsSyncEnabled))
         {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("Cancellation requested. Stopping sync.");
+                return;
+            }
+
             var connectionDetails = await _sender.Send(new GetAzureDevOpsBoardsConnectionQuery(connection.Id), cancellationToken);
             if (connectionDetails is null)
             {
@@ -35,6 +41,12 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
 
             foreach (var workProcess in connectionDetails.Configuration.WorkProcesses)
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.LogInformation("Cancellation requested. Stopping sync.");
+                    return;
+                }
+
                 if (workProcess.IntegrationState is null || !workProcess.IntegrationState.IsActive)
                     continue;
 

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
@@ -2,6 +2,7 @@
 using MediatR;
 using Moda.AppIntegration.Application.Connections.Queries;
 using Moda.AppIntegration.Application.Interfaces;
+using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Work.Application.WorkProcesses.Commands;
 using Moda.Work.Application.WorkStatuses.Commands;
 using Moda.Work.Application.WorkTypes.Commands;
@@ -27,7 +28,15 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
                 return Result.Failure(message);
             }
 
-            foreach (var connection in connections.Where(c => c.IsValidConfiguration && c.IsSyncEnabled))
+            var activeConnections = connections.Where(c => c.IsValidConfiguration && c.IsSyncEnabled).ToList();
+
+            var activeConnectionsCount = activeConnections.Count;
+            var activeWorkProcessesCount = 0;
+            var activeWorkProcessesSyncedCount = 0;
+            var activeWorkspacesCount = 0;
+            var activeWorkspacesSyncedCount = 0;
+
+            foreach (var connection in activeConnections)
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
@@ -43,7 +52,18 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
                     continue;
                 }
 
-                foreach (var workProcess in connectionDetails.Configuration.WorkProcesses)
+                var activeWorkProcesses = connectionDetails.Configuration.WorkProcesses
+                    .Where(wp => wp.IntegrationState is not null && wp.IntegrationState.IsActive)
+                    .ToList();
+
+                if (activeWorkProcesses.Count == 0)
+                {
+                    _logger.LogInformation("No active work processes found for Azure DevOps Boards connection with ID {ConnectionId}.", connection.Id);
+                    continue;
+                }
+
+                activeWorkProcessesCount += activeWorkProcesses.Count;
+                foreach (var workProcess in activeWorkProcesses)
                 {
                     if (cancellationToken.IsCancellationRequested)
                     {
@@ -52,23 +72,53 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
                         return Result.Success();
                     }
 
-                    if (workProcess.IntegrationState is null || !workProcess.IntegrationState.IsActive)
-                        continue;
-
                     var syncResult = await SyncWorkProcess(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, workProcess.ExternalId, cancellationToken);
                     if (syncResult.IsFailure)
                     {
-                        _logger.LogError("An error occurred while syncing Azure DevOps Boards work process with ID {WorkProcessId}. Error: {Error}", workProcess.Id, syncResult.Error);
+                        _logger.LogError("An error occurred while syncing Azure DevOps Boards work process {WorkProcessId}. Error: {Error}", workProcess.IntegrationState!.InternalId, syncResult.Error);
                         continue;
                     }
-                    else
-                    {
-                        _logger.LogInformation("Successfully synced Azure DevOps Boards work process with ID {WorkProcessId}.", workProcess.Id);
-                    }
+
+                    _logger.LogInformation("Successfully synced Azure DevOps Boards work process {WorkProcessId}.", workProcess.IntegrationState!.InternalId);
+                    activeWorkProcessesSyncedCount++;
 
                     // TODO: sync workspaces
+                    var activeWorkspaces = connectionDetails.Configuration.Workspaces
+                        .Where(w => w.WorkProcessId == workProcess.ExternalId
+                            && w.IntegrationState is not null
+                            && w.IntegrationState.IsActive)
+                        .ToList();
+
+                    if (activeWorkspaces.Count == 0)
+                    {
+                        _logger.LogInformation("No active workspaces found for Azure DevOps Boards work process {WorkProcessId}.", workProcess.IntegrationState!.InternalId);
+                        continue;
+                    }
+
+                    activeWorkspacesCount += activeWorkspaces.Count;
+                    foreach (var workspace in activeWorkspaces)
+                    {
+                        if (cancellationToken.IsCancellationRequested)
+                        {
+                            var message = "Cancellation requested. Stopping sync.";
+                            _logger.LogInformation(message);
+                            return Result.Success();
+                        }
+
+                        var syncWorkspaceResult = await SyncWorkspace(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, workspace.ExternalId, cancellationToken);
+                        if (syncWorkspaceResult.IsFailure)
+                        {
+                            _logger.LogError("An error occurred while syncing Azure DevOps Boards workspace {WorkspaceId}. Error: {Error}", workspace.IntegrationState!.InternalId, syncWorkspaceResult.Error);
+                            continue;
+                        }
+
+                        _logger.LogInformation("Successfully synced Azure DevOps Boards workspace {WorkspaceId}.", workspace.IntegrationState!.InternalId);
+                        activeWorkspacesSyncedCount++;
+                    }
                 }
             }
+
+            _logger.LogInformation("Synced {ActiveWorkProcessesSyncedCount} of {ActiveWorkProcessesCount} active work processes and {ActiveWorkspacesSyncedCount} of {ActiveWorkspacesCount} active workspaces for {ActiveConnectionsCount} active Azure DevOps Boards connections.", activeWorkProcessesSyncedCount, activeWorkProcessesCount, activeWorkspacesSyncedCount, activeWorkspacesCount, activeConnectionsCount);
 
             return Result.Success();
         }
@@ -77,7 +127,7 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
             string message = "An error occurred while trying to sync external employees.";
             _logger.LogError(ex, message);
             return Result.Failure(message);
-        }        
+        }
     }
 
     private async Task<Result> SyncWorkProcess(string organizationUrl, string personalAccessToken, Guid workProcessExternalId, CancellationToken cancellationToken)
@@ -114,5 +164,22 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
         return updateWorkProcessResult.IsSuccess
             ? Result.Success()
             : updateWorkProcessResult;
+    }
+
+    private async Task<Result> SyncWorkspace(string organizationUrl, string personalAccessToken, Guid workspaceExternalId, CancellationToken cancellationToken)
+    {
+        Guard.Against.NullOrWhiteSpace(organizationUrl, nameof(organizationUrl));
+        Guard.Against.NullOrWhiteSpace(personalAccessToken, nameof(personalAccessToken));
+        Guard.Against.Default(workspaceExternalId, nameof(workspaceExternalId));
+
+        var workspaceResult = await _azureDevOpsService.GetWorkspace(organizationUrl, personalAccessToken, workspaceExternalId, cancellationToken);
+        if (workspaceResult.IsFailure)
+            return workspaceResult.ConvertFailure();
+
+        var updateResult = await _sender.Send(new UpdateExternalWorkspaceCommand(workspaceResult.Value), cancellationToken);
+
+        return updateResult.IsSuccess
+            ? Result.Success()
+            : updateResult;
     }
 }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
@@ -1,0 +1,104 @@
+﻿using Ardalis.GuardClauses;
+using MediatR;
+using Moda.AppIntegration.Application.Connections.Queries;
+using Moda.AppIntegration.Application.Interfaces;
+using Moda.Work.Application.WorkProcesses.Commands;
+using Moda.Work.Application.WorkStatuses.Commands;
+using Moda.Work.Application.WorkTypes.Commands;
+
+namespace Moda.AppIntegration.Application.Connections.Managers;
+public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncManager> logger, IAzureDevOpsService azureDevOpsService, ISender sender) : IAzureDevOpsBoardsSyncManager
+{
+    private readonly ILogger<AzureDevOpsBoardsSyncManager> _logger = logger;
+    private readonly IAzureDevOpsService _azureDevOpsService = azureDevOpsService;
+    private readonly ISender _sender = sender;
+
+    public async Task<Result> Sync(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Syncing Azure DevOps Boards");
+
+        try
+        {
+            var connections = await _sender.Send(new GetConnectionsQuery(false, Connector.AzureDevOpsBoards), cancellationToken);
+            if (!connections.Any(c => c.IsValidConfiguration && c.IsSyncEnabled))
+            {
+                _logger.LogInformation("No active Azure DevOps Boards connections found.");
+                return Result.Success();
+            }
+
+            foreach (var connection in connections.Where(c => c.IsValidConfiguration && c.IsSyncEnabled))
+            {
+                var connectionDetails = await _sender.Send(new GetAzureDevOpsBoardsConnectionQuery(connection.Id), cancellationToken);
+                if (connectionDetails is null)
+                {
+                    _logger.LogError("Unable to retrieve connection details for Azure DevOps Boards connection with ID {ConnectionId}.", connection.Id);
+                    continue;
+                }
+
+                foreach (var workProcess in connectionDetails.Configuration.WorkProcesses)
+                {
+                    if (workProcess.IntegrationState is null || !workProcess.IntegrationState.IsActive)
+                        continue;
+
+                    var syncResult = await SyncWorkProcess(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, workProcess.ExternalId, cancellationToken);
+                    if (syncResult.IsFailure)
+                    {
+                        _logger.LogError("An error occurred while syncing Azure DevOps Boards work process with ID {WorkProcessId}. Error: {Error}", workProcess.Id, syncResult.Error);
+                        continue;
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Successfully synced Azure DevOps Boards work process with ID {WorkProcessId}.", workProcess.Id);
+                    }
+
+                    // TODO: sync workspaces
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            // TODO: this doesn't fail the job
+            _logger.LogError(ex, "An error occurred while syncing Azure DevOps Boards.");
+            return Result.Failure("An error occurred while syncing Azure DevOps Boards.");
+        }
+
+        return Result.Success();
+    }
+
+    private async Task<Result> SyncWorkProcess(string organizationUrl, string personalAccessToken, Guid workProcessExternalId, CancellationToken cancellationToken)
+    {
+        Guard.Against.NullOrWhiteSpace(organizationUrl, nameof(organizationUrl));
+        Guard.Against.NullOrWhiteSpace(personalAccessToken, nameof(personalAccessToken));
+        Guard.Against.Default(workProcessExternalId, nameof(workProcessExternalId));
+
+        // get the process, types, states, and workflow
+        var processResult = await _azureDevOpsService.GetWorkProcess(organizationUrl, personalAccessToken, workProcessExternalId, cancellationToken);
+        if (processResult.IsFailure)
+            return processResult.ConvertFailure();
+
+        // create new types
+        if (processResult.Value.WorkTypes.Any())
+        {
+            var syncWorkTypesResult = await _sender.Send(new SyncExternalWorkTypesCommand(processResult.Value.WorkTypes), cancellationToken);
+            if (syncWorkTypesResult.IsFailure)
+                return syncWorkTypesResult.ConvertFailure<Guid>();
+        }
+
+        // create new statuses
+        if (processResult.Value.WorkStatuses.Any())
+        {
+            var syncWorkStatusesResult = await _sender.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);
+            if (syncWorkStatusesResult.IsFailure)
+                return syncWorkStatusesResult.ConvertFailure<Guid>();
+        }
+
+        // update the work process
+        // TODO: update work process scheme
+        var updateWorkProcessResult = await _sender.Send(new UpdateExternalWorkProcessCommand(processResult.Value), cancellationToken);
+
+        return updateWorkProcessResult.IsSuccess
+            ? Result.Success()
+            : updateWorkProcessResult;
+    }
+
+}

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
@@ -13,57 +13,71 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
     private readonly IAzureDevOpsService _azureDevOpsService = azureDevOpsService;
     private readonly ISender _sender = sender;
 
-    public async Task Sync(CancellationToken cancellationToken)
+    public async Task<Result> Sync(CancellationToken cancellationToken)
     {
         _logger.LogInformation("Syncing Azure DevOps Boards");
 
-        var connections = await _sender.Send(new GetConnectionsQuery(false, Connector.AzureDevOpsBoards), cancellationToken);
-        if (!connections.Any(c => c.IsValidConfiguration && c.IsSyncEnabled))
+        try
         {
-            _logger.LogInformation("No active Azure DevOps Boards connections found.");
-            return;
-        }
-
-        foreach (var connection in connections.Where(c => c.IsValidConfiguration && c.IsSyncEnabled))
-        {
-            if (cancellationToken.IsCancellationRequested)
+            var connections = await _sender.Send(new GetConnectionsQuery(false, Connector.AzureDevOpsBoards), cancellationToken);
+            if (!connections.Any(c => c.IsValidConfiguration && c.IsSyncEnabled))
             {
-                _logger.LogInformation("Cancellation requested. Stopping sync.");
-                return;
+                var message = "No active Azure DevOps Boards connections found.";
+                _logger.LogInformation(message);
+                return Result.Failure(message);
             }
 
-            var connectionDetails = await _sender.Send(new GetAzureDevOpsBoardsConnectionQuery(connection.Id), cancellationToken);
-            if (connectionDetails is null)
-            {
-                _logger.LogError("Unable to retrieve connection details for Azure DevOps Boards connection with ID {ConnectionId}.", connection.Id);
-                continue;
-            }
-
-            foreach (var workProcess in connectionDetails.Configuration.WorkProcesses)
+            foreach (var connection in connections.Where(c => c.IsValidConfiguration && c.IsSyncEnabled))
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _logger.LogInformation("Cancellation requested. Stopping sync.");
-                    return;
+                    var message = "Cancellation requested. Stopping sync.";
+                    _logger.LogInformation(message);
+                    return Result.Success();
                 }
 
-                if (workProcess.IntegrationState is null || !workProcess.IntegrationState.IsActive)
-                    continue;
-
-                var syncResult = await SyncWorkProcess(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, workProcess.ExternalId, cancellationToken);
-                if (syncResult.IsFailure)
+                var connectionDetails = await _sender.Send(new GetAzureDevOpsBoardsConnectionQuery(connection.Id), cancellationToken);
+                if (connectionDetails is null)
                 {
-                    _logger.LogError("An error occurred while syncing Azure DevOps Boards work process with ID {WorkProcessId}. Error: {Error}", workProcess.Id, syncResult.Error);
+                    _logger.LogError("Unable to retrieve connection details for Azure DevOps Boards connection with ID {ConnectionId}.", connection.Id);
                     continue;
                 }
-                else
-                {
-                    _logger.LogInformation("Successfully synced Azure DevOps Boards work process with ID {WorkProcessId}.", workProcess.Id);
-                }
 
-                // TODO: sync workspaces
+                foreach (var workProcess in connectionDetails.Configuration.WorkProcesses)
+                {
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        var message = "Cancellation requested. Stopping sync.";
+                        _logger.LogInformation(message);
+                        return Result.Success();
+                    }
+
+                    if (workProcess.IntegrationState is null || !workProcess.IntegrationState.IsActive)
+                        continue;
+
+                    var syncResult = await SyncWorkProcess(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, workProcess.ExternalId, cancellationToken);
+                    if (syncResult.IsFailure)
+                    {
+                        _logger.LogError("An error occurred while syncing Azure DevOps Boards work process with ID {WorkProcessId}. Error: {Error}", workProcess.Id, syncResult.Error);
+                        continue;
+                    }
+                    else
+                    {
+                        _logger.LogInformation("Successfully synced Azure DevOps Boards work process with ID {WorkProcessId}.", workProcess.Id);
+                    }
+
+                    // TODO: sync workspaces
+                }
             }
+
+            return Result.Success();
         }
+        catch (Exception ex)
+        {
+            string message = "An error occurred while trying to sync external employees.";
+            _logger.LogError(ex, message);
+            return Result.Failure(message);
+        }        
     }
 
     private async Task<Result> SyncWorkProcess(string organizationUrl, string personalAccessToken, Guid workProcessExternalId, CancellationToken cancellationToken)

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsSyncManager.cs
@@ -1,0 +1,5 @@
+﻿namespace Moda.AppIntegration.Application.Interfaces;
+public interface IAzureDevOpsBoardsSyncManager : ITransientService
+{
+    Task<Result> Sync(CancellationToken cancellationToken);
+}

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsSyncManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace Moda.AppIntegration.Application.Interfaces;
 public interface IAzureDevOpsBoardsSyncManager : ITransientService
 {
-    Task<Result> Sync(CancellationToken cancellationToken);
+    Task Sync(CancellationToken cancellationToken);
 }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsSyncManager.cs
@@ -1,5 +1,5 @@
 ﻿namespace Moda.AppIntegration.Application.Interfaces;
 public interface IAzureDevOpsBoardsSyncManager : ITransientService
 {
-    Task Sync(CancellationToken cancellationToken);
+    Task<Result> Sync(CancellationToken cancellationToken);
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/UpdateExternalWorkProcessCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/UpdateExternalWorkProcessCommand.cs
@@ -1,0 +1,49 @@
+﻿using Moda.Common.Application.Interfaces.ExternalWork;
+using Moda.Common.Domain.Models;
+using Moda.Work.Application.WorkProcesses.Validators;
+
+namespace Moda.Work.Application.WorkProcesses.Commands;
+public sealed record UpdateExternalWorkProcessCommand(IExternalWorkProcessConfiguration ExternalWorkProcess) : ICommand;
+
+public sealed class UpdateExternalWorkProcessCommandValidator : CustomValidator<UpdateExternalWorkProcessCommand>
+{
+    public UpdateExternalWorkProcessCommandValidator()
+    {
+        RuleFor(c => c.ExternalWorkProcess)
+            .NotNull()
+            .SetValidator(new IExternalWorkProcessConfigurationValidator());
+    }
+}
+
+internal sealed class UpdateExternalWorkProcessCommandHandler(IWorkDbContext workDbContext, IDateTimeProvider dateTimeProvider, ILogger<UpdateExternalWorkProcessCommandHandler> logger) : ICommandHandler<UpdateExternalWorkProcessCommand>
+{
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+    private readonly ILogger<UpdateExternalWorkProcessCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateExternalWorkProcessCommand request, CancellationToken cancellationToken)
+    {
+        var workProcess = await _workDbContext.WorkProcesses.FirstOrDefaultAsync(wp => wp.ExternalId == request.ExternalWorkProcess.Id, cancellationToken);
+        if (workProcess is null)
+        {
+            _logger.LogWarning("{AppRequestName}: work process {WorkProcessExternalId} not found.", nameof(UpdateExternalWorkProcessCommand), request.ExternalWorkProcess.Id);
+            return Result.Failure<IntegrationState<Guid>>($"Work process {request.ExternalWorkProcess.Id} not found.");
+        }
+
+        var timestamp = _dateTimeProvider.Now;
+
+        var updateResult = workProcess.Update(request.ExternalWorkProcess.Name, request.ExternalWorkProcess.Description, timestamp);
+        if (updateResult.IsFailure)
+        {
+            _logger.LogError("{AppRequestName}: failed to update work process {WorkProcessId}. Error: {Error}", nameof(UpdateExternalWorkProcessCommand), workProcess.Id, updateResult.Error);
+            return Result.Failure<IntegrationState<Guid>>(updateResult.Error);
+        }
+
+        _workDbContext.WorkProcesses.Update(workProcess);
+        await _workDbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("{AppRequestName}: updated work process {WorkProcessName}.", nameof(UpdateExternalWorkProcessCommand), workProcess.Name);
+
+        return Result.Success();
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/SyncExternalWorkTypesCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/SyncExternalWorkTypesCommand.cs
@@ -34,7 +34,7 @@ public sealed class SyncExternalWorkTypesCommandHandler(IWorkDbContext workDbCon
             .Select(e => WorkType.Create(e.Name, e.Description, _dateTimeProvider.Now))
             .ToList();
 
-        if (workTypesToCreate.Count != 0)
+        if (workTypesToCreate.Count > 0)
         {
             _workDbContext.WorkTypes.AddRange(workTypesToCreate);
             await _workDbContext.SaveChangesAsync(cancellationToken);

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/UpdateExternalWorkspaceCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/UpdateExternalWorkspaceCommandHandler.cs
@@ -1,0 +1,53 @@
+﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.WorkProcesses.Commands;
+using Moda.Work.Application.Workspaces.Validators;
+
+namespace Moda.Work.Application.Workspaces.Commands;
+
+public sealed class UpdateExternalWorkspaceCommandHandlerValidator : CustomValidator<UpdateExternalWorkspaceCommand>
+{
+    private readonly IWorkDbContext _workDbContext;
+
+    public UpdateExternalWorkspaceCommandHandlerValidator(IWorkDbContext workDbContext)
+    {
+        _workDbContext = workDbContext;
+
+        RuleFor(c => c.ExternalWorkspace)
+            .NotNull()
+            .SetValidator(new IExternalWorkspaceConfigurationValidator());
+    }
+}
+
+internal sealed class UpdateExternalWorkspaceCommandHandler(IWorkDbContext workDbContext, IDateTimeProvider dateTimeProvider, ILogger<UpdateExternalWorkspaceCommandHandler> logger) : ICommandHandler<UpdateExternalWorkspaceCommand>
+{
+    private const string AppRequestName = nameof(UpdateExternalWorkProcessCommand);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+    private readonly ILogger<UpdateExternalWorkspaceCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateExternalWorkspaceCommand request, CancellationToken cancellationToken)
+    {
+        var workspace = await _workDbContext.Workspaces.FirstOrDefaultAsync(wp => wp.ExternalId == request.ExternalWorkspace.Id, cancellationToken);
+        if (workspace is null)
+        {
+            _logger.LogWarning("{AppRequestName}: workspace {WorkspaceExternalId} not found.", AppRequestName, request.ExternalWorkspace.Id);
+            return Result.Failure($"Workspace {request.ExternalWorkspace.Id} not found.");
+        }
+
+        // TODO: The workspace name may have been changed, so don't update at this time.  This will be handled in a future release.
+        var workspaceResult = workspace.Update(workspace.Name, request.ExternalWorkspace.Description, _dateTimeProvider.Now);
+        if (workspaceResult.IsFailure)
+        {
+            _logger.LogError("{AppRequestName}: failed to update workspace {WorkspaceId}. Error: {Error}", AppRequestName, workspace.Id, workspaceResult.Error);
+            return Result.Failure(workspaceResult.Error);
+        }
+
+        _workDbContext.Workspaces.Update(workspace);
+        await _workDbContext.SaveChangesAsync(cancellationToken);
+
+        _logger.LogInformation("{AppRequestName}: updated Workspace {WorkspaceName}.", AppRequestName, workspace.Name);
+
+        return Result.Success();
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Admin/BackgroundJobsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Admin/BackgroundJobsController.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Common.Application.BackgroundJobs;
+﻿using Moda.AppIntegration.Application.Interfaces;
+using Moda.Common.Application.BackgroundJobs;
 using Moda.Common.Application.Interfaces;
 
 namespace Moda.Web.Api.Controllers.Admin;
@@ -11,14 +12,12 @@ public class BackgroundJobsController : ControllerBase
     private readonly ILogger<BackgroundJobsController> _logger;
     private readonly IJobService _jobService;
     private readonly ISender _sender;
-    private readonly IEmployeeService _employeeService;
 
-    public BackgroundJobsController(ILogger<BackgroundJobsController> logger, IJobService jobService, ISender sender, IEmployeeService employeeService)
+    public BackgroundJobsController(ILogger<BackgroundJobsController> logger, IJobService jobService, ISender sender)
     {
         _logger = logger;
         _jobService = jobService;
         _sender = sender;
-        _employeeService = employeeService;
     }
 
     [HttpGet("job-types")]
@@ -49,14 +48,24 @@ public class BackgroundJobsController : ControllerBase
     [OpenApiOperation("Run a background job.", "")]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
     [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
-    public IActionResult Run(int jobTypeId, CancellationToken cancellationToken)
+    public IActionResult Run(int jobTypeId, 
+        [FromServices] IEmployeeService employeeService,
+        [FromServices] IAzureDevOpsBoardsSyncManager azdoBoardsSyncManager,
+        CancellationToken cancellationToken)
     {
-        switch ((BackgroundJobType)jobTypeId)
+        var jobType = (BackgroundJobType)jobTypeId;
+        _logger.LogInformation("Running job type {jobType}", jobType);
+
+        switch (jobType)
         {
-            case BackgroundJobType.EmployeeImport:
-                _jobService.Enqueue(() => _employeeService.SyncExternalEmployees(cancellationToken));
+            case BackgroundJobType.EmployeeSync:
+                _jobService.Enqueue(() => employeeService.SyncExternalEmployees(cancellationToken));
+                break;
+            case BackgroundJobType.AzdoBoardsSync:
+                _jobService.Enqueue(() => azdoBoardsSyncManager.Sync(cancellationToken));
                 break;
             default:
+                _logger.LogWarning("Unknown job type {jobType} requested", jobType);
                 return BadRequest();
         }
         return Accepted();

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Admin/BackgroundJobsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Admin/BackgroundJobsController.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.AppIntegration.Application.Interfaces;
 using Moda.Common.Application.BackgroundJobs;
+using Moda.Common.Application.Exceptions;
 using Moda.Common.Application.Interfaces;
 
 namespace Moda.Web.Api.Controllers.Admin;

--- a/Moda.Web/src/Moda.Web.Api/Controllers/AppIntegrations/AzureDevOpsBoardsConnectionsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/AppIntegrations/AzureDevOpsBoardsConnectionsController.cs
@@ -97,6 +97,30 @@ public class AzureDevOpsBoardsConnectionsController : ControllerBase
         return NoContent();
     }
 
+    [HttpPost("{id}/sync-state")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.Connections)]
+    [OpenApiOperation("Update an Azure DevOps Boards connection sync state.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> UpdateSyncState(Guid id, bool isSyncEnabled, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new UpdateAzureDevOpsBoardsConnectionSyncStateCommand(id, isSyncEnabled), cancellationToken);
+
+        if (result.IsFailure)
+        {
+            var error = new ErrorResult
+            {
+                StatusCode = 400,
+                SupportMessage = result.Error,
+                Source = "AzureDevOpsBoardsConnectionsController.Update"
+            };
+            return BadRequest(error);
+        }
+
+        return NoContent();
+    }
+
     [HttpDelete("{id}")]
     [MustHavePermission(ApplicationAction.Delete, ApplicationResource.Connections)]
     [OpenApiOperation("Delete an Azure DevOps Boards connection.", "")]

--- a/Moda.Web/src/Moda.Web.Api/Interfaces/IJobManager.cs
+++ b/Moda.Web/src/Moda.Web.Api/Interfaces/IJobManager.cs
@@ -1,0 +1,7 @@
+﻿namespace Moda.Web.Api.Interfaces;
+
+public interface IJobManager
+{
+    Task RunSyncExternalEmployees(CancellationToken cancellationToken);
+    Task RunSyncAzureDevOpsBoards(CancellationToken cancellationToken);
+}

--- a/Moda.Web/src/Moda.Web.Api/Program.cs
+++ b/Moda.Web/src/Moda.Web.Api/Program.cs
@@ -12,6 +12,7 @@ using Moda.Links;
 using Moda.Organization.Application;
 using Moda.Planning.Application;
 using Moda.Web.Api.Configurations;
+using Moda.Web.Api.Interfaces;
 using Moda.Web.Api.Services;
 using Moda.Work.Application;
 using NodaTime.Serialization.SystemTextJson;
@@ -74,6 +75,7 @@ try
     builder.Services.AddAppIntegrationApplication();
 
     builder.Services.AddScoped<ICsvService, CsvService>();
+    builder.Services.AddScoped<IJobManager, JobManager>();
 
     var app = builder.Build();
 

--- a/Moda.Web/src/Moda.Web.Api/Services/JobManager.cs
+++ b/Moda.Web/src/Moda.Web.Api/Services/JobManager.cs
@@ -1,0 +1,39 @@
+﻿using Hangfire;
+using Moda.AppIntegration.Application.Interfaces;
+using Moda.Common.Application.Exceptions;
+using Moda.Common.Application.Interfaces;
+using Moda.Web.Api.Interfaces;
+
+namespace Moda.Web.Api.Services;
+
+public class JobManager(ILogger<JobManager> logger, IEmployeeService employeeService, IAzureDevOpsBoardsSyncManager azdoBoardsSyncManager) : IJobManager
+{
+    // TODO: does this belong in JobService/HangfireService?
+
+    private readonly ILogger<JobManager> _logger = logger;
+    private readonly IEmployeeService _employeeService = employeeService;
+    private readonly IAzureDevOpsBoardsSyncManager _azdoBoardsSyncManager = azdoBoardsSyncManager;
+
+    [DisableConcurrentExecution(60)]
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = [30, 60, 120])]
+    public async Task RunSyncExternalEmployees(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Running SyncExternalEmployees job");
+        var result = await _employeeService.SyncExternalEmployees(cancellationToken);
+        if (result.IsFailure)
+        {
+            _logger.LogError("Failed to sync external employees: {Error}", result.Error);
+            throw new InternalServerException($"Failed to sync external employees. Error: {result.Error}");
+        }
+        _logger.LogInformation("Completed SyncExternalEmployees job");
+    }
+
+    [DisableConcurrentExecution(60 * 3)]
+    [AutomaticRetry(Attempts = 3, DelaysInSeconds = [30, 60, 120])]
+    public async Task RunSyncAzureDevOpsBoards(CancellationToken cancellationToken)
+    {
+        _logger.LogInformation("Running SyncAzureDevOpsBoards job");
+        await _azdoBoardsSyncManager.Sync(cancellationToken);
+        _logger.LogInformation("Completed SyncAzureDevOpsBoards job");
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -10,6 +10,21 @@
     "version": "v1"
   },
   "paths": {
+    "/startup": {
+      "get": {
+        "operationId": "GetStartup",
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/user-management/permissions": {
       "get": {
         "tags": [

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -10,21 +10,6 @@
     "version": "v1"
   },
   "paths": {
-    "/startup": {
-      "get": {
-        "operationId": "GetStartup",
-        "responses": {
-          "200": {
-            "description": ""
-          }
-        },
-        "security": [
-          {
-            "Bearer": []
-          }
-        ]
-      }
-    },
     "/api/user-management/permissions": {
       "get": {
         "tags": [

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -9687,6 +9687,9 @@
           },
           "isValidConfiguration": {
             "type": "boolean"
+          },
+          "isSyncEnabled": {
+            "type": "boolean"
           }
         }
       },

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -6473,6 +6473,67 @@
         ]
       }
     },
+    "/api/app-integrations/azure-devops-boards-connections/{id}/sync-state": {
+      "post": {
+        "tags": [
+          "AzureDevOpsBoardsConnections"
+        ],
+        "summary": "Update an Azure DevOps Boards connection sync state.",
+        "operationId": "AzureDevOpsBoardsConnections_UpdateSyncState",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "isSyncEnabled",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/app-integrations/azure-devops-boards-connections/test": {
       "post": {
         "tags": [

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/azdo-boards-connection-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/[id]/azdo-boards-connection-details.tsx
@@ -24,6 +24,9 @@ const AzdoBoardsConnectionDetails = ({
             <Item label="Is Valid Configuration?">
               {connection.isValidConfiguration ? 'Yes' : 'No'}
             </Item>
+            <Item label="Is Sync Enabled?">
+              {connection.isSyncEnabled ? 'Yes' : 'No'}
+            </Item>
           </Descriptions>
         </Col>
         <Col xs={24} md={12}>

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/page.tsx
@@ -40,6 +40,7 @@ const ConnectionsPage = () => {
       { field: 'connector' },
       { field: 'isActive' },
       { field: 'isValidConfiguration' },
+      { field: 'isSyncEnabled' },
     ],
     [],
   )

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -7698,6 +7698,75 @@ export class AzureDevOpsBoardsConnectionsClient {
     }
 
     /**
+     * Update an Azure DevOps Boards connection sync state.
+     * @param isSyncEnabled (optional) 
+     */
+    updateSyncState(id: string, isSyncEnabled: boolean | undefined, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/app-integrations/azure-devops-boards-connections/{id}/sync-state?";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (isSyncEnabled === null)
+            throw new Error("The parameter 'isSyncEnabled' cannot be null.");
+        else if (isSyncEnabled !== undefined)
+            url_ += "isSyncEnabled=" + encodeURIComponent("" + isSyncEnabled) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateSyncState(_response);
+        });
+    }
+
+    protected processUpdateSyncState(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = JSON.parse(resultData422);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Test Azure DevOps Boards connection configuration.
      */
     testConfig(request: TestAzureDevOpsBoardConnectionRequest, cancelToken?: CancelToken): Promise<void> {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -11,6 +11,64 @@
 import axios, { AxiosError } from 'axios';
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
 
+export class Client {
+    protected instance: AxiosInstance;
+    protected baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, instance?: AxiosInstance) {
+
+        this.instance = instance || axios.create();
+
+        this.baseUrl = baseUrl ?? "";
+
+    }
+
+    getStartup( cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/startup";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetStartup(_response);
+        });
+    }
+
+    protected processGetStartup(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+}
+
 export class PermissionsClient {
     protected instance: AxiosInstance;
     protected baseUrl: string;

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9012,6 +9012,7 @@ export interface ConnectionListDto {
     connector?: string;
     isActive?: boolean;
     isValidConfiguration?: boolean;
+    isSyncEnabled?: boolean;
 }
 
 export interface AzureDevOpsBoardsConnectionDetailsDto {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -11,64 +11,6 @@
 import axios, { AxiosError } from 'axios';
 import type { AxiosInstance, AxiosRequestConfig, AxiosResponse, CancelToken } from 'axios';
 
-export class Client {
-    protected instance: AxiosInstance;
-    protected baseUrl: string;
-    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
-
-    constructor(baseUrl?: string, instance?: AxiosInstance) {
-
-        this.instance = instance || axios.create();
-
-        this.baseUrl = baseUrl ?? "";
-
-    }
-
-    getStartup( cancelToken?: CancelToken): Promise<void> {
-        let url_ = this.baseUrl + "/startup";
-        url_ = url_.replace(/[?&]$/, "");
-
-        let options_: AxiosRequestConfig = {
-            method: "GET",
-            url: url_,
-            headers: {
-            },
-            cancelToken
-        };
-
-        return this.instance.request(options_).catch((_error: any) => {
-            if (isAxiosError(_error) && _error.response) {
-                return _error.response;
-            } else {
-                throw _error;
-            }
-        }).then((_response: AxiosResponse) => {
-            return this.processGetStartup(_response);
-        });
-    }
-
-    protected processGetStartup(response: AxiosResponse): Promise<void> {
-        const status = response.status;
-        let _headers: any = {};
-        if (response.headers && typeof response.headers === "object") {
-            for (const k in response.headers) {
-                if (response.headers.hasOwnProperty(k)) {
-                    _headers[k] = response.headers[k];
-                }
-            }
-        }
-        if (status === 200) {
-            const _responseText = response.data;
-            return Promise.resolve<void>(null as any);
-
-        } else if (status !== 200 && status !== 204) {
-            const _responseText = response.data;
-            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
-        }
-        return Promise.resolve<void>(null as any);
-    }
-}
-
 export class PermissionsClient {
     protected instance: AxiosInstance;
     protected baseUrl: string;

--- a/Moda.Web/src/moda.web.reactclient/src/services/queries/app-integration-queries.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/queries/app-integration-queries.ts
@@ -71,6 +71,31 @@ export const useDeleteAzdoBoardsConnectionMutation = () => {
   })
 }
 
+export interface UpdateAzdoBoardsConnectionSyncStateMutationRequest {
+  connectionId: string
+  isSyncEnabled: boolean
+}
+export const useUpdateAzdoBoardsConnectionSyncStateMutation = () => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (
+      request: UpdateAzdoBoardsConnectionSyncStateMutationRequest,
+    ) =>
+      (await getAzureDevOpsBoardsConnectionsClient()).updateSyncState(
+        request.connectionId,
+        request.isSyncEnabled,
+      ),
+    onSuccess: (data, variables) => {
+      queryClient.invalidateQueries([QK.AZDO_BOARDS_CONNECTIONS, false])
+      queryClient.invalidateQueries([QK.AZDO_BOARDS_CONNECTIONS, true])
+      queryClient.invalidateQueries([
+        QK.AZDO_BOARDS_CONNECTIONS,
+        variables.connectionId,
+      ])
+    },
+  })
+}
+
 export const useSyncAzdoBoardsConnectionOrganizationMutation = () => {
   const queryClient = useQueryClient()
   return useMutation({


### PR DESCRIPTION
- Added the initial AzureDevOpsBoardsSyncManager.Sync method to sync WorkProcesses. 
- Added SyncWorkspace to the AzureDevOpsBoardsSyncManager.Sync workflow.
- Added the ability to update a connections sync state.
- Added cancellation checks into the sync.
- Added a JobsManager to allow Hangfire job configuration to be more granular.
- Updated hangfire retry settings.

