### PR TITLE
Feature/link work items to objectives

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -68,7 +68,7 @@
             "name": "Compound: Launch Moda on Host",
             "configurations": [
                 "Debug Moda API on Host",
-                "Next.js: debug client side"
+                "Next.js: debug full stack"
             ],
             "stopAll": true
         },

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428170744_Add-index-to-WorkItems-for-searching.Designer.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428170744_Add-index-to-WorkItems-for-searching.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moda.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Moda.Infrastructure.Persistence.Context;
 namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ModaDbContext))]
-    partial class ModaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240428170744_Add-index-to-WorkItems-for-searching")]
+    partial class AddindextoWorkItemsforsearching
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428170744_Add-index-to-WorkItems-for-searching.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428170744_Add-index-to-WorkItems-for-searching.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Moda.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddindextoWorkItemsforsearching : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_Key_Title",
+            schema: "Work",
+            table: "WorkItems",
+            columns: new[] { "Key", "Title" })
+            .Annotation("SqlServer:Include", new[] { "Id", "WorkspaceId", "ExternalId", "AssignedToId", "TypeId", "StatusId" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_Key_Title",
+            schema: "Work",
+            table: "WorkItems");
+    }
+}

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428183430_Add-WorkItem-Links.Designer.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428183430_Add-WorkItem-Links.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moda.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Moda.Infrastructure.Persistence.Context;
 namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ModaDbContext))]
-    partial class ModaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240428183430_Add-WorkItem-Links")]
+    partial class AddWorkItemLinks
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428183430_Add-WorkItem-Links.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240428183430_Add-WorkItem-Links.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddWorkItemLinks : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "WorkItemLinks",
+                schema: "Work",
+                columns: table => new
+                {
+                    WorkItemId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ObjectId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Context = table.Column<string>(type: "varchar(64)", maxLength: 64, nullable: false),
+                    SystemCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemCreatedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    SystemLastModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemLastModifiedBy = table.Column<Guid>(type: "uniqueidentifier", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_WorkItemLinks", x => new { x.WorkItemId, x.ObjectId });
+                    table.ForeignKey(
+                        name: "FK_WorkItemLinks_WorkItems_WorkItemId",
+                        column: x => x.WorkItemId,
+                        principalSchema: "Work",
+                        principalTable: "WorkItems",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkItemLinks_ObjectId_Context",
+                schema: "Work",
+                table: "WorkItemLinks",
+                columns: new[] { "ObjectId", "Context" })
+                .Annotation("SqlServer:Include", new[] { "WorkItemId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_WorkItemLinks_WorkItemId",
+                schema: "Work",
+                table: "WorkItemLinks",
+                column: "WorkItemId")
+                .Annotation("SqlServer:Include", new[] { "ObjectId", "Context" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "WorkItemLinks",
+                schema: "Work");
+        }
+    }
+}

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -68,6 +68,30 @@ public class BacklogLevelConfig : IEntityTypeConfiguration<BacklogLevel>
         builder.Property(w => w.IsDeleted);
     }
 }
