### PR TITLE
Feature/add external workitem url

### DIFF
--- a/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/CreateExternalWorkspaceCommand.cs
+++ b/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/CreateExternalWorkspaceCommand.cs
@@ -3,4 +3,4 @@ using Moda.Common.Domain.Models;
 using Moda.Common.Models;
 
 namespace Moda.Common.Application.Requests.WorkManagement;
-public sealed record CreateExternalWorkspaceCommand(IExternalWorkspaceConfiguration ExternalWorkspace, WorkspaceKey WorkspaceKey, string WorkspaceName) : ICommand<IntegrationState<Guid>>;
+public sealed record CreateExternalWorkspaceCommand(IExternalWorkspaceConfiguration ExternalWorkspace, WorkspaceKey WorkspaceKey, string WorkspaceName, string? ExternalViewWorkItemUrlTemplate) : ICommand<IntegrationState<Guid>>;

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240502110940_Add-ExternalViewWorkItemUrlTemplate-to-Workspace.Designer.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240502110940_Add-ExternalViewWorkItemUrlTemplate-to-Workspace.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moda.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Moda.Infrastructure.Persistence.Context;
 namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ModaDbContext))]
-    partial class ModaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240502110940_Add-ExternalViewWorkItemUrlTemplate-to-Workspace")]
+    partial class AddExternalViewWorkItemUrlTemplatetoWorkspace
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240502110940_Add-ExternalViewWorkItemUrlTemplate-to-Workspace.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240502110940_Add-ExternalViewWorkItemUrlTemplate-to-Workspace.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Moda.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddExternalViewWorkItemUrlTemplatetoWorkspace : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "ExternalViewWorkItemUrlTemplate",
+            schema: "Work",
+            table: "Workspaces",
+            type: "nvarchar(256)",
+            maxLength: 256,
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ExternalViewWorkItemUrlTemplate",
+            schema: "Work",
+            table: "Workspaces");
+    }
+}

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -282,6 +282,7 @@ public class WorkspaceConfig : IEntityTypeConfiguration<Workspace>
             .HasColumnType("varchar")
             .HasMaxLength(32);
         builder.Property(w => w.ExternalId);
+        builder.Property(w => w.ExternalViewWorkItemUrlTemplate).HasMaxLength(256);
         builder.Property(w => w.IsActive);
 
         // Audit

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsInitManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsInitManager.cs
@@ -146,7 +146,7 @@ public sealed class AzureDevOpsBoardsInitManager(ILogger<AzureDevOpsBoardsInitMa
         }
     }
 
