### PR TITLE
Feature/enable roadmaplink ordering

### DIFF
--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapCommand.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapCommand.cs
@@ -28,6 +28,8 @@ public sealed class UpdateRoadmapCommandValidator : AbstractValidator<UpdateRoad
 
 internal sealed class UpdateRoadmapCommandHandler(IPlanningDbContext planningDbContext, ICurrentUser currentUser, ILogger<UpdateRoadmapCommandHandler> logger) : ICommandHandler<UpdateRoadmapCommand>
 {
+    private const string AppRequestName = nameof(UpdateRoadmapLinksOrderCommand);
+
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
     private readonly Guid _currentUserEmployeeId = Guard.Against.NullOrEmpty(currentUser.GetEmployeeId());
     private readonly ILogger<UpdateRoadmapCommandHandler> _logger = logger;
@@ -57,7 +59,7 @@ internal sealed class UpdateRoadmapCommandHandler(IPlanningDbContext planningDbC
                 await _planningDbContext.Entry(roadmap).ReloadAsync(cancellationToken);
                 roadmap.ClearDomainEvents();
 
-                _logger.LogError("Moda Request: Failure for Request {Name} {@Request}.  Error message: {Error}", request.GetType().Name, request, updateResult.Error);
+                _logger.LogError("Failure for Request {CommandName} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
                 return Result.Failure(updateResult.Error);
             }
 
@@ -67,11 +69,8 @@ internal sealed class UpdateRoadmapCommandHandler(IPlanningDbContext planningDbC
         }
         catch (Exception ex)
         {
-            var requestName = request.GetType().Name;
-
-            _logger.LogError(ex, "Moda Request: Exception for Request {Name} {@Request}", requestName, request);
-
-            return Result.Failure($"Moda Request: Exception for Request {requestName} {request}");
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
         }
     }
 }

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapLinkOrderCommand.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapLinkOrderCommand.cs
@@ -1,0 +1,73 @@
+﻿using Ardalis.GuardClauses;
+
+namespace Moda.Planning.Application.Roadmaps.Commands;
+public sealed record UpdateRoadmapLinkOrderCommand(Guid RoadmapId, Guid RoadmapLinkId, int Order) : ICommand;
+
+public sealed class UpdateRoadmapLinkOrderCommandValidator : CustomValidator<UpdateRoadmapLinkOrderCommand>
+{
+    public UpdateRoadmapLinkOrderCommandValidator()
+    {
+        RuleLevelCascadeMode = CascadeMode.Stop;
+
+        RuleFor(o => o.RoadmapId)
+            .NotEmpty()
+            .WithMessage("A valid roadmap must be provided.");
+
+        RuleFor(o => o.RoadmapLinkId)
+            .NotEmpty()
+            .WithMessage("A valid roadmap link must be provided.");
+
+        RuleFor(o => o.Order)
+            .GreaterThan(0)
+            .WithMessage("Order must be greater than 0.");
+    }
+}
+
+internal sealed class UpdateRoadmapLinkOrderCommandHandler(IPlanningDbContext planningDbContext, ICurrentUser currentUser, ILogger<UpdateRoadmapLinkOrderCommandHandler> logger) : ICommandHandler<UpdateRoadmapLinkOrderCommand>
+{
+    private const string AppRequestName = nameof(UpdateRoadmapLinkOrderCommand);
+
+    private readonly IPlanningDbContext _planningDbContext = planningDbContext;
+    private readonly Guid _currentUserEmployeeId = Guard.Against.NullOrEmpty(currentUser.GetEmployeeId());
+    private readonly ILogger<UpdateRoadmapLinkOrderCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateRoadmapLinkOrderCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var roadmap = await _planningDbContext.Roadmaps
+                .Include(x => x.Managers)
+                .Include(x => x.ChildLinks)
+                .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
+
+            if (roadmap is null)
+                return Result.Failure($"Roadmap with id {request.RoadmapId} not found");
+
+            var roadmapLink = roadmap.ChildLinks.FirstOrDefault(x => x.Id == request.RoadmapLinkId);
+            if (roadmapLink is null)
+                return Result.Failure($"Roadmap link with id {request.RoadmapLinkId} not found");
+
+            var updateResult = roadmap.SetChildLinksOrder(request.RoadmapLinkId, request.Order, _currentUserEmployeeId);
+            if (updateResult.IsFailure)
+            {
+                // Reset the entity
+                await _planningDbContext.Entry(roadmap).ReloadAsync(cancellationToken);
+                roadmap.ClearDomainEvents();
+
+                _logger.LogError("Failure for Request {CommandName} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _planningDbContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}
+
+

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapLinkOrderCommand.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapLinkOrderCommand.cs
@@ -43,7 +43,7 @@ internal sealed class UpdateRoadmapLinkOrderCommandHandler(IPlanningDbContext pl
             if (roadmap is null)
                 return Result.Failure($"Roadmap with id {request.RoadmapId} not found");
 
-            var roadmapLink = roadmap.ChildLinks.FirstOrDefault(x => x.Id == request.RoadmapLinkId);
+            var roadmapLink = roadmap.ChildLinks.FirstOrDefault(x => x.ChildId == request.RoadmapLinkId);
             if (roadmapLink is null)
                 return Result.Failure($"Roadmap link with id {request.RoadmapLinkId} not found");
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapLinksOrderCommand.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Application/Roadmaps/Commands/UpdateRoadmapLinksOrderCommand.cs
@@ -1,0 +1,72 @@
+﻿using Ardalis.GuardClauses;
+
+namespace Moda.Planning.Application.Roadmaps.Commands;
+public sealed record UpdateRoadmapLinksOrderCommand(Guid RoadmapId, Dictionary<Guid,int> RoadmapLinks) : ICommand;
+
+public sealed class UpdateRoadmapLinksOrderCommandValidator : CustomValidator<UpdateRoadmapLinksOrderCommand>
+{
+    public UpdateRoadmapLinksOrderCommandValidator()
+    {
+        RuleLevelCascadeMode = CascadeMode.Stop;
+
+        RuleFor(o => o.RoadmapId)
+            .NotEmpty()
+            .WithMessage("A roadmap must be selected.");
+
+        RuleFor(o => o.RoadmapLinks)
+            .NotEmpty()
+            .WithMessage("At least one roadmap link must be provided.");
+    }
+}
+
+internal sealed class UpdateRoadmapLinksOrderCommandHandler(IPlanningDbContext planningDbContext, ICurrentUser currentUser, ILogger<UpdateRoadmapLinksOrderCommandHandler> logger) : ICommandHandler<UpdateRoadmapLinksOrderCommand>
+{
+    private const string AppRequestName = nameof(UpdateRoadmapLinksOrderCommand);
+
+    private readonly IPlanningDbContext _planningDbContext = planningDbContext;
+    private readonly Guid _currentUserEmployeeId = Guard.Against.NullOrEmpty(currentUser.GetEmployeeId());
+    private readonly ILogger<UpdateRoadmapLinksOrderCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateRoadmapLinksOrderCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var roadmap = await _planningDbContext.Roadmaps
+                .Include(x => x.Managers)
+                .Include(x => x.ChildLinks)
+                .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
+
+            if (roadmap is null)
+                return Result.Failure($"Roadmap with id {request.RoadmapId} not found");
+
+            if (roadmap.ChildLinks.Count != request.RoadmapLinks.Count)
+            {
+                var missingRoadmapLinks = request.RoadmapLinks.Keys.Except(roadmap.ChildLinks.Select(o => o.Id));
+                _logger.LogWarning("Not all roadmap links provided were found for roadmap {RoadmapId}. The following roadmap links were not found: {RoadmapLinkIds}", roadmap.Id, missingRoadmapLinks);
+                return Result.Failure("Not all roadmap links provided were found.");
+            }
+
+            var updateResult = roadmap.SetChildLinksOrder(request.RoadmapLinks, _currentUserEmployeeId);
+            if (updateResult.IsFailure)
+            {
+                // Reset the entity
+                await _planningDbContext.Entry(roadmap).ReloadAsync(cancellationToken);
+                roadmap.ClearDomainEvents();
+
+                _logger.LogError("Failure for Request {CommandName} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _planningDbContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}
+
+

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
@@ -360,18 +360,9 @@ public class PlanningIntervalsController : ControllerBase
 
         var result = await _sender.Send(new UpdatePlanningIntervalObjectivesOrderCommand(request.PlanningIntervalId, request.Objectives), cancellationToken);
 
-        if (result.IsFailure)
-        {
-            var error = new ErrorResult
-            {
-                StatusCode = 400,
-                SupportMessage = result.Error,
-                Source = "PlanningIntervalsController.UpdateObjectivesOrder"
-            };
-            return BadRequest(error);
-        }
-
-        return NoContent();
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(ErrorResult.CreateBadRequest(result.Error, "PlanningIntervalsController.UpdateObjectivesOrder"));
     }
 
     [HttpGet("{idOrKey}/objectives/health-report")]

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/RoadmapsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/RoadmapsController.cs
@@ -142,7 +142,7 @@ public class RoadmapsController : ControllerBase
         if (id != request.RoadmapId)
             return BadRequest();
 
-        if (roadmapLinkId != request.RoadmapId)
+        if (roadmapLinkId != request.RoadmapLinkId)
             return BadRequest();
 
 

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Planning/RoadmapsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Planning/RoadmapsController.cs
@@ -115,6 +115,44 @@ public class RoadmapsController : ControllerBase
         return Ok(roadmaps);
     }
 
+    [HttpPost("{id}/child-links/order")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.Roadmaps)]
+    [OpenApiOperation("Update the order of child roadmap links.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> UpdateChildLinksOrder(Guid id, [FromBody] UpdateRoadmapLinksOrderRequest request, CancellationToken cancellationToken)
+    {
+        if (id != request.RoadmapId)
+            return BadRequest();
+
+        var result = await _sender.Send(new UpdateRoadmapLinksOrderCommand(request.RoadmapId, request.RoadmapLinks), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(ErrorResult.CreateBadRequest(result.Error, "RoadmapsController.UpdateChildLinksOrder"));
+    }
+
+    [HttpPost("{id}/child-links/{roadmapLinkId}/order")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.Roadmaps)]
+    [OpenApiOperation("Update the order of child roadmap links based on a single change.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ErrorResult), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> UpdateChildLinkOrder(Guid id, Guid roadmapLinkId, [FromBody] UpdateRoadmapLinkOrderRequest request, CancellationToken cancellationToken)
+    {
+        if (id != request.RoadmapId)
+            return BadRequest();
+
+        if (roadmapLinkId != request.RoadmapId)
+            return BadRequest();
+
+
+        var result = await _sender.Send(new UpdateRoadmapLinkOrderCommand(request.RoadmapId, request.RoadmapLinkId, request.Order), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(ErrorResult.CreateBadRequest(result.Error, "RoadmapsController.UpdateChildLinkOrder"));
+    }
+
     [HttpGet("visibility-options")]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Risks)]
     [OpenApiOperation("Get a list of all visibility.", "")]

--- a/Moda.Web/src/Moda.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapLinkOrderRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapLinkOrderRequest.cs
@@ -1,0 +1,26 @@
+﻿namespace Moda.Web.Api.Models.Planning.Roadmaps;
+
+public sealed class UpdateRoadmapLinkOrderRequest
+{
+    public Guid RoadmapId { get; set; }
+    public Guid RoadmapLinkId { get; set; }
+    public int Order { get; set; }
+}
+
+public sealed class UpdateRoadmapLinkOrderRequestValidator : CustomValidator<UpdateRoadmapLinkOrderRequest>
+{
+    public UpdateRoadmapLinkOrderRequestValidator()
+    {
+        RuleFor(o => o.RoadmapId)
+            .NotEmpty()
+            .WithMessage("A valid roadmap must be provided.");
+
+        RuleFor(o => o.RoadmapLinkId)
+            .NotEmpty()
+            .WithMessage("A valid roadmap link must be provided.");
+
+        RuleFor(o => o.Order)
+            .GreaterThan(0)
+            .WithMessage("Order must be greater than 0.");
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapLinksOrderRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapLinksOrderRequest.cs
@@ -1,0 +1,7 @@
+﻿namespace Moda.Web.Api.Models.Planning.Roadmaps;
+
+public sealed class UpdateRoadmapLinksOrderRequest
+{
+    public Guid RoadmapId { get; set; }
+    public Dictionary<Guid, int> RoadmapLinks { get; set; } = [];
+}

--- a/Moda.Web/src/Moda.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapRequest.cs
@@ -50,6 +50,7 @@ public sealed class UpdateRoadmapRequestValidator : CustomValidator<UpdateRoadma
         RuleFor(t => t.Id)
             .NotEmpty();
 
+
         RuleFor(t => t.Name)
             .NotEmpty()
             .MaximumLength(128);

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -3401,6 +3401,128 @@
         ]
       }
     },
+    "/api/planning/roadmaps/{id}/child-links/order": {
+      "post": {
+        "tags": [
+          "Roadmaps"
+        ],
+        "summary": "Update the order of child roadmap links.",
+        "operationId": "Roadmaps_UpdateChildLinksOrder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRoadmapLinksOrderRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
+    "/api/planning/roadmaps/{id}/child-links/{roadmapLinkId}/order": {
+      "post": {
+        "tags": [
+          "Roadmaps"
+        ],
+        "summary": "Update the order of child roadmap links based on a single change.",
+        "operationId": "Roadmaps_UpdateChildLinkOrder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "roadmapLinkId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRoadmapLinkOrderRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResult"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/planning/roadmaps/visibility-options": {
       "get": {
         "tags": [
@@ -10379,6 +10501,55 @@
           "order": {
             "type": "integer",
             "format": "int32"
+          }
+        }
+      },
+      "UpdateRoadmapLinksOrderRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "roadmapId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "roadmapLinks": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      },
+      "UpdateRoadmapLinkOrderRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "roadmapId",
+          "roadmapLinkId"
+        ],
+        "properties": {
+          "roadmapId": {
+            "type": "string",
+            "format": "guid",
+            "minLength": 1,
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "roadmapLinkId": {
+            "type": "string",
+            "format": "guid",
+            "minLength": 1,
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 0.0,
+            "exclusiveMinimum": true
           }
         }
       },

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/page.tsx
@@ -155,23 +155,29 @@ const RoadmapDetailsPage = ({ params }) => {
         tags={visibilityTag}
       />
       {roadmapData && (
-        <Descriptions>
-          <Item label="Dates">
-            <ModaDateRange
-              dateRange={{ start: roadmapData.start, end: roadmapData.end }}
-            />
-          </Item>
-          {roadmapData.description && (
-            <Item>
-              <ModaMarkdownDescription content={roadmapData.description} />
+        <>
+          <Descriptions>
+            <Item label="Dates">
+              <ModaDateRange
+                dateRange={{ start: roadmapData.start, end: roadmapData.end }}
+              />
             </Item>
-          )}
-        </Descriptions>
+          </Descriptions>
+          <Descriptions>
+            {roadmapData.description && (
+              <Item>
+                <ModaMarkdownDescription content={roadmapData.description} />
+              </Item>
+            )}
+          </Descriptions>
+        </>
       )}
       <RoadmapViewManager
         roadmap={roadmapData}
         isLoading={isLoading}
         refreshRoadmap={refetchRoadmap}
+        canUpdateRoadmap={canUpdateRoadmap}
+        messageApi={messageApi}
       />
       {openCreateRoadmapForm && (
         <CreateRoadmapForm

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/roadmap-view-manager.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/roadmap-view-manager.tsx
@@ -6,11 +6,14 @@ import Segmented, { SegmentedLabeledOption } from 'antd/es/segmented'
 import { useEffect, useMemo, useState } from 'react'
 import RoadmapsGrid from '../components/roadmaps-grid'
 import RoadmapsTimeline from '../components/roadmaps-timeline'
+import { MessageInstance } from 'antd/es/message/interface'
 
 interface RoadmapViewManagerProps {
   roadmap: RoadmapDetailsDto
   isLoading: boolean
   refreshRoadmap: () => void
+  canUpdateRoadmap: boolean
+  messageApi: MessageInstance
 }
 
 const RoadmapViewManager = (props: RoadmapViewManagerProps) => {
@@ -64,6 +67,9 @@ const RoadmapViewManager = (props: RoadmapViewManagerProps) => {
           refreshRoadmaps={props.refreshRoadmap}
           gridHeight={550}
           viewSelector={viewSelector}
+          enableRowDrag={props.canUpdateRoadmap}
+          parentRoadmapId={props.roadmap.id}
+          messageApi={props.messageApi}
         />
       )}
       {currentView === 'Timeline' && (

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/components/edit-roadmap-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/components/edit-roadmap-form.tsx
@@ -93,9 +93,9 @@ const EditRoadmapForm = (props: EditRoadmapFormProps) => {
   ) => {
     try {
       const request = mapToRequestValues(values, roadmap.id)
-      await updateRoadmap({ request, cacheKey: roadmap.key })
+      updateRoadmap({ request, cacheKey: roadmap.key })
         .unwrap()
-        .then((response) => {
+        .then(() => {
           props.messageApi.success(`Roadmap updated successfully.`)
         })
         .catch((error) => {

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/components/roadmaps-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/components/roadmaps-grid.tsx
@@ -1,18 +1,26 @@
 'use client'
 
 import { ModaGrid } from '@/src/app/components/common'
-import { RoadmapListDto } from '@/src/services/moda-api'
-import { ColDef } from 'ag-grid-community'
+import {
+  RoadmapListDto,
+  UpdateRoadmapLinkOrderRequest,
+} from '@/src/services/moda-api'
+import { useUpdateChildLinkOrderMutation } from '@/src/store/features/planning/roadmaps-api'
+import { ColDef, RowDragEndEvent } from 'ag-grid-community'
+import { MessageInstance } from 'antd/es/message/interface'
 import dayjs from 'dayjs'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 export interface RoadmapsGridProps {
   roadmapsData: RoadmapListDto[]
   roadmapsLoading: boolean
   refreshRoadmaps: () => void
+  messageApi: MessageInstance
   gridHeight?: number | undefined
   viewSelector?: React.ReactNode | undefined
+  enableRowDrag?: boolean | undefined
+  parentRoadmapId?: string | undefined
 }
 
 const RoadmapLinkCellRenderer = ({ value, data }) => {
@@ -22,10 +30,18 @@ const RoadmapLinkCellRenderer = ({ value, data }) => {
 const RoadmapsGrid: React.FC<RoadmapsGridProps> = (
   props: RoadmapsGridProps,
 ) => {
+  const [enableRowDrag, setEnableRowDrag] = useState(
+    props.enableRowDrag ?? false,
+  )
+
+  const [updateChildLinkOrder, { error: mutationError }] =
+    useUpdateChildLinkOrderMutation()
+
   // TODO: dates are formatted correctly and filter, but the filter is string based, not date based
   const columnDefs = useMemo<ColDef<RoadmapListDto>[]>(
     () => [
-      { field: 'key', width: 90 },
+      // rowDrag is typically set on the first column
+      { field: 'key', width: enableRowDrag ? 110 : 90, rowDrag: enableRowDrag },
       { field: 'name', width: 350, cellRenderer: RoadmapLinkCellRenderer },
       {
         field: 'start',
@@ -43,8 +59,28 @@ const RoadmapsGrid: React.FC<RoadmapsGridProps> = (
         width: 125,
       },
     ],
-    [],
+    [enableRowDrag],
   )
+
+  const onRowDragEnd = useCallback(
+    async (e: RowDragEndEvent) => {
+      updateChildLinkOrder({
+        roadmapId: props.parentRoadmapId,
+        roadmapLinkId: e.api.getRowNode(e.node.id).data.id,
+        order: e.node.rowIndex + 1,
+      } as UpdateRoadmapLinkOrderRequest)
+        .unwrap()
+        .then(() => {
+          props.messageApi.success(`Roadmap link order updated successfully.`)
+        })
+        .catch((error) => {
+          props.messageApi.success(`Error updating roadmap link order.`)
+          console.error('Error updating roadmap link order:', error)
+        })
+    },
+    [props, updateChildLinkOrder],
+  )
+
   return (
     <ModaGrid
       height={props.gridHeight ?? 650}
@@ -53,6 +89,8 @@ const RoadmapsGrid: React.FC<RoadmapsGridProps> = (
       loadData={props.refreshRoadmaps}
       isDataLoading={props.roadmapsLoading}
       toolbarActions={props.viewSelector}
+      rowDragManaged={true}
+      onRowDragEnd={onRowDragEnd}
     />
   )
 }

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/page.tsx
@@ -63,6 +63,7 @@ const RoadmapsPage: React.FC = () => {
         roadmapsData={roadmapData || []}
         roadmapsLoading={isLoading}
         refreshRoadmaps={refresh}
+        messageApi={messageApi}
       />
       {openCreateRoadmapForm && (
         <CreateRoadmapForm

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -4031,6 +4031,131 @@ export class RoadmapsClient {
     }
 
     /**
+     * Update the order of child roadmap links.
+     */
+    updateChildLinksOrder(id: string, request: UpdateRoadmapLinksOrderRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/planning/roadmaps/{id}/child-links/order";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateChildLinksOrder(_response);
+        });
+    }
+
+    protected processUpdateChildLinksOrder(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Update the order of child roadmap links based on a single change.
+     */
+    updateChildLinkOrder(id: string, roadmapLinkId: string, request: UpdateRoadmapLinkOrderRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/planning/roadmaps/{id}/child-links/{roadmapLinkId}/order";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (roadmapLinkId === undefined || roadmapLinkId === null)
+            throw new Error("The parameter 'roadmapLinkId' must be defined.");
+        url_ = url_.replace("{roadmapLinkId}", encodeURIComponent("" + roadmapLinkId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateChildLinkOrder(_response);
+        });
+    }
+
+    protected processUpdateChildLinkOrder(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Get a list of all visibility.
      */
     getVisibilityOptions( cancelToken?: CancelToken): Promise<VisibilityDto[]> {
@@ -10503,6 +10628,17 @@ export interface UpdateRoadmapRequest {
 export interface RoadmapLinkDto {
     parentId?: string;
     roadmap?: RoadmapListDto;
+    order?: number;
+}
+
+export interface UpdateRoadmapLinksOrderRequest {
+    roadmapId?: string;
+    roadmapLinks?: { [key: string]: number; };
+}
+
+export interface UpdateRoadmapLinkOrderRequest {
+    roadmapId: string;
+    roadmapLinkId: string;
     order?: number;
 }
 

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/planning/roadmaps-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/planning/roadmaps-api.ts
@@ -1,6 +1,8 @@
 import {
   CreateRoadmapReponse,
   RoadmapLinkDto,
+  UpdateRoadmapLinkOrderRequest,
+  UpdateRoadmapLinksOrderRequest,
 } from './../../../services/moda-api'
 import {
   CreateRoadmapRequest,
@@ -116,6 +118,43 @@ export const roadmapApi = apiSlice.injectEndpoints({
         }
       },
     }),
+    updateChildLinksOrder: builder.mutation<
+      void,
+      UpdateRoadmapLinksOrderRequest
+    >({
+      queryFn: async (request) => {
+        try {
+          const data = await (
+            await getRoadmapsClient()
+          ).updateChildLinksOrder(request.roadmapId, request)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [QueryTags.Roadmap],
+    }),
+    updateChildLinkOrder: builder.mutation<void, UpdateRoadmapLinkOrderRequest>(
+      {
+        queryFn: async (request) => {
+          try {
+            const data = await (
+              await getRoadmapsClient()
+            ).updateChildLinkOrder(
+              request.roadmapId,
+              request.roadmapLinkId,
+              request,
+            )
+            return { data }
+          } catch (error) {
+            console.error('API Error:', error)
+            return { error }
+          }
+        },
+        invalidatesTags: (result, error, arg) => [QueryTags.Roadmap],
+      },
+    ),
     getVisibilityOptions: builder.query<OptionModel<number>[], void>({
       queryFn: async () => {
         try {
@@ -152,5 +191,7 @@ export const {
   useUpdateRoadmapMutation,
   useDeleteRoadmapMutation,
   useGetRoadmapLinksQuery,
+  useUpdateChildLinksOrderMutation,
+  useUpdateChildLinkOrderMutation,
   useGetVisibilityOptionsQuery,
 } = roadmapApi


### PR DESCRIPTION
- Added API endpoints to enable reordering of roadmap child links.
- Updated the Roadmap details page to support reordering child links from the grid.