### PR TITLE
Feature/add team mappings to azdo workitem sync

### DIFF
--- a/Moda.Common/src/Moda.Common.Application/Interfaces/ExternalWork/IExternalTeam.cs
+++ b/Moda.Common/src/Moda.Common.Application/Interfaces/ExternalWork/IExternalTeam.cs
@@ -4,4 +4,5 @@ public interface IExternalTeam
     Guid Id { get; }
     string Name { get; }
     Guid WorkspaceId { get; }
+    Guid? BoardId { get; }
 }

--- a/Moda.Common/src/Moda.Common.Application/Interfaces/ExternalWork/IExternalWorkItem.cs
+++ b/Moda.Common/src/Moda.Common.Application/Interfaces/ExternalWork/IExternalWorkItem.cs
@@ -15,5 +15,6 @@ public interface IExternalWorkItem
     double StackRank { get; }
     Instant? ActivatedTimestamp { get; }
     Instant? DoneTimestamp { get; }
+    public Guid? TeamId { get; set; }
     string? ExternalTeamIdentifier { get; }
 }

--- a/Moda.Common/src/Moda.Common.Application/Interfaces/IAzureDevOpsService.cs
+++ b/Moda.Common/src/Moda.Common.Application/Interfaces/IAzureDevOpsService.cs
@@ -9,7 +9,7 @@ public interface IAzureDevOpsService
     Task<Result<IExternalWorkspaceConfiguration>> GetWorkspace(string organizationUrl, string token, Guid workspaceId, CancellationToken cancellationToken);
     Task<Result<List<IExternalWorkspace>>> GetWorkspaces(string organizationUrl, string token, CancellationToken cancellationToken);
     Task<Result<List<IExternalTeam>>> GetTeams(string organizationUrl, string token, Guid[] projectIds, CancellationToken cancellationToken);
-    Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken);
     Task<Result<int[]>> GetDeletedWorkItemIds(string organizationUrl, string token, string projectName, DateTime lastChangedDate, CancellationToken cancellationToken);
     Task<Result> TestConnection(string organizationUrl, string token);
 }

--- a/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/SyncExternalWorkItemsCommand.cs
+++ b/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/SyncExternalWorkItemsCommand.cs
@@ -2,7 +2,14 @@
 using Moda.Common.Application.Validators;
 
 namespace Moda.Common.Application.Requests.WorkManagement;
-public sealed record SyncExternalWorkItemsCommand(Guid WorkspaceId, List<IExternalWorkItem> WorkItems) : ICommand;
+
+/// <summary>
+/// 
+/// </summary>
+/// <param name="WorkspaceId"></param>
+/// <param name="WorkItems"></param>
+/// <param name="teamMappings">The key is set to the external team id and value is set to the internal (Moda) team id.</param>
+public sealed record SyncExternalWorkItemsCommand(Guid WorkspaceId, List<IExternalWorkItem> WorkItems, Dictionary<Guid, Guid?> teamMappings) : ICommand;
 
 public sealed class SyncExternalWorkItemsCommandValidator : CustomValidator<SyncExternalWorkItemsCommand>
 {
@@ -14,5 +21,24 @@ public sealed class SyncExternalWorkItemsCommandValidator : CustomValidator<Sync
         RuleForEach(c => c.WorkItems)
             .NotNull()
             .SetValidator(new IExternalWorkItemValidator());
+
+        RuleFor(c => c.teamMappings)
+            .NotNull();
+
+        When(c => c.teamMappings.Count > 0, () =>
+        {
+            RuleForEach(c => c.teamMappings).ChildRules(teamMapping =>
+            {
+                teamMapping.RuleFor(tm => tm.Key)
+                    .NotEmpty();
+
+                teamMapping.When(tm => tm.Value.HasValue, () =>
+                {
+                    teamMapping.RuleFor(tm => tm.Value)
+                        .NotEmpty()
+                        .Must(v => v.HasValue && v.Value != Guid.Empty);
+                });
+            });
+        });
     }
 }

--- a/Moda.Common/src/Moda.Common/Extensions/GenericExtensions.cs
+++ b/Moda.Common/src/Moda.Common/Extensions/GenericExtensions.cs
@@ -23,4 +23,56 @@ public static class GenericExtensions
             }
         }
     }
+
+    public static IEnumerable<TOut> FlattenHierarchy<TIn,TOut>(
+        this TIn root, 
+        Func<TIn, IEnumerable<TIn>?> branchSelector, 
+        Func<TIn, TOut> projection)
+    {
+        ArgumentNullException.ThrowIfNull(branchSelector);
+
+        Stack<TIn> stack = new();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            yield return projection(current);
+
+            if (current is null)
+                continue;
+
+            foreach (var child in branchSelector(current) ?? [])
+            {
+                stack.Push(child);
+            }
+        }
+    }
+
+    public static IEnumerable<TOut> FlattenHierarchy<TIn, TOut>(
+        this TIn root,
+        Func<TIn, IEnumerable<TIn>?> branchSelector,
+        Func<TIn, TOut> projection,
+        Func<TOut, TOut> projectionEnricher)
+    {
+        ArgumentNullException.ThrowIfNull(branchSelector);
+
+        Stack<TIn> stack = new();
+        stack.Push(root);
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            var mappedValue = projection(current);
+            yield return projectionEnricher(mappedValue);
+
+            if (current is null)
+                continue;
+
+            foreach (var child in branchSelector(current) ?? [])
+            {
+                stack.Push(child);
+            }
+        }
+    }
 }

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/AzureDevOpsService.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/AzureDevOpsService.cs
@@ -36,26 +36,6 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
         }
     }
 
-    //public async Task<Result<List<ClassificationNodeDto>>> GetAreas(string organizationUrl, string token, Guid projectId, CancellationToken cancellationToken)
-    //{
-    //    var connection = CreateVssConnection(organizationUrl, token);
-    //    var areaService = GetService<AreaService>(connection);
-
-    //    var areas = await areaService.GetAreas(projectId, cancellationToken);
-
-    //    return areas; // map to local type and return interface instead of concrete type
-    //}
-
-    //public async Task<Result<List<ClassificationNodeDto>>> GetIterations(string organizationUrl, string token, Guid projectId, CancellationToken cancellationToken)
-    //{
-    //    var connection = CreateVssConnection(organizationUrl, token);
-    //    var iterationService = GetService<IterationService>(connection);
-
-    //    var iterations = await iterationService.GetIterations(projectId, cancellationToken);
-
-    //    return iterations; // map to local type and return interface instead of concrete type
-    //}
-
     public async Task<Result<List<IExternalWorkProcess>>> GetWorkProcesses(string organizationUrl, string token, CancellationToken cancellationToken)
     {
         var processService = GetService<ProcessService>(organizationUrl, token);
@@ -115,11 +95,11 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
         return Result.Success(result.Value);
     }
 