-    public async Task<Result<Guid>> InitWorkspaceIntegration(Guid connectionId, Guid workspaceExternalId, string workspaceKey, string workspaceName, CancellationToken cancellationToken)
+    public async Task<Result<Guid>> InitWorkspaceIntegration(Guid connectionId, Guid workspaceExternalId, string workspaceKey, string workspaceName, string? externalViewWorkItemUrlTemplate, CancellationToken cancellationToken)
     {
         try
         {
@@ -188,7 +188,7 @@ public sealed class AzureDevOpsBoardsInitManager(ILogger<AzureDevOpsBoardsInitMa
                 return workspaceResult.ConvertFailure<Guid>();
 
             // create the workspace
-            var createWorkspaceResult = await _sender.Send(new CreateExternalWorkspaceCommand(workspaceResult.Value, new WorkspaceKey(workspaceKey), workspaceName), cancellationToken);
+            var createWorkspaceResult = await _sender.Send(new CreateExternalWorkspaceCommand(workspaceResult.Value, new WorkspaceKey(workspaceKey), workspaceName, externalViewWorkItemUrlTemplate), cancellationToken);
             if (createWorkspaceResult.IsFailure)
                 return createWorkspaceResult.ConvertFailure<Guid>();
 

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsInitManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Interfaces/IAzureDevOpsBoardsInitManager.cs
@@ -3,5 +3,5 @@ public interface IAzureDevOpsBoardsInitManager : ITransientService
 {
     Task<Result> SyncOrganizationConfiguration(Guid connectionId, CancellationToken cancellationToken);
     Task<Result<Guid>> InitWorkProcessIntegration(Guid connectionId, Guid workProcessExternalId, CancellationToken cancellationToken);
-    Task<Result<Guid>> InitWorkspaceIntegration(Guid connectionId, Guid workspaceExternalId, string workspaceKey, string workspaceName, CancellationToken cancellationToken);
+    Task<Result<Guid>> InitWorkspaceIntegration(Guid connectionId, Guid workspaceExternalId, string workspaceKey, string workspaceName, string? externalViewWorkItemUrlTemplate, CancellationToken cancellationToken);
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
@@ -18,6 +18,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
     public EmployeeNavigationDto? CreatedBy { get; set; }
     public Instant LastModified { get; private set; }
     public EmployeeNavigationDto? LastModifiedBy { get; set; }
+    public string? ExternalViewWorkItemUrl { get; set; }
 
     public void ConfigureMapping(TypeAdapterConfig config)
     {
@@ -27,6 +28,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
             .Map(dest => dest.Status, src => src.Status.Name)
             .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
             .Map(dest => dest.CreatedBy, src => src.CreatedBy == null ? null : EmployeeNavigationDto.From(src.CreatedBy))
-            .Map(dest => dest.LastModifiedBy, src => src.LastModifiedBy == null ? null : EmployeeNavigationDto.From(src.LastModifiedBy));
+            .Map(dest => dest.LastModifiedBy, src => src.LastModifiedBy == null ? null : EmployeeNavigationDto.From(src.LastModifiedBy))
+            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
@@ -12,6 +12,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
     public required string Status { get; set; }
     public WorkItemNavigationDto? Parent { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
+    public string? ExternalViewWorkItemUrl { get; set; }
 
     public void ConfigureMapping(TypeAdapterConfig config)
     {
@@ -19,7 +20,8 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
             .Map(dest => dest.Key, src => src.Key.ToString())
             .Map(dest => dest.Type, src => src.Type.Name)
             .Map(dest => dest.Status, src => src.Status.Name)
-            .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo));
+            .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
+            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
     }
 }
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/CreateExternalWorkspaceCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/CreateExternalWorkspaceCommandHandler.cs
@@ -26,6 +26,9 @@ public sealed class CreateExternalWorkspaceCommandHandlerValidator : CustomValid
             .NotEmpty()
             .MaximumLength(64)
             .MustAsync(BeUniqueWorkspaceName).WithMessage("The workspace name already exists.");
+
+        RuleFor(c => c.ExternalViewWorkItemUrlTemplate)
+            .MaximumLength(256);
     }
 
     public async Task<bool> BeUniqueWorkspaceKey(WorkspaceKey workspaceKey, CancellationToken cancellationToken)
@@ -58,7 +61,7 @@ internal sealed class CreateExternalWorkspaceCommandHandler(IWorkDbContext workD
 
         var timestamp = _dateTimeProvider.Now;
 
-        var workspace = Workspace.CreateExternal(request.WorkspaceKey, request.WorkspaceName, request.ExternalWorkspace.Description, request.ExternalWorkspace.Id, workProcess.Id, timestamp);
+        var workspace = Workspace.CreateExternal(request.WorkspaceKey, request.WorkspaceName, request.ExternalWorkspace.Description, request.ExternalWorkspace.Id, workProcess.Id, request.ExternalViewWorkItemUrlTemplate, timestamp);
 
         _workDbContext.Workspaces.Add(workspace);
         await _workDbContext.SaveChangesAsync(cancellationToken);

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/SetExternalViewWorkItemUrlTemplateCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/SetExternalViewWorkItemUrlTemplateCommand.cs
@@ -1,0 +1,40 @@
+﻿namespace Moda.Work.Application.Workspaces.Commands;
+public sealed record SetExternalViewWorkItemUrlTemplateCommand(Guid WorkspaceId, string? ExternalViewWorkItemUrlTemplate) : ICommand;
+
+internal sealed class SetExternalViewWorkItemUrlTemplateCommandHandler(IWorkDbContext workDbContext, ILogger<SetExternalViewWorkItemUrlTemplateCommandHandler> logger, IDateTimeProvider dateTimeProvider) : ICommandHandler<SetExternalViewWorkItemUrlTemplateCommand>
+{
+    private const string AppRequestName = nameof(SetExternalViewWorkItemUrlTemplateCommand);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<SetExternalViewWorkItemUrlTemplateCommandHandler> _logger = logger;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+
+    public async Task<Result> Handle(SetExternalViewWorkItemUrlTemplateCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var workspace = await _workDbContext.Workspaces.FirstOrDefaultAsync(w => w.Id == request.WorkspaceId, cancellationToken);
+            if (workspace is null)
+            {
+                _logger.LogWarning("Unable to set external view work item URL template for workspace {WorkspaceExternalId}. Workspace not found.", request.WorkspaceId);
+                return Result.Failure($"Unable to set external view work item URL template for workspace {{request.ExternalWorkspaceId}}. Workspace not found.");
+            }
+
+            var result = workspace.SetExternalViewWorkItemUrlTemplate(request.ExternalViewWorkItemUrlTemplate, _dateTimeProvider.Now);
+            if (result.IsFailure)
+            {
+                _logger.LogError("Failed to set external view work item URL template for workspace {WorkspaceExternalId}. Error: {Error}", request.WorkspaceId, result.Error);
+                return Result.Failure(result.Error);
+            }
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogDebug("Successfully set external view work item URL template for workspace {WorkspaceExternalId}.", request.WorkspaceId);
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/UpdateExternalWorkspaceCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/UpdateExternalWorkspaceCommandHandler.cs
@@ -1,7 +1,6 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Work.Application.WorkProcesses.Commands;
 using Moda.Work.Application.Workspaces.Validators;
-using Moda.Work.Domain.Models;
 
 namespace Moda.Work.Application.Workspaces.Commands;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Dtos/WorkspaceDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Dtos/WorkspaceDto.cs
@@ -10,6 +10,7 @@ public sealed record WorkspaceDto : IMapFrom<Workspace>
     public required SimpleNavigationDto Ownership { get; set; }
     public required SimpleNavigationDto WorkProcess { get; set; }
     public Guid? ExternalId { get; set; }
+    public string? ExternalViewWorkItemUrlTemplate { get; set; }
     public bool IsActive { get; set; }
 
     public void ConfigureMapping(TypeAdapterConfig config)

--- a/Moda.Web/src/Moda.Web.Api/Configurations/hangfire.json
+++ b/Moda.Web/src/Moda.Web.Api/Configurations/hangfire.json
@@ -12,7 +12,7 @@
                 "default",
                 "notdefault"
             ],
-            "SchedulePollingInterval": "00:00:15",
+            "SchedulePollingInterval": "00:01:00",
             "ServerCheckInterval": "00:05:00",
             "ServerName": null,
             "ServerTimeout": "00:05:00",
@@ -24,7 +24,7 @@
             "ConnectionString": "Data Source=(localdb)\\mssqllocaldb;Initial Catalog=Moda;Integrated Security=True;MultipleActiveResultSets=True",
             "Options": {
                 "CommandBatchMaxTimeout": "00:05:00",
-                "QueuePollInterval": "00:00:01",
+                "QueuePollInterval": "00:00:15",
                 "UseRecommendedIsolationLevel": true,
                 "SlidingInvisibilityTimeout": "00:05:00",
                 "DisableGlobalLocks": true,

--- a/Moda.Web/src/Moda.Web.Api/Controllers/AppIntegrations/AzureDevOpsBoardsConnectionsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/AppIntegrations/AzureDevOpsBoardsConnectionsController.cs
@@ -238,7 +238,7 @@ public class AzureDevOpsBoardsConnectionsController : ControllerBase
         if (id != request.Id)
             return BadRequest();
 
-        var result = await azureDevOpsBoardsImportService.InitWorkspaceIntegration(request.Id, request.ExternalId, request.WorkspaceKey, request.WorkspaceName, cancellationToken);
+        var result = await azureDevOpsBoardsImportService.InitWorkspaceIntegration(request.Id, request.ExternalId, request.WorkspaceKey, request.WorkspaceName, request.ExternalViewWorkItemUrlTemplate, cancellationToken);
         if (result.IsFailure)
         {
             var error = new ErrorResult

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
@@ -1,6 +1,8 @@
 ﻿using Moda.Common.Extensions;
+using Moda.Web.Api.Models.Work.Workspaces;
 using Moda.Work.Application.WorkItems.Dtos;
 using Moda.Work.Application.WorkItems.Queries;
+using Moda.Work.Application.Workspaces.Commands;
 using Moda.Work.Application.Workspaces.Dtos;
 using Moda.Work.Application.Workspaces.Queries;
 using Moda.Work.Domain.Models;
@@ -56,6 +58,22 @@ public class WorkspacesController(ILogger<WorkspacesController> logger, ISender 
                 ? result.Value
                 : NotFound();
     }
+
+    [HttpPut("{id}/external-url-templates")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.Workspaces)]
+    [OpenApiOperation("Set the external view work item URL template for a workspace.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> SetExternalUrlTemplates(Guid id, [FromBody] SetExternalUrlTemplatesRequest dto, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new SetExternalViewWorkItemUrlTemplateCommand(id, dto.ExternalViewWorkItemUrlTemplate), cancellationToken);
+
+        return result.IsFailure
+            ? BadRequest(ErrorResult.CreateBadRequest(result.Error, "WorkspacesController.SetExternalViewWorkItemUrlTemplate"))
+            : NoContent();
+    }
+
+    #region Work Items
 
     [HttpGet("{idOrKey}/work-items")]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.WorkItems)]
@@ -132,4 +150,5 @@ public class WorkspacesController(ILogger<WorkspacesController> logger, ISender 
             : Ok(result.Value.OrderByKey(true));
     }
 
+    #endregion Work Items
 }

--- a/Moda.Web/src/Moda.Web.Api/Models/AppIntegrations/Connections/InitWorkspaceIntegrationRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/AppIntegrations/Connections/InitWorkspaceIntegrationRequest.cs
@@ -23,6 +23,11 @@ public sealed record InitWorkspaceIntegrationRequest
     /// The name for the workspace.
     /// </summary>
     public required string WorkspaceName { get; set; }
+
+    /// <summary>
+    /// A url template for external work items.  This template plus the work item external id will create a url to view the work item in the external system.
+    /// </summary>
+    public string? ExternalViewWorkItemUrlTemplate { get; set; }
 }
 
 public sealed class InitWorkspaceIntegrationRequestValidator : CustomValidator<InitWorkspaceIntegrationRequest>
@@ -47,5 +52,8 @@ public sealed class InitWorkspaceIntegrationRequestValidator : CustomValidator<I
         RuleFor(c => c.WorkspaceName)
             .NotEmpty()
             .MaximumLength(64);
+
+        RuleFor(c => c.ExternalViewWorkItemUrlTemplate)
+            .MaximumLength(256);
     }
 }

