### PR TITLE
Feature/add workitem management in piobjective drawer

### DIFF
--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-list-card.tsx
@@ -5,16 +5,19 @@ import WorkItemListItem from './work-item-list-item'
 
 export interface WorkItemsListCardProps {
   workItems: WorkItemListDto[]
+  isLoading: boolean
 }
 
-const WorkItemsListCard = ({ workItems }: WorkItemsListCardProps) => {
-  if (!workItems || workItems.length === 0)
-    return <ModaEmpty message="No work items" />
-
+const WorkItemsListCard = ({
+  workItems,
+  isLoading,
+}: WorkItemsListCardProps) => {
   return (
     <List
       size="small"
+      loading={isLoading}
       dataSource={workItems}
+      locale={{ emptyText: <ModaEmpty message="No work items" /> }}
       renderItem={(workItem) => <WorkItemListItem workItem={workItem} />}
     />
   )

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/components/planning-interval-objectives-drawer.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/components/planning-interval-objectives-drawer.tsx
@@ -14,6 +14,7 @@ interface PlanningIntervalObjectiveDetailsDrawerProps {
   objectiveId: string
   drawerOpen: boolean
   onDrawerClose: () => void
+  canManageObjectives: boolean
 }
 
 const PlanningIntervalObjectiveDetailsDrawer = (
@@ -93,7 +94,7 @@ const PlanningIntervalObjectiveDetailsDrawer = (
       <PlanningIntervalObjectiveWorkItemsCard
         planningIntervalId={props.planningIntervalId}
         objectiveId={props.objectiveId}
-        canLinkWorkItems={false}
+        canLinkWorkItems={props.canManageObjectives}
       />
     </Drawer>
   )

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/components/planning-interval-objectives-drawer.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/components/planning-interval-objectives-drawer.tsx
@@ -33,7 +33,7 @@ const PlanningIntervalObjectiveDetailsDrawer = (
     return null
   }
 
-  if (!objectiveData) return null
+  if (!objectiveDataIsLoading && !objectiveData) return null
 
   return (
     <Drawer
@@ -42,6 +42,7 @@ const PlanningIntervalObjectiveDetailsDrawer = (
       onClose={props.onDrawerClose}
       open={props.drawerOpen}
       destroyOnClose={true}
+      loading={objectiveDataIsLoading}
       width={
         window.innerWidth >= 1500
           ? '30%'

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-details.tsx
@@ -82,6 +82,7 @@ const PlanningIntervalObjectiveDetails = ({
           planningIntervalId={objective.planningInterval?.id}
           objectiveId={objective.id}
           canLinkWorkItems={canManageObjectives}
+          width={400}
         />
         <LinksCard objectId={objective.id} />
       </Space>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -59,7 +59,7 @@ const PlanningIntervalObjectiveWorkItemsCard = (
           </>
         }
       >
-        <WorkItemsListCard workItems={workItemsData} />
+        <WorkItemsListCard workItems={workItemsData} isLoading={isLoading} />
       </Card>
       {openManageWorkItemsForm && (
         <ManagePlanningIntervalObjectiveWorkItemsForm

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -13,6 +13,7 @@ export interface PlanningIntervalObjectiveWorkItemsCardProps {
   planningIntervalId: string
   objectiveId: string
   canLinkWorkItems: boolean
+  width?: string | number
 }
 
 const PlanningIntervalObjectiveWorkItemsCard = (
@@ -43,7 +44,7 @@ const PlanningIntervalObjectiveWorkItemsCard = (
       <Card
         size="small"
         title="Work Items"
-        style={{ width: 400 }}
+        style={{ width: props.width ? props.width : '100%' }}
         // add search from api input
         extra={
           <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-objectives-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-objectives-list-card.tsx
@@ -6,7 +6,6 @@ import { Badge, Button, Card, List, Space, message } from 'antd'
 import ObjectiveListItem from './objective-list-item'
 import ModaEmpty from '@/src/app/components/common/moda-empty'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import useAuth from '@/src/app/components/contexts/auth'
 import CreatePlanningIntervalObjectiveForm from '../../../components/create-planning-interval-objective-form'
 import useTheme from '@/src/app/components/contexts/theme'
 import {
@@ -35,6 +34,8 @@ export interface TeamObjectivesListCardProps {
   newObjectivesAllowed?: boolean
   refreshPlanningInterval: () => void
   onObjectiveClick: (objectiveId: string) => void
+  canManageObjectives: boolean
+  canCreateHealthChecks: boolean
 }
 
 const sortOrderedObjectives = (
@@ -58,6 +59,8 @@ const TeamObjectivesListCard = ({
   newObjectivesAllowed = false,
   refreshPlanningInterval,
   onObjectiveClick,
+  canManageObjectives,
+  canCreateHealthChecks,
 }: TeamObjectivesListCardProps) => {
   const [openCreateObjectiveForm, setOpenCreateObjectiveForm] =
     useState<boolean>(false)
@@ -69,16 +72,8 @@ const TeamObjectivesListCard = ({
 
   const { badgeColor } = useTheme()
 
-  const { hasClaim } = useAuth()
-  const canManageObjectives = hasClaim(
-    'Permission',
-    'Permissions.PlanningIntervalObjectives.Manage',
-  )
   const canCreateObjectives =
     newObjectivesAllowed && planningIntervalId && canManageObjectives
-  const canCreateHealthChecks =
-    !!canManageObjectives &&
-    hasClaim('Permission', 'Permissions.HealthChecks.Create')
 
   const sensors = useSensors(
     useSensor(PointerSensor),

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-plan-review.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-plan-review.tsx
@@ -21,6 +21,7 @@ import {
   useGetTeamPlanningIntervalPredictability,
 } from '@/src/services/queries/planning-queries'
 import { useGetPlanningIntervalObjectivesQuery } from '@/src/store/features/planning/planning-interval-api'
+import useAuth from '@/src/app/components/contexts/auth'
 
 const { Title } = Typography
 
@@ -72,6 +73,17 @@ const TeamPlanReview = ({
     planningInterval?.id,
     team?.id,
   )
+
+  const { hasClaim } = useAuth()
+  const canManageObjectives = hasClaim(
+    'Permission',
+    'Permissions.PlanningIntervalObjectives.Manage',
+  )
+  const canCreatePIObjectiveHealthChecks =
+    !!canManageObjectives &&
+    hasClaim('Permission', 'Permissions.HealthChecks.Create')
+  const canCreateRisks = hasClaim('Permission', 'Permissions.Risks.Create')
+  const canUpdateRisks = hasClaim('Permission', 'Permissions.Risks.Update')
 
   const viewSelector = useMemo(
     () => (
@@ -128,10 +140,17 @@ const TeamPlanReview = ({
               }
               refreshPlanningInterval={refreshPlanningInterval}
               onObjectiveClick={onObjectiveClick}
+              canManageObjectives={canManageObjectives}
+              canCreateHealthChecks={canCreatePIObjectiveHealthChecks}
             />
           </Col>
           <Col xs={24} sm={24} md={24} lg={12}>
-            <TeamRisksListCard riskQuery={risksQuery} teamId={team?.id} />
+            <TeamRisksListCard
+              riskQuery={risksQuery}
+              teamId={team?.id}
+              canCreateRisks={canCreateRisks}
+              canUpdateRisks={canUpdateRisks}
+            />
           </Col>
         </Row>
       ) : (
@@ -146,6 +165,7 @@ const TeamPlanReview = ({
           objectiveId={selectedObjectiveId}
           drawerOpen={drawerOpen}
           onDrawerClose={onDrawerClose}
+          canManageObjectives={canManageObjectives}
         />
       )}
     </>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-risks-list-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-risks-list-card.tsx
@@ -6,7 +6,6 @@ import { Badge, Button, Card, List, Space } from 'antd'
 import RiskListItem from './risk-list-item'
 import ModaEmpty from '@/src/app/components/common/moda-empty'
 import { useCallback, useMemo, useState } from 'react'
-import useAuth from '@/src/app/components/contexts/auth'
 import CreateRiskForm from '@/src/app/components/common/planning/create-risk-form'
 import { UseQueryResult } from 'react-query'
 import useTheme from '@/src/app/components/contexts/theme'
@@ -14,18 +13,21 @@ import useTheme from '@/src/app/components/contexts/theme'
 export interface TeamRisksListCardProps {
   riskQuery: UseQueryResult<RiskListDto[], unknown>
   teamId: string
+  canCreateRisks: boolean
+  canUpdateRisks: boolean
 }
 
 const categoryOrder = ['Owned', 'Accepted', 'Mitigated', 'Resolved']
 const exposureOrder = ['High', 'Medium', 'Low']
 
-const TeamRisksListCard = ({ riskQuery, teamId }: TeamRisksListCardProps) => {
+const TeamRisksListCard = ({
+  riskQuery,
+  teamId,
+  canCreateRisks,
+  canUpdateRisks,
+}: TeamRisksListCardProps) => {
   const [openCreateRiskForm, setOpenCreateRiskForm] = useState<boolean>(false)
   const theme = useTheme()
-
-  const { hasClaim } = useAuth()
-  const canCreateRisks = hasClaim('Permission', 'Permissions.Risks.Create')
-  const canUpdateRisks = hasClaim('Permission', 'Permissions.Risks.Update')
 
   const refreshRisks = useCallback(() => {
     riskQuery.refetch()


### PR DESCRIPTION
- Moved the claims checks up to the team plan review component. Enabled work item management on the PI objective panel based on permissions.
- Added an optional width prop to PlanningIntervalObjectiveWorkItemsCardProps to improve layout capabilities.
- Added loading indicators for the PI objective panel and work items components.