-    public async Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid,Guid?> teamSettings, CancellationToken cancellationToken)
     {
         var projectService = GetService<ProjectService>(organizationUrl, token);
 
-        var iterationsResult = await projectService.GetIterationPaths(projectName, cancellationToken);
+        var iterationsResult = await projectService.GetIterations(projectName, teamSettings, cancellationToken);
         if (iterationsResult.IsFailure)
             return Result.Failure<List<IExternalWorkItem>>(iterationsResult.Error);
 

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/AzureDevOpsService.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/AzureDevOpsService.cs
@@ -119,16 +119,16 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
     {
         var projectService = GetService<ProjectService>(organizationUrl, token);
 
-        var areasResult = await projectService.GetAreaPaths(projectName, cancellationToken);
-        if (areasResult.IsFailure)
-            return Result.Failure<List<IExternalWorkItem>>(areasResult.Error);
+        var iterationsResult = await projectService.GetIterationPaths(projectName, cancellationToken);
+        if (iterationsResult.IsFailure)
+            return Result.Failure<List<IExternalWorkItem>>(iterationsResult.Error);
 
         var workItemService = GetService<WorkItemService>(organizationUrl, token);
 
         var result = await workItemService.GetWorkItems(projectName, lastChangedDate, workItemTypes, cancellationToken);
 
         return result.IsSuccess
-            ? Result.Success(result.Value.ToIExternalWorkItems(areasResult.Value))
+            ? Result.Success(result.Value.ToIExternalWorkItems(iterationsResult.Value))
             : Result.Failure<List<IExternalWorkItem>>(result.Error);
     }
 

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Clients/ProjectClient.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Clients/ProjectClient.cs
@@ -45,25 +45,19 @@ internal sealed class ProjectClient : BaseClient
         return await _client.ExecuteAsync<ListResponse<TeamDto>>(request, cancellationToken);
     }
 
-    internal async Task<Dictionary<Guid, TeamSettingsResponse?>> GetProjectTeamsSettings(Guid projectId, Guid[] teamIds, CancellationToken cancellationToken)
+    /// <summary>
+    /// Returns the team settings for the specified team.
+    /// </summary>
+    /// <param name="projectId"></param>
+    /// <param name="teamId"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    internal async Task<RestResponse<TeamSettingsResponse>> GetProjectTeamsSettings(Guid projectId, Guid teamId, CancellationToken cancellationToken)
     {
-        Dictionary<Guid,TeamSettingsResponse?> teamSettings = [];
-        foreach (var teamId in teamIds)
-        {
-            var request = new RestRequest();
-            SetupRequest(request);
+        var request = new RestRequest($"/{projectId}/{teamId}/_apis/work/teamsettings", Method.Get);
+        SetupRequest(request);
 
-            // TODO: should this be in a different client?  WorkClient?
-            request.Resource = $"/{projectId}/{teamId}/_apis/work/teamsettings";
-
-            var response = await _client.ExecuteAsync<TeamSettingsResponse>(request, cancellationToken);
-            if (response.IsSuccessful)
-            {
-                teamSettings.Add(teamId, response.Data);
-            }
-        }
-
-        return teamSettings;
+        return await _client.ExecuteAsync<TeamSettingsResponse>(request, cancellationToken);
     }
 
     /// <summary>

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Clients/ProjectClient.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Clients/ProjectClient.cs
@@ -45,6 +45,27 @@ internal sealed class ProjectClient : BaseClient
         return await _client.ExecuteAsync<ListResponse<TeamDto>>(request, cancellationToken);
     }
 
+    internal async Task<Dictionary<Guid, TeamSettingsResponse?>> GetProjectTeamsSettings(Guid projectId, Guid[] teamIds, CancellationToken cancellationToken)
+    {
+        Dictionary<Guid,TeamSettingsResponse?> teamSettings = [];
+        foreach (var teamId in teamIds)
+        {
+            var request = new RestRequest();
+            SetupRequest(request);
+
+            // TODO: should this be in a different client?  WorkClient?
+            request.Resource = $"/{projectId}/{teamId}/_apis/work/teamsettings";
+
+            var response = await _client.ExecuteAsync<TeamSettingsResponse>(request, cancellationToken);
+            if (response.IsSuccessful)
+            {
+                teamSettings.Add(teamId, response.Data);
+            }
+        }
+
+        return teamSettings;
+    }
+
     /// <summary>
     /// Returns the root area path and all child area paths for the project.
     /// </summary>