--- a/Moda.Web/src/Moda.Web.Api/Models/Work/Workspaces/SetExternalUrlTemplatesRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Work/Workspaces/SetExternalUrlTemplatesRequest.cs
@@ -1,0 +1,14 @@
+﻿namespace Moda.Web.Api.Models.Work.Workspaces;
+
+public sealed record SetExternalUrlTemplatesRequest(string? ExternalViewWorkItemUrlTemplate);
+
+public sealed class SetExternalUrlTemplatesRequestValidator : CustomValidator<SetExternalUrlTemplatesRequest>
+{
+    public SetExternalUrlTemplatesRequestValidator()
+    {
+        RuleLevelCascadeMode = CascadeMode.Stop;
+
+        RuleFor(c => c.ExternalViewWorkItemUrlTemplate)
+            .MaximumLength(256);
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -3532,6 +3532,61 @@
         ]
       }
     },
+    "/api/work/workspaces/{id}/external-url-templates": {
+      "put": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Set the external view work item URL template for a workspace.",
+        "operationId": "Workspaces_SetExternalUrlTemplates",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "dto",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetExternalUrlTemplatesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/work/workspaces/{idOrKey}/work-items": {
       "get": {
         "tags": [
@@ -9319,8 +9374,24 @@
             "nullable": true,
             "example": "00000000-0000-0000-0000-000000000000"
           },
+          "externalViewWorkItemUrlTemplate": {
+            "type": "string",
+            "nullable": true
+          },
           "isActive": {
             "type": "boolean"
+          }
+        }
+      },
+      "SetExternalUrlTemplatesRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "externalViewWorkItemUrlTemplate": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 0,
+            "nullable": true
           }
         }
       },

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -8691,6 +8691,10 @@
                 "$ref": "#/components/schemas/EmployeeNavigationDto"
               }
             ]