+public class WorkItemLinkConfig : IEntityTypeConfiguration<WorkItemLink>
+{
+    public void Configure(EntityTypeBuilder<WorkItemLink> builder)
+    {
+        builder.ToTable("WorkItemLinks", SchemaNames.Work);
+
+        builder.HasKey(w => new { w.WorkItemId, w.ObjectId });
+
+        builder.HasIndex(w => w.WorkItemId)
+            .IncludeProperties(w => new { w.ObjectId, w.Context });
+
+        builder.HasIndex(w => new { w.ObjectId, w.Context })
+            .IncludeProperties(w => new { w.WorkItemId });
+
+        // Properties
+        builder.Property(h => h.Context).IsRequired()
+            .HasConversion<EnumConverter<SystemContext>>()
+            .HasColumnType("varchar")
+            .HasMaxLength(64);
+
+
+        // Relationships
+    }
+}
 
 public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
 {
@@ -131,6 +155,11 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             .WithMany()
             .HasForeignKey(w => w.LastModifiedById)
             .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany<WorkItemLink>()
+            .WithOne()
+            .HasForeignKey(w => w.WorkItemId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -84,6 +84,9 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
         builder.HasIndex(w => w.Key)
             .IncludeProperties(w => new { w.Id, w.Title, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId });
 
+        builder.HasIndex(w => new { w.Key, w.Title })
+            .IncludeProperties(w => new { w.Id, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId });
+
         builder.HasIndex(w => w.ExternalId)
             .IncludeProperties(w => new { w.Id, w.Key , w.Title, w.WorkspaceId, w.AssignedToId, w.TypeId, w.StatusId });
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Context/ModaDbContext.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Context/ModaDbContext.cs
@@ -73,6 +73,7 @@ public class ModaDbContext : BaseDbContext, IAppIntegrationDbContext, IGoalsDbCo
 
     public DbSet<BacklogLevelScheme> BacklogLevelSchemes => Set<BacklogLevelScheme>();
     public DbSet<Workflow> Workflows => Set<Workflow>();
+    public DbSet<WorkItemLink> WorkItemLinks => Set<WorkItemLink>();
     public DbSet<WorkItem> WorkItems => Set<WorkItem>();
     public DbSet<WorkProcess> WorkProcesses => Set<WorkProcess>();
     public DbSet<Workspace> Workspaces => Set<Workspace>();

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/PlanningIntervals/Commands/ManagePlanningIntervalTeamsCommand.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/PlanningIntervals/Commands/ManagePlanningIntervalTeamsCommand.cs
@@ -4,6 +4,8 @@ public sealed record ManagePlanningIntervalTeamsCommand(Guid Id, IEnumerable<Gui
 
 internal sealed class ManagePlanningIntervalTeamsCommandHandler : ICommandHandler<ManagePlanningIntervalTeamsCommand>
 {
+    private const string AppRequestName = nameof(ManagePlanningIntervalTeamsCommand);
+
     private readonly IPlanningDbContext _planningDbContext;
     private readonly ILogger<ManagePlanningIntervalTeamsCommandHandler> _logger;
 
@@ -38,8 +40,8 @@ internal sealed class ManagePlanningIntervalTeamsCommandHandler : ICommandHandle
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error handling {CommandName} command.", nameof(ManagePlanningIntervalTeamsCommand));
-            return Result.Failure($"Error handling {nameof(ManagePlanningIntervalTeamsCommand)} command.");
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
         }
     }
 }

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/PlanningIntervals/Queries/CheckPlanningIntervalObjectiveExistsQuery.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/PlanningIntervals/Queries/CheckPlanningIntervalObjectiveExistsQuery.cs
@@ -1,0 +1,13 @@
+﻿namespace Moda.Planning.Application.PlanningIntervals.Queries;
+public sealed record CheckPlanningIntervalObjectiveExistsQuery(Guid PlanningIntervalId, Guid ObjectiveId) : IQuery<bool>;
+
+internal sealed class CheckPlanningIntervalObjectiveExistsQueryHandler(IPlanningDbContext planningDbContext) : IQueryHandler<CheckPlanningIntervalObjectiveExistsQuery, bool>
+{
+    private readonly IPlanningDbContext _planningDbContext = planningDbContext;
+
+    public async Task<bool> Handle(CheckPlanningIntervalObjectiveExistsQuery request, CancellationToken cancellationToken)
+    {
+        return await _planningDbContext.PlanningIntervals
+            .AnyAsync(p => p.Id == request.PlanningIntervalId && p.Objectives.Any(o => o.Id == request.ObjectiveId), cancellationToken);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Persistence/IWorkDbContext.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Persistence/IWorkDbContext.cs
@@ -3,6 +3,7 @@ public interface IWorkDbContext : IModaDbContext
 {
     DbSet<BacklogLevelScheme> BacklogLevelSchemes { get; }
     DbSet<Workflow> Workflows { get; }
+    DbSet<WorkItemLink> WorkItemLinks { get; }
     DbSet<WorkItem> WorkItems { get; }
     DbSet<WorkProcess> WorkProcesses { get; }
     DbSet<Workspace> Workspaces { get; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/ManageExternalObjectWorkItemsCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/ManageExternalObjectWorkItemsCommand.cs
@@ -1,0 +1,50 @@
+﻿using Moda.Common.Domain.Enums;
+
+namespace Moda.Work.Application.WorkItems.Commands;
+public sealed record ManageExternalObjectWorkItemsCommand(Guid PlanningIntervalId, Guid ObjectiveId, SystemContext Context, IEnumerable<Guid> WorkItemIds) : ICommand;
+
+internal sealed class ManageExternalObjectWorkItemsCommandHandler(IWorkDbContext workDbContext, ILogger<ManageExternalObjectWorkItemsCommandHandler> logger) : ICommandHandler<ManageExternalObjectWorkItemsCommand>
+{
+    private const string AppRequestName = nameof(ManageExternalObjectWorkItemsCommand);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<ManageExternalObjectWorkItemsCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ManageExternalObjectWorkItemsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var workItemLinks = await _workDbContext.WorkItemLinks
+                .Where(w => w.ObjectId == request.ObjectiveId)
+                .ToListAsync(cancellationToken);
+
+            var existingWorkItemIds = workItemLinks.Select(x => x.WorkItemId).ToHashSet();
+            var newWorkItemIds = request.WorkItemIds.ToHashSet();
+
+            var workItemIdsToRemove = existingWorkItemIds.Except(newWorkItemIds).ToArray();
+            _logger.LogDebug("Removing {WorkItemsToRemoveCount} from Objective {ObjectiveId}.", workItemIdsToRemove.Length, request.ObjectiveId);
+            if (workItemIdsToRemove.Length > 0)
+            {
+                var workItemLinksToRemove = workItemLinks.Where(x => workItemIdsToRemove.Contains(x.WorkItemId)).ToArray();
+                _workDbContext.WorkItemLinks.RemoveRange(workItemLinksToRemove);
+            }
+
+            var workItemIdsToAdd = newWorkItemIds.Except(existingWorkItemIds).ToArray();
+            _logger.LogDebug("Adding {WorkItemsToAddCount} to Objective {ObjectiveId}.", workItemIdsToAdd.Length, request.ObjectiveId);
+            if (workItemIdsToAdd.Length > 0)
+            {
+                var workItemLinksToAdd = workItemIdsToAdd.Select(x => WorkItemLink.Create(x, request.ObjectiveId, request.Context)).ToArray();
+                await _workDbContext.WorkItemLinks.AddRangeAsync(workItemLinksToAdd, cancellationToken);
+            }
+
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Successfully managed work items for Objective {ObjectiveId}.", request.ObjectiveId);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
@@ -1,0 +1,20 @@
+﻿using Moda.Work.Application.WorkItems.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Queries;
+public sealed record GetExternalObjectWorkItemsQuery(Guid ObjectId) : IQuery<IReadOnlyCollection<WorkItemListDto>>;
+
+internal sealed class GetExternalObjectWorkItemsQueryHandler(IWorkDbContext workDbContext, ILogger<GetExternalObjectWorkItemsQueryHandler> logger) : IQueryHandler<GetExternalObjectWorkItemsQuery, IReadOnlyCollection<WorkItemListDto>>
+{
+    private const string AppRequestName = nameof(GetExternalObjectWorkItemsQuery);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<GetExternalObjectWorkItemsQueryHandler> _logger = logger;
+
+    public async Task<IReadOnlyCollection<WorkItemListDto>> Handle(GetExternalObjectWorkItemsQuery request, CancellationToken cancellationToken)
+    {
+        return await _workDbContext.WorkItemLinks
+            .Where(e => e.ObjectId == request.ObjectId)
+            .ProjectToType<WorkItemListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
@@ -12,8 +12,16 @@ internal sealed class GetExternalObjectWorkItemsQueryHandler(IWorkDbContext work
 
     public async Task<IReadOnlyCollection<WorkItemListDto>> Handle(GetExternalObjectWorkItemsQuery request, CancellationToken cancellationToken)
     {
-        return await _workDbContext.WorkItemLinks
+        var workItemIds = await _workDbContext.WorkItemLinks
             .Where(e => e.ObjectId == request.ObjectId)
+            .Select(e => e.WorkItemId)
+            .ToArrayAsync(cancellationToken);
+
+        if (workItemIds.Length == 0)
+            return [];
+
+        return await _workDbContext.WorkItems
+            .Where(e => workItemIds.Contains(e.Id))
             .ProjectToType<WorkItemListDto>()
             .ToListAsync(cancellationToken);
     }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/SearchWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/SearchWorkItemsQuery.cs
@@ -1,0 +1,31 @@
+﻿using Moda.Work.Application.WorkItems.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Queries;
+public sealed record SearchWorkItemsQuery(string SearchTerm, int Top) : IQuery<Result<IReadOnlyCollection<WorkItemListDto>>>;
+
+internal sealed class SearchWorkItemsQueryHandler(IWorkDbContext workDbContext, ILogger<SearchWorkItemsQueryHandler> logger) : IQueryHandler<SearchWorkItemsQuery, Result<IReadOnlyCollection<WorkItemListDto>>>
+{
+    private const string AppRequestName = nameof(SearchWorkItemsQuery);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<SearchWorkItemsQueryHandler> _logger = logger;
+
+    public async Task<Result<IReadOnlyCollection<WorkItemListDto>>> Handle(SearchWorkItemsQuery request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(request.SearchTerm))
+        {
+            _logger.LogWarning("{AppRequestName}: No search term provided. {@Request}", AppRequestName, request);
+            return Result.Failure<IReadOnlyCollection<WorkItemListDto>>("No search term provided.");
+        }
+
+        return await _workDbContext.WorkItems
+            .Where(e => e.Title.Contains(request.SearchTerm))
+            //|| e.Key.ToString().Contains(request.SearchTerm))
+            //.OrderBy(e => e.Key.WorkspaceKey)
+            //    .ThenBy(e => e.Key.WorkItemNumber)
+            .Take(request.Top)
+            .ProjectToType<WorkItemListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}
+

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemKey.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemKey.cs
@@ -38,7 +38,10 @@ public sealed class WorkItemKey : ValueObject
         }
     }
 
-    public string Value { get; init; } = null!;
+    public string Value { get; init; } = default!;
+
+    public string WorkspaceKey => Value.Split('-')[0];
+    public int WorkItemNumber => int.Parse(Value.Split('-')[1]);
 
     protected override IEnumerable<IComparable> GetEqualityComponents()
     {

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemLink.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemLink.cs
@@ -1,0 +1,24 @@
+﻿namespace Moda.Work.Domain.Models;
+public sealed class WorkItemLink : ISystemAuditable
+{
+    private WorkItemLink() { }
+    public WorkItemLink(Guid workItemId, Guid objectId, SystemContext context)
+    {
+        WorkItemId = workItemId;
+        ObjectId = objectId;
+        Context = context;
+    }
+
+    public Guid WorkItemId { get; private init; }
+    public Guid ObjectId { get; private init; }
+
+    /// <summary>
+    /// The context of the object being linked to the work item.
+    /// </summary>
+    public SystemContext Context { get; private init; }
+
+    public static WorkItemLink Create(Guid workItemId, Guid objectId, SystemContext context)
+    {
+        return new WorkItemLink(workItemId, objectId, context);
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
@@ -12,6 +12,8 @@ using Moda.Planning.Application.Risks.Dtos;
 using Moda.Planning.Application.Risks.Queries;
 using Moda.Web.Api.Dtos.Planning;
 using Moda.Web.Api.Models.Planning.PlanningIntervals;
+using Moda.Work.Application.WorkItems.Dtos;
+using Moda.Work.Application.WorkItems.Queries;
 
 namespace Moda.Web.Api.Controllers.Planning;
 
@@ -380,6 +382,23 @@ public class PlanningIntervalsController : ControllerBase
         return Ok(objectiveHealthChecks);
     }
 
+    [HttpGet("{id}/objectives/{objectiveId}/work-items")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.PlanningIntervalObjectives)]
+    [OpenApiOperation("Get work items for a planning interval objective.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<IEnumerable<WorkItemListDto>>> GetObjectiveWorkItems(Guid id, Guid objectiveId, CancellationToken cancellationToken)
+    {
+        var exists = await _sender.Send(new CheckPlanningIntervalObjectiveExistsQuery(id, objectiveId), cancellationToken);
+        if (!exists)
+            return NotFound();
+
+        var workItems = await _sender.Send(new GetExternalObjectWorkItemsQuery(objectiveId), cancellationToken);
+
+        return Ok(workItems);
+    }
+
     [HttpPost("{id}/objectives/import")]
     [MustHavePermission(ApplicationAction.Import, ApplicationResource.PlanningIntervalObjectives)]
     [OpenApiOperation("Import objectives for a planning interval from a csv file.", "")]
@@ -392,7 +411,7 @@ public class PlanningIntervalsController : ControllerBase
         {
             var importedObjectives = _csvService.ReadCsv<ImportPlanningIntervalObjectivesRequest>(file.OpenReadStream());
 
-            List<ImportPlanningIntervalObjectiveDto> objectives = new();
+            List<ImportPlanningIntervalObjectiveDto> objectives = [];
             var validator = new ImportPlanningIntervalObjectivesRequestValidator();
             foreach (var objective in importedObjectives)
             {

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
@@ -404,6 +404,8 @@ public class PlanningIntervalsController : ControllerBase
     [OpenApiOperation("Manage objective work items.", "")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ManageObjectiveWorkItems(Guid id, Guid objectiveId, [FromBody] ManagePlanningIntervalObjectiveWorkItemsRequest request, CancellationToken cancellationToken)
     {
         if (id != request.PlanningIntervalId || objectiveId != request.ObjectiveId)

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
@@ -396,7 +396,7 @@ public class PlanningIntervalsController : ControllerBase
 
         var workItems = await _sender.Send(new GetExternalObjectWorkItemsQuery(objectiveId), cancellationToken);
 
-        return Ok(workItems);
+        return Ok(workItems.OrderByKey(true));
     }
 
     [HttpPost("{id}/objectives/import")]

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
@@ -117,4 +117,19 @@ public class WorkspacesController(ILogger<WorkspacesController> logger, ISender 
                 ? result.Value
                 : NotFound();
     }
+
+    [HttpGet("work-items/search")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.WorkItems)]
+    [OpenApiOperation("Search for a work item using its key or title.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<WorkItemListDto>>> SearchWorkItems(string query, CancellationToken cancellationToken, int top = 50)
+    {
+        var result = await _sender.Send(new SearchWorkItemsQuery(query, top), cancellationToken);
+
+        return result.IsFailure
+            ? BadRequest(ErrorResult.CreateBadRequest(result.Error, "WorkspacesController.SearchWorkItems"))
+            : Ok(result.Value.OrderByKey(true));
+    }
+
 }

--- a/Moda.Web/src/Moda.Web.Api/Models/Planning/PlanningIntervals/ManagePlanningIntervalObjectiveWorkItemsRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Planning/PlanningIntervals/ManagePlanningIntervalObjectiveWorkItemsRequest.cs
@@ -1,0 +1,16 @@
+﻿using Moda.Common.Domain.Enums;
+using Moda.Work.Application.WorkItems.Commands;
+
+namespace Moda.Web.Api.Models.Planning.PlanningIntervals;
+
+public sealed record ManagePlanningIntervalObjectiveWorkItemsRequest
+{
+    public Guid PlanningIntervalId { get; set; }
+    public Guid ObjectiveId { get; set; }
+    public IEnumerable<Guid> WorkItemIds { get; set; } = [];
+
+    public ManageExternalObjectWorkItemsCommand ToManageExternalObjectWorkItemsCommand()
+    {
+        return new ManageExternalObjectWorkItemsCommand(PlanningIntervalId, ObjectiveId, SystemContext.PlanningPlanningIntervalObjective, WorkItemIds);
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -3488,6 +3488,65 @@
         ]
       }
     },
+    "/api/work/workspaces/work-items/search": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Search for a work item using its key or title.",
+        "operationId": "Workspaces_SearchWorkItems",
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "top",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkItemListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/work/work-status-categories": {
       "get": {
         "tags": [

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -2032,6 +2032,81 @@
         ]
       }
     },
+    "/api/planning/planning-intervals/{id}/objectives/{objectiveId}/work-items": {
+      "get": {
+        "tags": [
+          "PlanningIntervals"
+        ],
+        "summary": "Get work items for a planning interval objective.",
+        "operationId": "PlanningIntervals_GetObjectiveWorkItems",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "objectiveId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkItemListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/planning/planning-intervals/{id}/objectives/import": {
       "post": {
         "tags": [
@@ -8395,6 +8470,82 @@
           }
         }
       },
+      "WorkItemListDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/WorkspaceNavigationDto"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "assignedTo": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EmployeeNavigationDto"
+              }
+            ]
+          }
+        }
+      },
+      "WorkspaceNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDtoOfGuidAndString"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
+      },
+      "NavigationDtoOfGuidAndString": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "EmployeeNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
+      },
       "PlanningIntervalObjectiveStatusDto": {
         "type": "object",
         "additionalProperties": false,
@@ -8468,17 +8619,6 @@
             "nullable": true
           }
         }
-      },
-      "EmployeeNavigationDto": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NavigationDto"
-          },
-          {
-            "type": "object",
-            "additionalProperties": false
-          }
-        ]
       },
       "RiskDetailsDto": {
         "type": "object",
@@ -9002,71 +9142,6 @@
           },
           "isActive": {
             "type": "boolean"
-          }
-        }
-      },
-      "WorkItemListDto": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "guid",
-            "nullable": false,
-            "example": "00000000-0000-0000-0000-000000000000"
-          },
-          "key": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "workspace": {
-            "$ref": "#/components/schemas/WorkspaceNavigationDto"
-          },
-          "type": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "assignedTo": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EmployeeNavigationDto"
-              }
-            ]
-          }
-        }
-      },
-      "WorkspaceNavigationDto": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NavigationDtoOfGuidAndString"
-          },
-          {
-            "type": "object",
-            "additionalProperties": false
-          }
-        ]
-      },
-      "NavigationDtoOfGuidAndString": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "guid",
-            "nullable": false,
-            "example": "00000000-0000-0000-0000-000000000000"
-          },
-          "key": {
-            "type": "string",
-            "nullable": true
-          },
-          "name": {
-            "type": "string"
           }
         }
       },

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -2037,7 +2037,7 @@
         "tags": [
           "PlanningIntervals"
         ],