@@ -54,6 +75,21 @@ internal sealed class ProjectClient : BaseClient
     internal async Task<RestResponse<ClassificationNodeResponse>> GetAreaPaths(string projectName, CancellationToken cancellationToken)
     {
         var request = new RestRequest($"/{projectName}/_apis/wit/classificationnodes/areas", Method.Get);
+        SetupRequest(request);
+        request.AddParameter("$depth", 100); // TODO: make this configurable
+
+        return await _client.ExecuteAsync<ClassificationNodeResponse>(request, cancellationToken);
+    }
+
+    /// <summary>
+    /// Returns the root iteration path and all child iteration paths for the project.
+    /// </summary>
+    /// <param name="projectName"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    internal async Task<RestResponse<ClassificationNodeResponse>> GetIterationPaths(string projectName, CancellationToken cancellationToken)
+    {
+        var request = new RestRequest($"/{projectName}/_apis/wit/classificationnodes/iterations", Method.Get);
         SetupRequest(request);
         request.AddParameter("$depth", 100); // TODO: make this configurable
 

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Extensions/IterationNodeDtoExtensions.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Extensions/IterationNodeDtoExtensions.cs
@@ -1,0 +1,37 @@
+﻿using Moda.Integrations.AzureDevOps.Models.Projects;
+
+namespace Moda.Integrations.AzureDevOps.Extensions;
+internal static class IterationNodeDtoExtensions
+{
+    public static IterationNodeDto SetTeamIds(this IterationNodeDto root, Dictionary<Guid,Guid> iterationTeamMappings)
+    {
+        Stack<IterationNodeDtoStackItem> stack = new();
+        stack.Push(IterationNodeDtoStackItem.Create(root, null));
+
+        while (stack.Count > 0)
+        {
+            var current = stack.Pop();
+            current.Iteration.TeamId = iterationTeamMappings.TryGetValue(current.Iteration.Identifier, out var teamId) ? teamId : current.ParentTeamId;
+
+            foreach (var child in current.Iteration.Children ?? [])
+            {
+                stack.Push(IterationNodeDtoStackItem.Create(child, current.Iteration.TeamId));
+            }
+        }
+
+        return root;
+    }
+
+    private record IterationNodeDtoStackItem
+    {
+        public IterationNodeDto Iteration { get; set; } = null!;
+        public Guid? ParentTeamId { get; set; }
+
+        public static IterationNodeDtoStackItem Create(IterationNodeDto iterationNodeDto, Guid? parentTeamId) =>
+            new()
+            {
+                Iteration = iterationNodeDto,
+                ParentTeamId = parentTeamId
+            };
+    }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/ClassificationNodeResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/ClassificationNodeResponse.cs
@@ -12,14 +12,14 @@ internal record ClassificationNodeResponse
     [JsonPropertyName("name")]
     public required string Name { get; set; }
 
-    [JsonPropertyName("hasChildren")]
-    public bool? HasChildren { get; set; }
+    //[JsonPropertyName("hasChildren")]
+    //public bool? HasChildren { get; set; }
 
     [JsonPropertyName("children")]
     public List<ClassificationNodeResponse>? Children { get; set; }
 
-    [JsonPropertyName("path")]
-    public required string Path { get; set; }
+    //[JsonPropertyName("path")]
+    //public required string Path { get; set; }
 
     //[JsonIgnore]
     //public string WorkItemPath => Path[1..].Replace("\\Area", "");

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Contracts/AzdoTeam.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Contracts/AzdoTeam.cs
@@ -8,4 +8,6 @@ public sealed record AzdoTeam : IExternalTeam
     public required string Name { get; set; }
 
     public Guid WorkspaceId { get; set; }
+
+    public Guid? BoardId { get; set; }
 }

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Contracts/AzdoWorkItem.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Contracts/AzdoWorkItem.cs
@@ -18,5 +18,6 @@ public sealed record AzdoWorkItem : IExternalWorkItem
     public double StackRank { get; set; }
     public Instant? ActivatedTimestamp { get; set; }
     public Instant? DoneTimestamp { get; set; }
+    public Guid? TeamId { get; set; }
     public string? ExternalTeamIdentifier { get; set; }
 }

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/IterationDto.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/IterationDto.cs
@@ -1,0 +1,17 @@
+﻿namespace Moda.Integrations.AzureDevOps.Models.Projects;
+internal record IterationDto
+{
+    public int Id { get; set; }
+    public Guid Identifier { get; set; }
+    public required string Name { get; set; }
+    public Guid? TeamId { get; set; }
+
+    public static Func<IterationNodeDto, IterationDto> FromIterationNodeDto =>
+        iterationNodeDto => new IterationDto()
+        {
+            Id = iterationNodeDto.Id,
+            Identifier = iterationNodeDto.Identifier,
+            Name = iterationNodeDto.Name,
+            TeamId = iterationNodeDto.TeamId
+        };
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/IterationNodeDto.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/IterationNodeDto.cs
@@ -1,0 +1,24 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Moda.Integrations.AzureDevOps.Models.Projects;
+internal record IterationNodeDto
+{
+    public int Id { get; set; }
+
+    public Guid Identifier { get; set; }
+
+    public required string Name { get; set; }
+
+    public Guid? TeamId { get; set; }
+
+    public List<IterationNodeDto>? Children { get; set; }
+
+    public static explicit operator IterationNodeDto(ClassificationNodeResponse classificationNodeResponse) =>
+        new()
+        {
+            Id = classificationNodeResponse.Id,
+            Identifier = classificationNodeResponse.Identifier,
+            Name = classificationNodeResponse.Name,
+            Children = classificationNodeResponse.Children?.Select(x => (IterationNodeDto)x).ToList()
+        };
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/TeamDto.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/TeamDto.cs
@@ -6,27 +6,19 @@ internal record TeamDto
 {
     public Guid Id { get; set; }
     public required string Name { get; set; }
+
 }
 
 internal static class TeamDtoExtensions
 {
-    public static AzdoTeam ToAzdoTeam(this TeamDto team, Guid workspaceId)
+    public static AzdoTeam ToAzdoTeam(this TeamDto team, Guid workspaceId, Guid? boardId)
     {
         return new AzdoTeam
         {
             Id = team.Id,
             Name = team.Name,
-            WorkspaceId = workspaceId
+            WorkspaceId = workspaceId,
+            BoardId = boardId
         };
-    }
-
-    public static List<IExternalTeam> ToIExternalTeams(this List<TeamDto> teams, Guid workspaceId)
-    {
-        var azdoTeams = new List<IExternalTeam>(teams.Count);
-        foreach (var team in teams)
-        {
-            azdoTeams.Add(team.ToAzdoTeam(workspaceId));
-        }
-        return azdoTeams;
     }
 }

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/TeamSettingsBacklogIterationResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/TeamSettingsBacklogIterationResponse.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Moda.Integrations.AzureDevOps.Models.Projects;
+internal record TeamSettingsBacklogIterationResponse
+{
+    [JsonPropertyName("id")]
+    public Guid? Id { get; set; }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/TeamSettingsResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Projects/TeamSettingsResponse.cs
@@ -1,0 +1,8 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Moda.Integrations.AzureDevOps.Models.Projects;
+internal record TeamSettingsResponse
+{
+    [JsonPropertyName("backlogIteration")]
+    public TeamSettingsBacklogIterationResponse? BacklogIteration { get; set; }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/WorkItemFieldsResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/WorkItemFieldsResponse.cs
@@ -36,8 +36,8 @@ internal class WorkItemFieldsResponse
     [JsonPropertyName("System.AssignedTo")]
     public UserResponse? AssignedTo { get; set; }
 
-    [JsonPropertyName("System.AreaId")]
-    public int AreaId { get; set; }
+    [JsonPropertyName("System.IterationId")]
+    public int IterationId { get; set; }
 
     [JsonPropertyName("Microsoft.VSTS.Common.ActivatedDate")]
     public DateTime? ActivatedDate { get; set; }

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json.Serialization;
 using Moda.Common.Application.Interfaces.Work;
 using Moda.Integrations.AzureDevOps.Models.Contracts;
+using Moda.Integrations.AzureDevOps.Models.Projects;
 using NodaTime;
 
 namespace Moda.Integrations.AzureDevOps.Models.WorkItems;
@@ -20,7 +21,7 @@ internal static class WorkItemResponseExtensions
 {
     private static readonly double _defaultStackRank = 999_999_999_999D;
 
-    public static AzdoWorkItem ToAzdoWorkItem(this WorkItemResponse workItem, string iterationPathId)
+    public static AzdoWorkItem ToAzdoWorkItem(this WorkItemResponse workItem, IterationDto iteration)
     {
         return new AzdoWorkItem()
         {
@@ -38,18 +39,19 @@ internal static class WorkItemResponseExtensions
             StackRank = workItem.Fields.StackRank > 0 ? workItem.Fields.StackRank : _defaultStackRank,
             ActivatedTimestamp = workItem.Fields.ActivatedDate.HasValue ? Instant.FromDateTimeUtc(workItem.Fields.ActivatedDate.Value) : null,
             DoneTimestamp = workItem.Fields.ClosedDate.HasValue ? Instant.FromDateTimeUtc(workItem.Fields.ClosedDate.Value) : null,
-            ExternalTeamIdentifier = iterationPathId
+            TeamId = iteration.TeamId,
+            ExternalTeamIdentifier = iteration.Identifier.ToString()
         };
     }
 
-    public static List<IExternalWorkItem> ToIExternalWorkItems(this List<WorkItemResponse> workItems, List<ClassificationNodeResponse> iterationPaths)
+    public static List<IExternalWorkItem> ToIExternalWorkItems(this List<WorkItemResponse> workItems, List<IterationDto> iterations)
     {
-        var iterationPathsDictionary = iterationPaths.ToDictionary(x => x.Id, x => x.Identifier.ToString());
+        var iterationsDictionary = iterations.ToDictionary(x => x.Id, x => x);
         var result = new List<IExternalWorkItem>(workItems.Count);
         foreach (var workItem in workItems)
         {
-            var iterationPathId = iterationPathsDictionary[workItem.Fields.IterationId];
-            result.Add(workItem.ToAzdoWorkItem(iterationPathId));
+            var iteration = iterationsDictionary[workItem.Fields.IterationId];
+            result.Add(workItem.ToAzdoWorkItem(iteration));
         }
         return result;
     }

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
@@ -20,7 +20,7 @@ internal static class WorkItemResponseExtensions
 {
     private static readonly double _defaultStackRank = 999_999_999_999D;
 
-    public static AzdoWorkItem ToAzdoWorkItem(this WorkItemResponse workItem, string areaPathId)
+    public static AzdoWorkItem ToAzdoWorkItem(this WorkItemResponse workItem, string iterationPathId)
     {
         return new AzdoWorkItem()
         {
@@ -38,18 +38,18 @@ internal static class WorkItemResponseExtensions
             StackRank = workItem.Fields.StackRank > 0 ? workItem.Fields.StackRank : _defaultStackRank,
             ActivatedTimestamp = workItem.Fields.ActivatedDate.HasValue ? Instant.FromDateTimeUtc(workItem.Fields.ActivatedDate.Value) : null,
             DoneTimestamp = workItem.Fields.ClosedDate.HasValue ? Instant.FromDateTimeUtc(workItem.Fields.ClosedDate.Value) : null,
-            ExternalTeamIdentifier = areaPathId
+            ExternalTeamIdentifier = iterationPathId
         };
     }
 
-    public static List<IExternalWorkItem> ToIExternalWorkItems(this List<WorkItemResponse> workItems, List<ClassificationNodeResponse> areaPaths)
+    public static List<IExternalWorkItem> ToIExternalWorkItems(this List<WorkItemResponse> workItems, List<ClassificationNodeResponse> iterationPaths)
     {
-        var areaPathsDictionary = areaPaths.ToDictionary(x => x.Id, x => x.Identifier.ToString());
+        var iterationPathsDictionary = iterationPaths.ToDictionary(x => x.Id, x => x.Identifier.ToString());
         var result = new List<IExternalWorkItem>(workItems.Count);
         foreach (var workItem in workItems)
         {
-            var areaPathId = areaPathsDictionary[workItem.Fields.AreaId];
-            result.Add(workItem.ToAzdoWorkItem(areaPathId));
+            var iterationPathId = iterationPathsDictionary[workItem.Fields.IterationId];
+            result.Add(workItem.ToAzdoWorkItem(iterationPathId));
         }
         return result;
     }

--- a/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Sut/Extensions/IterationNodeDtoExtensionsTests.cs
+++ b/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Sut/Extensions/IterationNodeDtoExtensionsTests.cs
@@ -1,0 +1,174 @@
+﻿using Moda.Integrations.AzureDevOps.Extensions;
+using Moda.Integrations.AzureDevOps.Models.Projects;
+
+namespace Moda.Integrations.AzureDevOps.Tests.Sut.Extensions;
+
+public class IterationNodeDtoExtensionsTests
+{
+    [Fact]
+    public void SetTeamIds_ShouldAssignTeamId_WhenMappingExists()
+    {
+        // Arrange
+        var root = new IterationNodeDto
+        {
+            Id = 1,
+            Identifier = Guid.NewGuid(),
+            Name = "Root",
+            Children = []
+        };
+        var teamId = Guid.NewGuid();
+        var iterationTeamMappings = new Dictionary<Guid, Guid>
+        {
+            { root.Identifier, teamId }
+        };
+
+        // Act
+        var result = root.SetTeamIds(iterationTeamMappings);
+
+        // Assert
+        Assert.Equal(teamId, result.TeamId);
+    }
+
+    [Fact]
+    public void SetTeamIds_WithChildrenShouldAssignTeamId_WhenMappingExists()
+    {
+        // Arrange
+        var child2Id = Guid.NewGuid();
+        var root = new IterationNodeDto
+        {
+            Id = 1,
+            Identifier = Guid.NewGuid(),
+            Name = "Root",
+            Children =
+                [
+                    new IterationNodeDto
+                    {
+                        Id = 2,
+                        Identifier = Guid.NewGuid(),
+                        Name = "Child 1"
+                    },
+                    new IterationNodeDto
+                    {
+                        Id = 2,
+                        Identifier = child2Id,
+                        Name = "Child 2"
+                    }
+                ]
+        };
+        var rootTeamId = Guid.NewGuid();
+        var child2TeamId = Guid.NewGuid();
+        var iterationTeamMappings = new Dictionary<Guid, Guid>
+        {
+            { root.Identifier, rootTeamId },
+            { child2Id, child2TeamId }
+        };
+
+        // Act
+        var result = root.SetTeamIds(iterationTeamMappings);
+
+        // Assert
+        Assert.Equal(rootTeamId, result.TeamId);
+        Assert.NotNull(result.Children);
+        Assert.Equal(rootTeamId, result.Children[0].TeamId);
+        Assert.Equal(child2TeamId, result.Children[1].TeamId);
+    }
+
+    [Fact]
+    public void SetTeamIds_ShouldAssignParentTeamId_WhenMappingDoesNotExist()
+    {
+        // Arrange
+        var root = new IterationNodeDto
+        {
+            Id = 1,
+            Identifier = Guid.NewGuid(),
+            Name = "Root",
+            Children =
+                [
+                    new IterationNodeDto
+                    {
+                        Id = 2,
+                        Identifier = Guid.NewGuid(),
+                        Name = "Child"
+                    }
+                ]
+        };
+        var teamId = Guid.NewGuid();
+        var iterationTeamMappings = new Dictionary<Guid, Guid>
+        {
+            { root.Identifier, teamId }
+        };
+
+        // Act
+        var result = root.SetTeamIds(iterationTeamMappings);
+
+        // Assert
+        Assert.Equal(teamId, result.TeamId);
+        Assert.NotNull(result.Children);
+        Assert.Equal(teamId, result.Children[0].TeamId);
+    }
+
+    [Fact]
+    public void SetTeamIds_ShouldHandleEmptyChildren()
+    {
+        // Arrange
+        var root = new IterationNodeDto
+        {
+            Id = 1,
+            Identifier = Guid.NewGuid(),
+            Name = "Root",
+            Children = []
+        };
+        var teamId = Guid.NewGuid();
+        var iterationTeamMappings = new Dictionary<Guid, Guid>
+        {
+            { root.Identifier, teamId }
+        };
+
+        // Act
+        var result = root.SetTeamIds(iterationTeamMappings);
+
+        // Assert
+        Assert.NotNull(result.Children);
+        Assert.Empty(result.Children);
+    }
+
+    [Fact]
+    public void SetTeamIds_ShouldHandleNullChildren()
+    {
+        // Arrange
+        var root = new IterationNodeDto
+        {
+            Id = 1,
+            Identifier = Guid.NewGuid(),
+            Name = "Root",
+            Children = null
+        };
+        var iterationTeamMappings = new Dictionary<Guid, Guid>();
+
+        // Act
+        var result = root.SetTeamIds(iterationTeamMappings);
+
+        // Assert
+        Assert.Null(result.Children);
+    }
+
+    [Fact]
+    public void SetTeamIds_ShouldHandleNoIterationTeamMapping()
+    {
+        // Arrange
+        var root = new IterationNodeDto
+        {
+            Id = 1,
+            Identifier = Guid.NewGuid(),
+            Name = "Root"
+        };
+        var iterationTeamMappings = new Dictionary<Guid, Guid>();
+
+        // Act
+        var result = root.SetTeamIds(iterationTeamMappings);
+
+        // Assert
+        Assert.Null(result.TeamId);
+        Assert.Null(result.Children);
+    }
+}

--- a/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Sut/Models/ClassificationNodeDtoTests.cs
+++ b/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Sut/Models/ClassificationNodeDtoTests.cs
@@ -21,10 +21,10 @@ public class ClassificationNodeDtoTests : CommonResponseOptions
         actualResponse.Id.Should().Be(45);
         actualResponse.Identifier.Should().Be(Guid.Parse("e060e843-5539-4ec4-becf-f61c5f3c5f85"));
         actualResponse.Name.Should().Be("Moda");
-        actualResponse.HasChildren.Should().BeTrue();
+        //actualResponse.HasChildren.Should().BeTrue();
         actualResponse.Children.Should().NotBeNull();
         actualResponse.Children!.Count.Should().Be(3);
-        actualResponse.Path.Should().Be("\\Moda\\Area");
+        //actualResponse.Path.Should().Be("\\Moda\\Area");
 
         var list = actualResponse.FlattenHierarchy(a => a.Children).ToList();
 

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsWorkspaceTeamDto.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Dtos/AzureDevOpsBoardsWorkspaceTeamDto.cs
@@ -19,6 +19,11 @@ public sealed record AzureDevOpsBoardsWorkspaceTeamDto : IMapFrom<AzureDevOpsBoa
     public required string TeamName { get; set; }
 
     /// <summary>
+    /// The unique identifier for the board in the Azure DevOps Boards system.
+    /// </summary>
+    public Guid? BoardId { get; set; }
+
+    /// <summary>
     /// The unique identifier for the team within Moda.
     /// </summary>
     public Guid? InternalTeamId { get; set; }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsInitManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsInitManager.cs
@@ -83,7 +83,6 @@ public sealed class AzureDevOpsBoardsInitManager(ILogger<AzureDevOpsBoardsInitMa
             _logger.LogError(ex, "An error occurred while trying to import projects from Azure DevOps for connection {ConnectionId}.", connectionId);
             return Result.Failure($"An error occurred while trying to import projects from Azure DevOps for connection {connectionId}.");
         }
-
     }
 
     public async Task<Result<Guid>> InitWorkProcessIntegration(Guid connectionId, Guid workProcessExternalId, CancellationToken cancellationToken)

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
@@ -138,7 +138,11 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
                                 _ => new DateTime(1900, 01, 01)
                             };
 
-                            var syncWorkItemsResult = await SyncWorkItems(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, lastChangedDate, workspace.IntegrationState!.InternalId, workspace.Name, cancellationToken);
+                            var workspaceTeams = connectionDetails.TeamConfiguration.WorkspaceTeams
+                                .Where(t => t.WorkspaceId == workspace.ExternalId)
+                                .ToArray();
+
+                            var syncWorkItemsResult = await SyncWorkItems(connectionDetails.Configuration.OrganizationUrl, connectionDetails.Configuration.PersonalAccessToken, lastChangedDate, workspace.IntegrationState!.InternalId, workspace.Name, workspaceTeams, cancellationToken);
                             if (syncWorkItemsResult.IsFailure)
                             {
                                 _logger.LogError("An error occurred while syncing Azure DevOps Boards workspace {WorkspaceId} work items. Error: {Error}", workspace.IntegrationState!.InternalId, syncWorkItemsResult.Error);
@@ -273,7 +277,7 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
             : updateResult;
     }
 
-    private async Task<Result> SyncWorkItems(string organizationUrl, string personalAccessToken, DateTime lastChangedDate, Guid workspaceId, string azdoWorkspaceName, CancellationToken cancellationToken)
+    private async Task<Result> SyncWorkItems(string organizationUrl, string personalAccessToken, DateTime lastChangedDate, Guid workspaceId, string azdoWorkspaceName, AzureDevOpsBoardsWorkspaceTeamDto[] workspaceTeams, CancellationToken cancellationToken)
     {
         Guard.Against.NullOrWhiteSpace(organizationUrl, nameof(organizationUrl));
         Guard.Against.NullOrWhiteSpace(personalAccessToken, nameof(personalAccessToken));
@@ -283,7 +287,26 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
         if (workTypesResult.IsFailure)
             return workTypesResult.ConvertFailure();
 
-        var workItemsResult = await _azureDevOpsService.GetWorkItems(organizationUrl, personalAccessToken, azdoWorkspaceName, lastChangedDate, workTypesResult.Value.Select(t => t.Name).ToArray(), cancellationToken);
+        Dictionary<Guid, Guid?> teamSettings;
+        Dictionary<Guid, Guid?> teamMappings;
+        if (workspaceTeams.Length > 0)
+        {
+            teamSettings = new Dictionary<Guid, Guid?>(workspaceTeams.Length);
+            teamMappings = new Dictionary<Guid, Guid?>(workspaceTeams.Length);
+
+            foreach (var team in workspaceTeams)
+            {
+                teamSettings[team.TeamId] = team.BoardId;
+                teamMappings[team.TeamId] = team.InternalTeamId;
+            }
+        }
+        else
+        {
+            teamSettings = [];
+            teamMappings = [];
+        }
+
+        var workItemsResult = await _azureDevOpsService.GetWorkItems(organizationUrl, personalAccessToken, azdoWorkspaceName, lastChangedDate, workTypesResult.Value.Select(t => t.Name).ToArray(), teamSettings, cancellationToken);
         if (workItemsResult.IsFailure)
             return workItemsResult.ConvertFailure();
 
@@ -292,7 +315,7 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
         if (workItemsResult.Value.Count == 0)
             return Result.Success();
 
-        var syncWorkItemsResult = await _sender.Send(new SyncExternalWorkItemsCommand(workspaceId, workItemsResult.Value), cancellationToken);
+        var syncWorkItemsResult = await _sender.Send(new SyncExternalWorkItemsCommand(workspaceId, workItemsResult.Value, teamMappings), cancellationToken);
 
         return syncWorkItemsResult.IsSuccess
             ? Result.Success()

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Application/Connections/Managers/AzureDevOpsBoardsSyncManager.cs
@@ -296,6 +296,10 @@ public sealed class AzureDevOpsBoardsSyncManager(ILogger<AzureDevOpsBoardsSyncMa
 
             foreach (var team in workspaceTeams)
             {
+                // Only add teams that have an internal team id.  This will allow mapped parent teams to be set for items that are assigned to teams that haven't been mapped.
+                if (team.InternalTeamId is null)
+                    continue;
+
                 teamSettings[team.TeamId] = team.BoardId;
                 teamMappings[team.TeamId] = team.InternalTeamId;
             }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
@@ -176,7 +176,7 @@ public sealed class AzureDevOpsBoardsConnection : Connection<AzureDevOpsBoardsCo
 
             foreach (var team in teams)
             {
-                var result = TeamConfiguration.UpsertWorkspaceTeam(team.WorkspaceId, team.Id, team.Name);
+                var result = TeamConfiguration.UpsertWorkspaceTeam(team.WorkspaceId, team.Id, team.Name, team.BoardId);
                 if (result.IsFailure)
                     return result;
             }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsTeamConfiguration.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsTeamConfiguration.cs
@@ -13,22 +13,23 @@ public sealed class AzureDevOpsBoardsTeamConfiguration
     /// </summary>
     public List<AzureDevOpsBoardsWorkspaceTeam> WorkspaceTeams { get; private set; } = [];
 
-    public Result UpsertWorkspaceTeam(Guid workspaceId, Guid teamId, string teamName)
+    public Result UpsertWorkspaceTeam(Guid workspaceId, Guid teamId, string teamName, Guid? boardId)
     {
         try
         {
             Guard.Against.Default(workspaceId, nameof(workspaceId));
             Guard.Against.Default(teamId, nameof(teamId));
             Guard.Against.NullOrWhiteSpace(teamName, nameof(teamName));
+            Guard.Against.Default(boardId, nameof(boardId));
 
             var existingTeam = WorkspaceTeams.SingleOrDefault(w => w.WorkspaceId == workspaceId && w.TeamId == teamId);
             if (existingTeam is null)
             {
-                WorkspaceTeams.Add(new AzureDevOpsBoardsWorkspaceTeam(workspaceId, teamId, teamName));
+                WorkspaceTeams.Add(new AzureDevOpsBoardsWorkspaceTeam(workspaceId, teamId, teamName, boardId));
             }
             else
             {
-                existingTeam.Update(teamName);
+                existingTeam.Update(teamName, boardId);
             }
 
             return Result.Success();
@@ -75,7 +76,7 @@ public sealed class AzureDevOpsBoardsTeamConfiguration
             var team = WorkspaceTeams.Single(w => w.TeamId == teamId);
             WorkspaceTeams.Remove(team);
 
-            WorkspaceTeams.Add(new AzureDevOpsBoardsWorkspaceTeam(team.WorkspaceId, team.TeamId, team.TeamName));
+            WorkspaceTeams.Add(new AzureDevOpsBoardsWorkspaceTeam(team.WorkspaceId, team.TeamId, team.TeamName, team.BoardId));
 
             return Result.Success();
         }

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsWorkspaceTeam.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/AzureDevOpsBoardsWorkspaceTeam.cs
@@ -5,11 +5,12 @@ public sealed class AzureDevOpsBoardsWorkspaceTeam
 
     private AzureDevOpsBoardsWorkspaceTeam() { }
 
-    public AzureDevOpsBoardsWorkspaceTeam(Guid workspaceId, Guid teamId, string teamName)
+    public AzureDevOpsBoardsWorkspaceTeam(Guid workspaceId, Guid teamId, string teamName, Guid? boardId)
     {
         WorkspaceId = workspaceId;
         TeamId = teamId;
         TeamName = teamName;
+        BoardId = boardId;
     }
 
     /// <summary>
@@ -31,14 +32,17 @@ public sealed class AzureDevOpsBoardsWorkspaceTeam
         private set => _teamName = Guard.Against.NullOrWhiteSpace(value, nameof(TeamName)); 
     }
 
+    public Guid? BoardId { get; private set; }
+
     /// <summary>
     /// InternalTeamId is the unique identifier for the team in the Moda system.
     /// </summary>
     public Guid? InternalTeamId { get; private set; }
 
-    public void Update(string teamName)
+    public void Update(string teamName, Guid? boardId)
     {
         TeamName = teamName;
+        BoardId = boardId;
     }
 
     public void MapInternalTeam(Guid? internalTeamId)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
@@ -129,6 +129,11 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
                     var workItem = workspace.WorkItems.FirstOrDefault(wi => wi.ExternalId == externalWorkItem.Id);
                     try
                     {
+                        Guid? teamId = null;
+                        if (externalWorkItem.TeamId.HasValue)
+                        {
+                            request.teamMappings.TryGetValue(externalWorkItem.TeamId.Value, out teamId);
+                        }
 
                         if (workItem is null)
                         {
@@ -140,7 +145,7 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
                                 workFlowSchemeData.WorkStatus.Id,
                                 workFlowSchemeData.WorkStatusCategory,
                                 parentWorkItemInfo,
-                                null,
+                                teamId,
                                 externalWorkItem.Created,
                                 employees.SingleOrDefault(e => e.Email == externalWorkItem.CreatedBy)?.Id,
                                 externalWorkItem.LastModified,
@@ -164,7 +169,7 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
                                 workFlowSchemeData.WorkStatus.Id,
                                 workFlowSchemeData.WorkStatusCategory,
                                 parentWorkItemInfo,
-                                null,
+                                teamId,
                                 externalWorkItem.LastModified,
                                 employees.SingleOrDefault(e => e.Email == externalWorkItem.LastModifiedBy)?.Id,
                                 employees.SingleOrDefault(e => e.Email == externalWorkItem.AssignedTo)?.Id,

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
@@ -1,6 +1,7 @@
 ﻿using Moda.Common.Application.Dtos;
 using Moda.Common.Application.Employees.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
+using Moda.Work.Application.WorkTeams.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Dtos;
 public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
@@ -16,6 +17,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
     public required SimpleNavigationDto StatusCategory { get; set; }
     public int? Priority { get; set; }
     public WorkItemNavigationDto? Parent { get; set; }
+    public WorkTeamNavigationDto? Team { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
     public Instant Created { get; set; }
     public EmployeeNavigationDto? CreatedBy { get; set; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
@@ -1,6 +1,7 @@
 ﻿using Moda.Common.Application.Dtos;
 using Moda.Common.Application.Employees.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
+using Moda.Work.Application.WorkTeams.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Dtos;
 public sealed record WorkItemListDto : IMapFrom<WorkItem>
@@ -13,6 +14,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
     public required string Status { get; set; }
     public required SimpleNavigationDto StatusCategory { get; set; }
     public WorkItemNavigationDto? Parent { get; set; }
+    public WorkTeamNavigationDto? Team { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
     public double StackRank { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTeams/Dtos/WorkTeamNavigationDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTeams/Dtos/WorkTeamNavigationDto.cs
@@ -1,0 +1,24 @@
+﻿using Moda.Common.Application.Dtos;
+
+namespace Moda.Work.Application.WorkTeams.Dtos;
+public record WorkTeamNavigationDto : NavigationDto, IMapFrom<WorkTeam>
+{
+    public required string Type { get; set; }
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<WorkTeam, WorkTeamNavigationDto>()
+            .Map(dest => dest.Type, src => src.Type.GetDisplayName());
+    }
+
+    public static WorkTeamNavigationDto FromWorkTeam(WorkTeam team)
+    {
+        return new WorkTeamNavigationDto()
+        {
+            Id = team.Id,
+            Key = team.Key,
+            Name = team.Name,
+            Type = team.Type.GetDisplayName()
+        };
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemExtended.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemExtended.cs
@@ -5,14 +5,14 @@ public sealed class WorkItemExtended
 {
     private WorkItemExtended() { }
 
-    private WorkItemExtended(Guid id, string? areaPath)
+    private WorkItemExtended(Guid id, string? iterationPath)
     {
         Id = id;
-        ExternalTeamIdentifier = areaPath;
+        ExternalTeamIdentifier = iterationPath;
     }
 
-    private WorkItemExtended(string? areaPath)
-        : this(Guid.Empty, areaPath) // the guid is empty when the work item is not yet created. EF will fill it in.
+    private WorkItemExtended(string? iterationPath)
+        : this(Guid.Empty, iterationPath) // the guid is empty when the work item is not yet created. EF will fill it in.
     { }
 
     /// <summary>

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -11461,6 +11461,12 @@
           "teamName": {
             "type": "string"
           },
+          "boardId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": true,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
           "internalTeamId": {
             "type": "string",
             "format": "guid",

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -9250,6 +9250,14 @@
               }
             ]
           },
+          "team": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkTeamNavigationDto"
+              }
+            ]
+          },
           "assignedTo": {
             "nullable": true,
             "oneOf": [
@@ -9322,6 +9330,22 @@
             "nullable": true
           }
         }
+      },
+      "WorkTeamNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        ]
       },
       "EmployeeNavigationDto": {
         "allOf": [
@@ -10042,6 +10066,14 @@
             "oneOf": [
               {
                 "$ref": "#/components/schemas/WorkItemNavigationDto"
+              }
+            ]
+          },
+          "team": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkTeamNavigationDto"
               }
             ]
           },

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/ag-grid-transfer.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/grid/ag-grid-transfer.tsx
@@ -116,7 +116,7 @@ export const AgGridTransfer = <TData extends object>(
 
   const getGrid = useCallback(
     (isLeft: boolean) => (
-      <div className={agGridTheme} style={{ minHeight: 250, width: '100%' }}>
+      <div className={agGridTheme} style={{ minHeight: 400, width: '100%' }}>
         <AgGridReact
           ref={isLeft ? leftGridRef : rightGridRef}
           getRowId={props.getRowId}

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-item-list-item.tsx
@@ -40,10 +40,14 @@ export default WorkItemListItem
 const WorkItemListItemDescription = ({ workItem }: WorkItemListItemProps) => {
   return (
     <Space wrap>
-      <Tag>{workItem.type}</Tag>
-      <Tag color={getWorkStatusCategoryColor(workItem.statusCategory.name)}>
+      <Tag title="Work Item Type">{workItem.type}</Tag>
+      <Tag
+        title="Work Item Status"
+        color={getWorkStatusCategoryColor(workItem.statusCategory.name)}
+      >
         {workItem.status}
       </Tag>
+      {workItem.team && <Tag title="Work Item Team">{workItem.team.name}</Tag>}
     </Space>
   )
 }

--- a/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/components/common/work/work-items-grid.tsx
@@ -6,6 +6,7 @@ import { ColDef } from 'ag-grid-community'
 import Link from 'next/link'
 import { useCallback, useMemo } from 'react'
 import { ExportOutlined } from '@ant-design/icons'
+import { NestedTeamNameLinkCellRenderer } from '../moda-grid-cell-renderers'
 
 export interface WorkItemsGridProps {
   workItems: WorkItemListDto[]
@@ -111,9 +112,9 @@ const WorkItemsGrid = (props: WorkItemsGridProps) => {
         comparator: workStatusCategoryComparator,
       },
       {
-        field: 'assignedTo.name',
-        headerName: 'Assigned To',
-        cellRenderer: AssignedToLinkCellRenderer,
+        field: 'team.name',
+        headerName: 'Team',
+        cellRenderer: NestedTeamNameLinkCellRenderer,
       },
       {
         field: 'parent.key',
@@ -125,6 +126,11 @@ const WorkItemsGrid = (props: WorkItemsGridProps) => {
         field: 'parent.title',
         headerName: 'Parent',
         width: 400,
+      },
+      {
+        field: 'assignedTo.name',
+        headerName: 'Assigned To',
+        cellRenderer: AssignedToLinkCellRenderer,
       },
     ],
     [],

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -57,6 +57,11 @@ const workItemColDefs: ColDef<WorkItemModel>[] = [
     minWidth: 100,
   },
   {
+    field: 'team.name',
+    headerName: 'Team',
+    minWidth: 100,
+  },
+  {
     field: 'parent.key',
     headerName: 'Parent Key',
     minWidth: 100,

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { WorkItemDetailsDto } from '@/src/services/moda-api'
-import { Descriptions, Steps } from 'antd'
+import { Descriptions } from 'antd'
 import dayjs from 'dayjs'
 import Link from 'next/link'
 import WorkItemSteps from './work-item-steps'
@@ -15,6 +15,11 @@ export interface WorkItemDetailsProps {
 const WorkItemDetails = ({ workItem }: WorkItemDetailsProps) => {
   if (!workItem) return null
 
+  const teamLink =
+    workItem.team?.type === 'Team'
+      ? `/organizations/teams/${workItem.team?.key}`
+      : `/organizations/team-of-teams/${workItem.team?.key}`
+
   return (
     <>
       <Descriptions>
@@ -23,14 +28,8 @@ const WorkItemDetails = ({ workItem }: WorkItemDetailsProps) => {
         <Item label="Status">{workItem.status}</Item>
         <Item label="Status Category">{workItem.statusCategory.name}</Item>
         <Item label="Priority">{workItem.priority}</Item>
-        <Item label="Assigned To">
-          {workItem.assignedTo ? (
-            <Link href={`/organizations/employees/${workItem.assignedTo.key}`}>
-              {workItem.assignedTo.name}
-            </Link>
-          ) : (
-            'Unassigned'
-          )}
+        <Item label="Team">
+          <Link href={teamLink}>{workItem.team?.name}</Link>
         </Item>
         <Item label="Parent">
           {workItem.parent ? (
@@ -41,6 +40,15 @@ const WorkItemDetails = ({ workItem }: WorkItemDetailsProps) => {
             </Link>
           ) : (
             'No Parent'
+          )}
+        </Item>
+        <Item label="Assigned To">
+          {workItem.assignedTo ? (
+            <Link href={`/organizations/employees/${workItem.assignedTo.key}`}>
+              {workItem.assignedTo.name}
+            </Link>
+          ) : (
+            'Unassigned'
           )}
         </Item>
         <Item label="Created By">

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9800,6 +9800,7 @@ export interface WorkItemListDto {
     status?: string;
     statusCategory?: SimpleNavigationDto;
     parent?: WorkItemNavigationDto | undefined;
+    team?: WorkTeamNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;
     stackRank?: number;
     externalViewWorkItemUrl?: string | undefined;
@@ -9820,6 +9821,10 @@ export interface WorkItemNavigationDto {
     title?: string;
     workspaceKey?: string;
     externalViewWorkItemUrl?: string | undefined;
+}
+
+export interface WorkTeamNavigationDto extends NavigationDto {
+    type?: string;
 }
 
 export interface EmployeeNavigationDto extends NavigationDto {
@@ -10022,6 +10027,7 @@ export interface WorkItemDetailsDto {
     statusCategory?: SimpleNavigationDto;
     priority?: number | undefined;
     parent?: WorkItemNavigationDto | undefined;
+    team?: WorkTeamNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;
     created?: Date;
     createdBy?: EmployeeNavigationDto | undefined;

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -10411,6 +10411,7 @@ export interface AzureDevOpsBoardsWorkspaceTeamDto {
     workspaceId?: string;
     teamId?: string;
     teamName?: string;
+    boardId?: string | undefined;
     internalTeamId?: string | undefined;
 }
 


### PR DESCRIPTION
- The Team BoardId is now persisted on sync.
- Finished wiring up the ability to sync work items with teamIds.
- Added Team info to existing UI elements.
- Updated the sync work item flow for synced teams only.