### PR TITLE
Prevents timeline recreation on dialog open/close

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.idea/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/page.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/src/store/features/planning/roadmaps-api'
 import { notFound, usePathname, useRouter } from 'next/navigation'
 import RoadmapDetailsLoading from './loading'
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { BreadcrumbItem, setBreadcrumbRoute } from '@/src/store/breadcrumbs'
 import { LockOutlined, UnlockOutlined } from '@ant-design/icons'
 import { Descriptions, MenuProps, message } from 'antd'
@@ -146,61 +146,79 @@ const RoadmapDetailsPage = ({ params }) => {
     return items
   }, [canDeleteRoadmap, canUpdateRoadmap])
 
+  const onEditRoadmapFormClosed = useCallback(
+    (wasSaved: boolean) => {
+      setOpenEditRoadmapForm(false)
+      if (wasSaved) {
+        refetchRoadmap()
+      }
+    },
+    [refetchRoadmap],
+  )
+
+  const onDeleteFormClosed = useCallback(
+    (wasDeleted: boolean) => {
+      setOpenDeleteRoadmapForm(false)
+      if (wasDeleted) {
+        router.push('/planning/roadmaps/')
+      }
+    },
+    [router],
+  )
+
+  const onCreateRoadmapActivityFormClosed = useCallback(
+    (wasCreated: boolean) => {
+      setOpenCreateActivityForm(false)
+      if (wasCreated) {
+        refetchRoadmapItems()
+      }
+    },
+    [refetchRoadmapItems],
+  )
+
+  const onCreateRoadmapTimeboxFormClosed = useCallback(
+    (wasCreated: boolean) => {
+      setOpenCreateTimeboxForm(false)
+      if (wasCreated) {
+        refetchRoadmapItems()
+      }
+    },
+    [refetchRoadmapItems],
+  )
+
+  const visibilityTag = useMemo(
+    () =>
+      roadmapData?.visibility?.name === 'Public' ? (
+        <UnlockOutlined title={visibilityTitle('Public', managersInfo)} />
+      ) : (
+        <LockOutlined title={visibilityTitle('Private', managersInfo)} />
+      ),
+    [managersInfo, roadmapData?.visibility?.name],
+  )
+
+  const showDrawer = useCallback(() => {
+    setDrawerOpen(true)
+  }, [])
+
+  const onDrawerClose = useCallback(() => {
+    setDrawerOpen(false)
+    setSelectedItemId(null)
+  }, [])
+
+  const openRoadmapItemDrawer = useCallback(
+    (itemId: string) => {
+      setSelectedItemId(itemId)
+      showDrawer()
+    },
+    [showDrawer],
+  )
+
   if (isLoading) {
     return <RoadmapDetailsLoading />
   }
 
   if (!roadmapData) {
     notFound()
-  }
-
-  const onEditRoadmapFormClosed = (wasSaved: boolean) => {
-    setOpenEditRoadmapForm(false)
-    if (wasSaved) {
-      refetchRoadmap()
-    }
-  }
-
-  const onDeleteFormClosed = (wasDeleted: boolean) => {
-    setOpenDeleteRoadmapForm(false)
-    if (wasDeleted) {
-      router.push('/planning/roadmaps/')
-    }
-  }
-
-  const onCreateRoadmapActivityFormClosed = (wasCreated: boolean) => {
-    setOpenCreateActivityForm(false)
-    if (wasCreated) {
-      refetchRoadmapItems()
-    }
-  }
-
-  const onCreateRoadmapTimeboxFormClosed = (wasCreated: boolean) => {
-    setOpenCreateTimeboxForm(false)
-    if (wasCreated) {
-      refetchRoadmapItems()
-    }
-  }
-
-  const visibilityTag =
-    roadmapData?.visibility?.name === 'Public' ? (
-      <UnlockOutlined title={visibilityTitle('Public', managersInfo)} />
-    ) : (
-      <LockOutlined title={visibilityTitle('Private', managersInfo)} />
-    )
-
-  const showDrawer = () => {
-    setDrawerOpen(true)
-  }
-
-  const onDrawerClose = () => {
-    setDrawerOpen(false)
-    setSelectedItemId(null)
-  }
-
-  const openRoadmapItemDrawer = (itemId: string) => {
-    setSelectedItemId(itemId)
-    showDrawer()
   }
 
   return (

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/roadmap-view-manager.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/[key]/roadmap-view-manager.tsx
@@ -3,7 +3,7 @@
 import { RoadmapDetailsDto, RoadmapItemListDto } from '@/src/services/moda-api'
 import { BuildOutlined, MenuOutlined } from '@ant-design/icons'
 import Segmented, { SegmentedLabeledOption } from 'antd/es/segmented'
-import { useEffect, useMemo, useState } from 'react'
+import { memo, useEffect, useMemo, useState } from 'react'
 import { MessageInstance } from 'antd/es/message/interface'
 import { RoadmapsTimeline } from '../components'
 import RoadmapItemsGrid from '../components/roadmap-items-grid'
@@ -81,4 +81,4 @@ const RoadmapViewManager = (props: RoadmapViewManagerProps) => {
   )
 }
 
-export default RoadmapViewManager
+export default memo(RoadmapViewManager)


### PR DESCRIPTION
This commit aims to resolve #313: 

> "The ModaTimeline component re-renders when opening a modal"

  by memoizing the default export of `roadmap-view-manager.tsx` as well
  as memoizing any reactive variables inside the `<RoadmapDetailsPage/>`
  component.

[Do to React's requirement that hooks must not be used conditionally](https://react.dev/reference/rules/rules-of-hooks#only-call-hooks-at-the-top-level),
I had to move a handful of the functions/objects before any conditional
return on the `<RoadmapDetailsPage/>` component.

_Also Added `.idea/` to the `.gitignore`_