### PR TITLE
Feature/add strategic initiative projects

### DIFF
--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningInterval.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningInterval.cs
@@ -199,6 +199,8 @@ public class PlanningInterval : BaseSoftDeletableEntity<Guid>, ILocalSchedule, I
     /// <returns></returns>
     public Result ManageTeams(IEnumerable<Guid> teamIds)
     {
+        Guard.Against.Null(teamIds, nameof(teamIds));
+
         var removedTeams = _teams.Where(x => !teamIds.Contains(x.TeamId)).ToList();
         foreach (var removedTeam in removedTeams)
         {

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/StrategicInitiatives/Commands/ManageStrategicInitiativeProjectsCommand.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/StrategicInitiatives/Commands/ManageStrategicInitiativeProjectsCommand.cs
@@ -1,0 +1,67 @@
+﻿namespace Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands;
+
+public sealed record ManageStrategicInitiativeProjectsCommand(Guid Id, List<Guid> ProjectIds) : ICommand;
+
+public sealed class ManageStrategicInitiativeProjectsCommandValidator : AbstractValidator<ManageStrategicInitiativeProjectsCommand>
+{
+    public ManageStrategicInitiativeProjectsCommandValidator()
+    {
+        RuleFor(v => v.Id)
+            .NotEmpty();
+
+        RuleFor(v => v.ProjectIds)
+            .NotNull();
+    }
+}
+
+internal sealed class ManageStrategicInitiativeProjectsCommandHandler(IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext, ILogger<ManageStrategicInitiativeProjectsCommandHandler> logger) : ICommandHandler<ManageStrategicInitiativeProjectsCommand>
+{
+    private const string AppRequestName = nameof(ManageStrategicInitiativeProjectsCommand);
+
+    private readonly IProjectPortfolioManagementDbContext _ppmDbContext = projectPortfolioManagementDbContext;
+    private readonly ILogger<ManageStrategicInitiativeProjectsCommandHandler> _logger = logger;
+    public async Task<Result> Handle(ManageStrategicInitiativeProjectsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var strategicInitiative = await _ppmDbContext.StrategicInitiatives
+                .Include(i => i.StrategicInitiativeProjects)
+                .SingleOrDefaultAsync(i => i.Id == request.Id, cancellationToken);
+            if (strategicInitiative == null)
+            {
+                _logger.LogInformation("Strategic Initiative with Id {StrategicInitiativeId} not found.", request.Id);
+                return Result.Failure("Strategic Initiative not found.");
+            }
+
+            // validate projects exist
+            var projectIds = request.ProjectIds.ToList();
+
+            var existingProjectCount = await _ppmDbContext.Projects
+                .Where(p => p.PortfolioId == strategicInitiative.PortfolioId)
+                .CountAsync(p => projectIds.Contains(p.Id), cancellationToken);
+            if (existingProjectCount != projectIds.Count)
+            {
+                _logger.LogError("Unable to update projects for Strategic Initiative {StrategicInitiativeId} because one or more projects do not exist within the portfolio.", request.Id);
+                return Result.Failure("One or more projects do not exist.");
+            }
+
+            var result = strategicInitiative.ManageProjects(projectIds);
+            if (result.IsFailure)
+            {
+                _logger.LogError("Failed to update projects for Strategic Initiative {StrategicInitiativeId}. Error message: {Error}", request.Id, result.Error);
+                return Result.Failure(result.Error);
+            }
+
+            await _ppmDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogDebug("Successfully updated projects for Strategic Initiative {StrategicInitiativeId}.", request.Id);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/StrategicInitiatives/Queries/GetStrategicInitiativeProjectsQuery.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/StrategicInitiatives/Queries/GetStrategicInitiativeProjectsQuery.cs
@@ -1,0 +1,37 @@
+﻿using System.Linq.Expressions;
+using Moda.Common.Application.Models;
+using Moda.ProjectPortfolioManagement.Application.Projects.Dtos;
+using Moda.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
+
+namespace Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Queries;
+public sealed record GetStrategicInitiativeProjectsQuery : IQuery<List<ProjectListDto>?>
+{
+    public GetStrategicInitiativeProjectsQuery(IdOrKey strategicInitiativeIdOrKey)
+    {
+        StrategicInitiativeIdOrKeyFilter = strategicInitiativeIdOrKey.CreateFilter<StrategicInitiative>();
+    }
+
+    public Expression<Func<StrategicInitiative, bool>> StrategicInitiativeIdOrKeyFilter { get; }
+}
+
+internal sealed class GetStrategicInitiativeProjectsQueryHandler(IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext)
+    : IQueryHandler<GetStrategicInitiativeProjectsQuery, List<ProjectListDto>?>
+{
+    private readonly IProjectPortfolioManagementDbContext _ppmDbContext = projectPortfolioManagementDbContext;
+
+    public async Task<List<ProjectListDto>?> Handle(GetStrategicInitiativeProjectsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _ppmDbContext.StrategicInitiatives
+            .Where(request.StrategicInitiativeIdOrKeyFilter);
+
+        if (!await query.AnyAsync(cancellationToken))
+        {
+            return null;
+        }
+
+        return await query
+            .SelectMany(i => i.StrategicInitiativeProjects.Select(ip => ip.Project))
+            .ProjectToType<ProjectListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/StrategicInitiatives/StrategicInitiativeProject.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/StrategicInitiatives/StrategicInitiativeProject.cs
@@ -12,11 +12,11 @@ public class StrategicInitiativeProject
 
     public Guid StrategicInitiativeId { get; private init; }
 
-    public StrategicInitiative? StrategicInitiative { get; set; }
+    public StrategicInitiative? StrategicInitiative { get; private set; }
 
     public Guid ProjectId { get; private init; }
 
-    public Project? Project { get; set; }
+    public Project? Project { get; private set; }
 
     internal static StrategicInitiativeProject Create(Guid strategicInitiativeId, Guid projectId)
     {

--- a/Moda.Services/Moda.ProjectPortfolioManagement/tests/Moda.ProjectPortfolioManagement.Domain.Tests/Data/Extensions/StrategicInitiativeDataExtensions.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/tests/Moda.ProjectPortfolioManagement.Domain.Tests/Data/Extensions/StrategicInitiativeDataExtensions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Moda.ProjectPortfolioManagement.Domain.Models;
+﻿using Moda.ProjectPortfolioManagement.Domain.Models;
 using Moda.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 using Moda.Tests.Shared;
 using Moda.Tests.Shared.Extensions;
@@ -34,19 +29,28 @@ public static class StrategicInitiativeDataExtensions
 
         var projectFaker = new ProjectFaker();
 
-        var projectsList = GenericExtensions.GetPrivateHashSet<Project>(strategicInitiative, "_projects");
+        var projectsList = GenericExtensions.GetPrivateHashSet<StrategicInitiativeProject>(strategicInitiative, "_strategicInitiativeProjects");
 
         // TODO: add logic based on the current status of the strategic initiative
         for (int i = 0; i < count - 1; i++)
         {
-            var project = projectFaker.AsActive(dateTimeProvider, strategicInitiative.Id);
-            projectsList.Add(project);
+            var project = projectFaker.AsActive(dateTimeProvider, strategicInitiative.PortfolioId);
+            projectsList.Add(CreateStrategicInitiativeProject(strategicInitiative.Id, project));
         }
 
         // Add a proposed strategic initiative as the last one
-        var lastProject = projectFaker.AsProposed(dateTimeProvider, strategicInitiative.Id);
-        projectsList.Add(lastProject);
+        var lastProject = projectFaker.AsProposed(dateTimeProvider, strategicInitiative.PortfolioId);
+        projectsList.Add(CreateStrategicInitiativeProject(strategicInitiative.Id, lastProject));
 
         return strategicInitiative;
+    }
+
+    private static StrategicInitiativeProject CreateStrategicInitiativeProject(Guid strategicInitiativeId, Project project)
+    {
+        var strategicInitiativeProject = StrategicInitiativeProject.Create(strategicInitiativeId, project.Id);
+
+        strategicInitiativeProject.SetPrivate(p => p.Project, project);
+
+        return strategicInitiativeProject;
     }
 }

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
@@ -279,7 +279,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     #region Projects
 
     [HttpGet("{idOrKey}/projects")]
-    [MustHavePermission(ApplicationAction.View, ApplicationResource.Projects)]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.StrategicInitiatives)]
     [OpenApiOperation("Get a list of projects for the strategic initiative.", "")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
@@ -290,6 +290,24 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         return projects is not null
             ? Ok(projects)
             : NotFound();
+    }
+
+    [HttpPost("{id}/projects")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.StrategicInitiatives)]
+    [OpenApiOperation("Manage projects for the strategic initiative.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> ManageProjects(Guid id, [FromBody] ManageStrategicInitiativeProjectsRequest request, CancellationToken cancellationToken)
+    {
+        if (id != request.Id)
+            return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
+
+        var result = await _sender.Send(request.ToManageStrategicInitiativeProjectsCommand(), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
     #endregion Projects

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
@@ -1,4 +1,6 @@
 ﻿using Moda.Common.Application.Models;
+using Moda.ProjectPortfolioManagement.Application.Projects.Dtos;
+using Moda.ProjectPortfolioManagement.Application.Projects.Queries;
 using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands;
 using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis;
 using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Dtos;
@@ -273,4 +275,22 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     }
 
     #endregion KPIs
+
+    #region Projects
+
+    [HttpGet("{idOrKey}/projects")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.Projects)]
+    [OpenApiOperation("Get a list of projects for the strategic initiative.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<ProjectListDto>>> GetProjects(string idOrKey, CancellationToken cancellationToken)
+    {
+        var projects = await _sender.Send(new GetStrategicInitiativeProjectsQuery(idOrKey), cancellationToken);
+
+        return projects is not null
+            ? Ok(projects)
+            : NotFound();
+    }
+
+    #endregion Projects
 }

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
@@ -1,6 +1,5 @@
 ﻿using Moda.Common.Application.Models;
 using Moda.ProjectPortfolioManagement.Application.Projects.Dtos;
-using Moda.ProjectPortfolioManagement.Application.Projects.Queries;
 using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands;
 using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis;
 using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Dtos;

--- a/Moda.Web/src/Moda.Web.Api/Models/Planning/PlanningIntervals/ManagePlanningIntervalTeamsRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Planning/PlanningIntervals/ManagePlanningIntervalTeamsRequest.cs
@@ -4,9 +4,15 @@ namespace Moda.Web.Api.Models.Planning.PlanningIntervals;
 
 public sealed record ManagePlanningIntervalTeamsRequest
 {
+    /// <summary>
+    /// The ID of the planning interval to manage teams for.
+    /// </summary>
     public Guid Id { get; set; }
 
-    public IEnumerable<Guid> TeamIds { get; set; } = new List<Guid>();
+    /// <summary>
+    /// The list of team IDs to be associated with the planning interval.
+    /// </summary>
+    public List<Guid> TeamIds { get; set; } = [];
 
     public ManagePlanningIntervalTeamsCommand ToManagePlanningIntervalTeamsCommand()
     {

--- a/Moda.Web/src/Moda.Web.Api/Models/Ppm/StrategicInitiatives/ManageStrategicInitiativeProjectsRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Ppm/StrategicInitiatives/ManageStrategicInitiativeProjectsRequest.cs
@@ -1,0 +1,35 @@
+﻿using Moda.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands;
+
+namespace Moda.Web.Api.Models.Ppm.StrategicInitiatives;
+
+public sealed record ManageStrategicInitiativeProjectsRequest
+{
+    /// <summary>
+    /// The ID of the strategic initiative to manage projects for.
+    /// </summary>
+    public Guid Id { get; set; }
+
+    /// <summary>
+    /// The list of project IDs to be associated with the strategic initiative.
+    /// </summary>
+    public List<Guid> ProjectIds { get; set; } = [];
+
+    public ManageStrategicInitiativeProjectsCommand ToManageStrategicInitiativeProjectsCommand()
+    {
+        return new ManageStrategicInitiativeProjectsCommand(Id, ProjectIds);
+    }
+}
+
+public sealed class ManageStrategicInitiativeProjectsRequestValidator : AbstractValidator<ManageStrategicInitiativeProjectsRequest>
+{
+    public ManageStrategicInitiativeProjectsRequestValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty();
+
+        RuleFor(x => x.ProjectIds)
+            .NotNull()
+            .Must(ids => ids.All(id => id != Guid.Empty))
+            .WithMessage("ProjectIds cannot contain empty GUIDs.");
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -4240,6 +4240,56 @@
         ]
       }
     },
+    "/api/ppm/strategic-initiatives/{idOrKey}/projects": {
+      "get": {
+        "tags": [
+          "StrategicInitiatives"
+        ],
+        "summary": "Get a list of projects for the strategic initiative.",
+        "operationId": "StrategicInitiatives_GetProjects",
+        "parameters": [
+          {
+            "name": "idOrKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProjectListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/planning/planning-intervals": {
       "get": {
         "tags": [

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -4290,6 +4290,71 @@
         ]
       }
     },
+    "/api/ppm/strategic-initiatives/{id}/projects": {
+      "post": {
+        "tags": [
+          "StrategicInitiatives"
+        ],
+        "summary": "Manage projects for the strategic initiative.",
+        "operationId": "StrategicInitiatives_ManageProjects",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ManageStrategicInitiativeProjectsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/planning/planning-intervals": {
       "get": {
         "tags": [
@@ -14336,6 +14401,35 @@
           }
         ]
       },
+      "ManageStrategicInitiativeProjectsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "projectIds"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "The ID of the strategic initiative to manage projects for.",
+            "format": "guid",
+            "minLength": 1,
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "projectIds": {
+            "type": "array",
+            "description": "The list of project IDs to be associated with the strategic initiative.",
+            "nullable": false,
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      },
       "PlanningIntervalListDto": {
         "type": "object",
         "additionalProperties": false,
@@ -14795,12 +14889,14 @@
         "properties": {
           "id": {
             "type": "string",
+            "description": "The ID of the planning interval to manage teams for.",
             "format": "guid",
             "nullable": false,
             "example": "00000000-0000-0000-0000-000000000000"
           },
           "teamIds": {
             "type": "array",
+            "description": "The list of team IDs to be associated with the planning interval.",
             "items": {
               "type": "string",
               "format": "guid",

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/planning-interval-objective-work-items-card.tsx
@@ -100,7 +100,7 @@ const PlanningIntervalObjectiveWorkItemsCard = (
           planningIntervalId={props.planningIntervalId}
           objectiveId={props.objectiveId}
           showForm={openManageWorkItemsForm}
-          onFormSave={() => onManageWorkItemsFormClosed(true)}
+          onFormComplete={() => onManageWorkItemsFormClosed(true)}
           onFormCancel={() => onManageWorkItemsFormClosed(false)}
         />
       )}

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/[key]/page.tsx
@@ -12,6 +12,7 @@ import { BreadcrumbItem, setBreadcrumbRoute } from '@/src/store/breadcrumbs'
 import { ItemType } from 'antd/es/menu/interface'
 import {
   useGetStrategicInitiativeKpisQuery,
+  useGetStrategicInitiativeProjectsQuery,
   useGetStrategicInitiativeQuery,
 } from '@/src/store/features/ppm/strategic-initiatives-api'
 import {
@@ -23,11 +24,12 @@ import {
 } from '../_components'
 import EditStrategicInitiativeForm from '../_components/edit-strategic-initiative-form'
 import { StrategicInitiativeStatusAction } from '../_components/change-strategic-initiative-status-form'
-import { useMessage } from '@/src/components/contexts/messaging'
+import { ProjectViewManager } from '../../_components'
 
 enum StrategicInitiativeTabs {
   Details = 'details',
   Kpis = 'kpis',
+  Projects = 'projects',
 }
 
 enum StrategicInitiativeAction {
@@ -43,6 +45,7 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
   useDocumentTitle('Strategic Initiative Details')
   const [activeTab, setActiveTab] = useState(StrategicInitiativeTabs.Details)
   const [kpisQueried, setKpisQueried] = useState(false)
+  const [projectsQueried, setProjectsQueried] = useState(false)
   const [isReadOnly, setIsReadOnly] = useState(false)
 
   const [openEditStrategicInitiativeForm, setOpenEditStrategicInitiativeForm] =
@@ -68,8 +71,6 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
     setOpenDeleteStrategicInitiativeForm,
   ] = useState<boolean>(false)
   const [openCreateKpiForm, setOpenCreateKpiForm] = useState(false)
-
-  //const messageApi = useMessage();
 
   const pathname = usePathname()
   const dispatch = useAppDispatch()
@@ -98,6 +99,15 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
     refetch: refetchKpis,
   } = useGetStrategicInitiativeKpisQuery(strategicInitiativeData?.id, {
     skip: !kpisQueried,
+  })
+
+  const {
+    data: projectData,
+    isLoading: isLoadingProjects,
+    error: errorProjects,
+    refetch: refetchProjects,
+  } = useGetStrategicInitiativeProjectsQuery(params.key, {
+    skip: !projectsQueried,
   })
 
   useEffect(() => {
@@ -153,15 +163,29 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
           />
         ),
       },
+      {
+        key: StrategicInitiativeTabs.Projects,
+        label: 'Projects',
+        content: (
+          <ProjectViewManager
+            projects={projectData}
+            isLoading={isLoadingProjects}
+            refetch={refetchProjects}
+          />
+        ),
+      },
     ]
     return pageTabs
   }, [
+    strategicInitiativeData,
+    kpiData,
     canUpdateStrategicInitiative,
     isLoadingKpis,
-    kpiData,
     refetchKpis,
-    strategicInitiativeData,
     isReadOnly,
+    projectData,
+    isLoadingProjects,
+    refetchProjects,
   ])
 
   // doesn't trigger on first render
@@ -169,11 +193,16 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
     (tabKey: StrategicInitiativeTabs) => {
       if (tabKey === StrategicInitiativeTabs.Kpis && !kpisQueried) {
         setKpisQueried(true)
+      } else if (
+        tabKey === StrategicInitiativeTabs.Projects &&
+        !projectsQueried
+      ) {
+        setProjectsQueried(true)
       }
 
       setActiveTab(tabKey)
     },
-    [kpisQueried],
+    [kpisQueried, projectsQueried],
   )
 
   const actionsMenuItems: MenuProps['items'] = useMemo(() => {

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/[key]/page.tsx
@@ -19,6 +19,7 @@ import {
   ChangeStrategicInitiativeStatusForm,
   CreateStrategicInitiativeKpiForm,
   DeleteStrategicInitiativeForm,
+  ManageStrategicInitiativeProjectsForm,
   StrategicInitiativeDetails,
   StrategicInitiativeKpisGrid,
 } from '../_components'
@@ -71,6 +72,7 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
     setOpenDeleteStrategicInitiativeForm,
   ] = useState<boolean>(false)
   const [openCreateKpiForm, setOpenCreateKpiForm] = useState(false)
+  const [openManageProjectsForm, setOpenManageProjectsForm] = useState(false)
 
   const pathname = usePathname()
   const dispatch = useAppDispatch()
@@ -106,7 +108,7 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
     isLoading: isLoadingProjects,
     error: errorProjects,
     refetch: refetchProjects,
-  } = useGetStrategicInitiativeProjectsQuery(params.key, {
+  } = useGetStrategicInitiativeProjectsQuery(strategicInitiativeData?.id, {
     skip: !projectsQueried,
   })
 
@@ -311,17 +313,26 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
       })
     }
 
-    //KPI actions
+    //KPI and Project actions
     if (!isReadOnly && canUpdateStrategicInitiative) {
       items.push(
         {
-          key: 'manage-divider-2',
+          key: 'manage-divider-kps',
           type: 'divider',
         },
         {
           key: 'createKpi',
           label: 'Create KPI',
           onClick: () => setOpenCreateKpiForm(true),
+        },
+        {
+          key: 'manage-divider-projects',
+          type: 'divider',
+        },
+        {
+          key: 'manageProjects',
+          label: 'Manage Projects',
+          onClick: () => setOpenManageProjectsForm(true),
         },
       )
     }
@@ -480,6 +491,15 @@ const StrategicInitiativeDetailsPage = ({ params }) => {
           showForm={openCreateKpiForm}
           onFormComplete={() => onCreateKpiFormClosed()}
           onFormCancel={() => onCreateKpiFormClosed()}
+        />
+      )}
+      {openManageProjectsForm && (
+        <ManageStrategicInitiativeProjectsForm
+          strategicInitiativeId={strategicInitiativeData?.id}
+          portfolioKey={strategicInitiativeData?.portfolio.key}
+          showForm={openManageProjectsForm}
+          onFormComplete={() => setOpenManageProjectsForm(false)}
+          onFormCancel={() => setOpenManageProjectsForm(false)}
         />
       )}
     </>

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/_components/index.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/_components/index.ts
@@ -6,5 +6,6 @@ export { default as DeleteStrategicInitiativeForm } from './delete-strategic-ini
 export { default as DeleteStrategicInitiativeKpiForm } from './delete-strategic-initiative-kpi-form'
 export { default as EditStrategicInitiativeForm } from './edit-strategic-initiative-form'
 export { default as EditStrategicInitiativeKpiForm } from './edit-strategic-initiative-kpi-form'
+export { default as ManageStrategicInitiativeProjectsForm } from './manage-strategic-initiative-projects-form'
 export { default as StrategicInitiativeDetails } from './strategic-initiative-details'
 export { default as StrategicInitiativeKpisGrid } from './strategic-initiative-kpis-grid'

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/_components/manage-strategic-initiative-projects-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/strategic-initiatives/_components/manage-strategic-initiative-projects-form.tsx
@@ -1,0 +1,208 @@
+'use client'
+
+import {
+  AgGridTransfer,
+  asDeletableColDefs,
+  asDraggableColDefs,
+} from '@/src/components/common/grid/ag-grid-transfer'
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ManageStrategicInitiativeProjectsRequest,
+  ProjectListDto,
+} from '@/src/services/moda-api'
+import { useGetPortfolioProjectsQuery } from '@/src/store/features/ppm/portfolios-api'
+import {
+  useGetStrategicInitiativeProjectsQuery,
+  useManageStrategicInitiativeProjectsMutation,
+} from '@/src/store/features/ppm/strategic-initiatives-api'
+import { ColDef } from 'ag-grid-community'
+import { Modal } from 'antd'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+
+export interface ManageStrategicInitiativeProjectsFormProps {
+  showForm: boolean
+  strategicInitiativeId: string
+  portfolioKey: number
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+const projectColDefs: ColDef<ProjectListDto>[] = [
+  {
+    field: 'key',
+    headerName: 'Key',
+    width: 75,
+  },
+  {
+    field: 'name',
+    headerName: 'Name',
+    flex: 1,
+  },
+  {
+    field: 'status.name',
+    headerName: 'Status',
+    width: 100,
+  },
+]
+
+const leftColDefs = [...asDraggableColDefs(projectColDefs)]
+
+const defaultSort = (a: ProjectListDto, b: ProjectListDto) => {
+  return a.name.localeCompare(b.name)
+}
+
+const ManageStrategicInitiativeProjectsForm = (
+  props: ManageStrategicInitiativeProjectsFormProps,
+) => {
+  const {
+    showForm,
+    strategicInitiativeId,
+    portfolioKey,
+    onFormComplete,
+    onFormCancel,
+  } = props
+
+  const [isOpen, setIsOpen] = useState(showForm)
+  const [isSaving, setIsSaving] = useState(false)
+  const [sourceProjects, setSourceProjects] = useState<ProjectListDto[]>([])
+  const [targetProjects, setTargetProjects] = useState<ProjectListDto[]>([])
+
+  const messageApi = useMessage()
+
+  const {
+    data: existingProjectsData,
+    isLoading: existingProjectsIsLoading,
+    error: existingProjectsError,
+  } = useGetStrategicInitiativeProjectsQuery(strategicInitiativeId)
+
+  const {
+    data: projectData,
+    isLoading: projectsIsLoading,
+    error: projectsError,
+  } = useGetPortfolioProjectsQuery(portfolioKey.toString())
+
+  const [manageProjects, { error: manageProjectsError }] =
+    useManageStrategicInitiativeProjectsMutation()
+
+  useEffect(() => {
+    if (!existingProjectsData) return
+    setTargetProjects(existingProjectsData?.slice().sort(defaultSort) ?? [])
+  }, [existingProjectsData])
+
+  useEffect(() => {
+    if (!projectData) return
+
+    const selectedIds = existingProjectsData?.map((item) => item.id) ?? []
+    const filteredProjects = projectData
+      .filter((item) => !selectedIds.includes(item.id))
+      .sort(defaultSort)
+
+    setSourceProjects(filteredProjects)
+  }, [projectData, existingProjectsData])
+
+  const onDragStop = useCallback((items: ProjectListDto[]) => {
+    // using the functional update form of setState to ensure we are using the latest state
+    if (items.length === 0) return
+
+    setSourceProjects((prevSource) =>
+      prevSource.filter((p) => !items.some((i) => i.id === p.id)),
+    )
+
+    setTargetProjects((prevTarget) =>
+      [...prevTarget, ...items].sort(defaultSort),
+    )
+  }, [])
+
+  const handleDelete = useCallback((item: ProjectListDto) => {
+    // using the functional update form of setState to ensure we are using the latest state
+    if (!item) return
+
+    setTargetProjects((prevTarget) =>
+      prevTarget.filter((p) => p.id !== item.id),
+    )
+
+    setSourceProjects((prevSource) => [...prevSource, item].sort(defaultSort))
+  }, [])
+
+  const rightColDefs = useMemo(
+    () => asDeletableColDefs(projectColDefs, handleDelete),
+    [handleDelete],
+  )
+
+  const formAction = async (): Promise<boolean> => {
+    try {
+      const request: ManageStrategicInitiativeProjectsRequest = {
+        id: strategicInitiativeId,
+        projectIds: targetProjects.map((item) => item.id),
+      }
+
+      const response = await manageProjects(request)
+
+      if (response.error) {
+        throw response.error
+      }
+
+      messageApi.success(`Projects updated successfully.`)
+
+      return true
+    } catch (error) {
+      messageApi.error(
+        error.detail ??
+          'An error occurred while updating the projects. Please try again.',
+      )
+      console.error(error)
+
+      return false
+    }
+  }
+
+  const handleOk = async () => {
+    setIsSaving(true)
+    try {
+      if (await formAction()) {
+        setIsOpen(false)
+        onFormComplete()
+      }
+    } catch (error) {
+      console.error(error)
+      messageApi.error(
+        'An error occurred while managing the projects. Please try again.',
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleCancel = useCallback(() => {
+    setIsOpen(false)
+    onFormCancel()
+  }, [onFormCancel])
+
+  return (
+    <Modal
+      title="Manage Strategic Initiative Projects"
+      open={isOpen}
+      width={'80vw'}
+      onOk={handleOk}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      maskClosable={false}
+      keyboard={false} // disable esc key to close modal
+      destroyOnClose={true}
+    >
+      {
+        <AgGridTransfer
+          leftGridData={sourceProjects}
+          rightGridData={targetProjects}
+          leftColumnDef={leftColDefs}
+          rightColumnDef={rightColDefs}
+          onDragStop={onDragStop}
+          getRowId={(param) => param.data.id}
+        />
+      }
+    </Modal>
+  )
+}
+
+export default ManageStrategicInitiativeProjectsForm

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-item-utils.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-item-utils.ts
@@ -1,4 +1,4 @@
-export const workItemKeyComparator = (key1, key2) => {
+export const workItemKeyComparator = (key1: string, key2: string) => {
   if (!key1) return 1 // sort empty keys to the end
   if (!key2) return -1
 
@@ -11,7 +11,10 @@ export const workItemKeyComparator = (key1, key2) => {
   return parseInt(num1) - parseInt(num2)
 }
 
-export const workStatusCategoryComparator = (category1, category2) => {
+export const workStatusCategoryComparator = (
+  category1: string,
+  category2: string,
+) => {
   const categories = ['Proposed', 'Active', 'Done', 'Removed']
   return categories.indexOf(category1) - categories.indexOf(category2)
 }

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -5524,6 +5524,74 @@ export class StrategicInitiativesClient {
         }
         return Promise.resolve<ProjectListDto[]>(null as any);
     }
+
+    /**
+     * Manage projects for the strategic initiative.
+     */
+    manageProjects(id: string, request: ManageStrategicInitiativeProjectsRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/ppm/strategic-initiatives/{id}/projects";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processManageProjects(_response);
+        });
+    }
+
+    protected processManageProjects(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = JSON.parse(resultData422);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
 }
 
 export class PlanningIntervalsClient {
@@ -15397,6 +15465,13 @@ export interface StrategicInitiativeKpiUnitDto extends CommonEnumDto {
 export interface StrategicInitiativeKpiTargetDirectionDto extends CommonEnumDto {
 }
 
+export interface ManageStrategicInitiativeProjectsRequest {
+    /** The ID of the strategic initiative to manage projects for. */
+    id: string;
+    /** The list of project IDs to be associated with the strategic initiative. */
+    projectIds: string[];
+}
+
 export interface PlanningIntervalListDto {
     id: string;
     key: number;
@@ -15518,7 +15593,9 @@ export interface PlanningIntervalIterationUpsertRequest {
 }
 
 export interface ManagePlanningIntervalTeamsRequest {
+    /** The ID of the planning interval to manage teams for. */
     id: string;
+    /** The list of team IDs to be associated with the planning interval. */
     teamIds: string[];
 }
 

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -5463,6 +5463,67 @@ export class StrategicInitiativesClient {
         }
         return Promise.resolve<StrategicInitiativeKpiTargetDirectionDto[]>(null as any);
     }
+
+    /**
+     * Get a list of projects for the strategic initiative.
+     */
+    getProjects(idOrKey: string, cancelToken?: CancelToken): Promise<ProjectListDto[]> {
+        let url_ = this.baseUrl + "/api/ppm/strategic-initiatives/{idOrKey}/projects";
+        if (idOrKey === undefined || idOrKey === null)
+            throw new Error("The parameter 'idOrKey' must be defined.");
+        url_ = url_.replace("{idOrKey}", encodeURIComponent("" + idOrKey));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetProjects(_response);
+        });
+    }
+
+    protected processGetProjects(response: AxiosResponse): Promise<ProjectListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<ProjectListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ProjectListDto[]>(null as any);
+    }
 }
 
 export class PlanningIntervalsClient {

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/strategic-initiatives-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/strategic-initiatives-api.ts
@@ -1,10 +1,9 @@
 import {
   AddStrategicInitiativeKpiMeasurementRequest,
   CreateStrategicInitiativeKpiRequest,
+  ProjectListDto,
   StrategicInitiativeKpiDetailsDto,
   StrategicInitiativeKpiListDto,
-  StrategicInitiativeKpiTargetDirectionDto,
-  StrategicInitiativeKpiUnitDto,
   UpdateStrategicInitiativeKpiRequest,
 } from './../../../services/moda-api'
 import { apiSlice } from './../apiSlice'
@@ -397,6 +396,22 @@ export const strategicInitiativesApi = apiSlice.injectEndpoints({
         { type: QueryTags.StrategicInitiativeKpiTargetDirection, id: 'LIST' },
       ],
     }),
+    getStrategicInitiativeProjects: builder.query<ProjectListDto[], string>({
+      queryFn: async (idOrKey) => {
+        try {
+          const data =
+            await getStrategicInitiativesClient().getProjects(idOrKey)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        { type: QueryTags.StrategicInitiativeProject, id: 'LIST' },
+        { type: QueryTags.StrategicInitiativeProject, id: arg },
+      ],
+    }),
   }),
 })
 
@@ -418,4 +433,5 @@ export const {
   useAddStrategicInitiativeKpiMeasurementMutation,
   useGetStrategicInitiativeKpiUnitOptionsQuery,
   useGetStrategicInitiativeKpiTargetDirectionOptionsQuery,
+  useGetStrategicInitiativeProjectsQuery,
 } = strategicInitiativesApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/strategic-initiatives-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/strategic-initiatives-api.ts
@@ -1,6 +1,7 @@
 import {
   AddStrategicInitiativeKpiMeasurementRequest,
   CreateStrategicInitiativeKpiRequest,
+  ManageStrategicInitiativeProjectsRequest,
   ProjectListDto,
   StrategicInitiativeKpiDetailsDto,
   StrategicInitiativeKpiListDto,
@@ -412,6 +413,27 @@ export const strategicInitiativesApi = apiSlice.injectEndpoints({
         { type: QueryTags.StrategicInitiativeProject, id: arg },
       ],
     }),
+    manageStrategicInitiativeProjects: builder.mutation<
+      void,
+      ManageStrategicInitiativeProjectsRequest
+    >({
+      queryFn: async (request) => {
+        try {
+          const data = await getStrategicInitiativesClient().manageProjects(
+            request.id,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [
+        { type: QueryTags.StrategicInitiativeProject, id: 'LIST' },
+        { type: QueryTags.StrategicInitiativeProject, id: arg.id },
+      ],
+    }),
   }),
 })
 
@@ -434,4 +456,5 @@ export const {
   useGetStrategicInitiativeKpiUnitOptionsQuery,
   useGetStrategicInitiativeKpiTargetDirectionOptionsQuery,
   useGetStrategicInitiativeProjectsQuery,
+  useManageStrategicInitiativeProjectsMutation,
 } = strategicInitiativesApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
@@ -45,6 +45,7 @@ export enum QueryTags {
   StrategicInitiativeKpiMeasurement = 'Ppm.StrategicInitiativeKpiMeasurement',
   StrategicInitiativeKpiUnit = 'Ppm.StrategicInitiativeKpiUnit',
   StrategicInitiativeKpiTargetDirection = 'Ppm.StrategicInitiativeKpiTargetDirection',
+  StrategicInitiativeProject = 'Ppm.StrategicInitiativeProject',
 
   // STRATEGIC MANAGEMENT
   StrategicTheme = 'StrategicManagement.StrategicTheme',


### PR DESCRIPTION
- Setup a new query and API endpoint to get projects for a strategic initiative.
- Added a projects tab to the Strategic Initiative page.
- Setup a command and API endpoint to manage projects for a strategic initiative.
- Updated the ag-grid-transfer component functionality.
  - Updated the PI objectives work item manager based on the latest ag-grid-transfer component.
- Added a new form to manage strategic initiative projects.
