### PR TITLE
Feature/add sync azdo parent links process

### DIFF
--- a/Moda.Common/src/Moda.Common.Application/Interfaces/ExternalWork/IExternalWorkItemLink.cs
+++ b/Moda.Common/src/Moda.Common.Application/Interfaces/ExternalWork/IExternalWorkItemLink.cs
@@ -1,0 +1,14 @@
+﻿using Moda.Common.Domain.Enums.Work;
+
+namespace Moda.Common.Application.Interfaces.ExternalWork;
+public interface IExternalWorkItemLink
+{
+    WorkItemLinkType LinkType { get; set; }
+    int SourceId { get; set; }
+    int TargetId { get; set; }
+    DateTime ChangedDate { get; set; }
+    bool IsActive { get; set; }
+    string ChangedOperation { get; set; }
+    Guid SourceProjectId { get; set; }
+    Guid TargetProjectId { get; set; }
+}

--- a/Moda.Common/src/Moda.Common.Application/Interfaces/IAzureDevOpsService.cs
+++ b/Moda.Common/src/Moda.Common.Application/Interfaces/IAzureDevOpsService.cs
@@ -10,6 +10,7 @@ public interface IAzureDevOpsService
     Task<Result<List<IExternalWorkspace>>> GetWorkspaces(string organizationUrl, string token, CancellationToken cancellationToken);
     Task<Result<List<IExternalTeam>>> GetTeams(string organizationUrl, string token, Guid[] projectIds, CancellationToken cancellationToken);
     Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkItemLink>>> GetParentLinkChanges(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
     Task<Result<int[]>> GetDeletedWorkItemIds(string organizationUrl, string token, string projectName, DateTime lastChangedDate, CancellationToken cancellationToken);
     Task<Result> TestConnection(string organizationUrl, string token);
 }

--- a/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/SyncExternalWorkItemParentChangesCommand.cs
+++ b/Moda.Common/src/Moda.Common.Application/Requests/WorkManagement/SyncExternalWorkItemParentChangesCommand.cs
@@ -1,0 +1,18 @@
+﻿using Moda.Common.Application.Interfaces.ExternalWork;
+using Moda.Common.Application.Validators;
+
+namespace Moda.Common.Application.Requests.WorkManagement;
+public sealed record SyncExternalWorkItemParentChangesCommand(Guid WorkspaceId, List<IExternalWorkItemLink> WorkItemLinks) : ICommand;
+
+public sealed class SyncExternalWorkItemParentChangesCommandValidator : CustomValidator<SyncExternalWorkItemParentChangesCommand>
+{
+    public SyncExternalWorkItemParentChangesCommandValidator()
+    {
+        RuleFor(c => c.WorkspaceId)
+            .NotEmpty();
+
+        RuleForEach(c => c.WorkItemLinks)
+            .NotNull()
+            .SetValidator(new IExternalWorkItemLinkValidator());
+    }
+}

--- a/Moda.Common/src/Moda.Common.Application/Validators/IExternalWorkItemLinkValidator.cs
+++ b/Moda.Common/src/Moda.Common.Application/Validators/IExternalWorkItemLinkValidator.cs
@@ -17,12 +17,8 @@ public sealed class IExternalWorkItemLinkValidator : CustomValidator<IExternalWo
         RuleFor(c => c.ChangedDate)
             .NotEmpty();
 
-        RuleFor(c => c.IsActive)
-            .NotEmpty();
-
         RuleFor(c => c.ChangedOperation)
-            .NotEmpty()
-            .MaximumLength(32);
+            .NotEmpty();
 
         RuleFor(c => c.SourceProjectId)
             .NotEmpty();