+          },
+          "externalViewWorkItemUrl": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -9472,6 +9476,10 @@
                 "$ref": "#/components/schemas/EmployeeNavigationDto"
               }
             ]
+          },
+          "externalViewWorkItemUrl": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -10817,6 +10817,13 @@
             "maxLength": 64,
             "minLength": 1,
             "nullable": false
+          },
+          "externalViewWorkItemUrlTemplate": {
+            "type": "string",
+            "description": "A url template for external work items.  This template plus the work item external id will create a url to view the work item in the external system.",
+            "maxLength": 256,
+            "minLength": 0,
+            "nullable": true
           }
         }
       },

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/external-icon-link.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/external-icon-link.tsx
@@ -1,0 +1,30 @@
+import { ExportOutlined } from '@ant-design/icons'
+import Link from 'next/link'
+
+export interface ExternalIconLinkProps {
+  content: string | JSX.Element
+  url?: string | undefined
+  tooltip?: string | undefined
+}
+
+const ExternalIconLink = ({
+  content,
+  url,
+  tooltip,
+}: ExternalIconLinkProps): string | JSX.Element => {
+  if (!url) return content
+
+  return (
+    <>
+      {content}
+      &nbsp;
+      {
+        <Link href={url} target="_blank" title={tooltip}>
+          <ExportOutlined style={{ width: '12px' }} />
+        </Link>
+      }
+    </>
+  )
+}
+
+export default ExternalIconLink

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
@@ -1,6 +1,7 @@
 import { WorkItemListDto } from '@/src/services/moda-api'
 import { List, Space, Tag } from 'antd'
 import Link from 'next/link'