-        "summary": "Get work items for a planning interval objective.",
+        "summary": "Get work items for an objective.",
         "operationId": "PlanningIntervals_GetObjectiveWorkItems",
         "parameters": [
           {
@@ -2095,6 +2095,71 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "PlanningIntervals"
+        ],
+        "summary": "Manage objective work items.",
+        "operationId": "PlanningIntervals_ManageObjectiveWorkItems",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "objectiveId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManagePlanningIntervalObjectiveWorkItemsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
                 }
               }
             }
@@ -8545,6 +8610,33 @@
             "additionalProperties": false
           }
         ]
+      },
+      "ManagePlanningIntervalObjectiveWorkItemsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "planningIntervalId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "objectiveId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "workItemIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
       },
       "PlanningIntervalObjectiveStatusDto": {
         "type": "object",

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -2163,6 +2163,26 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
           }
         },
         "security": [

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/index.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/index.ts
@@ -1,0 +1,1 @@
+export { default as WorkItemsListCard } from './work-items-list-card'

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
@@ -1,0 +1,31 @@
+import { WorkItemListDto } from '@/src/services/moda-api'
+import { List, Space, Tag } from 'antd'
+
+const { Item } = List
+const { Meta } = Item
+
+export interface WorkItemListItemProps {
+  workItem: WorkItemListDto
+}
+
+const WorkItemListItem = ({ workItem }: WorkItemListItemProps) => {
+  return (
+    <Item key={workItem.id}>
+      <Meta
+        title={`${workItem.key} - ${workItem.title}`}
+        description={<WorkItemListItemDescription workItem={workItem} />}
+      />
+    </Item>
+  )
+}
+
+export default WorkItemListItem
+
+const WorkItemListItemDescription = ({ workItem }: WorkItemListItemProps) => {
+  return (
+    <Space wrap>
+      <Tag>{workItem.type}</Tag>
+      <Tag>{workItem.status}</Tag>
+    </Space>
+  )
+}

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
@@ -1,0 +1,21 @@
+'use client'
+
+import { WorkItemListDto } from '@/src/services/moda-api'
+
+export interface WorkItemsListCardProps {
+  workItems: WorkItemListDto[]
+}
+
+const WorkItemsListCard = ({ workItems }: WorkItemsListCardProps) => {
+  return (
+    <div>
+      {workItems.map((workItem) => (
+        <div key={workItem.id}>
+          {workItem.key} {workItem.title}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default WorkItemsListCard

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
@@ -1,20 +1,24 @@
-'use client'
-
 import { WorkItemListDto } from '@/src/services/moda-api'
+import ModaEmpty from '../moda-empty'
+import { List } from 'antd'
+import WorkItemListItem from './work-item-list-item'
 
 export interface WorkItemsListCardProps {
   workItems: WorkItemListDto[]
 }
 
 const WorkItemsListCard = ({ workItems }: WorkItemsListCardProps) => {
+  if (!workItems || workItems.length === 0)
+    return <ModaEmpty message="No work items" />
+
+  console.log(workItems)
+
   return (
-    <div>
-      {workItems.map((workItem) => (
-        <div key={workItem.id}>
-          {workItem.key} {workItem.title}
-        </div>
-      ))}
-    </div>
+    <List
+      size="small"
+      dataSource={workItems}
+      renderItem={(workItem) => <WorkItemListItem workItem={workItem} />}
+    />
   )
 }
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
@@ -11,8 +11,6 @@ const WorkItemsListCard = ({ workItems }: WorkItemsListCardProps) => {
   if (!workItems || workItems.length === 0)
     return <ModaEmpty message="No work items" />
 
-  console.log(workItems)
-
   return (
     <List
       size="small"

--- a/Moda.Web/src/moda.web.reactclient/src/app/hooks/index.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/hooks/index.ts
@@ -4,6 +4,7 @@ import type { AppDispatch, RootState } from '@/src/store'
 
 export { useLocalStorageState } from './use-local-storage-state'
 export { useDocumentTitle } from './use-document-title'
+export { useDebounce } from './use-debounce'
 
 export const useAppDispatch: () => AppDispatch = useDispatch
 export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/Moda.Web/src/moda.web.reactclient/src/app/hooks/use-debounce.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/hooks/use-debounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export const useDebounce = (value: string, delay: number = 500) => {
+  const [debouncedValue, setDebouncedValue] = useState(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -23,7 +23,7 @@ export type TransferDirection = 'left' | 'right'
 
 export interface ManagePlanningIntervalObjectiveWorkItemsFormProps {
   showForm: boolean
-  id: string
+  objectiveId: string
   onFormSave: () => void
   onFormCancel: () => void
 }

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -117,11 +117,11 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
         skip: debounceSearchQuery === '',
     })
 
-    const merge = (searchResult: WorkItemListDto[], workItems: WorkItemListDto[]) : WorkItemListDto[] => {
+    const merge = (searchResult: WorkItemListDto[], workItems: WorkItemListDto[]): WorkItemListDto[] => {
         const spread = [...searchResult ?? []]
         workItems.forEach((item) => {
             const found = searchResult.find((x) => x.key === item.key)
-            if(!found) spread.push(item)
+            if (!found) spread.push(item)
         })
         return spread;
     }
@@ -178,7 +178,7 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
             <Modal
                 title="Manage PI Objective Work Items"
                 open={isOpen}
-                width={900}
+                width={950}
                 onOk={handleOk}
                 okText="Save"
                 confirmLoading={isSaving}

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -166,8 +166,9 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
     }
 
     const onChange = (nextTargetKeys: string[]) => {
-        var workItems = searchResult?.filter((item) => nextTargetKeys.includes(item.key))
-        setWorkItems(workItems)
+        var selectedWorkItems = searchResult?.filter((item) => nextTargetKeys.includes(item.key))
+        var mergedWorkItems = merge(workItems ?? [], selectedWorkItems ?? [])
+        setWorkItems(mergedWorkItems)
         setTargetKeys(nextTargetKeys)
     }
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -1,12 +1,23 @@
 'use client'
 
+import { ModaEmpty } from '@/src/app/components/common'
 import { useDebounce } from '@/src/app/hooks'
 import { WorkItemListDto } from '@/src/services/moda-api'
 import { useSearchWorkItemsQuery } from '@/src/store/features/work-management/workspace-api'
-import { Modal, Spin, Table, Transfer, TransferProps, message } from 'antd'
+import {
+  Modal,
+  Spin,
+  Table,
+  Transfer,
+  TransferProps,
+  Typography,
+  message,
+} from 'antd'
 import type { ColumnsType, TableRowSelection } from 'antd/es/table/interface'
 import { difference } from 'lodash'
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
+
+const { Text } = Typography
 
 export type TransferDirection = 'left' | 'right'
 
@@ -27,7 +38,7 @@ const TableTransfer = ({
   rightColumns,
   ...restProps
 }: TableTransferProps) => (
-  <Transfer oneWay {...restProps}>
+  <Transfer {...restProps}>
     {({
       direction,
       filteredItems,
@@ -62,9 +73,12 @@ const TableTransfer = ({
           dataSource={filteredItems}
           size="small"
           pagination={false}
-          scroll={{ y: 600 }}
+          scroll={{ y: '50vh' }}
           style={{
             pointerEvents: listDisabled ? 'none' : undefined,
+          }}
+          locale={{
+            emptyText: <ModaEmpty message="No work items found" />,
           }}
           onRow={({ key }) => ({
             onClick: () => {
@@ -169,7 +183,6 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
   }
 
   const handleSearch = (direction: TransferDirection, newValue: string) => {
-    console.log('handleSearch', direction, newValue)
     if (direction === 'left') {
       setSearchQuery(newValue)
     }
@@ -213,6 +226,7 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
               leftColumns={tableColumns}
               rightColumns={tableColumns}
             />
+            <Text>Search results are limited to 50 records.</Text>
           </Spin>
         }
       </Modal>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -11,189 +11,200 @@ import { useEffect, useState } from 'react'
 export type TransferDirection = 'left' | 'right'
 
 export interface ManagePlanningIntervalObjectiveWorkItemsFormProps {
-  showForm: boolean
-  id: string
-  onFormSave: () => void
-  onFormCancel: () => void
+    showForm: boolean
+    id: string
+    onFormSave: () => void
+    onFormCancel: () => void
 }
 
 interface TableTransferProps extends TransferProps<WorkItemListDto> {
-  leftColumns: ColumnsType<WorkItemListDto>
-  rightColumns: ColumnsType<WorkItemListDto>
+    leftColumns: ColumnsType<WorkItemListDto>
+    rightColumns: ColumnsType<WorkItemListDto>
 }
 
 const TableTransfer = ({
-  leftColumns,
-  rightColumns,
-  ...restProps
+    leftColumns,
+    rightColumns,
+    ...restProps
 }: TableTransferProps) => (
-  <Transfer oneWay {...restProps}>
-    {({
-      direction,
-      filteredItems,
-      onItemSelectAll,
-      onItemSelect,
-      selectedKeys: listSelectedKeys,
-      disabled: listDisabled,
-    }) => {
-      const columns = direction === 'left' ? leftColumns : rightColumns
+    <Transfer oneWay {...restProps}>
+        {({
+            direction,
+            filteredItems,
+            onItemSelectAll,
+            onItemSelect,
+            selectedKeys: listSelectedKeys,
+            disabled: listDisabled,
+        }) => {
+            const columns = direction === 'left' ? leftColumns : rightColumns
 
-      const rowSelection: TableRowSelection<WorkItemListDto> = {
-        getCheckboxProps: (item) => ({
-          disabled: listDisabled,
-        }),
-        onSelectAll(selected, selectedRows) {
-          const treeSelectedKeys = selectedRows.map(({ key }) => key)
-          const diffKeys = selected
-            ? difference(treeSelectedKeys, listSelectedKeys)
-            : difference(listSelectedKeys, treeSelectedKeys)
-          onItemSelectAll(diffKeys as string[], selected)
-        },
-        onSelect({ key }, selected) {
-          onItemSelect(key as string, selected)
-        },
-        selectedRowKeys: listSelectedKeys,
-      }
+            const rowSelection: TableRowSelection<WorkItemListDto> = {
+                getCheckboxProps: (item) => ({
+                    disabled: listDisabled,
+                }),
+                onSelectAll(selected, selectedRows) {
+                    const treeSelectedKeys = selectedRows.map(({ key }) => key)
+                    const diffKeys = selected
+                        ? difference(treeSelectedKeys, listSelectedKeys)
+                        : difference(listSelectedKeys, treeSelectedKeys)
+                    onItemSelectAll(diffKeys as string[], selected)
+                },
+                onSelect({ key }, selected) {
+                    onItemSelect(key as string, selected)
+                },
+                selectedRowKeys: listSelectedKeys,
+            }
 
-      return (
-        <Table
-          rowSelection={rowSelection}
-          columns={columns}
-          dataSource={filteredItems}
-          size="small"
-          pagination={false}
-          style={{ pointerEvents: listDisabled ? 'none' : undefined }}
-          onRow={({ key }) => ({
-            onClick: () => {
-              onItemSelect(
-                key as string,
-                !listSelectedKeys.includes(key as string),
-              )
-            },
-          })}
-        />
-      )
-    }}
-  </Transfer>
+            return (
+                <Table
+                    rowSelection={rowSelection}
+                    columns={columns}
+                    dataSource={filteredItems}
+                    size="small"
+                    pagination={false}
+                    style={{ pointerEvents: listDisabled ? 'none' : undefined }}
+                    onRow={({ key }) => ({
+                        onClick: () => {
+                            onItemSelect(
+                                key as string,
+                                !listSelectedKeys.includes(key as string),
+                            )
+                        },
+                    })}
+                />
+            )
+        }}
+    </Transfer>
 )
 
 const tableColumns: ColumnsType<WorkItemListDto> = [
-  {
-    dataIndex: 'key',
-    title: 'Key',
-  },
-  {
-    dataIndex: 'title',
-    title: 'Title',
-  },
-  {
-    dataIndex: 'type',
-    title: 'Type',
-  },
-  {
-    dataIndex: 'status',
-    title: 'Status',
-  },
+    {
+        dataIndex: 'key',
+        title: 'Key',
+    },
+    {
+        dataIndex: 'title',
+        title: 'Title',
+    },
+    {
+        dataIndex: 'type',
+        title: 'Type',
+    },
+    {
+        dataIndex: 'status',
+        title: 'Status',
+    },
 ]
 
 const ManagePlanningIntervalObjectiveWorkItemsForm = (
-  props: ManagePlanningIntervalObjectiveWorkItemsFormProps,
+    props: ManagePlanningIntervalObjectiveWorkItemsFormProps,
 ) => {
-  const [isOpen, setIsOpen] = useState(props.showForm)
-  const [isSaving, setIsSaving] = useState(false)
-  const [workItems, setWorkItems] = useState<WorkItemListDto[]>([])
-  const [targetKeys, setTargetKeys] = useState<string[]>([])
-  const [messageApi, contextHolder] = message.useMessage()
+    const [isOpen, setIsOpen] = useState(props.showForm)
+    const [isSaving, setIsSaving] = useState(false)
+    const [workItems, setWorkItems] = useState<WorkItemListDto[]>([])
+    const [targetKeys, setTargetKeys] = useState<string[]>([])
+    const [messageApi, contextHolder] = message.useMessage()
 
-  const [searchQuery, setSearchQuery] = useState<string>('')
+    const [searchQuery, setSearchQuery] = useState<string>('')
 
-  const debounceSearchQuery = useDebounce(searchQuery, 500)
-  const {
-    data: searchResult,
-    isSuccess,
-    isLoading,
-    isError,
-  } = useSearchWorkItemsQuery(debounceSearchQuery, {
-    skip: debounceSearchQuery === '',
-  })
+    const debounceSearchQuery = useDebounce(searchQuery, 500)
+    const {
+        data: searchResult,
+        isSuccess,
+        isLoading,
+        isError,
+    } = useSearchWorkItemsQuery(debounceSearchQuery, {
+        skip: debounceSearchQuery === '',
+    })
 
-  // useEffect(() => {
-  //   if (!props.id) return
-  //   setSearchQuery('AHTG')
-  // }, [props.id])
-
-  // useEffect(() => {
-  //   console.log('searchResult:', searchResult?.length)
-  //   setWorkItems(searchResult ?? [])
-  // }, [searchQuery, searchResult])
-
-  const handleOk = async () => {
-    setIsSaving(true)
-    try {
-      if (true) {
-        // add api call to save
-        setIsOpen(false)
-        setIsSaving(false)
-        props.onFormSave()
-        messageApi.success(`Successfully updated PI Objective Work Items.`)
-      } else {
-        setIsSaving(false)
-      }
-    } catch (errorInfo) {
-      setIsSaving(false)
+    const merge = (searchResult: WorkItemListDto[], workItems: WorkItemListDto[]) : WorkItemListDto[] => {
+        const spread = [...searchResult ?? []]
+        workItems.forEach((item) => {
+            const found = searchResult.find((x) => x.key === item.key)
+            if(!found) spread.push(item)
+        })
+        return spread;
     }
-  }
 
-  const handleCancel = () => {
-    setIsOpen(false)
-    props.onFormCancel()
-  }
+    // useEffect(() => {
+    //   if (!props.id) return
+    //   setSearchQuery('AHTG')
+    // }, [props.id])
 
-  const handleSearch = (direction: TransferDirection, newValue: string) => {
-    console.log('handleSearch', direction, newValue)
-    if (direction === 'left') {
-      setSearchQuery(newValue)
-    }
-  }
+    // useEffect(() => {
+    //   console.log('searchResult:', searchResult?.length)
+    //   setWorkItems(searchResult ?? [])
+    // }, [searchQuery, searchResult])
 
-  const onChange = (nextTargetKeys: string[]) => {
-    setTargetKeys(nextTargetKeys)
-  }
-
-  return (
-    <>
-      {contextHolder}
-      <Modal
-        title="Manage PI Objective Work Items"
-        open={isOpen}
-        width={900}
-        onOk={handleOk}
-        okText="Save"
-        confirmLoading={isSaving}
-        onCancel={handleCancel}
-        maskClosable={false}
-        keyboard={false} // disable esc key to close modal
-        destroyOnClose={true}
-      >
-        {
-          <Spin spinning={isLoading} size="large">
-            <TableTransfer
-              dataSource={searchResult}
-              targetKeys={targetKeys}
-              showSearch={true}
-              onChange={onChange}
-              onSearch={handleSearch}
-              filterOption={(inputValue, item, direction) =>
-                direction === 'left'
-              }
-              leftColumns={tableColumns}
-              rightColumns={tableColumns}
-            />
-          </Spin>
+    const handleOk = async () => {
+        setIsSaving(true)
+        try {
+            if (true) {
+                // add api call to save
+                setIsOpen(false)
+                setIsSaving(false)
+                props.onFormSave()
+                messageApi.success(`Successfully updated PI Objective Work Items.`)
+            } else {
+                setIsSaving(false)
+            }
+        } catch (errorInfo) {
+            setIsSaving(false)
         }
-      </Modal>
-    </>
-  )
+    }
+
+    const handleCancel = () => {
+        setIsOpen(false)
+        props.onFormCancel()
+    }
+
+    const handleSearch = (direction: TransferDirection, newValue: string) => {
+        console.log('handleSearch', direction, newValue)
+        if (direction === 'left') {
+            setSearchQuery(newValue)
+        }
+    }
+
+    const onChange = (nextTargetKeys: string[]) => {
+        var workItems = searchResult?.filter((item) => nextTargetKeys.includes(item.key))
+        setWorkItems(workItems)
+        setTargetKeys(nextTargetKeys)
+    }
+
+    return (
+        <>
+            {contextHolder}
+            <Modal
+                title="Manage PI Objective Work Items"
+                open={isOpen}
+                width={900}
+                onOk={handleOk}
+                okText="Save"
+                confirmLoading={isSaving}
+                onCancel={handleCancel}
+                maskClosable={false}
+                keyboard={false} // disable esc key to close modal
+                destroyOnClose={true}
+            >
+                {
+                    <Spin spinning={isLoading} size="large">
+                        <TableTransfer
+                            dataSource={merge(searchResult, workItems)}
+                            targetKeys={targetKeys}
+                            showSearch={true}
+                            onChange={onChange}
+                            onSearch={handleSearch}
+                            filterOption={(inputValue, item, direction) =>
+                                direction === 'left'
+                            }
+                            leftColumns={tableColumns}
+                            rightColumns={tableColumns}
+                        />
+                    </Spin>
+                }
+            </Modal>
+        </>
+    )
 }
 
 export default ManagePlanningIntervalObjectiveWorkItemsForm

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -11,201 +11,213 @@ import { useEffect, useState } from 'react'
 export type TransferDirection = 'left' | 'right'
 
 export interface ManagePlanningIntervalObjectiveWorkItemsFormProps {
-    showForm: boolean
-    id: string
-    onFormSave: () => void
-    onFormCancel: () => void
+  showForm: boolean
+  id: string
+  onFormSave: () => void
+  onFormCancel: () => void
 }
 
 interface TableTransferProps extends TransferProps<WorkItemListDto> {
-    leftColumns: ColumnsType<WorkItemListDto>
-    rightColumns: ColumnsType<WorkItemListDto>
+  leftColumns: ColumnsType<WorkItemListDto>
+  rightColumns: ColumnsType<WorkItemListDto>
 }
 
 const TableTransfer = ({
-    leftColumns,
-    rightColumns,
-    ...restProps
+  leftColumns,
+  rightColumns,
+  ...restProps
 }: TableTransferProps) => (
-    <Transfer oneWay {...restProps}>
-        {({
-            direction,
-            filteredItems,
-            onItemSelectAll,
-            onItemSelect,
-            selectedKeys: listSelectedKeys,
-            disabled: listDisabled,
-        }) => {
-            const columns = direction === 'left' ? leftColumns : rightColumns
+  <Transfer oneWay {...restProps}>
+    {({
+      direction,
+      filteredItems,
+      onItemSelectAll,
+      onItemSelect,
+      selectedKeys: listSelectedKeys,
+      disabled: listDisabled,
+    }) => {
+      const columns = direction === 'left' ? leftColumns : rightColumns
 
-            const rowSelection: TableRowSelection<WorkItemListDto> = {
-                getCheckboxProps: (item) => ({
-                    disabled: listDisabled,
-                }),
-                onSelectAll(selected, selectedRows) {
-                    const treeSelectedKeys = selectedRows.map(({ key }) => key)
-                    const diffKeys = selected
-                        ? difference(treeSelectedKeys, listSelectedKeys)
-                        : difference(listSelectedKeys, treeSelectedKeys)
-                    onItemSelectAll(diffKeys as string[], selected)
-                },
-                onSelect({ key }, selected) {
-                    onItemSelect(key as string, selected)
-                },
-                selectedRowKeys: listSelectedKeys,
-            }
+      const rowSelection: TableRowSelection<WorkItemListDto> = {
+        getCheckboxProps: (item) => ({
+          disabled: listDisabled,
+        }),
+        onSelectAll(selected, selectedRows) {
+          const treeSelectedKeys = selectedRows.map(({ key }) => key)
+          const diffKeys = selected
+            ? difference(treeSelectedKeys, listSelectedKeys)
+            : difference(listSelectedKeys, treeSelectedKeys)
+          onItemSelectAll(diffKeys as string[], selected)
+        },
+        onSelect({ key }, selected) {
+          onItemSelect(key as string, selected)
+        },
+        selectedRowKeys: listSelectedKeys,
+      }
 
-            return (
-                <Table
-                    rowSelection={rowSelection}
-                    columns={columns}
-                    dataSource={filteredItems}
-                    size="small"
-                    pagination={false}
-                    style={{ pointerEvents: listDisabled ? 'none' : undefined }}
-                    onRow={({ key }) => ({
-                        onClick: () => {
-                            onItemSelect(
-                                key as string,
-                                !listSelectedKeys.includes(key as string),
-                            )
-                        },
-                    })}
-                />
-            )
-        }}
-    </Transfer>
+      return (
+        <Table
+          rowSelection={rowSelection}
+          columns={columns}
+          dataSource={filteredItems}
+          size="small"
+          pagination={false}
+          scroll={{ y: 600 }}
+          style={{
+            pointerEvents: listDisabled ? 'none' : undefined,
+          }}
+          onRow={({ key }) => ({
+            onClick: () => {
+              onItemSelect(
+                key as string,
+                !listSelectedKeys.includes(key as string),
+              )
+            },
+          })}
+        />
+      )
+    }}
+  </Transfer>
 )
 
 const tableColumns: ColumnsType<WorkItemListDto> = [
-    {
-        dataIndex: 'key',
-        title: 'Key',
-    },
-    {
-        dataIndex: 'title',
-        title: 'Title',
-    },
-    {
-        dataIndex: 'type',
-        title: 'Type',
-    },
-    {
-        dataIndex: 'status',
-        title: 'Status',
-    },
+  {
+    dataIndex: 'key',
+    title: 'Key',
+    key: '1',
+  },
+  {
+    dataIndex: 'title',
+    title: 'Title',
+    key: '2',
+  },
+  {
+    dataIndex: 'type',
+    title: 'Type',
+    key: '3',
+  },
+  {
+    dataIndex: 'status',
+    title: 'Status',
+    key: '4',
+  },
 ]
 
 const ManagePlanningIntervalObjectiveWorkItemsForm = (
-    props: ManagePlanningIntervalObjectiveWorkItemsFormProps,
+  props: ManagePlanningIntervalObjectiveWorkItemsFormProps,
 ) => {
-    const [isOpen, setIsOpen] = useState(props.showForm)
-    const [isSaving, setIsSaving] = useState(false)
-    const [workItems, setWorkItems] = useState<WorkItemListDto[]>([])
-    const [targetKeys, setTargetKeys] = useState<string[]>([])
-    const [messageApi, contextHolder] = message.useMessage()
+  const [isOpen, setIsOpen] = useState(props.showForm)
+  const [isSaving, setIsSaving] = useState(false)
+  const [workItems, setWorkItems] = useState<WorkItemListDto[]>([])
+  const [targetKeys, setTargetKeys] = useState<string[]>([])
+  const [messageApi, contextHolder] = message.useMessage()
 
-    const [searchQuery, setSearchQuery] = useState<string>('')
+  const [searchQuery, setSearchQuery] = useState<string>('')
 
-    const debounceSearchQuery = useDebounce(searchQuery, 500)
-    const {
-        data: searchResult,
-        isSuccess,
-        isLoading,
-        isError,
-    } = useSearchWorkItemsQuery(debounceSearchQuery, {
-        skip: debounceSearchQuery === '',
+  const debounceSearchQuery = useDebounce(searchQuery, 500)
+  const {
+    data: searchResult,
+    isSuccess,
+    isLoading,
+    isError,
+  } = useSearchWorkItemsQuery(debounceSearchQuery, {
+    skip: debounceSearchQuery === '',
+  })
+
+  const merge = (
+    searchResult: WorkItemListDto[],
+    workItems: WorkItemListDto[],
+  ): WorkItemListDto[] => {
+    const spread = [...(searchQuery === '' ? [] : searchResult ?? [])]
+    workItems.forEach((item) => {
+      const found = searchResult.find((x) => x.key === item.key)
+      if (!found) spread.push(item)
     })
+    return spread
+  }
 
-    const merge = (searchResult: WorkItemListDto[], workItems: WorkItemListDto[]): WorkItemListDto[] => {
-        const spread = [...searchResult ?? []]
-        workItems.forEach((item) => {
-            const found = searchResult.find((x) => x.key === item.key)
-            if (!found) spread.push(item)
-        })
-        return spread;
-    }
+  // useEffect(() => {
+  //   if (!props.id) return
+  //   setSearchQuery('AHTG')
+  // }, [props.id])
 
-    // useEffect(() => {
-    //   if (!props.id) return
-    //   setSearchQuery('AHTG')
-    // }, [props.id])
+  // useEffect(() => {
+  //   console.log('searchResult:', searchResult?.length)
+  //   setWorkItems(searchResult ?? [])
+  // }, [searchQuery, searchResult])
 
-    // useEffect(() => {
-    //   console.log('searchResult:', searchResult?.length)
-    //   setWorkItems(searchResult ?? [])
-    // }, [searchQuery, searchResult])
-
-    const handleOk = async () => {
-        setIsSaving(true)
-        try {
-            if (true) {
-                // add api call to save
-                setIsOpen(false)
-                setIsSaving(false)
-                props.onFormSave()
-                messageApi.success(`Successfully updated PI Objective Work Items.`)
-            } else {
-                setIsSaving(false)
-            }
-        } catch (errorInfo) {
-            setIsSaving(false)
-        }
-    }
-
-    const handleCancel = () => {
+  const handleOk = async () => {
+    setIsSaving(true)
+    try {
+      if (true) {
+        // add api call to save
         setIsOpen(false)
-        props.onFormCancel()
+        setIsSaving(false)
+        props.onFormSave()
+        messageApi.success(`Successfully updated PI Objective Work Items.`)
+      } else {
+        setIsSaving(false)
+      }
+    } catch (errorInfo) {
+      setIsSaving(false)
     }
+  }
 
-    const handleSearch = (direction: TransferDirection, newValue: string) => {
-        console.log('handleSearch', direction, newValue)
-        if (direction === 'left') {
-            setSearchQuery(newValue)
-        }
+  const handleCancel = () => {
+    setIsOpen(false)
+    props.onFormCancel()
+  }
+
+  const handleSearch = (direction: TransferDirection, newValue: string) => {
+    console.log('handleSearch', direction, newValue)
+    if (direction === 'left') {
+      setSearchQuery(newValue)
     }
+  }
 
-    const onChange = (nextTargetKeys: string[]) => {
-        var selectedWorkItems = searchResult?.filter((item) => nextTargetKeys.includes(item.key))
-        var mergedWorkItems = merge(workItems ?? [], selectedWorkItems ?? [])
-        setWorkItems(mergedWorkItems)
-        setTargetKeys(nextTargetKeys)
-    }
-
-    return (
-        <>
-            {contextHolder}
-            <Modal
-                title="Manage PI Objective Work Items"
-                open={isOpen}
-                width={950}
-                onOk={handleOk}
-                okText="Save"
-                confirmLoading={isSaving}
-                onCancel={handleCancel}
-                maskClosable={false}
-                keyboard={false} // disable esc key to close modal
-                destroyOnClose={true}
-            >
-                {
-                    <Spin spinning={isLoading} size="large">
-                        <TableTransfer
-                            dataSource={merge(searchResult, workItems)}
-                            targetKeys={targetKeys}
-                            showSearch={true}
-                            onChange={onChange}
-                            onSearch={handleSearch}
-                            filterOption={(inputValue, item, direction) =>
-                                direction === 'left'
-                            }
-                            leftColumns={tableColumns}
-                            rightColumns={tableColumns}
-                        />
-                    </Spin>
-                }
-            </Modal>
-        </>
+  const onChange = (nextTargetKeys: string[]) => {
+    var selectedWorkItems = searchResult?.filter((item) =>
+      nextTargetKeys.includes(item.key),
     )
+    var mergedWorkItems = merge(workItems ?? [], selectedWorkItems ?? [])
+    setWorkItems(mergedWorkItems)
+    setTargetKeys(nextTargetKeys)
+  }
+
+  return (
+    <>
+      {contextHolder}
+      <Modal
+        title="Manage PI Objective Work Items"
+        open={isOpen}
+        width={'80vw'}
+        onOk={handleOk}
+        okText="Save"
+        confirmLoading={isSaving}
+        onCancel={handleCancel}
+        maskClosable={false}
+        keyboard={false} // disable esc key to close modal
+        destroyOnClose={true}
+      >
+        {
+          <Spin spinning={isLoading} size="large">
+            <TableTransfer
+              dataSource={merge(searchResult, workItems)}
+              targetKeys={targetKeys}
+              showSearch={true}
+              onChange={onChange}
+              onSearch={handleSearch}
+              filterOption={(inputValue, item, direction) =>
+                direction === 'left'
+              }
+              leftColumns={tableColumns}
+              rightColumns={tableColumns}
+            />
+          </Spin>
+        }
+      </Modal>
+    </>
+  )
 }
 
 export default ManagePlanningIntervalObjectiveWorkItemsForm

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { WorkItemListDto } from '@/src/services/moda-api'
+import { Table, Transfer, TransferProps } from 'antd'
+import type { ColumnsType, TableRowSelection } from 'antd/es/table/interface'
+import { difference } from 'lodash'
+
+export interface ManagePlanningIntervalObjectiveWorkItemsFormProps {
+  showForm: boolean
+  id: string
+  onFormSave: () => void
+  onFormCancel: () => void
+}
+
+interface TableTransferProps extends TransferProps<WorkItemListDto> {
+  dataSource: WorkItemListDto[]
+  leftColumns: ColumnsType<WorkItemListDto>
+  rightColumns: ColumnsType<WorkItemListDto>
+}
+
+const TableTransfer = ({
+  leftColumns,
+  rightColumns,
+  ...restProps
+}: TableTransferProps) => (
+  <Transfer {...restProps}>
+    {({
+      direction,
+      filteredItems,
+      onItemSelectAll,
+      onItemSelect,
+      selectedKeys: listSelectedKeys,
+      disabled: listDisabled,
+    }) => {
+      const columns = direction === 'left' ? leftColumns : rightColumns
+
+      const rowSelection: TableRowSelection<WorkItemListDto> = {
+        getCheckboxProps: (item) => ({
+          disabled: listDisabled,
+        }),
+        onSelectAll(selected, selectedRows) {
+          const treeSelectedKeys = selectedRows.map(({ key }) => key)
+          const diffKeys = selected
+            ? difference(treeSelectedKeys, listSelectedKeys)
+            : difference(listSelectedKeys, treeSelectedKeys)
+          onItemSelectAll(diffKeys as string[], selected)
+        },
+        onSelect({ key }, selected) {
+          onItemSelect(key as string, selected)
+        },
+        selectedRowKeys: listSelectedKeys,
+      }
+
+      return (
+        <Table
+          rowSelection={rowSelection}
+          columns={columns}
+          dataSource={filteredItems}
+          size="small"
+          pagination={false}
+          style={{ pointerEvents: listDisabled ? 'none' : undefined }}
+          onRow={({ key }) => ({
+            onClick: () => {
+              onItemSelect(
+                key as string,
+                !listSelectedKeys.includes(key as string),
+              )
+            },
+          })}
+        />
+      )
+    }}
+  </Transfer>
+)
+
+const tableColumns: ColumnsType<WorkItemListDto> = [
+  {
+    dataIndex: 'key',
+    title: 'Key',
+  },
+  {
+    dataIndex: 'title',
+    title: 'Title',
+  },
+]

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/page.tsx
@@ -59,7 +59,12 @@ const ObjectiveDetailsPage = ({ params }) => {
     {
       key: 'details',
       tab: 'Details',
-      content: <PlanningIntervalObjectiveDetails objective={objectiveData} />,
+      content: (
+        <PlanningIntervalObjectiveDetails
+          objective={objectiveData}
+          canManageObjectives={canManageObjectives}
+        />
+      ),
     },
   ]
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-details.tsx
@@ -5,15 +5,18 @@ import { Card, Col, Descriptions, Progress, Row, Space, Tooltip } from 'antd'
 import dayjs from 'dayjs'
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown'
+import PlanningIntervalObjectiveWorkItemsCard from './planning-interval-objective-work-items-card'
 
 const { Item } = Descriptions
 
 interface PlanningIntervalObjectiveDetailsProps {
   objective: PlanningIntervalObjectiveDetailsDto
+  canManageObjectives: boolean
 }
 
 const PlanningIntervalObjectiveDetails = ({
   objective,
+  canManageObjectives,
 }: PlanningIntervalObjectiveDetailsProps) => {
   if (!objective) return null
 
@@ -75,6 +78,10 @@ const PlanningIntervalObjectiveDetails = ({
         <Card size="small">
           <HealthReportChart objectId={objective.id} />
         </Card>
+        <PlanningIntervalObjectiveWorkItemsCard
+          objectiveId={objective.id}
+          canLinkWorkItems={canManageObjectives}
+        />
         <LinksCard objectId={objective.id} />
       </Space>
     </>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-details.tsx
@@ -79,6 +79,7 @@ const PlanningIntervalObjectiveDetails = ({
           <HealthReportChart objectId={objective.id} />
         </Card>
         <PlanningIntervalObjectiveWorkItemsCard
+          planningIntervalId={objective.planningInterval?.id}
           objectiveId={objective.id}
           canLinkWorkItems={canManageObjectives}
         />

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -125,6 +125,7 @@ const PlanningIntervalObjectiveWorkItemsCard = (
       </Card>
       {openManageWorkItemsForm && (
         <ManagePlanningIntervalObjectiveWorkItemsForm
+          planningIntervalId={props.planningIntervalId}
           objectiveId={props.objectiveId}
           showForm={openManageWorkItemsForm}
           onFormSave={() => onManageWorkItemsFormClosed(true)}

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -1,74 +1,61 @@
 'use client'
 
 import { WorkItemsListCard } from '@/src/app/components/common/work'
-import useAuth from '@/src/app/components/contexts/auth'
-import { useDebounce } from '@/src/app/hooks'
-import { useSearchWorkItemsQuery } from '@/src/store/features/work-management/workspace-api'
 import { FormOutlined } from '@ant-design/icons'
-import { Button, Card, Input, Select, SelectProps } from 'antd'
+import { Button, Card, Input } from 'antd'
 import { useState } from 'react'
 import ManagePlanningIntervalObjectiveWorkItemsForm from './manage-planning-interval-objective-work-items-form'
+import { useGetObjectiveWorkItemsQuery } from '@/src/store/features/planning/planning-interval-api'
 
 const { Search } = Input
 
 export interface PlanningIntervalObjectiveWorkItemsCardProps {
+  planningIntervalId: string
   objectiveId: string
   canLinkWorkItems: boolean
 }
 
-const PlanningIntervalObjectiveWorkItemsCard = ({
-  objectiveId,
-  canLinkWorkItems,
-}: PlanningIntervalObjectiveWorkItemsCardProps) => {
+const PlanningIntervalObjectiveWorkItemsCard = (
+  props: PlanningIntervalObjectiveWorkItemsCardProps,
+) => {
   const [openManageWorkItemsForm, setOpenManageWorkItemsForm] =
     useState<boolean>(false)
 
-  //   const [data, setData] = useState<SelectProps['options']>([])
-  //   const [searchQuery, setSearchQuery] = useState<string>('')
+  const {
+    data: workItemsData,
+    isLoading,
+    isError,
+    refetch,
+  } = useGetObjectiveWorkItemsQuery({
+    planningIntervalId: props.planningIntervalId,
+    objectiveId: props.objectiveId,
+  })
 
-  //   const debounceSearchQuery = useDebounce(searchQuery, 500)
-  //   const {
-  //     data: searchResult,
-  //     isSuccess,
-  //     isLoading,
-  //     isError,
-  //   } = useSearchWorkItemsQuery(debounceSearchQuery, {
-  //     skip: debounceSearchQuery === '',
-  //   })
-
-  //   const handleSearch = (newValue: string) => {
-  //     setSearchQuery(newValue)
-  //   }
-
-  //   const handleChange = (newValue: string) => {
-  //     //setSearchQuery(newValue)
-  //   }
-
-  const testWorkItems = [
-    {
-      id: '1',
-      key: 'TEST-1',
-      title: 'Work Item 1',
-      status: 'In Progress',
-    },
-    {
-      id: '2',
-      key: 'TEST-2',
-      title: 'Work Item 2',
-      status: 'In Progress',
-    },
-    {
-      id: '3',
-      key: 'TEST-3',
-      title: 'Work Item 3',
-      status: 'In Progress',
-    },
-  ]
+  //   const testWorkItems = [
+  //     {
+  //       id: '1',
+  //       key: 'TEST-1',
+  //       title: 'Work Item 1',
+  //       status: 'In Progress',
+  //     },
+  //     {
+  //       id: '2',
+  //       key: 'TEST-2',
+  //       title: 'Work Item 2',
+  //       status: 'In Progress',
+  //     },
+  //     {
+  //       id: '3',
+  //       key: 'TEST-3',
+  //       title: 'Work Item 3',
+  //       status: 'In Progress',
+  //     },
+  //   ]
 
   const onManageWorkItemsFormClosed = (wasSaved: boolean) => {
     setOpenManageWorkItemsForm(false)
     if (wasSaved) {
-      //refreshObjectives()
+      refetch()
     }
   }
 
@@ -81,7 +68,7 @@ const PlanningIntervalObjectiveWorkItemsCard = ({
         // add search from api input
         extra={
           <>
-            {canLinkWorkItems && (
+            {props.canLinkWorkItems && (
               <Button
                 type="text"
                 icon={<FormOutlined />}
@@ -134,11 +121,11 @@ const PlanningIntervalObjectiveWorkItemsCard = ({
         //   </>
         // }
       >
-        <WorkItemsListCard workItems={testWorkItems} />
+        <WorkItemsListCard workItems={workItemsData} />
       </Card>
       {openManageWorkItemsForm && (
         <ManagePlanningIntervalObjectiveWorkItemsForm
-          id={objectiveId}
+          objectiveId={props.objectiveId}
           showForm={openManageWorkItemsForm}
           onFormSave={() => onManageWorkItemsFormClosed(true)}
           onFormCancel={() => onManageWorkItemsFormClosed(false)}

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -1,0 +1,135 @@
+'use client'
+
+import { WorkItemsListCard } from '@/src/app/components/common/work'
+import useAuth from '@/src/app/components/contexts/auth'
+import { useDebounce } from '@/src/app/hooks'
+import { useSearchWorkItemsQuery } from '@/src/store/features/work-management/workspace-api'
+import { PlusOutlined } from '@ant-design/icons'
+import { Button, Card, Input, Select, SelectProps } from 'antd'
+import { useState } from 'react'
+
+const { Search } = Input
+
+export interface PlanningIntervalObjectiveWorkItemsCardProps {
+  objectiveId: string
+  canLinkWorkItems: boolean
+}
+
+const PlanningIntervalObjectiveWorkItemsCard = ({
+  objectiveId,
+  canLinkWorkItems,
+}: PlanningIntervalObjectiveWorkItemsCardProps) => {
+  const [data, setData] = useState<SelectProps['options']>([])
+  const [searchQuery, setSearchQuery] = useState<string>('')
+
+  const debounceSearchQuery = useDebounce(searchQuery, 500)
+  const {
+    data: searchResult,
+    isSuccess,
+    isLoading,
+    isError,
+  } = useSearchWorkItemsQuery(debounceSearchQuery, {
+    skip: debounceSearchQuery === '',
+  })
+
+  //   const {
+  //     data: searchResult,
+  //     isSuccess,
+  //     isFetching,
+  //     isError,
+  //     refetch: fetch,
+  //   } = useSearchWorkItemsQuery(searchQuery, {
+  //     skip: searchQuery === '',
+  //   })
+
+  const handleSearch = (newValue: string) => {
+    setSearchQuery(newValue)
+  }
+
+  const handleChange = (newValue: string) => {
+    //setSearchQuery(newValue)
+  }
+
+  const testWorkItems = [
+    {
+      id: '1',
+      key: 'TEST-1',
+      title: 'Work Item 1',
+      status: 'In Progress',
+    },
+    {
+      id: '2',
+      key: 'TEST-2',
+      title: 'Work Item 2',
+      status: 'In Progress',
+    },
+    {
+      id: '3',
+      key: 'TEST-3',
+      title: 'Work Item 3',
+      status: 'In Progress',
+    },
+  ]
+  return (
+    <>
+      <Card
+        size="small"
+        title="Work Items"
+        style={{ width: 400 }}
+        // add search from api input
+        extra={
+          <>
+            {canLinkWorkItems && (
+              <Search
+                size="small"
+                placeholder="Add work item key"
+                allowClear
+                onSearch={handleSearch}
+              />
+              //   <Select
+              //     showSearch
+              //     allowClear
+              //     value={searchQuery}
+              //     placeholder="Add work item key"
+              //     size="small"
+              //     style={{ width: 200 }}
+              //     //style={props.style}
+              //     defaultActiveFirstOption={false}
+              //     suffixIcon={null}
+              //     filterOption={false}
+              //     onSearch={handleSearch}
+              //     onChange={handleChange}
+              //     notFoundContent={
+              //       isLoading ? 'Loading...' : 'No work items found'
+              //     }
+              //     options={(!searchQuery ? [] : searchResult || []).map((d) => ({
+              //       value: d.key,
+              //       label: `${d.key} - ${d.title}`,
+              //     }))}
+              //   />
+            )}
+          </>
+        }
+
+        // extra={
+        //   <>
+        //     {canCreateLinks && (
+        //       <Button
+        //         type="text"
+        //         icon={<PlusOutlined />}
+        //         onClick={() => setOpenCreateLinkForm(true)}
+        //       />
+        //     )}
+        //     {hasLinks && (canUpdateLinks || canDeleteLinks) && (
+        //       <EditModeButton />
+        //     )}
+        //   </>
+        // }
+      >
+        <WorkItemsListCard workItems={testWorkItems} />
+      </Card>
+    </>
+  )
+}
+
+export default PlanningIntervalObjectiveWorkItemsCard

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -4,9 +4,10 @@ import { WorkItemsListCard } from '@/src/app/components/common/work'
 import useAuth from '@/src/app/components/contexts/auth'
 import { useDebounce } from '@/src/app/hooks'
 import { useSearchWorkItemsQuery } from '@/src/store/features/work-management/workspace-api'
-import { PlusOutlined } from '@ant-design/icons'
+import { FormOutlined } from '@ant-design/icons'
 import { Button, Card, Input, Select, SelectProps } from 'antd'
 import { useState } from 'react'
+import ManagePlanningIntervalObjectiveWorkItemsForm from './manage-planning-interval-objective-work-items-form'
 
 const { Search } = Input
 
@@ -19,36 +20,29 @@ const PlanningIntervalObjectiveWorkItemsCard = ({
   objectiveId,
   canLinkWorkItems,
 }: PlanningIntervalObjectiveWorkItemsCardProps) => {
-  const [data, setData] = useState<SelectProps['options']>([])
-  const [searchQuery, setSearchQuery] = useState<string>('')
+  const [openManageWorkItemsForm, setOpenManageWorkItemsForm] =
+    useState<boolean>(false)
 
-  const debounceSearchQuery = useDebounce(searchQuery, 500)
-  const {
-    data: searchResult,
-    isSuccess,
-    isLoading,
-    isError,
-  } = useSearchWorkItemsQuery(debounceSearchQuery, {
-    skip: debounceSearchQuery === '',
-  })
+  //   const [data, setData] = useState<SelectProps['options']>([])
+  //   const [searchQuery, setSearchQuery] = useState<string>('')
 
+  //   const debounceSearchQuery = useDebounce(searchQuery, 500)
   //   const {
   //     data: searchResult,
   //     isSuccess,
-  //     isFetching,
+  //     isLoading,
   //     isError,
-  //     refetch: fetch,
-  //   } = useSearchWorkItemsQuery(searchQuery, {
-  //     skip: searchQuery === '',
+  //   } = useSearchWorkItemsQuery(debounceSearchQuery, {
+  //     skip: debounceSearchQuery === '',
   //   })
 
-  const handleSearch = (newValue: string) => {
-    setSearchQuery(newValue)
-  }
+  //   const handleSearch = (newValue: string) => {
+  //     setSearchQuery(newValue)
+  //   }
 
-  const handleChange = (newValue: string) => {
-    //setSearchQuery(newValue)
-  }
+  //   const handleChange = (newValue: string) => {
+  //     //setSearchQuery(newValue)
+  //   }
 
   const testWorkItems = [
     {
@@ -70,6 +64,14 @@ const PlanningIntervalObjectiveWorkItemsCard = ({
       status: 'In Progress',
     },
   ]
+
+  const onManageWorkItemsFormClosed = (wasSaved: boolean) => {
+    setOpenManageWorkItemsForm(false)
+    if (wasSaved) {
+      //refreshObjectives()
+    }
+  }
+
   return (
     <>
       <Card
@@ -80,12 +82,18 @@ const PlanningIntervalObjectiveWorkItemsCard = ({
         extra={
           <>
             {canLinkWorkItems && (
-              <Search
-                size="small"
-                placeholder="Add work item key"
-                allowClear
-                onSearch={handleSearch}
+              <Button
+                type="text"
+                icon={<FormOutlined />}
+                title="Manage work items"
+                onClick={() => setOpenManageWorkItemsForm(true)}
               />
+              //   <Search
+              //     size="small"
+              //     placeholder="Add work item key"
+              //     allowClear
+              //     onSearch={handleSearch}
+              //   />
               //   <Select
               //     showSearch
               //     allowClear
@@ -128,6 +136,14 @@ const PlanningIntervalObjectiveWorkItemsCard = ({
       >
         <WorkItemsListCard workItems={testWorkItems} />
       </Card>
+      {openManageWorkItemsForm && (
+        <ManagePlanningIntervalObjectiveWorkItemsForm
+          id={objectiveId}
+          showForm={openManageWorkItemsForm}
+          onFormSave={() => onManageWorkItemsFormClosed(true)}
+          onFormCancel={() => onManageWorkItemsFormClosed(false)}
+        />
+      )}
     </>
   )
 }

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -2463,7 +2463,7 @@ export class PlanningIntervalsClient {
     }
 
     /**
-     * Get work items for a planning interval objective.
+     * Get work items for an objective.
      */
     getObjectiveWorkItems(id: string, objectiveId: string, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
         let url_ = this.baseUrl + "/api/planning/planning-intervals/{id}/objectives/{objectiveId}/work-items";
@@ -2531,6 +2531,70 @@ export class PlanningIntervalsClient {
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);
         }
         return Promise.resolve<WorkItemListDto[]>(null as any);
+    }
+
+    /**
+     * Manage objective work items.
+     */
+    manageObjectiveWorkItems(id: string, objectiveId: string, request: ManagePlanningIntervalObjectiveWorkItemsRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/planning/planning-intervals/{id}/objectives/{objectiveId}/work-items";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (objectiveId === undefined || objectiveId === null)
+            throw new Error("The parameter 'objectiveId' must be defined.");
+        url_ = url_.replace("{objectiveId}", encodeURIComponent("" + objectiveId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processManageObjectiveWorkItems(_response);
+        });
+    }
+
+    protected processManageObjectiveWorkItems(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
     }
 
     /**
@@ -9063,6 +9127,12 @@ export interface WorkspaceNavigationDto extends NavigationDtoOfGuidAndString {
 }
 
 export interface EmployeeNavigationDto extends NavigationDto {
+}
+
+export interface ManagePlanningIntervalObjectiveWorkItemsRequest {
+    planningIntervalId?: string;
+    objectiveId?: string;
+    workItemIds?: string[];
 }
 
 export interface PlanningIntervalObjectiveStatusDto {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -4299,6 +4299,74 @@ export class WorkspacesClient {
         }
         return Promise.resolve<WorkItemDetailsDto>(null as any);
     }
+
+    /**
+     * Search for a work item using its key or title.
+     * @param query (optional) 
+     * @param top (optional) 
+     */
+    searchWorkItems(query: string | undefined, top: number | undefined, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
+        let url_ = this.baseUrl + "/api/work/workspaces/work-items/search?";
+        if (query === null)
+            throw new Error("The parameter 'query' cannot be null.");
+        else if (query !== undefined)
+            url_ += "query=" + encodeURIComponent("" + query) + "&";
+        if (top === null)
+            throw new Error("The parameter 'top' cannot be null.");
+        else if (top !== undefined)
+            url_ += "top=" + encodeURIComponent("" + top) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSearchWorkItems(_response);
+        });
+    }
+
+    protected processSearchWorkItems(response: AxiosResponse): Promise<WorkItemListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<WorkItemListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<WorkItemListDto[]>(null as any);
+    }
 }
 
 export class WorkStatusCategoriesClient {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -2590,6 +2590,20 @@ export class PlanningIntervalsClient {
             result400 = JSON.parse(resultData400);
             return throwException("A server side error occurred.", status, _responseText, _headers, result400);
 
+        } else if (status === 404) {
+            const _responseText = response.data;
+            let result404: any = null;
+            let resultData404  = _responseText;
+            result404 = JSON.parse(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = JSON.parse(resultData422);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
         } else if (status !== 200 && status !== 204) {
             const _responseText = response.data;
             return throwException("An unexpected server error occurred.", status, _responseText, _headers);

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -2463,6 +2463,77 @@ export class PlanningIntervalsClient {
     }
 
     /**
+     * Get work items for a planning interval objective.
+     */
+    getObjectiveWorkItems(id: string, objectiveId: string, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
+        let url_ = this.baseUrl + "/api/planning/planning-intervals/{id}/objectives/{objectiveId}/work-items";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (objectiveId === undefined || objectiveId === null)
+            throw new Error("The parameter 'objectiveId' must be defined.");
+        url_ = url_.replace("{objectiveId}", encodeURIComponent("" + objectiveId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetObjectiveWorkItems(_response);
+        });
+    }
+
+    protected processGetObjectiveWorkItems(response: AxiosResponse): Promise<WorkItemListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<WorkItemListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 404) {
+            const _responseText = response.data;
+            let result404: any = null;
+            let resultData404  = _responseText;
+            result404 = JSON.parse(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<WorkItemListDto[]>(null as any);
+    }
+
+    /**
      * Import objectives for a planning interval from a csv file.
      * @param contentType (optional) 
      * @param contentDisposition (optional) 
@@ -8972,6 +9043,28 @@ export interface PlanningIntervalObjectiveHealthCheckDto {
     note?: string | undefined;
 }
 
+export interface WorkItemListDto {
+    id?: string;
+    key?: string;
+    title?: string;
+    workspace?: WorkspaceNavigationDto;
+    type?: string;
+    status?: string;
+    assignedTo?: EmployeeNavigationDto | undefined;
+}
+
+export interface NavigationDtoOfGuidAndString {
+    id?: string;
+    key?: string | undefined;
+    name?: string;
+}
+
+export interface WorkspaceNavigationDto extends NavigationDtoOfGuidAndString {
+}
+
+export interface EmployeeNavigationDto extends NavigationDto {
+}
+
 export interface PlanningIntervalObjectiveStatusDto {
     id?: number;
     name?: string;
@@ -8990,9 +9083,6 @@ export interface RiskListDto {
     exposure?: string;
     assignee?: EmployeeNavigationDto | undefined;
     followUpDate?: Date | undefined;
-}
-
-export interface EmployeeNavigationDto extends NavigationDto {
 }
 
 export interface RiskDetailsDto {
@@ -9144,25 +9234,6 @@ export interface WorkspaceDto {
     workProcess?: SimpleNavigationDto;
     externalId?: string | undefined;
     isActive?: boolean;
-}
-
-export interface WorkItemListDto {
-    id?: string;
-    key?: string;
-    title?: string;
-    workspace?: WorkspaceNavigationDto;
-    type?: string;
-    status?: string;
-    assignedTo?: EmployeeNavigationDto | undefined;
-}
-
-export interface NavigationDtoOfGuidAndString {
-    id?: string;
-    key?: string | undefined;
-    name?: string;
-}
-
-export interface WorkspaceNavigationDto extends NavigationDtoOfGuidAndString {
 }
 
 export interface WorkItemDetailsDto {

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
@@ -69,10 +69,9 @@ export const planningIntervalApi = apiSlice.injectEndpoints({
       ],
     }),
     manageObjectiveWorkItems: builder.mutation<
-      null,
+      void,
       ManagePlanningIntervalObjectiveWorkItemsRequest
     >({
-      // TODO: why is this warning of an error
       queryFn: async (request) => {
         try {
           const data = await (

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
@@ -1,0 +1,71 @@
+import {
+  PlanningIntervalDetailsDto,
+  PlanningIntervalListDto,
+  WorkItemListDto,
+} from '@/src/services/moda-api'
+import { apiSlice } from '../apiSlice'
+import { getPlanningIntervalsClient } from '@/src/services/clients'
+import { QueryTags } from '../query-tags'
+
+export interface GetObjectiveWorkItemsRequest {
+  planningIntervalId: string
+  objectiveId: string
+}
+
+export const planningIntervalApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getPlanningIntervals: builder.query<PlanningIntervalListDto[], null>({
+      queryFn: async () => {
+        try {
+          const data = await (await getPlanningIntervalsClient()).getList()
+          return { data }
+        } catch (error) {
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        QueryTags.PlanningInterval,
+        ...result.map(({ id }) => ({ type: QueryTags.PlanningInterval, id })),
+      ],
+    }),
+    getPlanningInterval: builder.query<PlanningIntervalDetailsDto, string>({
+      queryFn: async (id: string) => {
+        try {
+          const data = await (await getPlanningIntervalsClient()).getById(id)
+          return { data }
+        } catch (error) {
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        { type: QueryTags.PlanningInterval, id: arg }, // typically arg is the key
+      ],
+    }),
+    getObjectiveWorkItems: builder.query<
+      WorkItemListDto[],
+      GetObjectiveWorkItemsRequest
+    >({
+      queryFn: async (request: GetObjectiveWorkItemsRequest) => {
+        try {
+          const data = await (
+            await getPlanningIntervalsClient()
+          ).getObjectiveWorkItems(
+            request.planningIntervalId,
+            request.objectiveId,
+          )
+          return { data }
+        } catch (error) {
+          console.error('Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        QueryTags.PlanningIntervalObjectiveWorkItem,
+        ...result.map(({ id }) => ({
+          type: QueryTags.PlanningIntervalObjectiveWorkItem,
+          id,
+        })),
+      ],
+    }),
+  }),
+})

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
@@ -69,3 +69,9 @@ export const planningIntervalApi = apiSlice.injectEndpoints({
     }),
   }),
 })
+
+export const {
+  useGetPlanningIntervalsQuery,
+  useGetPlanningIntervalQuery,
+  useGetObjectiveWorkItemsQuery,
+} = planningIntervalApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
@@ -72,15 +72,17 @@ export const planningIntervalApi = apiSlice.injectEndpoints({
       null,
       ManagePlanningIntervalObjectiveWorkItemsRequest
     >({
+      // TODO: why is this warning of an error
       queryFn: async (request) => {
         try {
-          await (
+          const data = await (
             await getPlanningIntervalsClient()
           ).manageObjectiveWorkItems(
             request.planningIntervalId,
             request.objectiveId,
             request,
           )
+          return { data }
         } catch (error) {
           console.error('Error:', error)
           return { error }
@@ -96,7 +98,6 @@ export const planningIntervalApi = apiSlice.injectEndpoints({
       },
     }),
   }),
-  overrideExisting: false,
 })
 
 export const {

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/planning/planning-interval-api.ts
@@ -1,4 +1,5 @@
 import {
+  ManagePlanningIntervalObjectiveWorkItemsRequest,
   PlanningIntervalDetailsDto,
   PlanningIntervalListDto,
   WorkItemListDto,
@@ -67,11 +68,40 @@ export const planningIntervalApi = apiSlice.injectEndpoints({
         })),
       ],
     }),
+    manageObjectiveWorkItems: builder.mutation<
+      null,
+      ManagePlanningIntervalObjectiveWorkItemsRequest
+    >({
+      queryFn: async (request) => {
+        try {
+          await (
+            await getPlanningIntervalsClient()
+          ).manageObjectiveWorkItems(
+            request.planningIntervalId,
+            request.objectiveId,
+            request,
+          )
+        } catch (error) {
+          console.error('Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => {
+        return [
+          {
+            type: QueryTags.PlanningIntervalObjectiveWorkItem,
+            id: arg.objectiveId,
+          },
+        ]
+      },
+    }),
   }),
+  overrideExisting: false,
 })
 
 export const {
   useGetPlanningIntervalsQuery,
   useGetPlanningIntervalQuery,
   useGetObjectiveWorkItemsQuery,
+  useManageObjectiveWorkItemsMutation,
 } = planningIntervalApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
@@ -1,4 +1,8 @@
 export enum QueryTags {
+  // PLANNING
+  PlanningInterval = 'Planning.PlanningInterval',
+  PlanningIntervalObjective = 'Planning.PlanningIntervalObjective',
+  PlanningIntervalObjectiveWorkItem = 'Planning.PlanningIntervalObjective.WorkItem',
   // WORK MANAGEMENT
   WorkItem = 'Work.WorkItem',
   WorkItemSearch = 'Work.WorkItem.Search',

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
@@ -1,6 +1,7 @@
 export enum QueryTags {
   // WORK MANAGEMENT
   WorkItem = 'Work.WorkItem',
+  WorkItemSearch = 'Work.WorkItem.Search',
   WorkProcess = 'Work.WorkProcess',
   Workspace = 'Work.Workspace',
 }

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/work-process-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/work-process-api.ts
@@ -66,14 +66,12 @@ export const workProcessApi = apiSlice.injectEndpoints({
           } else {
             data = await (await getWorkProcessesClient()).deactivate(id)
           }
-          console.log('changeWorkProcessIsActive', data)
           return { data }
         } catch (error) {
           return { error }
         }
       },
       invalidatesTags: (result, error, arg) => {
-        console.log('invalidatesTags', result, error, arg)
         return [{ type: QueryTags.WorkProcess, id: arg.id }]
       },
     }),

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -94,7 +94,6 @@ export const workspaceApi = apiSlice.injectEndpoints({
       ],
     }),
   }),
-  overrideExisting: false,
 })
 
 export const {

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -76,6 +76,24 @@ export const workspaceApi = apiSlice.injectEndpoints({
         { type: QueryTags.WorkItem, id: arg.workItemKey }, // typically arg is the key
       ],
     }),
+    searchWorkItems: builder.query<WorkItemListDto[], string>({
+      queryFn: async (searchTerm: string) => {
+        try {
+          console.log('searchWorkItems:', searchTerm)
+          const data = await (
+            await getWorkspacesClient()
+          ).searchWorkItems(searchTerm, 50)
+          return { data }
+        } catch (error) {
+          console.error('Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        QueryTags.WorkItemSearch,
+        ...result.map(({ key }) => ({ type: QueryTags.WorkItemSearch, key })),
+      ],
+    }),
   }),
 })
 
@@ -84,4 +102,5 @@ export const {
   useGetWorkspaceQuery,
   useGetWorkItemsQuery,
   useGetWorkItemQuery,
+  useSearchWorkItemsQuery,
 } = workspaceApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -79,7 +79,6 @@ export const workspaceApi = apiSlice.injectEndpoints({
     searchWorkItems: builder.query<WorkItemListDto[], string>({
       queryFn: async (searchTerm: string) => {
         try {
-          console.log('searchWorkItems:', searchTerm)
           const data = await (
             await getWorkspacesClient()
           ).searchWorkItems(searchTerm, 50)
@@ -95,6 +94,7 @@ export const workspaceApi = apiSlice.injectEndpoints({
       ],
     }),
   }),
+  overrideExisting: false,
 })
 
 export const {

--- a/Moda.Web/src/moda.web.reactclient/styles/globals.css
+++ b/Moda.Web/src/moda.web.reactclient/styles/globals.css
@@ -28,8 +28,3 @@ body {
 .site-layout .site-layout-background {
   background: #fff;
 }
-
-.ant-transfer-list-body-customize-wrapper {
-    height: 400px; /* static height here, maybe more? */
-    overflow-y: auto;
-}

--- a/Moda.Web/src/moda.web.reactclient/styles/globals.css
+++ b/Moda.Web/src/moda.web.reactclient/styles/globals.css
@@ -28,3 +28,8 @@ body {
 .site-layout .site-layout-background {
   background: #fff;
 }
+
+.ant-transfer-list-body-customize-wrapper {
+    height: 400px; /* static height here, maybe more? */
+    overflow-y: auto;
+}


### PR DESCRIPTION
- Added a new entity to map other objects like PI Objectives to WorkItems.
- Added a new query, API endpoint, and RTK store to
   - search for work items
   - get work items for a PI objective
- Added a command, API endpoint, and RTK store to manage PI objective work items.
- Added a card to the PI objective details page to view and manage work items.
- Added a form to add and remove work items from a PI objective.
- Added a debounce hook.

- Closes #237 