### PR TITLE
Feature/add statuscategory to workitems

### DIFF
--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240606024848_Add-WorkStatusCategory-to-WorkItem.Designer.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240606024848_Add-WorkStatusCategory-to-WorkItem.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moda.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Moda.Infrastructure.Persistence.Context;
 namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ModaDbContext))]
-    partial class ModaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240606024848_Add-WorkStatusCategory-to-WorkItem")]
+    partial class AddWorkStatusCategorytoWorkItem
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -2299,7 +2302,7 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 
             modelBuilder.Entity("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnection", b =>
                 {
-                    b.OwnsOne("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnection.Configuration#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnectionConfiguration", "Configuration", b1 =>
+                    b.OwnsOne("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnectionConfiguration", "Configuration", b1 =>
                         {
                             b1.Property<Guid>("AzureDevOpsBoardsConnectionId")
                                 .HasColumnType("uniqueidentifier");
@@ -2321,7 +2324,7 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
                             b1.WithOwner()
                                 .HasForeignKey("AzureDevOpsBoardsConnectionId");
 
-                            b1.OwnsMany("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnection.Configuration#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnectionConfiguration.WorkProcesses#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkProcess", "WorkProcesses", b2 =>
+                            b1.OwnsMany("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkProcess", "WorkProcesses", b2 =>
                                 {
                                     b2.Property<Guid>("AzureDevOpsBoardsConnectionConfigurationAzureDevOpsBoardsConnectionId")
                                         .HasColumnType("uniqueidentifier");
@@ -2347,7 +2350,7 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
                                     b2.WithOwner()
                                         .HasForeignKey("AzureDevOpsBoardsConnectionConfigurationAzureDevOpsBoardsConnectionId");
 
-                                    b2.OwnsOne("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnection.Configuration#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnectionConfiguration.WorkProcesses#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkProcess.IntegrationState#Moda.Common.Domain.Models.IntegrationState<System.Guid>", "IntegrationState", b3 =>
+                                    b2.OwnsOne("Moda.Common.Domain.Models.IntegrationState<System.Guid>", "IntegrationState", b3 =>
                                         {
                                             b3.Property<Guid>("AzureDevOpsBoardsWorkProcessAzureDevOpsBoardsConnectionConfigurationAzureDevOpsBoardsConnectionId")
                                                 .HasColumnType("uniqueidentifier");
@@ -2372,7 +2375,7 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
                                     b2.Navigation("IntegrationState");
                                 });
 
-                            b1.OwnsMany("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnection.Configuration#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnectionConfiguration.Workspaces#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkspace", "Workspaces", b2 =>
+                            b1.OwnsMany("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkspace", "Workspaces", b2 =>
                                 {
                                     b2.Property<Guid>("AzureDevOpsBoardsConnectionConfigurationAzureDevOpsBoardsConnectionId")
                                         .HasColumnType("uniqueidentifier");
@@ -2401,7 +2404,7 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
                                     b2.WithOwner()
                                         .HasForeignKey("AzureDevOpsBoardsConnectionConfigurationAzureDevOpsBoardsConnectionId");
 
-                                    b2.OwnsOne("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnection.Configuration#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsConnectionConfiguration.Workspaces#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkspace.IntegrationState#Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkspace.IntegrationState#IntegrationState", "IntegrationState", b3 =>
+                                    b2.OwnsOne("Moda.AppIntegration.Domain.Models.AzureDevOpsBoardsWorkspace.IntegrationState#IntegrationState", "IntegrationState", b3 =>
                                         {
                                             b3.Property<Guid>("AzureDevOpsBoardsWorkspaceAzureDevOpsBoardsConnectionConfigurationAzureDevOpsBoardsConnectionId")
                                                 .HasColumnType("uniqueidentifier");

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240606024848_Add-WorkStatusCategory-to-WorkItem.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20240606024848_Add-WorkStatusCategory-to-WorkItem.cs
@@ -1,0 +1,55 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Moda.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddWorkStatusCategorytoWorkItem : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "StatusCategory",
+            schema: "Work",
+            table: "WorkItems",
+            type: "varchar(32)",
+            maxLength: 32,
+            nullable: true);
+
+        // Update the StatusCategory column with the WorkStatusCategory from the Workflows table
+        migrationBuilder.Sql($@"
+            UPDATE wi
+            SET wi.StatusCategory = wfs.WorkStatusCategory
+            FROM [Work].WorkItems wi
+                INNER JOIN [Work].[Workspaces] ws ON wi.WorkspaceId = ws.Id
+                INNER JOIN [Work].[WorkProcesses] wp ON ws.WorkProcessId = wp.Id
+                INNER JOIN [Work].[WorkProcessSchemes] wps ON wp.Id = wps.WorkProcessId AND wi.TypeId = wps.WorkTypeId
+                INNER JOIN [Work].[Workflows] wf ON wps.WorkflowId = wf.Id
+                INNER JOIN [Work].[WorkflowSchemes] wfs ON wf.Id = wfs.WorkflowId AND wi.StatusId = wfs.WorkStatusId
+            WHERE wi.StatusCategory IS NULL");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "StatusCategory",
+            schema: "Work",
+            table: "WorkItems",
+            type: "varchar(32)",
+            maxLength: 32,
+            nullable: false,
+            defaultValue: "",
+            oldClrType: typeof(string),
+            oldType: "varchar(32)",
+            oldMaxLength: 32,
+            oldNullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "StatusCategory",
+            schema: "Work",
+            table: "WorkItems");
+    }
+}

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -63,7 +63,6 @@ public class WorkItemLinkConfig : IEntityTypeConfiguration<WorkItemLink>
             .HasColumnType("varchar")
             .HasMaxLength(64);
 
-
         // Relationships
     }
 }
@@ -136,7 +135,7 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             .HasForeignKey(w => w.LastModifiedById)
             .OnDelete(DeleteBehavior.Restrict);
 
-        builder.HasMany<WorkItemLink>()
+        builder.HasMany<WorkItemLink>(w => w.SystemLinks)
             .WithOne()
             .HasForeignKey(w => w.WorkItemId)
             .OnDelete(DeleteBehavior.Cascade);

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -96,6 +96,10 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             .HasColumnType("varchar")
             .HasMaxLength(64);
         builder.Property(w => w.Title).IsRequired().HasMaxLength(256);
+        builder.Property(w => w.StatusCategory).IsRequired()
+            .HasConversion<EnumConverter<WorkStatusCategory>>()
+            .HasColumnType("varchar")
+            .HasMaxLength(32);
         builder.Property(w => w.ExternalId);
         builder.Property(w => w.Priority);
         builder.Property(w => w.StackRank);

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Common.Application.Employees.Dtos;
+﻿using Moda.Common.Application.Dtos;
+using Moda.Common.Application.Employees.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Dtos;
@@ -11,6 +12,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
     public required WorkspaceNavigationDto Workspace { get; set; }
     public required string Type { get; set; }
     public required string Status { get; set; }
+    public required SimpleNavigationDto StatusCategory { get; set; }
     public int? Priority { get; set; }
     public WorkItemNavigationDto? Parent { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
@@ -26,6 +28,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
             .Map(dest => dest.Key, src => src.Key.ToString())
             .Map(dest => dest.Type, src => src.Type.Name)
             .Map(dest => dest.Status, src => src.Status.Name)
+            .Map(dest => dest.StatusCategory, src => SimpleNavigationDto.FromEnum(src.StatusCategory))
             .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
             .Map(dest => dest.CreatedBy, src => src.CreatedBy == null ? null : EmployeeNavigationDto.From(src.CreatedBy))
             .Map(dest => dest.LastModifiedBy, src => src.LastModifiedBy == null ? null : EmployeeNavigationDto.From(src.LastModifiedBy))

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
@@ -14,6 +14,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
     public required SimpleNavigationDto StatusCategory { get; set; }
     public WorkItemNavigationDto? Parent { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
+    public double StackRank { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }
 
     public void ConfigureMapping(TypeAdapterConfig config)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Common.Application.Employees.Dtos;
+﻿using Moda.Common.Application.Dtos;
+using Moda.Common.Application.Employees.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Dtos;
@@ -10,6 +11,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
     public required WorkspaceNavigationDto Workspace { get; set; }
     public required string Type { get; set; }
     public required string Status { get; set; }
+    public required SimpleNavigationDto StatusCategory { get; set; }
     public WorkItemNavigationDto? Parent { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }
@@ -20,6 +22,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
             .Map(dest => dest.Key, src => src.Key.ToString())
             .Map(dest => dest.Type, src => src.Type.Name)
             .Map(dest => dest.Status, src => src.Status.Name)
+            .Map(dest => dest.StatusCategory, src => SimpleNavigationDto.FromEnum(src.StatusCategory))
             .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
             .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
     }
@@ -30,9 +33,9 @@ public static class WorkItemListDtoExtensions
     public static IEnumerable<WorkItemListDto> OrderByKey(this IEnumerable<WorkItemListDto> query, bool ascending)
     {
         return ascending
-            ? query.OrderBy(x => x.Key.Split('-')[0])
-                   .ThenBy(x => int.Parse(x.Key.Split('-')[1]))
-            : query.OrderByDescending(x => x.Key.Split('-')[0])
-                   .ThenByDescending(x => int.Parse(x.Key.Split('-')[1]));
+            ? query.OrderBy(x => x.Key[..x.Key.IndexOf('-')])
+                   .ThenBy(x => int.Parse(x.Key[(x.Key.IndexOf('-') + 1)..]))
+            : query.OrderByDescending(x => x.Key[..x.Key.IndexOf('-')])
+                   .ThenByDescending(x => int.Parse(x.Key[(x.Key.IndexOf('-') + 1)..]));
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetChildWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetChildWorkItemsQuery.cs
@@ -1,0 +1,63 @@
+﻿using Moda.Common.Models;
+using Moda.Work.Application.WorkItems.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Queries;
+public sealed record GetChildWorkItemsQuery : IQuery<Result<IReadOnlyCollection<WorkItemListDto>>>
+{
+    public GetChildWorkItemsQuery(Guid workspaceId, WorkItemKey workItemKey)
+    {
+        Id = Guard.Against.NullOrEmpty(workspaceId);
+        WorkItemKey = workItemKey;
+    }
+
+    public GetChildWorkItemsQuery(WorkspaceKey workspaceKey, WorkItemKey workItemKey)
+    {
+        Key = Guard.Against.Default(workspaceKey);
+        WorkItemKey = workItemKey;
+    }
+
+    public Guid? Id { get; }
+    public WorkspaceKey? Key { get; }
+    public WorkItemKey WorkItemKey { get; }
+}
+
+internal sealed class GetChildWorkItemsQueryHandler(IWorkDbContext workDbContext, ILogger<GetChildWorkItemsQueryHandler> logger) : IQueryHandler<GetChildWorkItemsQuery, Result<IReadOnlyCollection<WorkItemListDto>>>
+{
+    private const string AppRequestName = nameof(GetChildWorkItemsQuery);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<GetChildWorkItemsQueryHandler> _logger = logger;
+
+    public async Task<Result<IReadOnlyCollection<WorkItemListDto>>> Handle(GetChildWorkItemsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _workDbContext.WorkItems
+            .Where(w => w.Key == request.WorkItemKey)
+            .AsQueryable();
+
+        if (request.Id.HasValue)
+        {
+            query = query.Where(w => w.WorkspaceId == request.Id);
+        }
+        else if (request.Key is not null)
+        {
+            query = query.Where(w => w.Workspace.Key == request.Key);
+        }
+        else
+        {
+            _logger.LogError("{AppRequestName}: No workspace id or key provided. {@Request}", AppRequestName, request);
+            return Result.Failure<IReadOnlyCollection<WorkItemListDto>>("No valid workspace id or key provided.");
+        }
+
+        var workItemId = await query.Select(e => e.Id).FirstOrDefaultAsync(cancellationToken);
+        if (workItemId.IsDefault())
+        {
+            _logger.LogError("{AppRequestName}: Work item not found. {@Request}", AppRequestName, request);
+            return Result.Failure<IReadOnlyCollection<WorkItemListDto>>("Work item not found.");
+        }
+
+        return await _workDbContext.WorkItems
+            .Where(w => w.ParentId == workItemId)
+            .ProjectToType<WorkItemListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
@@ -12,16 +12,8 @@ internal sealed class GetExternalObjectWorkItemsQueryHandler(IWorkDbContext work
 
     public async Task<IReadOnlyCollection<WorkItemListDto>> Handle(GetExternalObjectWorkItemsQuery request, CancellationToken cancellationToken)
     {
-        var workItemIds = await _workDbContext.WorkItemLinks
-            .Where(e => e.ObjectId == request.ObjectId)
-            .Select(e => e.WorkItemId)
-            .ToArrayAsync(cancellationToken);
-
-        if (workItemIds.Length == 0)
-            return [];
-
         return await _workDbContext.WorkItems
-            .Where(e => workItemIds.Contains(e.Id))
+            .Where(e => e.SystemLinks.Any(sl => sl.ObjectId == request.ObjectId))
             .ProjectToType<WorkItemListDto>()
             .ToListAsync(cancellationToken);
     }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemQuery.cs
@@ -31,16 +31,16 @@ internal sealed class GetWorkItemQueryHandler(IWorkDbContext workDbContext, ILog
     public async Task<Result<WorkItemDetailsDto?>> Handle(GetWorkItemQuery request, CancellationToken cancellationToken)
     {
         var query = _workDbContext.WorkItems
-            .Where(e => e.Key == request.WorkItemKey)
+            .Where(w => w.Key == request.WorkItemKey)
             .AsQueryable();
 
         if (request.Id.HasValue)
         {
-            query = query.Where(e => e.WorkspaceId == request.Id);
+            query = query.Where(w => w.WorkspaceId == request.Id);
         }
         else if (request.Key is not null)
         {
-            query = query.Where(e => e.Workspace.Key == request.Key);
+            query = query.Where(w => w.Workspace.Key == request.Key);
         }
         else
         {

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
@@ -9,6 +9,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
     private WorkItemKey _key = null!;
     private string _title = null!;
     private readonly List<WorkItem> _children = [];
+    private readonly List<WorkItemLink> _systemLinks = [];
 
     //private readonly List<WorkItemRevision> _history = [];
 
@@ -96,6 +97,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
     // TODO: other systems will use different types.  How to handle this?
     public double StackRank { get; private set; }  
 
+    public IReadOnlyCollection<WorkItemLink> SystemLinks => _systemLinks.AsReadOnly();
 
     /// <summary>
     /// The collection of revisions for the life of the work item.

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using Moda.Common.Domain.Employees;
+using Moda.Common.Domain.Enums.Work;
 using NodaTime;
 
 namespace Moda.Work.Domain.Models;
@@ -15,7 +16,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
 
     private WorkItem() { }
 
-    private WorkItem(WorkItemKey key, string title, Guid workspaceId, int? externalId, int typeId, int statusId, Guid? parentId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank)
+    private WorkItem(WorkItemKey key, string title, Guid workspaceId, int? externalId, int typeId, int statusId, WorkStatusCategory statusCategory, Guid? parentId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank)
     {
         Key = key;
         Title = title;
@@ -23,6 +24,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
         ExternalId = externalId;
         TypeId = typeId;
         StatusId = statusId;
+        StatusCategory = statusCategory;
         ParentId = parentId;
         Created = created;
         CreatedById = createdById;
@@ -62,13 +64,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
 
     public WorkStatus Status { get; private set; } = null!;
 
-    //public Guid BacklogLevelId { get; private set; }
-
-    //public BacklogLevel BacklogLevel { get; private set; } = null!;
-
-    //public Guid WorkProcessConfigurationId { get; private set; }
-
-    //public WorkProcessScheme WorkProcessConfiguration { get; private set; } = null!;
+    public WorkStatusCategory StatusCategory { get; private set; }
 
     public Guid? ParentId { get; private set; }
 
@@ -104,11 +100,12 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
     /// </summary>
     //public IReadOnlyCollection<WorkItemRevision> History => _history.AsReadOnly();
 
-    public void Update(string title, int typeId, int statusId, Guid? parentId, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank)
+    public void Update(string title, int typeId, int statusId, WorkStatusCategory statusCategory, Guid? parentId, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank)
     {
         Title = title;
         TypeId = typeId;
         StatusId = statusId;
+        StatusCategory = statusCategory;
         ParentId = parentId;
         LastModified = lastModified;
         LastModifiedById = lastModifiedById;
@@ -122,7 +119,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
         ParentId = parentId;
     }
 
-    public static WorkItem CreateExternal(Workspace workspace, int externalId, string title, int typeId, int statusId, Guid? parentId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank)
+    public static WorkItem CreateExternal(Workspace workspace, int externalId, string title, int typeId, int statusId, WorkStatusCategory statusCategory, Guid? parentId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank)
     {
         Guard.Against.Null(workspace, nameof(workspace));
         if (workspace.Ownership != Ownership.Managed)
@@ -131,7 +128,7 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable
         }
         
         var key = new WorkItemKey(workspace.Key, externalId);
-        return new WorkItem(key, title, workspace.Id, externalId, typeId, statusId, parentId, created, createdById, lastModified, lastModifiedById, assignedToId, priority, stackRank);
+        return new WorkItem(key, title, workspace.Id, externalId, typeId, statusId, statusCategory, parentId, created, createdById, lastModified, lastModifiedById, assignedToId, priority, stackRank);
 
         //var result = workspace.AddWorkItem(workItem);  // this is handled in the handler for performance reasons
     }

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
@@ -424,7 +424,7 @@ public class PlanningIntervalsController : ControllerBase
 
         var workItems = await _sender.Send(new GetExternalObjectWorkItemsQuery(objectiveId), cancellationToken);
 
-        return Ok(workItems.OrderByKey(true));
+        return Ok(workItems.OrderBy(w => w.StackRank));
     }
 
     [HttpPost("{id}/objectives/{objectiveId}/work-items")]

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -3587,6 +3587,65 @@
         ]
       }
     },
+    "/api/work/workspaces/{idOrKey}/work-items/{workItemKey}/children": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get a work item's child work items.",
+        "operationId": "Workspaces_GetChildWorkItems",
+        "parameters": [
+          {
+            "name": "idOrKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "workItemKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkItemListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/work/workspaces/work-items/search": {
       "get": {
         "tags": [
@@ -8913,6 +8972,10 @@
                 "$ref": "#/components/schemas/EmployeeNavigationDto"
               }
             ]
+          },
+          "stackRank": {
+            "type": "number",
+            "format": "double"
           },
           "externalViewWorkItemUrl": {
             "type": "string",

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -8895,6 +8895,9 @@
           "status": {
             "type": "string"
           },
+          "statusCategory": {
+            "$ref": "#/components/schemas/SimpleNavigationDto"
+          },
           "parent": {
             "nullable": true,
             "oneOf": [
@@ -9775,6 +9778,9 @@
           },
           "status": {
             "type": "string"
+          },
+          "statusCategory": {
+            "$ref": "#/components/schemas/SimpleNavigationDto"
           },
           "priority": {
             "type": "integer",

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/ag-grid-transfer.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/ag-grid-transfer.tsx
@@ -1,4 +1,10 @@
-import { ColDef, GetRowIdParams, GridReadyEvent, ICellRendererParams, RowDragEndEvent } from 'ag-grid-community'
+import {
+  ColDef,
+  GetRowIdParams,
+  GridReadyEvent,
+  ICellRendererParams,
+  RowDragEndEvent,
+} from 'ag-grid-community'
 import { DeleteOutlined } from '@ant-design/icons'
 import useTheme from '@/src/app/components/contexts/theme'
 import React, { useCallback, useRef, useState } from 'react'
@@ -6,7 +12,9 @@ import { AgGridReact } from 'ag-grid-react'
 import { Flex } from 'antd'
 import { AgGridReactProps } from 'ag-grid-react/dist/types/src/shared/interfaces'
 
-export const asDraggableColDefs = <TData extends object>(colDefs: ColDef<TData>[]): ColDef<TData>[] => [
+export const asDraggableColDefs = <TData extends object>(
+  colDefs: ColDef<TData>[],
+): ColDef<TData>[] => [
   {
     rowDrag: true,
     maxWidth: 50,
@@ -18,12 +26,14 @@ export const asDraggableColDefs = <TData extends object>(colDefs: ColDef<TData>[
         return dragItemCount + ' items'
       }
       return params.rowNode!.data.key
-    }
+    },
   },
-  ...colDefs
+  ...colDefs,
 ]
 
-export const asDeletableColDefs = <TData extends object>(colDefs: ColDef<TData>[]): ColDef<TData>[] => [
+export const asDeletableColDefs = <TData extends object>(
+  colDefs: ColDef<TData>[],
+): ColDef<TData>[] => [
   {
     maxWidth: 50,
     suppressHeaderMenuButton: true,
@@ -35,34 +45,38 @@ export const asDeletableColDefs = <TData extends object>(colDefs: ColDef<TData>[
         onClick={() => {
           props.api.applyTransaction({ remove: [props.data] })
 
-          props.context.leftGridRef?.current?.api?.applyTransaction({ add: [props.data] });
+          props.context.leftGridRef?.current?.api?.applyTransaction({
+            add: [props.data],
+          })
         }}
       />
-    )
+    ),
   },
-  ...colDefs
+  ...colDefs,
 ]
 
 interface GridTransferProps<TData extends object> {
-  leftGridData?: TData[];
-  rightGridData?: TData[];
-  leftColumnDef: ColDef<TData>[];
-  rightColumnDef: ColDef<TData>[];
-  getRowId: (params: GetRowIdParams<TData>) => string;
-  removeRowFromSource?: boolean;
-  includeCheckboxes?: boolean;
-  leftGridRef?: React.MutableRefObject<AgGridReact<TData>>;
-  rightGridRef?: React.MutableRefObject<AgGridReact<TData>>;
-  GridProps?: AgGridReactProps<TData>;
+  leftGridData?: TData[]
+  rightGridData?: TData[]
+  leftColumnDef: ColDef<TData>[]
+  rightColumnDef: ColDef<TData>[]
+  getRowId: (params: GetRowIdParams<TData>) => string
+  removeRowFromSource?: boolean
+  includeCheckboxes?: boolean
+  leftGridRef?: React.MutableRefObject<AgGridReact<TData>>
+  rightGridRef?: React.MutableRefObject<AgGridReact<TData>>
+  GridProps?: AgGridReactProps<TData>
 }
 
 const defaultColDef: ColDef = {
   flex: 1,
   minWidth: 50,
-  filter: false
+  filter: false,
 }
 
-export const AgGridTransfer = <TData extends object>(props: GridTransferProps<TData>): React.ReactNode => {
+export const AgGridTransfer = <TData extends object>(
+  props: GridTransferProps<TData>,
+): React.ReactNode => {
   const { agGridTheme } = useTheme()
 
   const localLeftGridRef = useRef<AgGridReact<TData>>(null)
@@ -71,45 +85,75 @@ export const AgGridTransfer = <TData extends object>(props: GridTransferProps<TD
   const leftGridRef = props.leftGridRef ?? localLeftGridRef
   const rightGridRef = props.rightGridRef ?? localRightGridRef
 
-  const onDragStop = useCallback((params: RowDragEndEvent) => {
-    if (props.removeRowFromSource)
-      leftGridRef.current.api?.applyTransaction({ remove: params.nodes.map(node => node.data) })
-    else
-      leftGridRef.current.api?.setNodesSelected({ nodes: params.nodes, newValue: false })
-  }, [leftGridRef, props.removeRowFromSource])
+  const onDragStop = useCallback(
+    (params: RowDragEndEvent) => {
+      if (props.removeRowFromSource)
+        leftGridRef.current.api?.applyTransaction({
+          remove: params.nodes.map((node) => node.data),
+        })
+      else
+        leftGridRef.current.api?.setNodesSelected({
+          nodes: params.nodes,
+          newValue: false,
+        })
+    },
+    [leftGridRef, props.removeRowFromSource],
+  )
 
-  const onGridReady = useCallback((event: GridReadyEvent<TData>) => {
+  const onGridReady = useCallback(
+    (event: GridReadyEvent<TData>) => {
+      if (leftGridRef.current === null || rightGridRef.current === null) return
 
-    if (leftGridRef.current === null || rightGridRef.current === null) return
+      const dropZoneParams = rightGridRef.current.api.getRowDropZoneParams({
+        onDragStop,
+      })
 
-    const dropZoneParams = rightGridRef.current.api.getRowDropZoneParams({ onDragStop })
+      leftGridRef.current.api.removeRowDropZone(dropZoneParams)
+      leftGridRef.current.api.addRowDropZone(dropZoneParams)
+    },
+    [leftGridRef, onDragStop, rightGridRef],
+  )
 
-    leftGridRef.current.api.removeRowDropZone(dropZoneParams)
-    leftGridRef.current.api.addRowDropZone(dropZoneParams)
-  }, [leftGridRef, onDragStop, rightGridRef])
-
-
-  const getGrid = useCallback((isLeft: boolean) => (
-    <div className={agGridTheme} style={{ minHeight: 250, width: '100%' }}>
-      <AgGridReact
-        ref={isLeft ? leftGridRef : rightGridRef}
-        getRowId={props.getRowId}
-        rowDragManaged={true}
-        rowSelection={isLeft ? 'multiple' : undefined}
-        rowDragMultiRow={isLeft}
-        suppressRowClickSelection={isLeft}
-        suppressMoveWhenRowDragging={isLeft}
-
-        rowData={isLeft ? props.leftGridData : props.rightGridData}
-        columnDefs={isLeft ? props.leftColumnDef : props.rightColumnDef}
-        onGridReady={onGridReady}
-        context={isLeft ? { rightGridRef: rightGridRef } : { leftGridRef: leftGridRef }}
-        {...props.GridProps}
-        defaultColDef={{ ...defaultColDef, ...(props?.GridProps?.defaultColDef ?? {}) }}
-      />
-    </div>
-  ), [agGridTheme, leftGridRef, rightGridRef, props.getRowId, props.leftGridData, props.rightGridData, props.leftColumnDef, props.rightColumnDef, props.GridProps, onGridReady])
-
+  const getGrid = useCallback(
+    (isLeft: boolean) => (
+      <div className={agGridTheme} style={{ minHeight: 250, width: '100%' }}>
+        <AgGridReact
+          ref={isLeft ? leftGridRef : rightGridRef}
+          getRowId={props.getRowId}
+          rowDragManaged={true}
+          rowSelection={isLeft ? 'multiple' : undefined}
+          rowDragMultiRow={isLeft}
+          suppressRowClickSelection={isLeft}
+          suppressMoveWhenRowDragging={isLeft}
+          rowData={isLeft ? props.leftGridData : props.rightGridData}
+          columnDefs={isLeft ? props.leftColumnDef : props.rightColumnDef}
+          onGridReady={onGridReady}
+          context={
+            isLeft
+              ? { rightGridRef: rightGridRef }
+              : { leftGridRef: leftGridRef }
+          }
+          {...props.GridProps}
+          defaultColDef={{
+            ...defaultColDef,
+            ...(props?.GridProps?.defaultColDef ?? {}),
+          }}
+        />
+      </div>
+    ),
+    [
+      agGridTheme,
+      leftGridRef,
+      rightGridRef,
+      props.getRowId,
+      props.leftGridData,
+      props.rightGridData,
+      props.leftColumnDef,
+      props.rightColumnDef,
+      props.GridProps,
+      onGridReady,
+    ],
+  )
 
   return (
     <Flex gap="middle" style={{ width: '100%' }}>
@@ -117,5 +161,4 @@ export const AgGridTransfer = <TData extends object>(props: GridTransferProps<TD
       {getGrid(false)}
     </Flex>
   )
-
 }

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/moda-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/moda-grid.tsx
@@ -3,7 +3,7 @@
 import 'ag-grid-community/styles/ag-grid.css'
 import 'ag-grid-community/styles/ag-theme-balham.css'
 import { AgGridReact, AgGridReactProps } from 'ag-grid-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import {
   Button,
   Col,

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/index.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/index.ts
@@ -1,1 +1,3 @@
 export { default as WorkItemsListCard } from './work-items-list-card'
+export { default as WorkItemListItem } from './work-item-list-item'
+export { default as WorkItemsGrid } from './work-items-grid'

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
@@ -2,6 +2,7 @@ import { WorkItemListDto } from '@/src/services/moda-api'
 import { List, Space, Tag } from 'antd'
 import Link from 'next/link'
 import ExternalIconLink from '../external-icon-link'
+import { getWorkStatusCategoryColor } from '@/src/utils'
 
 const { Item } = List
 const { Meta } = Item
@@ -40,7 +41,9 @@ const WorkItemListItemDescription = ({ workItem }: WorkItemListItemProps) => {
   return (
     <Space wrap>
       <Tag>{workItem.type}</Tag>
-      <Tag>{workItem.status}</Tag>
+      <Tag color={getWorkStatusCategoryColor(workItem.statusCategory.name)}>
+        {workItem.status}
+      </Tag>
     </Space>
   )
 }

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-grid.tsx
@@ -55,6 +55,11 @@ const workItemKeyComparator = (key1, key2) => {
   return parseInt(num1) - parseInt(num2)
 }
 
+const workStatusCategoryComparator = (category1, category2) => {
+  const categories = ['Proposed', 'Active', 'Done', 'Removed']
+  return categories.indexOf(category1) - categories.indexOf(category2)
+}
+
 const WorkItemsGrid = (props: WorkItemsGridProps) => {
   const { refetch } = props
 
@@ -68,6 +73,12 @@ const WorkItemsGrid = (props: WorkItemsGridProps) => {
       { field: 'title', width: 400 },
       { field: 'type', width: 125 },
       { field: 'status', width: 125 },
+      {
+        field: 'statusCategory.name',
+        headerName: 'Status Category',
+        width: 140,
+        comparator: workStatusCategoryComparator,
+      },
       {
         field: 'assignedTo.name',
         headerName: 'Assigned To',

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -1,10 +1,13 @@
 'use client'
 
 import { useDebounce } from '@/src/app/hooks'
-import { ManagePlanningIntervalObjectiveWorkItemsRequest, WorkItemListDto } from '@/src/services/moda-api'
+import {
+  ManagePlanningIntervalObjectiveWorkItemsRequest,
+  WorkItemListDto,
+} from '@/src/services/moda-api'
 import {
   useGetObjectiveWorkItemsQuery,
-  useManageObjectiveWorkItemsMutation
+  useManageObjectiveWorkItemsMutation,
 } from '@/src/store/features/planning/planning-interval-api'
 import { useSearchWorkItemsQuery } from '@/src/store/features/work-management/workspace-api'
 import { SearchOutlined } from '@ant-design/icons'
@@ -12,7 +15,11 @@ import { Input, message, Modal, Space, Typography } from 'antd'
 import { useEffect, useRef, useState } from 'react'
 import { ColDef } from 'ag-grid-community'
 import { AgGridReact } from 'ag-grid-react'
-import { AgGridTransfer, asDeletableColDefs, asDraggableColDefs } from '@/src/app/components/common/grid/ag-grid-transfer'
+import {
+  AgGridTransfer,
+  asDeletableColDefs,
+  asDraggableColDefs,
+} from '@/src/app/components/common/grid/ag-grid-transfer'
 
 const { Text } = Typography
 
@@ -28,24 +35,32 @@ type WorkItemModel = WorkItemListDto & {
   disabled: boolean
 }
 
-
 const workItemColDefs: ColDef<WorkItemModel>[] = [
   {
     field: 'key',
-    headerName: 'Key'
+    headerName: 'Key',
+    minWidth: 100,
   },
   {
     field: 'title',
-    headerName: 'Title'
+    headerName: 'Title',
+    minWidth: 250,
   },
   {
     field: 'type',
-    headerName: 'Type'
+    headerName: 'Type',
+    minWidth: 100,
+  },
+  {
+    field: 'status',
+    headerName: 'Status',
+    minWidth: 100,
   },
   {
     field: 'parent.key',
-    headerName: 'Parent Key'
-  }
+    headerName: 'Parent Key',
+    minWidth: 100,
+  },
 ]
 
 const leftWorkItemColDefs = [
@@ -54,19 +69,19 @@ const leftWorkItemColDefs = [
     maxWidth: 50,
     checkboxSelection: true,
     suppressHeaderMenuButton: true,
-    headerCheckboxSelection: true
+    headerCheckboxSelection: true,
   },
-  ...asDraggableColDefs(workItemColDefs)
+  ...asDraggableColDefs(workItemColDefs),
 ]
 
 const defaultColDef: ColDef = {
-  tooltipValueGetter: (params) => params.value
+  tooltipValueGetter: (params) => params.value,
 }
 
 const rightWorkItemColDefs = asDeletableColDefs(workItemColDefs)
 
 const ManagePlanningIntervalObjectiveWorkItemsForm = (
-  props: ManagePlanningIntervalObjectiveWorkItemsFormProps
+  props: ManagePlanningIntervalObjectiveWorkItemsFormProps,
 ) => {
   const [isOpen, setIsOpen] = useState(props.showForm)
   const [isSaving, setIsSaving] = useState(false)
@@ -84,17 +99,15 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
   const {
     data: existingWorkItemsData,
     isLoading: existingWorkItemsQueryIsLoading,
-    isError: existingWorkItemsQueryIsError
+    isError: existingWorkItemsQueryIsError,
   } = useGetObjectiveWorkItemsQuery({
     planningIntervalId: props.planningIntervalId,
-    objectiveId: props.objectiveId
+    objectiveId: props.objectiveId,
   })
 
   const debounceSearchQuery = useDebounce(searchQuery, 500)
-  const {
-    data: searchResult
-  } = useSearchWorkItemsQuery(debounceSearchQuery, {
-    skip: debounceSearchQuery === ''
+  const { data: searchResult } = useSearchWorkItemsQuery(debounceSearchQuery, {
+    skip: debounceSearchQuery === '',
   })
 
   const [manageObjectiveWorkItems, { error }] =
@@ -104,7 +117,7 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
     if (!existingWorkItemsData) return
     setTargetWorkItems(
       existingWorkItemsData?.map((item) => ({ ...item, disabled: false })) ??
-      []
+        [],
     )
   }, [existingWorkItemsData])
 
@@ -112,17 +125,17 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
     if (!searchResult) return
 
     setSearchResultWorkItems(
-      searchResult?.map((item) => ({ ...item, disabled: false })) ?? []
+      searchResult?.map((item) => ({ ...item, disabled: false })) ?? [],
     )
   }, [searchResult])
 
   useEffect(() => {
-
     let selectedIds = []
-    rightGridRef.current?.api?.forEachNode(n => selectedIds.push(n.data.id))
+    rightGridRef.current?.api?.forEachNode((n) => selectedIds.push(n.data.id))
 
-    setSourceWorkItems(searchResultWorkItems.filter((item) => !selectedIds.includes(item.id)))
-
+    setSourceWorkItems(
+      searchResultWorkItems.filter((item) => !selectedIds.includes(item.id)),
+    )
   }, [searchQuery, searchResultWorkItems, targetWorkItems])
 
   const saveWorkItemChanges = async (): Promise<boolean> => {
@@ -132,14 +145,14 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
       const request: ManagePlanningIntervalObjectiveWorkItemsRequest = {
         planningIntervalId: props.planningIntervalId,
         objectiveId: props.objectiveId,
-        workItemIds
+        workItemIds,
       }
       await manageObjectiveWorkItems(request)
       messageApi.success('Successfully updated objective work items.')
       return true
     } catch (error) {
       messageApi.error(
-        `Failed to update objective work items. Error: ${error.supportMessage}`
+        `Failed to update objective work items. Error: ${error.supportMessage}`,
       )
       console.error(error)
       return false
@@ -187,7 +200,10 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
         destroyOnClose={true}
       >
         {
-          <Space direction="vertical" style={{ display: 'flex', width: '100%' }}>
+          <Space
+            direction="vertical"
+            style={{ display: 'flex', width: '100%' }}
+          >
             <Input
               size="small"
               placeholder="Search for work items by key, title, or parent key"
@@ -206,7 +222,7 @@ const ManagePlanningIntervalObjectiveWorkItemsForm = (
               GridProps={{
                 tooltipShowDelay: 0,
                 tooltipHideDelay: 1000,
-                defaultColDef
+                defaultColDef,
               }}
             />
             <Text>Search results are limited to 50 records.</Text>

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/objective-list-item.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/objective-list-item.tsx
@@ -23,6 +23,7 @@ import { beginHealthCheckCreate } from '@/src/store/features/health-check-slice'
 import { EditPlanningIntervalObjectiveForm } from '../../../components'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import { getObjectiveStatusColor } from '@/src/utils'
 
 const { Item } = List
 const { Meta } = Item
@@ -35,20 +36,6 @@ export interface ObjectiveListItemProps {
   canCreateHealthChecks: boolean
   refreshObjectives: () => void
   onObjectiveClick: (objectiveId: string) => void
-}
-
-const getColorForStatus = (status: string) => {
-  switch (status) {
-    case 'In Progress':
-      return 'processing'
-    case 'Completed':
-      return 'success'
-    case 'Canceled':
-    case 'Missed':
-      return 'error'
-    default:
-      return 'default'
-  }
 }
 
 const ObjectiveListItem = ({
@@ -106,7 +93,7 @@ const ObjectiveListItem = ({
     return (
       <>
         <Space wrap>
-          <Tag color={getColorForStatus(objective.status.name)}>
+          <Tag color={getObjectiveStatusColor(objective.status.name)}>
             {objective.status.name}
           </Tag>
           {objective.isStretch && <Tag>Stretch</Tag>}

--- a/Moda.Web/src/moda.web.reactclient/src/app/settings/work-management/work-types/components/work-type-level-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/settings/work-management/work-types/components/work-type-level-card.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react'
 import { EditOutlined, HolderOutlined } from '@ant-design/icons'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
+import ModaMarkdownDescription from '@/src/app/components/common/moda-markdown-description'
 
 const { Item } = List
 const { Meta } = Item
@@ -70,7 +71,9 @@ const WorkTypeLevelCard = (props: WorkTypeLevelCardProps) => {
           )}
           <Meta
             title={props.level.name}
-            description={props.level.description}
+            description={
+              <ModaMarkdownDescription content={props.level.description} />
+            }
           />
         </Item>
       </Card>

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/page.tsx
@@ -13,9 +13,9 @@ import { notFound, usePathname } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import WorkspaceDetailsLoading from './loading'
 import WorkspaceDetails from './workspace-details'
-import WorkItemsGrid from './work-items-grid'
 import useAuth from '@/src/app/components/contexts/auth'
 import SetWorkspaceExternalUrlTemplatesForm from './set-workspace-external-url-templates-form'
+import { WorkItemsGrid } from '@/src/app/components/common/work'
 
 enum WorkspaceTabs {
   Details = 'details',

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/page.tsx
@@ -2,7 +2,10 @@
 
 import { useAppDispatch, useDocumentTitle } from '@/src/app/hooks'
 import { BreadcrumbItem, setBreadcrumbRoute } from '@/src/store/breadcrumbs'
-import { useGetWorkItemQuery } from '@/src/store/features/work-management/workspace-api'
+import {
+  useGetChildWorkItemsQuery,
+  useGetWorkItemQuery,
+} from '@/src/store/features/work-management/workspace-api'
 import { notFound, usePathname } from 'next/navigation'
 import { useCallback, useEffect, useState } from 'react'
 import WorkItemDetailsLoading from './loading'
@@ -10,12 +13,12 @@ import { PageTitle } from '@/src/app/components/common'
 import { Card } from 'antd'
 import { authorizePage } from '@/src/app/components/hoc'
 import WorkItemDetails from './work-item-details'
-import Link from 'next/link'
-import { ExportOutlined } from '@ant-design/icons'
 import ExternalIconLink from '@/src/app/components/common/external-icon-link'
+import { WorkItemsGrid } from '@/src/app/components/common/work'
 
 enum WorkItemTabs {
   Details = 'details',
+  WorkItems = 'workItems',
 }
 
 const WorkItemDetailsPage = ({ params }) => {
@@ -30,6 +33,11 @@ const WorkItemDetailsPage = ({ params }) => {
     error,
     refetch,
   } = useGetWorkItemQuery({ idOrKey: workspaceKey, workItemKey: workItemKey })
+
+  const childWorkItemsQuery = useGetChildWorkItemsQuery({
+    idOrKey: workspaceKey,
+    workItemKey: workItemKey,
+  })
 
   const dispatch = useAppDispatch()
   const pathname = usePathname()
@@ -78,6 +86,17 @@ const WorkItemDetailsPage = ({ params }) => {
       key: WorkItemTabs.Details,
       tab: 'Details',
       content: <WorkItemDetails workItem={workItemData} />,
+    },
+    {
+      key: WorkItemTabs.WorkItems,
+      tab: 'Work Items',
+      content: (
+        <WorkItemsGrid
+          workItems={childWorkItemsQuery.data}
+          isLoading={childWorkItemsQuery.isLoading}
+          refetch={childWorkItemsQuery.refetch}
+        />
+      ),
     },
   ]
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
@@ -18,6 +18,7 @@ const WorkItemDetails = ({ workItem }: WorkItemDetailsProps) => {
         <Item label="Key">{workItem.key}</Item>
         <Item label="Type">{workItem.type}</Item>
         <Item label="Status">{workItem.status}</Item>
+        <Item label="Status Category">{workItem.statusCategory.name}</Item>
         <Item label="Priority">{workItem.priority}</Item>
         <Item label="Assigned To">
           {workItem.assignedTo ? (

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -4309,6 +4309,70 @@ export class WorkspacesClient {
     }
 
     /**
+     * Get a work item's child work items.
+     */
+    getChildWorkItems(idOrKey: string, workItemKey: string, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
+        let url_ = this.baseUrl + "/api/work/workspaces/{idOrKey}/work-items/{workItemKey}/children";
+        if (idOrKey === undefined || idOrKey === null)
+            throw new Error("The parameter 'idOrKey' must be defined.");
+        url_ = url_.replace("{idOrKey}", encodeURIComponent("" + idOrKey));
+        if (workItemKey === undefined || workItemKey === null)
+            throw new Error("The parameter 'workItemKey' must be defined.");
+        url_ = url_.replace("{workItemKey}", encodeURIComponent("" + workItemKey));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetChildWorkItems(_response);
+        });
+    }
+
+    protected processGetChildWorkItems(response: AxiosResponse): Promise<WorkItemListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<WorkItemListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<WorkItemListDto[]>(null as any);
+    }
+
+    /**
      * Search for a work item using its key or title.
      * @param query (optional) 
      * @param top (optional) 
@@ -9465,6 +9529,7 @@ export interface WorkItemListDto {
     statusCategory?: SimpleNavigationDto;
     parent?: WorkItemNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;
+    stackRank?: number;
     externalViewWorkItemUrl?: string | undefined;
 }
 

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9462,6 +9462,7 @@ export interface WorkItemListDto {
     workspace?: WorkspaceNavigationDto;
     type?: string;
     status?: string;
+    statusCategory?: SimpleNavigationDto;
     parent?: WorkItemNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
@@ -9712,6 +9713,7 @@ export interface WorkItemDetailsDto {
     workspace?: WorkspaceNavigationDto;
     type?: string;
     status?: string;
+    statusCategory?: SimpleNavigationDto;
     priority?: number | undefined;
     parent?: WorkItemNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
@@ -8,6 +8,7 @@ export enum QueryTags {
   PlanningIntervalObjectiveWorkItem = 'Planning.PlanningIntervalObjective.WorkItem',
   // WORK MANAGEMENT
   WorkItem = 'Work.WorkItem',
+  WorkItemChildren = 'Work.WorkItem.Children',
   WorkItemSearch = 'Work.WorkItem.Search',
   WorkProcess = 'Work.WorkProcess',
   WorkProcessScheme = 'Work.WorkProcessScheme',

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -14,6 +14,11 @@ export interface GetWorkItemRequest {
   workItemKey: string
 }
 
+export interface GetChildWorkItemsRequest {
+  idOrKey: string
+  workItemKey: string
+}
+
 export interface SetWorkspaceExternalUrlTemplatesRequest {
   workspaceId: string
   externalUrlTemplatesRequest: SetExternalUrlTemplatesRequest
@@ -103,6 +108,26 @@ export const workspaceApi = apiSlice.injectEndpoints({
         { type: QueryTags.WorkItem, id: arg.workItemKey }, // typically arg is the key
       ],
     }),
+    getChildWorkItems: builder.query<
+      WorkItemListDto[],
+      GetChildWorkItemsRequest
+    >({
+      queryFn: async (request: GetChildWorkItemsRequest) => {
+        try {
+          const data = await (
+            await getWorkspacesClient()
+          ).getChildWorkItems(request.idOrKey, request.workItemKey)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        QueryTags.WorkItemChildren,
+        ...result.map(({ key }) => ({ type: QueryTags.WorkItemChildren, key })),
+      ],
+    }),
     searchWorkItems: builder.query<WorkItemListDto[], string>({
       queryFn: async (searchTerm: string) => {
         try {
@@ -128,6 +153,7 @@ export const {
   useGetWorkspaceQuery,
   useGetWorkItemsQuery,
   useGetWorkItemQuery,
+  useGetChildWorkItemsQuery,
   useSearchWorkItemsQuery,
   useSetWorkspaceExternalUrlTemplatesMutation,
 } = workspaceApi

--- a/Moda.Web/src/moda.web.reactclient/src/utils/color-helper.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/utils/color-helper.ts
@@ -1,0 +1,27 @@
+export const getWorkStatusCategoryColor = (statusCategory: string) => {
+  switch (statusCategory) {
+    case 'Active':
+      return 'processing'
+    case 'Done':
+      return 'success'
+    case 'Removed':
+      return 'error'
+    case 'Proposed':
+    default:
+      return 'default'
+  }
+}
+
+export const getObjectiveStatusColor = (status: string) => {
+  switch (status) {
+    case 'In Progress':
+      return 'processing'
+    case 'Completed':
+      return 'success'
+    case 'Canceled':
+    case 'Missed':
+      return 'error'
+    default:
+      return 'default'
+  }
+}

--- a/Moda.Web/src/moda.web.reactclient/src/utils/index.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/utils/index.ts
@@ -1,3 +1,7 @@
 export { daysRemaining } from './dates'
+export {
+  getWorkStatusCategoryColor,
+  getObjectiveStatusColor,
+} from './color-helper'
 
 export { default as toFormErrors } from './problem-details'


### PR DESCRIPTION
- Updated the WorkItem to include system links.
- Added the WorkStatusCategory to WorkItem and updated the sync process to verify that valid WorkTypeId, WorkStatusId, and WorkStatusCategory values are set based on the Workspace and configured WorkProcess.
- Added the StatusCategory property to the work item dto models.
- Updated the WorkItem grid and cards to include the WorkStatusCategory or to color the WorkStatus based on the value of the WorkStatusCategory.
- Added a new API endpoint to get child work items.
- Added a Work Items tab to the details page to display children. Added the API endpoint to the RTK store.
- Update the WorkTypeLevelCard to format the description as markdown.
- Updated the column widths and added the status column to the ManagePlanningIntervalObjectiveWorkItemsForm transfer grid.