--- a/Moda.Common/src/Moda.Common.Application/Validators/IExternalWorkItemLinkValidator.cs
+++ b/Moda.Common/src/Moda.Common.Application/Validators/IExternalWorkItemLinkValidator.cs
@@ -1,0 +1,33 @@
+﻿using Moda.Common.Application.Interfaces.ExternalWork;
+
+namespace Moda.Common.Application.Validators;
+public sealed class IExternalWorkItemLinkValidator : CustomValidator<IExternalWorkItemLink>
+{
+    public IExternalWorkItemLinkValidator()
+    {
+        RuleFor(c => c.LinkType)
+            .NotEmpty();
+
+        RuleFor(c => c.SourceId)
+            .GreaterThan(0);
+
+        RuleFor(c => c.TargetId)
+            .GreaterThan(0);
+
+        RuleFor(c => c.ChangedDate)
+            .NotEmpty();
+
+        RuleFor(c => c.IsActive)
+            .NotEmpty();
+
+        RuleFor(c => c.ChangedOperation)
+            .NotEmpty()
+            .MaximumLength(32);
+
+        RuleFor(c => c.SourceProjectId)
+            .NotEmpty();
+
+        RuleFor(c => c.TargetProjectId)
+            .NotEmpty();
+    }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Enums/Work/WorkItemLinkType.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Enums/Work/WorkItemLinkType.cs
@@ -1,0 +1,13 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Moda.Common.Domain.Enums.Work;
+public enum WorkItemLinkType
+{
+    [Display(Name = "Hierarchy", Description = "A link that defines a hierarchy between work items.", Order = 1)]
+    Hierarchy = 1,
+
+    [Display(Name = "Dependency", Description = "A link that defines a predecessor/successor dependency between work items.", Order = 2)]
+    Dependency = 2,
+
+    // TODO: add a link type for work items to other objects like objectives, risks, etc.
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/AzureDevOpsService.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/AzureDevOpsService.cs
@@ -112,6 +112,17 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<List<IExternalWorkItem>>(result.Error);
     }
 
+    public async Task<Result<List<IExternalWorkItemLink>>> GetParentLinkChanges(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
+    {
+        var workItemService = GetService<WorkItemService>(organizationUrl, token);
+
+        var result = await workItemService.GetParentLinkChanges(projectName, lastChangedDate, workItemTypes, cancellationToken);
+
+        return result.IsSuccess
+            ? Result.Success(result.Value.ToIExternalWorkItemLinks())
+            : Result.Failure<List<IExternalWorkItemLink>>(result.Error);
+    }
+
     public async Task<Result<int[]>> GetDeletedWorkItemIds(string organizationUrl, string token, string projectName, DateTime lastChangedDate, CancellationToken cancellationToken)
     {
         var workItemService = GetService<WorkItemService>(organizationUrl, token);

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Clients/BaseClient.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Clients/BaseClient.cs
@@ -1,6 +1,9 @@
-﻿using Ardalis.GuardClauses;
+﻿using System.Text.Json;
+using Ardalis.GuardClauses;
 using Moda.Integrations.AzureDevOps.Extensions;
+using Moda.Integrations.AzureDevOps.Models.Converters;
 using RestSharp;
+using RestSharp.Serializers.Json;
 
 namespace Moda.Integrations.AzureDevOps.Clients;
 internal abstract class BaseClient : IDisposable
@@ -24,7 +27,13 @@ internal abstract class BaseClient : IDisposable
             Timeout = TimeSpan.FromSeconds(300),
         };
 
-        _client = new RestClient(options);
+        var jsonSerializerOptions = new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            Converters = { new ReportingWorkItemLinkResponseConverter() }
+        };
+
+        _client = new RestClient(options, configureSerialization: s => s.UseSystemTextJson(jsonSerializerOptions));
     }
 
     protected void SetupRequest(RestRequest request, bool includePreviewTag = false)

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/BatchResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/BatchResponse.cs
@@ -1,0 +1,8 @@
+﻿namespace Moda.Integrations.AzureDevOps.Models;
+internal sealed record BatchResponse<T>
+{
+    public List<T> Values { get; set; } = [];
+    public bool IsLastBatch { get; set; }
+    public string? ContinuationToken { get; set; }
+    public string? NextLink { get; set; }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Contracts/AzdoWorkItemLink.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Contracts/AzdoWorkItemLink.cs
@@ -1,0 +1,15 @@
+﻿using Moda.Common.Application.Interfaces.ExternalWork;
+using Moda.Common.Domain.Enums.Work;
+
+namespace Moda.Integrations.AzureDevOps.Models.Contracts;
+public sealed record AzdoWorkItemLink : IExternalWorkItemLink
+{
+    public WorkItemLinkType LinkType { get; set; }
+    public int SourceId { get; set; }
+    public int TargetId { get; set; }
+    public DateTime ChangedDate { get; set; }
+    public bool IsActive { get; set; }
+    public required string ChangedOperation { get; set; }
+    public Guid SourceProjectId { get; set; }
+    public Guid TargetProjectId { get; set; }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Converters/ReportingWorkItemLinkResponseConverter.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/Converters/ReportingWorkItemLinkResponseConverter.cs
@@ -1,0 +1,44 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+using Moda.Integrations.AzureDevOps.Models.WorkItems;
+
+namespace Moda.Integrations.AzureDevOps.Models.Converters;
+internal class ReportingWorkItemLinkResponseConverter : JsonConverter<ReportingWorkItemLinkResponse>
+{
+    public override ReportingWorkItemLinkResponse Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        using (JsonDocument doc = JsonDocument.ParseValue(ref reader))
+        {
+            var root = doc.RootElement;
+            var attributes = root.GetProperty("attributes");
+
+            return new ReportingWorkItemLinkResponse
+            {
+                Rel = root.GetProperty("rel").GetString()!,
+                SourceId = attributes.GetProperty("sourceId").GetInt32(),
+                TargetId = attributes.GetProperty("targetId").GetInt32(),
+                ChangedDate = attributes.GetProperty("changedDate").GetDateTime(),
+                IsActive = attributes.GetProperty("isActive").GetBoolean(),
+                ChangedOperation = attributes.GetProperty("changedOperation").GetString()!,
+                SourceProjectId = attributes.GetProperty("sourceProjectId").GetGuid(),
+                TargetProjectId = attributes.GetProperty("targetProjectId").GetGuid()
+            };
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, ReportingWorkItemLinkResponse value, JsonSerializerOptions options)
+    {
+        writer.WriteStartObject();
+        writer.WriteString("rel", value.Rel);
+        writer.WriteStartObject("attributes");
+        writer.WriteNumber("sourceId", value.SourceId);
+        writer.WriteNumber("targetId", value.TargetId);
+        writer.WriteBoolean("isActive", value.IsActive);
+        writer.WriteString("changedDate", value.ChangedDate.ToString("o"));
+        writer.WriteString("changedOperation", value.ChangedOperation);
+        writer.WriteString("sourceProjectId", value.SourceProjectId.ToString());
+        writer.WriteString("targetProjectId", value.TargetProjectId.ToString());
+        writer.WriteEndObject();
+        writer.WriteEndObject();
+    }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/ReportingWorkItemLinkResponse.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Models/WorkItems/ReportingWorkItemLinkResponse.cs
@@ -1,0 +1,50 @@
+﻿using Moda.Common.Application.Interfaces.ExternalWork;
+using Moda.Common.Domain.Enums.Work;
+using Moda.Integrations.AzureDevOps.Models.Contracts;
+
+namespace Moda.Integrations.AzureDevOps.Models.WorkItems;
+internal sealed record ReportingWorkItemLinkResponse
+{
+    // TODO: Is Rel enough or shoule we use a LinkType to verify forward or reverse?
+    public required string Rel { get; init; }
+    public int SourceId { get; init; }
+    public int TargetId { get; init; }
+    public DateTime ChangedDate { get; init; }
+    public bool IsActive { get; set; }
+    public required string ChangedOperation { get; set; }
+    public Guid SourceProjectId { get; set; }
+    public Guid TargetProjectId { get; set; }
+}
+
+internal static class ReportingWorkItemLinkResponseExtensions
+{
+    public static AzdoWorkItemLink ToAzdoWorkItemLink(this ReportingWorkItemLinkResponse workItemLink)
+    {
+        return new AzdoWorkItemLink()
+        {
+            LinkType = workItemLink.Rel switch
+            {
+                "System.LinkTypes.Hierarchy" => WorkItemLinkType.Hierarchy,
+                "System.LinkTypes.Dependency" => WorkItemLinkType.Dependency,
+                _ => (WorkItemLinkType)999 // Unknown
+            },
+            SourceId = workItemLink.SourceId,   // Parent/Predecessor
+            TargetId = workItemLink.TargetId,   // Child/Successor
+            ChangedDate = workItemLink.ChangedDate,
+            IsActive = workItemLink.IsActive,
+            ChangedOperation = workItemLink.ChangedOperation,
+            SourceProjectId = workItemLink.SourceProjectId,
+            TargetProjectId = workItemLink.TargetProjectId
+        };
+    }
+
+    public static List<IExternalWorkItemLink> ToIExternalWorkItemLinks(this List<ReportingWorkItemLinkResponse> workItemLinks)
+    {
+        var result = new List<IExternalWorkItemLink>(workItemLinks.Count);
+        foreach (var workItemLink in workItemLinks)
+        {
+            result.Add(workItemLink.ToAzdoWorkItemLink());
+        }
+        return result;
+    }
+}

--- a/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Services/WorkItemService.cs
+++ b/Moda.Integrations/src/Moda.Integrations.AzureDevOps/Services/WorkItemService.cs
@@ -58,6 +58,25 @@ internal sealed class WorkItemService(string organizationUrl, string token, stri
         }
     }
 
+    public async Task<Result<List<ReportingWorkItemLinkResponse>>> GetParentLinkChanges(string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
+    {
+        try
+        {
+            string[] linkTypes = ["System.LinkTypes.Hierarchy"];
+
+            var links = await _workItemClient.GetWorkItemLinkChanges(projectName, lastChangedDate, linkTypes, workItemTypes, cancellationToken);
+
+            _logger.LogDebug("{LinkCount} parent link changes found for project {Project}", links.Count, projectName);
+
+            return Result.Success(links);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception thrown getting parent link changes for project {Project} from Azure DevOps", projectName);
+            return Result.Failure<List<ReportingWorkItemLinkResponse>>(ex.ToString());
+        }
+    }
+
     public async Task<Result<int[]>> GetDeletedWorkItemIds(string projectName, DateTime lastChangedDate, CancellationToken cancellationToken)
     {
         try

--- a/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Models/CommonResponseOptions.cs
+++ b/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Models/CommonResponseOptions.cs
@@ -1,10 +1,13 @@
 ﻿using System.Text.Json;
+using Moda.Integrations.AzureDevOps.Models.Converters;
 
 namespace Moda.Integrations.AzureDevOps.Tests.Models;
 public class CommonResponseOptions
 {
-    protected readonly JsonSerializerOptions _options = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+    protected readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web)
     {
         AllowTrailingCommas = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new ReportingWorkItemLinkResponseConverter() }
     };
 }

--- a/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Sut/Models/WorkItems/ReportingWorkItemLinkResponseTests.cs
+++ b/Moda.Integrations/tests/Moda.Integrations.AzureDevOps.Tests/Sut/Models/WorkItems/ReportingWorkItemLinkResponseTests.cs
@@ -1,0 +1,52 @@
+﻿using System.Text.Json;
+using Moda.Integrations.AzureDevOps.Models.WorkItems;
+using Moda.Integrations.AzureDevOps.Tests.Models;
+
+namespace Moda.Integrations.AzureDevOps.Tests.Sut.Models.WorkItems;
+public class ReportingWorkItemLinkResponseTests : CommonResponseOptions
+{
+    [Fact]
+    public void JsonSerilizer_Deserialize_Succeeds()
+    {
+        // Arrange
+        var json = GetJson();
+
+        // Act
+        var actualResponse = JsonSerializer.Deserialize<ReportingWorkItemLinkResponse>(json, _options);
+        Assert.NotNull(actualResponse);
+        actualResponse.Rel.Should().Be("System.LinkTypes.Hierarchy");
+        actualResponse.SourceId.Should().Be(28);
+        actualResponse.TargetId.Should().Be(58);
+        actualResponse.ChangedDate.ToUniversalTime().Should().Be(DateTime.Parse("2024-11-09T14:28:13.133Z").ToUniversalTime());
+        actualResponse.IsActive.Should().BeTrue();
+        actualResponse.ChangedOperation.Should().Be("create");
+        actualResponse.SourceProjectId.Should().Be(Guid.Parse("f37284b7-762d-49ea-9b7c-b119849dc57a"));
+        actualResponse.TargetProjectId.Should().Be(Guid.Parse("f37284b7-762d-49ea-9b7c-b119849dc57a"));
+    }
+
+    private static string GetJson()
+    {
+        return """
+            {
+                "rel": "System.LinkTypes.Hierarchy",
+                "attributes": {
+                    "linkType": "System.LinkTypes.Hierarchy-Forward",
+                    "sourceId": 28,
+                    "targetId": 58,
+                    "isActive": true,
+                    "changedDate": "2024-11-09T14:28:13.133Z",
+                    "changedBy": {
+                        "id": "b99e15b7-8a2d-48be-b29a-3d84e3d3e0c0",
+                        "displayName": "John Doe",
+                        "uniqueName": "john.doe@test.com",
+                        "descriptor": "msa.TESTTESTTEST"
+                    },
+                    "comment": null,
+                    "changedOperation": "create",
+                    "sourceProjectId": "f37284b7-762d-49ea-9b7c-b119849dc57a",
+                    "targetProjectId": "f37284b7-762d-49ea-9b7c-b119849dc57a"
+                }
+            }
+            """;
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemParentChangesCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemParentChangesCommandHandler.cs
@@ -1,0 +1,76 @@
+﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.WorkItems.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Commands;
+internal sealed class SyncExternalWorkItemParentChangesCommandHandler(IWorkDbContext workDbContext, ILogger<SyncExternalWorkItemParentChangesCommandHandler> logger) : ICommandHandler<SyncExternalWorkItemParentChangesCommand>
+{
+    private const string AppRequestName = nameof(SyncExternalWorkItemParentChangesCommand);
+
+    private static readonly Dictionary<string, int> _changedOperationOrder = new()
+    {
+        { "create", 1 },
+        { "remove", 2 }
+    };
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<SyncExternalWorkItemParentChangesCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(SyncExternalWorkItemParentChangesCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // get parent work items
+            var parentIds = request.WorkItemLinks
+                .Where(wil => wil.ChangedOperation == "create")
+                .Select(wil => wil.SourceId)
+                .Distinct().ToList();
+
+            var parentWorkItems = await _workDbContext.WorkItems
+                .Where(wi => wi.WorkspaceId == request.WorkspaceId && wi.ExternalId.HasValue && parentIds.Contains(wi.ExternalId.Value))
+                .ProjectToType<WorkItemParentInfo>()
+                .ToListAsync(cancellationToken);
+
+            // get distinct child: full work item
+            var childrenIds = request.WorkItemLinks.Select(wil => wil.TargetId).Distinct().ToArray();
+            var childrenWorkItems = await _workDbContext.WorkItems
+                .Include(wi => wi.Type)
+                    .ThenInclude(t => t.Level)
+                .Where(wi => wi.WorkspaceId == request.WorkspaceId && wi.ExternalId.HasValue && childrenIds.Contains(wi.ExternalId.Value))
+                .ToListAsync(cancellationToken);
+
+            // loop through the children and process the latest parent change
+            foreach (var child in childrenWorkItems)
+            {
+                var parentLink = request.WorkItemLinks
+                    .Where(wil => wil.TargetId == child.ExternalId!.Value)
+                    .OrderByDescending(wil => wil.ChangedDate)
+                        .ThenBy(wil => _changedOperationOrder.TryGetValue(wil.ChangedOperation, out int value) ? value : int.MaxValue)
+                    .First();
+
+                var parent = parentLink.ChangedOperation == "remove" 
+                    ? null 
+                    : parentWorkItems.FirstOrDefault(pwi => pwi.ExternalId == parentLink.SourceId);
+
+                var updateParentResult = child.UpdateParent(parent, child.Type);
+                if (updateParentResult.IsFailure)
+                {
+                    _logger.LogWarning("Error updating parent for work item {WorkItemId} (ExternalId: {ExternalId}): {Error}", child.Id, child.ExternalId, updateParentResult.Error);
+                }
+                else {
+                    _logger.LogDebug("Updated parent for work item {WorkItemId} (ExternalId: {ExternalId})", child.Id, child.ExternalId);
+                }
+            }
+
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception thrown handling {AppRequestName}", AppRequestName);
+            return Result.Failure(ex.ToString());
+        }
+
+    }
+
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
@@ -257,14 +257,6 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
             {
                 _logger.LogDebug("Unable to map missing parent for work item {ExternalId} in workspace {WorkspaceId}.", workItem.ExternalId, workspace.Id);
             }
-            else if (parentInfo.Tier != WorkTypeTier.Portfolio)
-            {
-                _logger.LogDebug("Only portfolio tier work items can be parents. Unable to map parent for work item {ExternalId} in workspace {WorkspaceId}.", workItem.ExternalId, workspace.Id);
-            }
-            else if (workItem.Type!.Level!.Order <= parentInfo.LevelOrder)
-            {
-                _logger.LogDebug("The parent must be a higher level than the work item {ExternalId} in workspace {WorkspaceId}.", workItem.ExternalId, workspace.Id);
-            }
             else
             {
                 var result = workItem.UpdateParent(parentInfo, workItem.Type);


### PR DESCRIPTION
- Added a new AzureDevOpsService method called GetParentLinkChanges.
- Added a new command and handler to sync external work item parent changes.
- Wired in the SyncWorkItemParentChanges process for differential syncs.