### PR TITLE
Bug/progress rollup should ignore duplicates

### DIFF
--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/WorkItemProgessSummaryBuilder.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/WorkItemProgessSummaryBuilder.cs
@@ -32,16 +32,18 @@ internal sealed class WorkItemProgessSummaryBuilder(IWorkDbContext workDbContext
             .ToDictionary(l => l, l => new List<Guid>());
 
         var rollupItems = new List<WorkItemProgressStateDto>();
+        var rollupItemIds = new HashSet<Guid>();
         foreach (var item in initialWorkItems)
         {
             if (item.Tier == WorkTypeTier.Portfolio)
             {
                 UpdatePortfolioItems(portfolioItems, item);
-
-                continue;
             }
-
-            rollupItems.Add(item);
+            else if (!rollupItemIds.Contains(item.Id))
+            {
+                rollupItems.Add(item);
+                rollupItemIds.Add(item.Id);
+            }
         }
 
         var startingLevel = portfolioItems.Keys.Min();
@@ -68,11 +70,11 @@ internal sealed class WorkItemProgessSummaryBuilder(IWorkDbContext workDbContext
                             continue;  // skip items that are not in the next level.  This should not happen, but just in case. Work Items shouldn't have parents in a higher level.
 
                         UpdatePortfolioItems(portfolioItems, item);
-
-                        continue;
+                    } else if (!rollupItemIds.Contains(item.Id))
+                    {
+                        rollupItems.Add(item);
+                        rollupItemIds.Add(item.Id);
                     }
-
-                    rollupItems.Add(item);
                 }
             }
         }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workflows/Commands/UpdateExternalWorkflowCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workflows/Commands/UpdateExternalWorkflowCommandHandler.cs
@@ -100,7 +100,7 @@ internal sealed class UpdateExternalWorkflowCommandHandler(IWorkDbContext workDb
 
         await _workDbContext.SaveChangesAsync(cancellationToken);
 
-        _logger.LogInformation("{AppRequestName}: created workflow {WorkflowName}.", AppRequestName, workflow.Name);
+        _logger.LogInformation("{AppRequestName}: updated workflow {WorkflowName}.", AppRequestName, workflow.Name);
 
         return Result.Success(workflow.Id);
     }


### PR DESCRIPTION
- Added logic to prevent calculating duplicate work items.
- Fixed a log message within the update external workflow command.