+import ExternalIconLink from '../external-icon-link'
 
 const { Item } = List
 const { Meta } = Item
@@ -10,15 +11,22 @@ export interface WorkItemListItemProps {
 }
 
 const WorkItemListItem = ({ workItem }: WorkItemListItemProps) => {
+  const workItemTitle = (
+    <Link
+      href={`/work/workspaces/${workItem.workspace.key}/work-items/${workItem.key}`}
+    >
+      {workItem.key} - {workItem.title}&nbsp;
+    </Link>
+  )
   return (
     <Item key={workItem.id}>
       <Meta
         title={
-          <Link
-            href={`/work/workspaces/${workItem.workspace.key}/work-items/${workItem.key}`}
-          >
-            {workItem.key} - {workItem.title}
-          </Link>
+          <ExternalIconLink
+            content={workItemTitle}
+            url={workItem.externalViewWorkItemUrl}
+            tooltip="Open in external system"
+          />
         }
         description={<WorkItemListItemDescription workItem={workItem} />}
       />

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/components/init-workspace-integration-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/connections/components/init-workspace-integration-form.tsx
@@ -6,6 +6,7 @@ import { Form, Input, Modal, message } from 'antd'
 import { useCallback, useEffect, useState } from 'react'
 
 const { Item } = Form
+const { TextArea } = Input
 
 export interface InitWorkspaceIntegrationFormProps {
   showForm: boolean
@@ -19,12 +20,14 @@ export interface InitWorkspaceIntegrationFormProps {
 interface InitWorkspaceIntegrationFormValues {
   workspaceKey: string
   workspaceName: string
+  viewWorkItemUrlTemplate?: string
 }
 
 const mapToRequestValues = (values: InitWorkspaceIntegrationFormValues) => {
   return {
     workspaceKey: values.workspaceKey,
     workspaceName: values.workspaceName,
+    externalViewWorkItemUrlTemplate: values.viewWorkItemUrlTemplate,
   } as InitWorkspaceIntegrationRequest
 }
 
@@ -180,6 +183,23 @@ const InitWorkspaceIntegrationForm = (
             rules={[{ required: true }]}
           >
             <Input showCount maxLength={64} />
+          </Item>
+          <Item
+            label="View Work Item URL Template"
+            name="viewWorkItemUrlTemplate"
+            extra={
+              <span>
+                <br />
+                This template plus the work item external id will create a URL
+                to view the work item in the external system.
+              </span>
+            }
+          >
+            <TextArea
+              autoSize={{ minRows: 1, maxRows: 4 }}
+              showCount
+              maxLength={256}
+            />
           </Item>
         </Form>
       </Modal>

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/set-workspace-external-url-templates-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/set-workspace-external-url-templates-form.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+import {
+  SetExternalUrlTemplatesRequest,
+  WorkspaceDto,
+} from '@/src/services/moda-api'
+import {
+  SetWorkspaceExternalUrlTemplatesRequest,
+  useGetWorkspaceQuery,
+  useSetWorkspaceExternalUrlTemplatesMutation,
+} from '@/src/store/features/work-management/workspace-api'
+import { toFormErrors } from '@/src/utils'
+import { Form, Input, Modal, message } from 'antd'
+import { useCallback, useEffect, useState } from 'react'
+
+const { Item } = Form
+const { TextArea } = Input
+
+export interface SetWorkspaceExternalUrlTemplatesFormProps {
+  showForm: boolean
+  workspaceId: string
+  onFormUpdate: () => void
+  onFormCancel: () => void
+}
+
+interface SetWorkspaceExternalUrlTemplatesFormValues {
+  externalViewWorkItemUrlTemplate?: string | undefined
+}
+
+const mapToRequestValues = (
+  workspaceId: string,
+  values: SetWorkspaceExternalUrlTemplatesFormValues,
+) => {
+  return {
+    workspaceId: workspaceId,
+    externalUrlTemplatesRequest: {
+      externalViewWorkItemUrlTemplate: values.externalViewWorkItemUrlTemplate,
+    } as SetExternalUrlTemplatesRequest,
+  } as SetWorkspaceExternalUrlTemplatesRequest
+}
+
+const SetWorkspaceExternalUrlTemplatesForm = (
+  props: SetWorkspaceExternalUrlTemplatesFormProps,
+) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isValid, setIsValid] = useState(false)
+  const [form] = Form.useForm<SetWorkspaceExternalUrlTemplatesFormValues>()
+  const formValues = Form.useWatch([], form)
+  const [messageApi, contextHolder] = message.useMessage()
+
+  const {
+    data: workspaceData,
+    isLoading,
+    refetch,
+  } = useGetWorkspaceQuery(props.workspaceId)
+  const [setWorkspaceExternalUrlTemplatesMutation] =
+    useSetWorkspaceExternalUrlTemplatesMutation()
+
+  const mapToFormValues = useCallback(
+    (workspace: WorkspaceDto) => {
+      form.setFieldsValue({
+        externalViewWorkItemUrlTemplate:
+          workspace.externalViewWorkItemUrlTemplate,
+      })
+    },
+    [form],
+  )
+
+  const update = async (
+    values: SetWorkspaceExternalUrlTemplatesFormValues,
+  ): Promise<boolean> => {
+    try {
+      const request = mapToRequestValues(props.workspaceId, values)
+      await setWorkspaceExternalUrlTemplatesMutation(request)
+      return true
+    } catch (error) {
+      if (error.status === 422 && error.errors) {
+        const formErrors = toFormErrors(error.errors)
+        form.setFields(formErrors)
+        messageApi.error('Correct the validation error(s) to continue.')
+      } else {
+        messageApi.error(
+          'An unexpected error occurred while updating external URL templates.',
+        )
+        console.error(error)
+      }
+      return false
+    }
+  }
+
+  const handleOk = async () => {
+    setIsSaving(true)
+    try {
+      const values = await form.validateFields()
+      if (await update(values)) {
+        setIsOpen(false)
+        form.resetFields()
+        props.onFormUpdate()
+        messageApi.success('Successfully set external URL templates')
+        refetch() // this makes sure the workspace data is updated if the form is opened again
+      }
+    } catch (errorInfo) {
+      console.log('handleOk error', errorInfo)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleCancel = useCallback(() => {
+    setIsOpen(false)
+    props.onFormCancel()
+    form.resetFields()
+  }, [props, form])
+
+  const loadData = useCallback(async () => {
+    try {
+      mapToFormValues(workspaceData)
+      setIsValid(true)
+    } catch (error) {
+      handleCancel()
+      messageApi.error('An unexpected error occurred while loading form data.')
+      console.error(error)
+    }
+  }, [handleCancel, mapToFormValues, messageApi, workspaceData])
+
+  useEffect(() => {
+    if (!workspaceData) return
+    setIsOpen(props.showForm)
+    if (props.showForm) {
+      loadData()
+    }
+  }, [isLoading, loadData, props.showForm, workspaceData])
+
+  useEffect(() => {
+    form.validateFields({ validateOnly: true }).then(
+      () => setIsValid(true && form.isFieldsTouched()),
+      () => setIsValid(false),
+    )
+  }, [form, formValues])
+
+  return (
+    <>
+      {contextHolder}
+      <Modal
+        title="Set External URL Templates"
+        open={isOpen}
+        onOk={handleOk}
+        okButtonProps={{ disabled: !isValid }}
+        okText="Save"
+        confirmLoading={isSaving}
+        onCancel={handleCancel}
+        maskClosable={false}
+        keyboard={false} // disable esc key to close modal
+        destroyOnClose={true}
+      >
+        <Form form={form} layout="vertical">
+          <Item
+            label="View Work Item URL"
+            name="externalViewWorkItemUrlTemplate"
+            extra={
+              <span>
+                <br />
+                This template plus the work item external id will create a url
+                to view the work item in the external system.
+              </span>
+            }
+            rules={[
+              {
+                max: 256,
+                message: 'The URL must be equal to or less than 256 characters',
+              },
+            ]}
+          >
+            <TextArea
+              autoSize={{ minRows: 1, maxRows: 4 }}
+              showCount
+              maxLength={256}
+            />
+          </Item>
+        </Form>
+      </Modal>
+    </>
+  )
+}
+
+export default SetWorkspaceExternalUrlTemplatesForm

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/page.tsx
@@ -1,11 +1,7 @@
 'use client'
 
 import { useAppDispatch, useDocumentTitle } from '@/src/app/hooks'
-import {
-  BreadcrumbItem,
-  setBreadcrumbRoute,
-  setBreadcrumbTitle,
-} from '@/src/store/breadcrumbs'
+import { BreadcrumbItem, setBreadcrumbRoute } from '@/src/store/breadcrumbs'
 import { useGetWorkItemQuery } from '@/src/store/features/work-management/workspace-api'
 import { notFound, usePathname } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
@@ -14,6 +10,9 @@ import { PageTitle } from '@/src/app/components/common'
 import { Card } from 'antd'
 import { authorizePage } from '@/src/app/components/hoc'
 import WorkItemDetails from './work-item-details'
+import Link from 'next/link'
+import { ExportOutlined } from '@ant-design/icons'
+import ExternalIconLink from '@/src/app/components/common/external-icon-link'
 
 enum WorkItemTabs {
   Details = 'details',
@@ -84,7 +83,16 @@ const WorkItemDetailsPage = ({ params }) => {
 
   return (
     <>
-      <PageTitle title={workItemData.title} subtitle="Work Item Details" />
+      <PageTitle
+        title={
+          <ExternalIconLink
+            content={workItemData?.title}
+            url={workItemData.externalViewWorkItemUrl}
+            tooltip="Open in external system"
+          />
+        }
+        subtitle="Work Item Details"
+      />
       <Card
         style={{ width: '100%' }}
         tabList={tabs}

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/page.tsx
@@ -31,7 +31,6 @@ const WorkspacesPage: React.FC = () => {
   const [currentView, setCurrentView] = useState<string | number>(Views.Cards)
 
   // TODO: add the ability to filter by active/inactive workspaces on both views
-  //const { includeInactive } = useAppSelector((state) => state.workspace)
 
   const {
     data: workspaceData,
@@ -39,7 +38,6 @@ const WorkspacesPage: React.FC = () => {
     error,
     refetch,
   } = useGetWorkspacesQuery(true)
-  //const dispatch = useAppDispatch()
 
   useEffect(() => {
     error && console.error(error)

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -4318,6 +4318,67 @@ export class WorkspacesClient {
     }
 
     /**
+     * Set the external view work item URL template for a workspace.
+     */
+    setExternalUrlTemplates(id: string, dto: SetExternalUrlTemplatesRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/work/workspaces/{id}/external-url-templates";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(dto);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSetExternalUrlTemplates(_response);
+        });
+    }
+
+    protected processSetExternalUrlTemplates(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Get work items for a workspace.
      */
     getWorkItems(idOrKey: string, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
@@ -9382,7 +9443,12 @@ export interface WorkspaceDto {
     ownership?: SimpleNavigationDto;
     workProcess?: SimpleNavigationDto;
     externalId?: string | undefined;
+    externalViewWorkItemUrlTemplate?: string | undefined;
     isActive?: boolean;
+}
+
+export interface SetExternalUrlTemplatesRequest {
+    externalViewWorkItemUrlTemplate?: string | undefined;
 }
 
 export interface WorkItemDetailsDto {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9795,6 +9795,8 @@ export interface InitWorkspaceIntegrationRequest {
     workspaceKey: string;
     /** The name for the workspace. */
     workspaceName: string;
+    /** A url template for external work items.  This template plus the work item external id will create a url to view the work item in the external system. */
+    externalViewWorkItemUrlTemplate?: string | undefined;
 }
 
 export interface ConnectorListDto {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9249,6 +9249,7 @@ export interface WorkItemListDto {
     status?: string;
     parent?: WorkItemNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;
+    externalViewWorkItemUrl?: string | undefined;
 }
 
 export interface NavigationDtoOfGuidAndString {
@@ -9467,6 +9468,7 @@ export interface WorkItemDetailsDto {
     createdBy?: EmployeeNavigationDto | undefined;
     lastModified?: Date;
     lastModifiedBy?: EmployeeNavigationDto | undefined;
+    externalViewWorkItemUrl?: string | undefined;
 }
 
 export interface WorkStatusCategoryListDto {

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -2,6 +2,7 @@ import { getWorkspacesClient } from '@/src/services/clients'
 import { apiSlice } from '../apiSlice'
 import { QueryTags } from '../query-tags'
 import {
+  SetExternalUrlTemplatesRequest,
   WorkItemDetailsDto,
   WorkItemListDto,
   WorkspaceDto,
@@ -11,6 +12,11 @@ import {
 export interface GetWorkItemRequest {
   workspaceIdOrKey: string
   workItemKey: string
+}
+
+export interface SetWorkspaceExternalUrlTemplatesRequest {
+  workspaceId: string
+  externalUrlTemplatesRequest: SetExternalUrlTemplatesRequest
 }
 
 export const workspaceApi = apiSlice.injectEndpoints({
@@ -43,6 +49,27 @@ export const workspaceApi = apiSlice.injectEndpoints({
       },
       providesTags: (result, error, arg) => [
         { type: QueryTags.Workspace, id: arg }, // typically arg is the key
+      ],
+    }),
+    setWorkspaceExternalUrlTemplates: builder.mutation<
+      void,
+      SetWorkspaceExternalUrlTemplatesRequest
+    >({
+      queryFn: async (request) => {
+        try {
+          await (
+            await getWorkspacesClient()
+          ).setExternalUrlTemplates(
+            request.workspaceId,
+            request.externalUrlTemplatesRequest,
+          )
+        } catch (error) {
+          console.error('Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [
+        { type: QueryTags.Workspace, id: arg.workspaceId },
       ],
     }),
     getWorkItems: builder.query<WorkItemListDto[], string>({
@@ -102,4 +129,5 @@ export const {
   useGetWorkItemsQuery,
   useGetWorkItemQuery,
   useSearchWorkItemsQuery,
+  useSetWorkspaceExternalUrlTemplatesMutation,
 } = workspaceApi


### PR DESCRIPTION
- Added the property ExternalViewWorkItemUrlTemplate to Workspace and updated the db configuration.
- Updated the init workspace process to include the ExternalViewWorkItemUrlTemplate.
- Added a new command and API endpoint to set URL templates for external work items. 
- Added the new endpoint to the RTK store and created a form to manage the values.
- Added the external icon link to the work item details page and objective work items.