### PR TITLE
Creates AgGrid transfer grid & updates work item grid to use it

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,6 +24,10 @@ dotnet_style_prefer_simplified_interpolation = true:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_readonly_field = true:warning
 
+# ts/tsx/js/jsx
+[*.{ts,tsx,js,jsx}]
+indent_size = 2
+
 # Xml files
 [*.xml]
 indent_size = 2

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/AgGridTransfer.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/AgGridTransfer.tsx
@@ -1,0 +1,110 @@
+import { ColDef, GetRowIdParams, GridReadyEvent, ICellRendererParams, RowDragEndEvent } from 'ag-grid-community'
+import { DeleteFilled } from '@ant-design/icons'
+import useTheme from '@/src/app/components/contexts/theme'
+import React, { useCallback, useRef, useState } from 'react'
+import { AgGridReact } from 'ag-grid-react'
+import { Flex } from 'antd'
+
+export const asDraggableColDefs = <TData extends object>(colDefs: ColDef<TData>[]): ColDef<TData>[] => [
+  {
+    rowDrag: true,
+    maxWidth: 50,
+    suppressHeaderMenuButton: true,
+    rowDragText: (params, dragItemCount) => {
+      if (dragItemCount > 1) {
+        return dragItemCount + ' items'
+      }
+      return params.rowNode!.data.key
+    }
+  },
+  ...colDefs
+]
+
+export const asDeletableColDefs = <TData extends object>(colDefs: ColDef<TData>[]): ColDef<TData>[] => [
+  ...colDefs,
+  {
+    maxWidth: 50,
+    suppressHeaderMenuButton: true,
+    cellStyle: { textAlign: 'center' },
+    cellRenderer: (props: ICellRendererParams<TData>) => (
+      <DeleteFilled
+        onClick={() => {
+          props.api.applyTransaction({ remove: [props.data] })
+        }}
+      />
+    )
+  }
+]
+
+interface GridTransferProps<TData extends object> {
+  leftGridData?: TData[];
+  rightGridData?: TData[];
+  leftColumnDef: ColDef<TData>[];
+  rightColumnDef: ColDef<TData>[];
+  getRowId: (params: GetRowIdParams<TData>) => string;
+  removeRowFromSource?: boolean;
+  leftGridRef?: React.MutableRefObject<AgGridReact<TData>>;
+  rightGridRef?: React.MutableRefObject<AgGridReact<TData>>;
+}
+
+const defaultColDef: ColDef = {
+  flex: 1,
+  minWidth: 50,
+  filter: false
+}
+
+export const AgGridTransfer = <TData extends object>(props: GridTransferProps<TData>): React.ReactNode => {
+  const { agGridTheme } = useTheme()
+
+  const localLeftGridRef = useRef<AgGridReact<TData>>(null)
+  const localRightGridRef = useRef<AgGridReact<TData>>(null)
+
+  const leftGridRef = props.leftGridRef ?? localLeftGridRef
+  const rightGridRef = props.rightGridRef ?? localRightGridRef
+
+  const onDragStop = useCallback((params: RowDragEndEvent) => {
+    if (props.removeRowFromSource)
+      leftGridRef.current.api?.applyTransaction({ remove: [params.node.data] })
+    else
+      leftGridRef.current.api?.setNodesSelected({ nodes: params.nodes, newValue: false })
+  }, [leftGridRef, props.removeRowFromSource])
+
+  const onGridReady = useCallback((event: GridReadyEvent<TData>) => {
+
+    if (leftGridRef.current === null || rightGridRef.current === null) return
+
+    const dropZoneParams = rightGridRef.current.api.getRowDropZoneParams({ onDragStop })
+
+    leftGridRef.current.api.removeRowDropZone(dropZoneParams)
+    leftGridRef.current.api.addRowDropZone(dropZoneParams)
+  }, [leftGridRef, onDragStop, rightGridRef])
+
+
+  const getGrid = useCallback((isLeft: boolean) => (
+    <div className={agGridTheme} style={{ minHeight: 250, width: '100%' }}>
+      <AgGridReact
+        ref={isLeft ? leftGridRef : rightGridRef}
+        defaultColDef={defaultColDef}
+        getRowId={props.getRowId}
+        rowDragManaged={true}
+        rowSelection={isLeft ? 'multiple' : undefined}
+        rowDragMultiRow={isLeft}
+        suppressRowClickSelection={isLeft}
+        suppressMoveWhenRowDragging={isLeft}
+
+        rowData={isLeft ? props.leftGridData : props.rightGridData}
+        columnDefs={isLeft ? props.leftColumnDef : props.rightColumnDef}
+        onGridReady={onGridReady}
+      />
+    </div>
+  ), [agGridTheme, leftGridRef, rightGridRef, props.getRowId, props.leftGridData, props.rightGridData, props.leftColumnDef, props.rightColumnDef, onGridReady])
+
+
+  return (
+    <Flex gap="middle" style={{ width: '100%' }}>
+      {getGrid(true)}
+      {getGrid(false)}
+    </Flex>
+  )
+
+}

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/ag-grid-transfer.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/ag-grid-transfer.tsx
@@ -1,5 +1,5 @@
 import { ColDef, GetRowIdParams, GridReadyEvent, ICellRendererParams, RowDragEndEvent } from 'ag-grid-community'
-import { DeleteFilled } from '@ant-design/icons'
+import { DeleteOutlined } from '@ant-design/icons'
 import useTheme from '@/src/app/components/contexts/theme'
 import React, { useCallback, useRef, useState } from 'react'
 import { AgGridReact } from 'ag-grid-react'
@@ -31,7 +31,7 @@ export const asDeletableColDefs = <TData extends object>(colDefs: ColDef<TData>[
     filter: false,
     sortable: false,
     cellRenderer: (props: ICellRendererParams<TData>) => (
-      <DeleteFilled
+      <DeleteOutlined
         onClick={() => {
           props.api.applyTransaction({ remove: [props.data] })
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -12,7 +12,7 @@ import { Input, message, Modal, Space, Typography } from 'antd'
 import { useEffect, useRef, useState } from 'react'
 import { ColDef } from 'ag-grid-community'
 import { AgGridReact } from 'ag-grid-react'
-import { AgGridTransfer, asDeletableColDefs, asDraggableColDefs } from '@/src/app/components/common/grid/AgGridTransfer'
+import { AgGridTransfer, asDeletableColDefs, asDraggableColDefs } from '@/src/app/components/common/grid/ag-grid-transfer'
 
 const { Text } = Typography
 


### PR DESCRIPTION
This PR creates the "AgGridTransfer" component which allows moving items from one grid to another.

It also updates the "Manage PI Objective Work Items" dialog to use this transfer component.
![image](https://github.com/destacey/Moda/assets/26073824/4b20ac1e-13c7-4364-a310-49f0df6cc1a1)
