### PR TITLE
Feature/link projects and workitems

### DIFF
--- a/Moda.Common/src/Moda.Common.Application/BackgroundJobs/BackgroundJobType.cs
+++ b/Moda.Common/src/Moda.Common.Application/BackgroundJobs/BackgroundJobType.cs
@@ -21,5 +21,8 @@ public enum BackgroundJobType
     TeamGraphSync = 1000,
 
     [Display(Name = "Strategic Themes Sync", Description = "Synchronize the latest strategic themes data.", Order = 1001, GroupName = "Data Replication Jobs")]
-    StrategicThemesSync = 1001
+    StrategicThemesSync = 1001,
+
+    [Display(Name = "Projects Sync", Description = "Synchronize the latest projects data.", Order = 1002, GroupName = "Data Replication Jobs")]
+    ProjectsSync = 1002,
 }

--- a/Moda.Common/src/Moda.Common.Domain/Authorization/ApplicationPermissions.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Authorization/ApplicationPermissions.cs
@@ -19,6 +19,7 @@ public static class ApplicationAction
 
     // Specific
     public const string ManageTeamMemberships = nameof(ManageTeamMemberships);
+    public const string ManageProjectWorkItems = nameof(ManageProjectWorkItems);
 }
 
 public static class ApplicationResource
@@ -183,6 +184,7 @@ public static class ApplicationPermissions
         new ("Create Projects", ApplicationAction.Create, ApplicationResource.Projects),
         new ("Update Projects", ApplicationAction.Update, ApplicationResource.Projects),
         new ("Delete Projects", ApplicationAction.Delete, ApplicationResource.Projects),
+        new ("Manage Project Work Items", ApplicationAction.ManageProjectWorkItems, ApplicationResource.Projects),
 
         new ("View Strategic Initiatives", ApplicationAction.View, ApplicationResource.StrategicInitiatives),
         new ("Create Strategic Initiatives", ApplicationAction.Create, ApplicationResource.StrategicInitiatives),

--- a/Moda.Common/src/Moda.Common.Domain/Events/ProjectPortfolioManagement/ProjectCreatedEvent.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Events/ProjectPortfolioManagement/ProjectCreatedEvent.cs
@@ -1,0 +1,44 @@
+﻿using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
+using Moda.Common.Models;
+using NodaTime;
+
+namespace Moda.Common.Domain.Events.ProjectPortfolioManagement;
+public sealed record ProjectCreatedEvent : DomainEvent, ISimpleProject
+{
+    public ProjectCreatedEvent(ISimpleProject project, int expenditureCategoryId, int statusId, LocalDateRange? dateRange, Guid portfolioId, Guid? programId, Dictionary<int, Guid[]> roles, Guid[] strategicThemes, Instant timestamp)
+    {
+        Id = project.Id;
+        Key = project.Key;
+        Name = project.Name;
+        Description = project.Description;
+        ExpenditureCategoryId = expenditureCategoryId;
+        StatusId = statusId;
+        DateRange = dateRange;
+        PortfolioId = portfolioId;
+        ProgramId = programId;
+        Roles = roles.ToDictionary(x => x.Key, x => x.Value.ToArray());
+        StrategicThemes = [.. strategicThemes];
+
+        Timestamp = timestamp;
+    }
+
+    public Guid Id { get; init; }
+    public int Key { get; init; }
+    public string Name { get; init; }
+    public string Description { get; init; }
+    public int ExpenditureCategoryId { get; init; }
+    public int StatusId { get; set; }
+    public LocalDateRange? DateRange { get; set; }
+    public Guid PortfolioId { get; set; }
+    public Guid? ProgramId { get; set; }
+
+    /// <summary>
+    /// The roles for the project.  The key is the role type id and the value is an array of user ids.
+    /// </summary>
+    public Dictionary<int, Guid[]>? Roles { get; set; }
+
+    /// <summary>
+    /// The strategic theme ids for the project.
+    /// </summary>
+    public Guid[] StrategicThemes { get; set; }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Events/ProjectPortfolioManagement/ProjectDeletedEvent.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Events/ProjectPortfolioManagement/ProjectDeletedEvent.cs
@@ -1,0 +1,15 @@
+﻿using NodaTime;
+
+namespace Moda.Common.Domain.Events.ProjectPortfolioManagement;
+
+public record ProjectDeletedEvent : DomainEvent
+{
+    public ProjectDeletedEvent(Guid id, Instant timestamp)
+    {
+        Id = id;
+
+        Timestamp = timestamp;
+    }
+
+    public Guid Id { get; init; }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Events/ProjectPortfolioManagement/ProjectDetailsUpdatedEvent.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Events/ProjectPortfolioManagement/ProjectDetailsUpdatedEvent.cs
@@ -1,0 +1,23 @@
+﻿using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
+using NodaTime;
+
+namespace Moda.Common.Domain.Events.ProjectPortfolioManagement;
+public sealed record ProjectDetailsUpdatedEvent : DomainEvent, ISimpleProject
+{
+    public ProjectDetailsUpdatedEvent(ISimpleProject project, int expenditureCategoryId, Instant timestamp)
+    {
+        Id = project.Id;
+        Key = project.Key;
+        Name = project.Name;
+        Description = project.Description;
+        ExpenditureCategoryId = expenditureCategoryId;
+
+        Timestamp = timestamp;
+    }
+
+    public Guid Id { get; init; }
+    public int Key { get; init; }
+    public string Name { get; init; }
+    public string Description { get; init; }
+    public int ExpenditureCategoryId { get; init; }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Interfaces/Ppm/ISimpleProject.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Interfaces/Ppm/ISimpleProject.cs
@@ -1,0 +1,8 @@
+﻿namespace Moda.Common.Domain.Interfaces.Ppm;
+
+public interface ISimpleProject
+{
+    Guid Id { get; }
+    int Key { get; }
+    string Name { get; }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Interfaces/ProjectPortfolioManagement/ISimpleProject.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Interfaces/ProjectPortfolioManagement/ISimpleProject.cs
@@ -1,8 +1,9 @@
-﻿namespace Moda.Common.Domain.Interfaces.Ppm;
+﻿namespace Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
 
 public interface ISimpleProject
 {
     Guid Id { get; }
     int Key { get; }
     string Name { get; }
+    string Description { get; }
 }

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250420145319_Add-Project-links-to-WorkItems.Designer.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250420145319_Add-Project-links-to-WorkItems.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Moda.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Moda.Infrastructure.Persistence.Context;
 namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ModaDbContext))]
-    partial class ModaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250420145319_Add-Project-links-to-WorkItems")]
+    partial class AddProjectlinkstoWorkItems
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250420145319_Add-Project-links-to-WorkItems.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250420145319_Add-Project-links-to-WorkItems.cs
@@ -1,0 +1,208 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Moda.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddProjectlinkstoWorkItems : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_ExternalId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_Id",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_Key",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_StatusCategory",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.AddColumn<Guid>(
+            name: "ParentProjectId",
+            schema: "Work",
+            table: "WorkItems",
+            type: "uniqueidentifier",
+            nullable: true);
+
+        migrationBuilder.AddColumn<Guid>(
+            name: "ProjectId",
+            schema: "Work",
+            table: "WorkItems",
+            type: "uniqueidentifier",
+            nullable: true);
+
+        migrationBuilder.CreateTable(
+            name: "WorkProjects",
+            schema: "Work",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                Key = table.Column<int>(type: "int", nullable: false),
+                Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_WorkProjects", x => x.Id);
+                table.UniqueConstraint("AK_WorkProjects_Key", x => x.Key);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_ExternalId",
+            schema: "Work",
+            table: "WorkItems",
+            column: "ExternalId")
+            .Annotation("SqlServer:Include", new[] { "Id", "Key", "Title", "WorkspaceId", "AssignedToId", "TypeId", "StatusId", "StatusCategory", "ActivatedTimestamp", "DoneTimestamp", "ProjectId", "ParentProjectId" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_Id",
+            schema: "Work",
+            table: "WorkItems",
+            column: "Id")
+            .Annotation("SqlServer:Include", new[] { "Key", "Title", "WorkspaceId", "ExternalId", "AssignedToId", "TypeId", "StatusId", "StatusCategory", "ActivatedTimestamp", "DoneTimestamp", "ProjectId", "ParentProjectId" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_Key",
+            schema: "Work",
+            table: "WorkItems",
+            column: "Key")
+            .Annotation("SqlServer:Include", new[] { "Id", "Title", "WorkspaceId", "ExternalId", "AssignedToId", "TypeId", "StatusId", "StatusCategory", "ActivatedTimestamp", "DoneTimestamp", "ProjectId", "ParentProjectId" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_ParentProjectId",
+            schema: "Work",
+            table: "WorkItems",
+            column: "ParentProjectId",
+            filter: "[ProjectId] IS NULL");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_ProjectId_ParentProjectId",
+            schema: "Work",
+            table: "WorkItems",
+            columns: new[] { "ProjectId", "ParentProjectId" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_StatusCategory",
+            schema: "Work",
+            table: "WorkItems",
+            column: "StatusCategory")
+            .Annotation("SqlServer:Include", new[] { "Id", "Key", "Title", "WorkspaceId", "AssignedToId", "TypeId", "StatusId", "ActivatedTimestamp", "DoneTimestamp", "ProjectId", "ParentProjectId" });
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_WorkItems_WorkProjects_ParentProjectId",
+            schema: "Work",
+            table: "WorkItems",
+            column: "ParentProjectId",
+            principalSchema: "Work",
+            principalTable: "WorkProjects",
+            principalColumn: "Id");
+
+        migrationBuilder.AddForeignKey(
+            name: "FK_WorkItems_WorkProjects_ProjectId",
+            schema: "Work",
+            table: "WorkItems",
+            column: "ProjectId",
+            principalSchema: "Work",
+            principalTable: "WorkProjects",
+            principalColumn: "Id");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropForeignKey(
+            name: "FK_WorkItems_WorkProjects_ParentProjectId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropForeignKey(
+            name: "FK_WorkItems_WorkProjects_ProjectId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropTable(
+            name: "WorkProjects",
+            schema: "Work");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_ExternalId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_Id",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_Key",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_ParentProjectId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_ProjectId_ParentProjectId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropIndex(
+            name: "IX_WorkItems_StatusCategory",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropColumn(
+            name: "ParentProjectId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.DropColumn(
+            name: "ProjectId",
+            schema: "Work",
+            table: "WorkItems");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_ExternalId",
+            schema: "Work",
+            table: "WorkItems",
+            column: "ExternalId")
+            .Annotation("SqlServer:Include", new[] { "Id", "Key", "Title", "WorkspaceId", "AssignedToId", "TypeId", "StatusId", "StatusCategory", "ActivatedTimestamp", "DoneTimestamp" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_Id",
+            schema: "Work",
+            table: "WorkItems",
+            column: "Id")
+            .Annotation("SqlServer:Include", new[] { "Key", "Title", "WorkspaceId", "ExternalId", "AssignedToId", "TypeId", "StatusId", "StatusCategory", "ActivatedTimestamp", "DoneTimestamp" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_Key",
+            schema: "Work",
+            table: "WorkItems",
+            column: "Key")
+            .Annotation("SqlServer:Include", new[] { "Id", "Title", "WorkspaceId", "ExternalId", "AssignedToId", "TypeId", "StatusId", "StatusCategory", "ActivatedTimestamp", "DoneTimestamp" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_WorkItems_StatusCategory",
+            schema: "Work",
+            table: "WorkItems",
+            column: "StatusCategory")
+            .Annotation("SqlServer:Include", new[] { "Id", "Key", "Title", "WorkspaceId", "AssignedToId", "TypeId", "StatusId", "ActivatedTimestamp", "DoneTimestamp" });
+    }
+}

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250425033443_Add-Project-links-to-WorkItems.Designer.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250425033443_Add-Project-links-to-WorkItems.Designer.cs
@@ -13,7 +13,7 @@ using Moda.Infrastructure.Persistence.Context;
 namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(ModaDbContext))]
-    [Migration("20250420145319_Add-Project-links-to-WorkItems")]
+    [Migration("20250425033443_Add-Project-links-to-WorkItems")]
     partial class AddProjectlinkstoWorkItems
     {
         /// <inheritdoc />
@@ -2735,8 +2735,10 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
                     b.Property<Guid>("Id")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("IsActive")
-                        .HasColumnType("bit");
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(2048)
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<int>("Key")
                         .HasColumnType("int");

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250425033443_Add-Project-links-to-WorkItems.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/20250425033443_Add-Project-links-to-WorkItems.cs
@@ -52,7 +52,7 @@ public partial class AddProjectlinkstoWorkItems : Migration
                 Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
                 Key = table.Column<int>(type: "int", nullable: false),
                 Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
-                IsActive = table.Column<bool>(type: "bit", nullable: false)
+                Description = table.Column<string>(type: "nvarchar(2048)", maxLength: 2048, nullable: false)
             },
             constraints: table =>
             {

--- a/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/ModaDbContextModelSnapshot.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure.Migrators.MSSQL/Migrations/ModaDbContextModelSnapshot.cs
@@ -2732,8 +2732,10 @@ namespace Moda.Infrastructure.Migrators.MSSQL.Migrations
                     b.Property<Guid>("Id")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<bool>("IsActive")
-                        .HasColumnType("bit");
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasMaxLength(2048)
+                        .HasColumnType("nvarchar(2048)");
 
                     b.Property<int>("Key")
                         .HasColumnType("int");

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -86,10 +86,10 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
         builder.HasAlternateKey(w => w.Key);
 
         builder.HasIndex(w => w.Id)
-            .IncludeProperties(w => new { w.Key, w.Title, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp });
+            .IncludeProperties(w => new { w.Key, w.Title, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp, w.ProjectId, w.ParentProjectId });
 
         builder.HasIndex(w => w.Key)
-            .IncludeProperties(w => new { w.Id, w.Title, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp });
+            .IncludeProperties(w => new { w.Id, w.Title, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp, w.ProjectId, w.ParentProjectId });
 
         builder.HasIndex(w => w.WorkspaceId)
             .IncludeProperties(w => new { w.Id, w.Key, w.Title, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp });
@@ -98,10 +98,10 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             .IncludeProperties(w => new { w.Id, w.WorkspaceId, w.ExternalId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp });
 
         builder.HasIndex(w => w.ExternalId)
-            .IncludeProperties(w => new { w.Id, w.Key , w.Title, w.WorkspaceId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp });
+            .IncludeProperties(w => new { w.Id, w.Key , w.Title, w.WorkspaceId, w.AssignedToId, w.TypeId, w.StatusId, w.StatusCategory, w.ActivatedTimestamp, w.DoneTimestamp, w.ProjectId, w.ParentProjectId });
 
         builder.HasIndex(w => w.StatusCategory)
-            .IncludeProperties(w => new { w.Id, w.Key, w.Title, w.WorkspaceId, w.AssignedToId, w.TypeId, w.StatusId, w.ActivatedTimestamp, w.DoneTimestamp });
+            .IncludeProperties(w => new { w.Id, w.Key, w.Title, w.WorkspaceId, w.AssignedToId, w.TypeId, w.StatusId, w.ActivatedTimestamp, w.DoneTimestamp, w.ProjectId, w.ParentProjectId });
 
         builder.HasIndex(w => new { w.WorkspaceId, w.ExternalId })
             .IncludeProperties(w => new
@@ -132,6 +132,13 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
                 w.TypeId
             })
             .HasFilter("[ExternalId] IS NOT NULL");
+
+        // Composite index for ProjectId and ParentProjectId
+        builder.HasIndex(w => new { w.ProjectId, w.ParentProjectId });
+
+        // Filtered index for cases where ProjectId is NULL
+        builder.HasIndex(w => w.ParentProjectId)
+            .HasFilter("[ProjectId] IS NULL");
 
         // Properties
         builder.Property(w => w.Key).IsRequired()
@@ -210,6 +217,16 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             .WithOne()
             .HasForeignKey<WorkItemExtended>(w => w.Id)
             .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(w => w.Project)
+            .WithMany()
+            .HasForeignKey(w => w.ProjectId)
+            .OnDelete(DeleteBehavior.ClientSetNull);
+
+        builder.HasOne(w => w.ParentProject)
+            .WithMany()
+            .HasForeignKey(w => w.ParentProjectId)
+            .OnDelete(DeleteBehavior.ClientSetNull);
     }
 }
 
@@ -361,6 +378,23 @@ public class WorkProcessSchemeConfig : IEntityTypeConfiguration<WorkProcessSchem
             .WithMany()
             .HasForeignKey(w => w.WorkflowId)
             .OnDelete(DeleteBehavior.Restrict);
+    }
+}
+
+public class WorkProjectConfig : IEntityTypeConfiguration<WorkProject>
+{
+    public void Configure(EntityTypeBuilder<WorkProject> builder)
+    {
+        builder.ToTable("WorkProjects", SchemaNames.Work);
+
+        builder.HasKey(w => w.Id);
+        builder.HasAlternateKey(w => w.Key);
+
+        builder.Property(w => w.Id).ValueGeneratedNever();
+        builder.Property(w => w.Key).ValueGeneratedNever();
+
+        // Properties
+        builder.Property(w => w.Name).IsRequired().HasMaxLength(128);
     }
 }
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -395,6 +395,7 @@ public class WorkProjectConfig : IEntityTypeConfiguration<WorkProject>
 
         // Properties
         builder.Property(w => w.Name).IsRequired().HasMaxLength(128);
+        builder.Property(p => p.Description).HasMaxLength(2048).IsRequired();
     }
 }
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/ConfigureServices.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/ConfigureServices.cs
@@ -7,6 +7,7 @@ using Moda.Links;
 using Moda.Planning.Application.Persistence;
 using Moda.ProjectPortfolioManagement.Application;
 using Moda.StrategicManagement.Application;
+using Moda.Work.Application.Persistence;
 using Serilog;
 
 namespace Moda.Infrastructure.Persistence;

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Context/ModaDbContext.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Context/ModaDbContext.cs
@@ -107,6 +107,7 @@ public class ModaDbContext : BaseDbContext, IAppIntegrationDbContext, IGoalsDbCo
     public DbSet<WorkItem> WorkItems => Set<WorkItem>();
     public DbSet<WorkItemLink> WorkItemLinks => Set<WorkItemLink>();
     public DbSet<WorkProcess> WorkProcesses => Set<WorkProcess>();
+    public DbSet<WorkProject> WorkProjects => Set<WorkProject>();
     public DbSet<Workspace> Workspaces => Set<Workspace>();
     public DbSet<WorkStatus> WorkStatuses => Set<WorkStatus>();
     public DbSet<WorkTeam> WorkTeams => Set<WorkTeam>();

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Context/ModaDbContext.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Context/ModaDbContext.cs
@@ -17,6 +17,7 @@ using Moda.ProjectPortfolioManagement.Domain.Models;
 using Moda.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 using Moda.StrategicManagement.Application;
 using Moda.StrategicManagement.Domain.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Domain.Models;
 using PpmStrategicTheme = Moda.ProjectPortfolioManagement.Domain.Models.StrategicTheme;
 using StrategicTheme = Moda.StrategicManagement.Domain.Models.StrategicTheme;

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Commands/CreateProjectCommand.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Commands/CreateProjectCommand.cs
@@ -48,13 +48,15 @@ public sealed class CreateProjectCommandValidator : AbstractValidator<CreateProj
 
 internal sealed class CreateProjectCommandHandler(
     IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext,
-    ILogger<CreateProjectCommandHandler> logger)
+    ILogger<CreateProjectCommandHandler> logger,
+    IDateTimeProvider dateTimeProvider)
     : ICommandHandler<CreateProjectCommand, ObjectIdAndKey>
 {
     private const string AppRequestName = nameof(CreateProjectCommand);
 
     private readonly IProjectPortfolioManagementDbContext _projectPortfolioManagementDbContext = projectPortfolioManagementDbContext;
     private readonly ILogger<CreateProjectCommandHandler> _logger = logger;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
 
     public async Task<Result<ObjectIdAndKey>> Handle(CreateProjectCommand request, CancellationToken cancellationToken)
     {
@@ -108,7 +110,8 @@ internal sealed class CreateProjectCommandHandler(
                 request.DateRange,
                 request.ProgramId,
                 roles,
-                [.. strategicThemes.Select(st => st.Id)]
+                [.. strategicThemes.Select(st => st.Id)],
+                _dateTimeProvider.Now
                 );
             if (createResult.IsFailure)
             {

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Commands/DeleteProjectCommand.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Commands/DeleteProjectCommand.cs
@@ -11,11 +11,13 @@ public sealed class DeleteProjectCommandValidator : AbstractValidator<DeleteProj
     }
 }
 
-internal sealed class DeleteProjectCommandHandler(IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext, ILogger<DeleteProjectCommandHandler> logger) : ICommandHandler<DeleteProjectCommand>
+internal sealed class DeleteProjectCommandHandler(IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext, ILogger<DeleteProjectCommandHandler> logger, IDateTimeProvider dateTimeProvider) : ICommandHandler<DeleteProjectCommand>
 {
     private const string AppRequestName = nameof(DeleteProjectCommand);
     private readonly IProjectPortfolioManagementDbContext _projectPortfolioManagementDbContext = projectPortfolioManagementDbContext;
     private readonly ILogger<DeleteProjectCommandHandler> _logger = logger;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+
     public async Task<Result> Handle(DeleteProjectCommand request, CancellationToken cancellationToken)
     {
         try
@@ -48,7 +50,7 @@ internal sealed class DeleteProjectCommandHandler(IProjectPortfolioManagementDbC
                 return Result.Failure("Portfolio not found.");
             }
 
-            var deleteResult = portfolio.DeleteProject(project.Id);
+            var deleteResult = portfolio.DeleteProject(project.Id, _dateTimeProvider.Now);
             if (deleteResult.IsFailure)
             {
                 _logger.LogError("Error deleting project {ProjectId}. Error message: {Error}", request.Id, deleteResult.Error);

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Commands/UpdateProjectCommand.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Commands/UpdateProjectCommand.cs
@@ -44,13 +44,15 @@ public sealed class UpdateProjectCommandValidator : AbstractValidator<UpdateProj
 
 internal sealed class UpdateProjectCommandHandler(
     IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext,
-    ILogger<UpdateProjectCommandHandler> logger)
+    ILogger<UpdateProjectCommandHandler> logger,
+    IDateTimeProvider dateTimeProvider)
     : ICommandHandler<UpdateProjectCommand>
 {
     private const string AppRequestName = nameof(UpdateProjectCommand);
 
     private readonly IProjectPortfolioManagementDbContext _projectPortfolioManagementDbContext = projectPortfolioManagementDbContext;
     private readonly ILogger<UpdateProjectCommandHandler> _logger = logger;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
 
     public async Task<Result> Handle(UpdateProjectCommand request, CancellationToken cancellationToken)
     {
@@ -69,7 +71,8 @@ internal sealed class UpdateProjectCommandHandler(
             var updateResult = project.UpdateDetails(
                 request.Name,
                 request.Description,
-                request.ExpenditureCategoryId
+                request.ExpenditureCategoryId,
+                _dateTimeProvider.Now
             );
             if (updateResult.IsFailure)
             {

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Queries/GetSimpleProjectsQuery.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/Projects/Queries/GetSimpleProjectsQuery.cs
@@ -1,0 +1,20 @@
+﻿using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
+
+namespace Moda.ProjectPortfolioManagement.Application.Projects.Queries;
+
+public sealed record GetSimpleProjectsQuery() : IQuery<List<ISimpleProject>>;
+
+internal sealed class GetSimpleProjectsQueryHandler(IProjectPortfolioManagementDbContext projectPortfolioManagementDbContext) 
+    : IQueryHandler<GetSimpleProjectsQuery, List<ISimpleProject>>
+{
+    private readonly IProjectPortfolioManagementDbContext _projectPortfolioManagementDbContext = projectPortfolioManagementDbContext;
+
+    public async Task<List<ISimpleProject>> Handle(GetSimpleProjectsQuery request, CancellationToken cancellationToken)
+    {
+        var projects = await _projectPortfolioManagementDbContext.Projects
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+        return [.. projects.OfType<ISimpleProject>()];
+    }
+}

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/StrategicThemes/Commands/SyncStrategicThemesCommand.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Application/StrategicThemes/Commands/SyncStrategicThemesCommand.cs
@@ -1,5 +1,4 @@
-﻿using Moda.Common.Application.Models;
-using Moda.Common.Domain.Interfaces.StrategicManagement;
+﻿using Moda.Common.Domain.Interfaces.StrategicManagement;
 using Moda.ProjectPortfolioManagement.Domain.Models;
 
 namespace Moda.ProjectPortfolioManagement.Application.StrategicThemes.Commands;
@@ -77,7 +76,7 @@ internal sealed class SyncStrategicThemesCommandHandler(
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
-            return Result.Failure<ObjectIdAndKey>($"Error handling {AppRequestName} command.");
+            return Result.Failure($"Error handling {AppRequestName} command.");
         }
     }
 }

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Project.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Project.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using CSharpFunctionalExtensions;
+using Moda.Common.Domain.Interfaces.Ppm;
 using Moda.ProjectPortfolioManagement.Domain.Enums;
 using Moda.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 using NodaTime;
@@ -9,7 +10,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents an individual project within a portfolio or program.
 /// </summary>
-public sealed class Project : BaseEntity<Guid>, ISystemAuditable, IHasIdAndKey
+public sealed class Project : BaseEntity<Guid>, ISystemAuditable, IHasIdAndKey, ISimpleProject
 {
     private string _name = default!;
     private string _description = default!;

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Project.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Project.cs
@@ -1,6 +1,7 @@
 ﻿using Ardalis.GuardClauses;
 using CSharpFunctionalExtensions;
-using Moda.Common.Domain.Interfaces.Ppm;
+using Moda.Common.Domain.Events.ProjectPortfolioManagement;
+using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
 using Moda.ProjectPortfolioManagement.Domain.Enums;
 using Moda.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 using NodaTime;
@@ -137,13 +138,20 @@ public sealed class Project : BaseEntity<Guid>, ISystemAuditable, IHasIdAndKey, 
     public bool CanBeDeleted() => Status is ProjectStatus.Proposed;
 
     /// <summary>
-    /// Updates the project details.
+    /// Updates the project's basic details.
     /// </summary>
-    public Result UpdateDetails(string name, string description, int expenditureCategoryId)
+    /// <param name="name"></param>
+    /// <param name="description"></param>
+    /// <param name="expenditureCategoryId"></param>
+    /// <param name="timestamp"></param>
+    /// <returns></returns>
+    public Result UpdateDetails(string name, string description, int expenditureCategoryId, Instant timestamp)
     {
         Name = name;
         Description = description;
         ExpenditureCategoryId = expenditureCategoryId;
+
+        AddDomainEvent(new ProjectDetailsUpdatedEvent(this, ExpenditureCategoryId, timestamp));
 
         return Result.Success();
     }
@@ -321,9 +329,28 @@ public sealed class Project : BaseEntity<Guid>, ISystemAuditable, IHasIdAndKey, 
     /// <param name="programId"></param>
     /// <param name="roles"></param>
     /// <param name="strategicThemes"></param>
+    /// <param name="timestamp"></param>
     /// <returns></returns>
-    internal static Project Create(string name, string description, int expenditureCategoryId, LocalDateRange? dateRange, Guid portfolioId, Guid? programId, Dictionary<ProjectRole, HashSet<Guid>>? roles = null, HashSet<Guid>? strategicThemes = null)
+    internal static Project Create(string name, string description, int expenditureCategoryId, LocalDateRange? dateRange, Guid portfolioId, Guid? programId, Dictionary<ProjectRole, HashSet<Guid>>? roles, HashSet<Guid>? strategicThemes, Instant timestamp)
     {
-        return new Project(name, description, ProjectStatus.Proposed, expenditureCategoryId, dateRange, portfolioId, programId, roles, strategicThemes);
+        var project = new Project(name, description, ProjectStatus.Proposed, expenditureCategoryId, dateRange, portfolioId, programId, roles, strategicThemes);
+
+        project.AddPostPersistenceAction(() => project.AddDomainEvent(
+            new ProjectCreatedEvent
+            (
+                project, 
+                project.ExpenditureCategoryId, 
+                (int)project.Status, 
+                project.DateRange, 
+                project.PortfolioId, 
+                project.ProgramId,
+                project.Roles
+                    .GroupBy(x => (int)x.Role)
+                    .ToDictionary(x => x.Key, x => x.Select(y => y.EmployeeId).ToArray()),
+                [.. project.StrategicThemeTags.Select(x => x.StrategicThemeId)],
+                timestamp
+            )));
+
+        return project;
     }
 }

--- a/Moda.Services/Moda.ProjectPortfolioManagement/tests/Moda.ProjectPortfolioManagement.Domain.Tests/Sut/Models/ProjectPortfolioTests.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/tests/Moda.ProjectPortfolioManagement.Domain.Tests/Sut/Models/ProjectPortfolioTests.cs
@@ -335,7 +335,7 @@ public class ProjectPortfolioTests
         // Arrange
         var portfolio = _portfolioFaker.AsActive(_dateTimeProvider);
         var project = _projectFaker.AsActive(_dateTimeProvider, portfolio.Id);
-        portfolio.CreateProject(project.Name, project.Description, 1, null);
+        portfolio.CreateProject(project.Name, project.Description, 1, null, null, null, null, _dateTimeProvider.Now);
 
         var endDate = _dateTimeProvider.Today.PlusDays(10);
 
@@ -355,7 +355,7 @@ public class ProjectPortfolioTests
 
         var fakeProject = _projectFaker.AsProposed(_dateTimeProvider, portfolio.Id);
         var projectDateRange = new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusMonths(3));
-        var createProjectReult = portfolio.CreateProject(fakeProject.Name, fakeProject.Description, 1, projectDateRange);
+        var createProjectReult = portfolio.CreateProject(fakeProject.Name, fakeProject.Description, 1, projectDateRange, null, null, null, _dateTimeProvider.Now);
         var project = createProjectReult.Value;
 
         var endDate = _dateTimeProvider.Today.PlusDays(10);
@@ -468,7 +468,7 @@ public class ProjectPortfolioTests
         var portfolio = _portfolioFaker.AsActive(_dateTimeProvider);
 
         // Act
-        var result = portfolio.CreateProject("Test Project", "Test Description", 1, null);
+        var result = portfolio.CreateProject("Test Project", "Test Description", 1, null, null, null, null, _dateTimeProvider.Now);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -484,7 +484,7 @@ public class ProjectPortfolioTests
         var program = _programFaker.Generate();
 
         // Act
-        var result = portfolio.CreateProject("Test Project", "Test Description", 1, null, program.Id);
+        var result = portfolio.CreateProject("Test Project", "Test Description", 1, null, program.Id, null, null, _dateTimeProvider.Now);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -503,7 +503,7 @@ public class ProjectPortfolioTests
         var program = createProgramResult.Value;
 
         // Act
-        var result = portfolio.CreateProject("Test Project", "Test Description", 1, null, program.Id);
+        var result = portfolio.CreateProject("Test Project", "Test Description", 1, null, program.Id, null, null, _dateTimeProvider.Now);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -519,7 +519,7 @@ public class ProjectPortfolioTests
         var program1 = portfolio.Programs.First();
         var program2 = portfolio.Programs.Last();
 
-        var project = portfolio.CreateProject("Test Project", "Description", 1, null, program1.Id);
+        var project = portfolio.CreateProject("Test Project", "Description", 1, null, program1.Id, null, null, _dateTimeProvider.Now);
         project.IsSuccess.Should().BeTrue();
 
         // Act
@@ -540,7 +540,7 @@ public class ProjectPortfolioTests
 
         var program = portfolio.Programs.First();
 
-        var project = portfolio.CreateProject("Test Project", "Description", 1, null, program.Id);
+        var project = portfolio.CreateProject("Test Project", "Description", 1, null, program.Id, null, null, _dateTimeProvider.Now);
         project.IsSuccess.Should().BeTrue();
 
         // Act
@@ -560,7 +560,7 @@ public class ProjectPortfolioTests
 
         var program = portfolio.Programs.First();
 
-        var project = portfolio.CreateProject("Test Project", "Description", 1, null, program.Id);
+        var project = portfolio.CreateProject("Test Project", "Description", 1, null, program.Id, null, null, _dateTimeProvider.Now);
         project.IsSuccess.Should().BeTrue();
 
         // Act
@@ -581,7 +581,7 @@ public class ProjectPortfolioTests
 
         var program2 = _programFaker.AsActive(_dateTimeProvider, Guid.NewGuid());
 
-        var projectResult = portfolio1.CreateProject("Test Project", "Description", 1, null, program1.Id);
+        var projectResult = portfolio1.CreateProject("Test Project", "Description", 1, null, program1.Id, null, null, _dateTimeProvider.Now);
         projectResult.IsSuccess.Should().BeTrue();
 
         // Act
@@ -597,7 +597,7 @@ public class ProjectPortfolioTests
     {
         // Arrange
         var portfolio = _portfolioFaker.AsActive(_dateTimeProvider);
-        var project = portfolio.CreateProject("Test Project", "Description", 1, null).Value;
+        var project = portfolio.CreateProject("Test Project", "Description", 1, null, null, null, null, _dateTimeProvider.Now).Value;
 
         // Act
         var result = portfolio.ChangeProjectProgram(project.Id, null);
@@ -616,7 +616,7 @@ public class ProjectPortfolioTests
         var project = portfolio.Projects.First(i => i.Status == ProjectStatus.Proposed);
 
         // Act
-        var result = portfolio.DeleteProject(project.Id);
+        var result = portfolio.DeleteProject(project.Id, _dateTimeProvider.Now);
 
         // Assert
         result.IsSuccess.Should().BeTrue();
@@ -631,7 +631,7 @@ public class ProjectPortfolioTests
         var portfolio = _portfolioFaker.Generate();
 
         // Act
-        var result = portfolio.DeleteProject(Guid.NewGuid());
+        var result = portfolio.DeleteProject(Guid.NewGuid(), _dateTimeProvider.Now);
 
         // Assert
         result.IsFailure.Should().BeTrue();
@@ -646,7 +646,7 @@ public class ProjectPortfolioTests
         var initiative = portfolio.Projects.First();
 
         // Act
-        var result = portfolio.DeleteProject(initiative.Id);
+        var result = portfolio.DeleteProject(initiative.Id, _dateTimeProvider.Now);
 
         // Assert
         result.IsFailure.Should().BeTrue();

--- a/Moda.Services/Moda.ProjectPortfolioManagement/tests/Moda.ProjectPortfolioManagement.Domain.Tests/Sut/Models/ProjectTests.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/tests/Moda.ProjectPortfolioManagement.Domain.Tests/Sut/Models/ProjectTests.cs
@@ -34,7 +34,7 @@ public class ProjectTests
         var expenditureCategoryId = 1;
 
         // Act
-        var project = Project.Create(name, description, expenditureCategoryId, null, portfolioId, null);
+        var project = Project.Create(name, description, expenditureCategoryId, null, portfolioId, null, null, null, _dateTimeProvider.Now);
 
         // Assert
         project.Should().NotBeNull();
@@ -54,7 +54,7 @@ public class ProjectTests
         var project = _projectFaker.Generate();
 
         // Act
-        Action action = () => project.UpdateDetails("", "Valid Description", project.ExpenditureCategoryId);
+        Action action = () => project.UpdateDetails("", "Valid Description", project.ExpenditureCategoryId, _dateTimeProvider.Now);
 
         // Assert
         action.Should().Throw<ArgumentException>().WithMessage("Required input Name was empty. (Parameter 'Name')");
@@ -67,7 +67,7 @@ public class ProjectTests
         var project = _projectFaker.Generate();
 
         // Act
-        Action action = () => project.UpdateDetails("Valid Name", "", project.ExpenditureCategoryId);
+        Action action = () => project.UpdateDetails("Valid Name", "", project.ExpenditureCategoryId, _dateTimeProvider.Now);
 
         // Assert
         action.Should().Throw<ArgumentException>().WithMessage("Required input Description was empty. (Parameter 'Description')");

--- a/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Application/StrategicThemes/Commands/DeleteStrategicThemeCommand.cs
+++ b/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Application/StrategicThemes/Commands/DeleteStrategicThemeCommand.cs
@@ -1,4 +1,6 @@
-﻿using Moda.Common.Application.Models;
+﻿using Moda.Common.Application.Events;
+using Moda.Common.Application.Models;
+using Moda.Common.Domain.Events.StrategicManagement;
 
 namespace Moda.StrategicManagement.Application.StrategicThemes.Commands;
 
@@ -12,12 +14,14 @@ public sealed class DeleteStrategicThemeCommandValidator : AbstractValidator<Del
     }
 }
 
-internal sealed class DeleteStrategicThemeCommandHandler(IStrategicManagementDbContext strategicManagementDbContext, ILogger<DeleteStrategicThemeCommandHandler> logger) : ICommandHandler<DeleteStrategicThemeCommand>
+internal sealed class DeleteStrategicThemeCommandHandler(IStrategicManagementDbContext strategicManagementDbContext, ILogger<DeleteStrategicThemeCommandHandler> logger, IDateTimeProvider dateTimeProvider, IEventPublisher eventPublisher) : ICommandHandler<DeleteStrategicThemeCommand>
 {
     private const string AppRequestName = nameof(DeleteStrategicThemeCommand);
 
     private readonly IStrategicManagementDbContext _strategicManagementDbContext = strategicManagementDbContext;
     private readonly ILogger<DeleteStrategicThemeCommandHandler> _logger = logger;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+    private readonly IEventPublisher _eventPublisher = eventPublisher;
 
     public async Task<Result> Handle(DeleteStrategicThemeCommand request, CancellationToken cancellationToken)
     {
@@ -42,6 +46,9 @@ internal sealed class DeleteStrategicThemeCommandHandler(IStrategicManagementDbC
             await _strategicManagementDbContext.SaveChangesAsync(cancellationToken);
 
             _logger.LogInformation("Strategic Theme {StrategicThemeId} deleted.", request.Id);
+
+            var deleteEvent = new StrategicThemeDeletedEvent(request.Id, _dateTimeProvider.Now);
+            await _eventPublisher.PublishAsync(deleteEvent);
 
             return Result.Success();
         }

--- a/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Application/StrategicThemes/Queries/GetStrategicThemesDataQuery.cs
+++ b/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Application/StrategicThemes/Queries/GetStrategicThemesDataQuery.cs
@@ -18,6 +18,6 @@ internal sealed class GetStrategicThemesDataQueryHandler(IStrategicManagementDbC
             .AsNoTracking()
             .ToListAsync(cancellationToken);
 
-        return themes.OfType<IStrategicThemeData>().ToList();
+        return [.. themes.OfType<IStrategicThemeData>()];
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/GlobalUsings.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/GlobalUsings.cs
@@ -1,5 +1,4 @@
-﻿global using Moda.AppIntegration.Application.Persistence;
-global using Moda.Common.Application.Interfaces;
+﻿global using Moda.Common.Application.Interfaces;
 global using Moda.Common.Application.Persistence;
 global using Moda.Common.Application.Validation;
 global using Moda.Common.Extensions;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Persistence/IWorkDbContext.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Persistence/IWorkDbContext.cs
@@ -7,6 +7,7 @@ public interface IWorkDbContext : IModaDbContext
     DbSet<WorkItem> WorkItems { get; }
     DbSet<WorkItemLink> WorkItemLinks { get; }
     DbSet<WorkProcess> WorkProcesses { get; }
+    DbSet<WorkProject> WorkProjects { get; }
     DbSet<Workspace> Workspaces { get; }
     DbSet<WorkStatus> WorkStatuses { get; }
     DbSet<WorkTeam> WorkTeams { get; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Persistence/IWorkDbContext.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Persistence/IWorkDbContext.cs
@@ -1,4 +1,4 @@
-﻿namespace Moda.AppIntegration.Application.Persistence;
+﻿namespace Moda.Work.Application.Persistence;
 public interface IWorkDbContext : IModaDbContext
 {
     DbSet<WorkTypeHierarchy> WorkTypeHierarchies { get; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/DeleteExternalWorkItemsCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/DeleteExternalWorkItemsCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Domain.Enums;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkItems.Commands;
 internal sealed class DeleteExternalWorkItemsCommandHandler(IWorkDbContext workDbContext, ILogger<SyncExternalWorkItemsCommandHandler> logger) : ICommandHandler<DeleteExternalWorkItemsCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/ManageExternalObjectWorkItemsCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/ManageExternalObjectWorkItemsCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Domain.Enums;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkItems.Commands;
 public sealed record ManageExternalObjectWorkItemsCommand(Guid PlanningIntervalId, Guid ObjectiveId, SystemContext Context, IEnumerable<Guid> WorkItemIds) : ICommand;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemDependencyChangesCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemDependencyChangesCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Interfaces.ExternalWork;
 using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkItems.Commands;
 internal sealed class SyncExternalWorkItemDependencyChangesCommandHandler(IWorkDbContext workDbContext, ILogger<SyncExternalWorkItemDependencyChangesCommandHandler> logger) : ICommandHandler<SyncExternalWorkItemDependencyChangesCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemParentChangesCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemParentChangesCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Commands;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Domain.Enums;
 using Moda.Common.Domain.Enums.Work;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 using Moda.Work.Domain.Interfaces;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/UpdateWorkItemProjectCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/UpdateWorkItemProjectCommand.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.Persistence;
+﻿using Moda.Common.Domain.Enums.Work;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Commands;
@@ -57,12 +58,61 @@ internal sealed class UpdateWorkItemProjectCommandHandler(
 
             _logger.LogInformation("Work item {WorkItemKey} project id updated.", request.WorkItemKey);
 
+            await UpdateChildren(workItem.Adapt<WorkItemParentInfo>(), cancellationToken);
+
+            _logger.LogInformation("Work item {WorkItemKey} descendants updated.", request.WorkItemKey);
+
             return Result.Success();
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
             return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+
+    // TODO: this should be moved to an event handler
+    private async Task UpdateChildren(WorkItemParentInfo parent, CancellationToken cancellationToken)
+    {
+        if (parent.Tier != WorkTypeTier.Portfolio)
+        {
+            return;
+        }
+
+        var children = await _workDbContext.WorkItems
+            .Include(wi => wi.Type)
+                .ThenInclude(t => t.Level)
+            .Where(wi => wi.ParentId == parent.Id)
+            .ToListAsync(cancellationToken);
+
+        if (children.Count == 0)
+            return;
+
+
+        int updateCount = 0;
+
+        foreach (var child in children)
+        {
+            var result = child.UpdateParent(parent, child.Type);
+            if (result.IsFailure)
+            {
+                _logger.LogError("Error updating parent for work item {WorkItemId}. {Error}", child.Id, result.Error);
+                continue;
+            }
+
+            updateCount++;
+        }
+
+        if (updateCount > 0)
+        {
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogDebug("Updated {UpdateCount} children for work item {WorkItemId}.", updateCount, parent.Id);
+        }
+
+        foreach (var child in children)
+        {
+            if (child.ProjectId is null)
+                await UpdateChildren(child.Adapt<WorkItemParentInfo>(), cancellationToken);
         }
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/UpdateWorkItemProjectCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/UpdateWorkItemProjectCommand.cs
@@ -1,0 +1,65 @@
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkItems.Commands;
+
+public sealed record UpdateWorkItemProjectCommand(WorkItemKey WorkItemKey, Guid? ProjectId) : ICommand;
+
+public sealed class UpdateWorkItemProjectCommandValidator : AbstractValidator<UpdateWorkItemProjectCommand>
+{
+    public UpdateWorkItemProjectCommandValidator()
+    {
+        RuleFor(x => x.WorkItemKey)
+            .NotNull();
+
+        When(x => x.ProjectId.HasValue, () =>
+        {
+            RuleFor(x => x.ProjectId)
+                .NotEmpty();
+        });
+    }
+}
+
+internal sealed class UpdateWorkItemProjectCommandHandler(
+    IWorkDbContext workDbContext,
+    ILogger<UpdateWorkItemProjectCommandHandler> logger) : ICommandHandler<UpdateWorkItemProjectCommand>
+{
+    private const string AppRequestName = nameof(UpdateWorkItemProjectCommand);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<UpdateWorkItemProjectCommandHandler> _logger = logger;
+    public async Task<Result> Handle(UpdateWorkItemProjectCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var workItem = await _workDbContext.WorkItems
+                .FirstOrDefaultAsync(w => w.Key == request.WorkItemKey, cancellationToken);
+            if (workItem is null)
+            {
+                _logger.LogInformation("Work item {WorkItemKey} not found.", request.WorkItemKey);
+                return Result.Failure("Work item not found.");
+            }
+
+            var result = workItem.UpdateProjectId(request.ProjectId);
+            if (result.IsFailure)
+            {
+                // Reset the entity
+                await _workDbContext.Entry(workItem).ReloadAsync(cancellationToken);
+                workItem.ClearDomainEvents();
+
+                _logger.LogError("Unable to update work item {WorkItemKey} project id to {ProjectId}. Error message: {Error}", request.WorkItemKey, request.ProjectId?.ToString() ?? "null", result.Error);
+                return Result.Failure(result.Error);
+            }
+
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Work item {WorkItemKey} project id updated.", request.WorkItemKey);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/UpdateWorkItemProjectCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/UpdateWorkItemProjectCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Commands;
 
@@ -32,6 +33,8 @@ internal sealed class UpdateWorkItemProjectCommandHandler(
         try
         {
             var workItem = await _workDbContext.WorkItems
+                .Include(i => i.Type)
+                    .ThenInclude(t => t.Level)
                 .FirstOrDefaultAsync(w => w.Key == request.WorkItemKey, cancellationToken);
             if (workItem is null)
             {

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemBacklogItemDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemBacklogItemDto.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Dtos;
 using Moda.Common.Application.Employees.Dtos;
+using Moda.Work.Application.WorkProjects.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
 using Moda.Work.Application.WorkTeams.Dtos;
 
@@ -20,6 +21,7 @@ public sealed record WorkItemBacklogItemDto : IMapFrom<WorkItem>
     public Instant Created { get; set; }
     public int Rank { get; set; }
     public int? ParentRank { get; set; }
+    public WorkProjectNavigationDto? Project { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }
 
     // This is used to set the rank of the work items in the backlog
@@ -33,6 +35,11 @@ public sealed record WorkItemBacklogItemDto : IMapFrom<WorkItem>
             .Map(dest => dest.Status, src => src.Status.Name)
             .Map(dest => dest.StatusCategory, src => SimpleNavigationDto.FromEnum(src.StatusCategory))
             .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
+            .Map(dest => dest.Project, src => src.Project != null
+                ? WorkProjectNavigationDto.From(src.Project)
+                : src.ParentProject != null
+                    ? WorkProjectNavigationDto.From(src.ParentProject)
+                    : null)
             .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Dtos;
 using Moda.Common.Application.Employees.Dtos;
+using Moda.Work.Application.WorkProjects.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
 using Moda.Work.Application.WorkTeams.Dtos;
 
@@ -25,6 +26,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
     public EmployeeNavigationDto? LastModifiedBy { get; set; }
     public Instant? ActivatedTimestamp { get; set; }
     public Instant? DoneTimestamp { get; set; }
+    public WorkProjectNavigationDto? Project { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }
 
     public void ConfigureMapping(TypeAdapterConfig config)
@@ -38,6 +40,11 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
             .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
             .Map(dest => dest.CreatedBy, src => src.CreatedBy == null ? null : EmployeeNavigationDto.From(src.CreatedBy))
             .Map(dest => dest.LastModifiedBy, src => src.LastModifiedBy == null ? null : EmployeeNavigationDto.From(src.LastModifiedBy))
+            .Map(dest => dest.Project, src => src.Project != null
+                ? WorkProjectNavigationDto.From(src.Project)
+                : src.ParentProject != null
+                    ? WorkProjectNavigationDto.From(src.ParentProject)
+                    : null)
             .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Dtos;
 using Moda.Common.Application.Employees.Dtos;
+using Moda.Work.Application.WorkProjects.Dtos;
 using Moda.Work.Application.Workspaces.Dtos;
 using Moda.Work.Application.WorkTeams.Dtos;
 
@@ -17,6 +18,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
     public WorkTeamNavigationDto? Team { get; set; }
     public EmployeeNavigationDto? AssignedTo { get; set; }
     public double StackRank { get; set; }
+    public WorkProjectNavigationDto? Project { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }
 
     public void ConfigureMapping(TypeAdapterConfig config)
@@ -27,6 +29,11 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
             .Map(dest => dest.Status, src => src.Status.Name)
             .Map(dest => dest.StatusCategory, src => SimpleNavigationDto.FromEnum(src.StatusCategory))
             .Map(dest => dest.AssignedTo, src => src.AssignedTo == null ? null : EmployeeNavigationDto.From(src.AssignedTo))
+            .Map(dest => dest.Project, src => src.Project != null 
+                ? WorkProjectNavigationDto.From(src.Project) 
+                : src.ParentProject != null 
+                    ? WorkProjectNavigationDto.From(src.ParentProject) 
+                    : null)
             .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemParentInfo.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemParentInfo.cs
@@ -8,11 +8,13 @@ public sealed record WorkItemParentInfo : IMapFrom<WorkItem>, IWorkItemParentInf
     public int? ExternalId { get; init; }
     public WorkTypeTier Tier { get; init; }
     public int LevelOrder { get; init; }
+    public Guid? ProjectId { get; init; }
 
     public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<WorkItem, WorkItemParentInfo>()
             .Map(dest => dest.LevelOrder, src => src.Type.Level!.Order)
-            .Map(dest => dest.Tier, src => src.Type.Level!.Tier);
+            .Map(dest => dest.Tier, src => src.Type.Level!.Tier)
+            .Map(dest => dest.ProjectId, src => src.ProjectId ?? src.ParentProjectId);
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemProgressRollupDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemProgressRollupDto.cs
@@ -29,43 +29,25 @@ public record WorkItemProgressRollupDto
 
     public static WorkItemProgressRollupDto Create(List<WorkItemProgressStateDto> workItems)
     {
-        int proposed = 0, active = 0, done = 0;
+        var counts = workItems
+            .GroupBy(w => w.StatusCategory)
+            .ToDictionary(g => g.Key, g => g.Count());
 
-        foreach (var workItem in workItems)
+        return new WorkItemProgressRollupDto
         {
-            switch (workItem.StatusCategory)
-            {
-                case WorkStatusCategory.Proposed:
-                    proposed++;
-                    break;
-                case WorkStatusCategory.Active:
-                    active++;
-                    break;
-                case WorkStatusCategory.Done:
-                    done++;
-                    break;
-            }
-        }
-
-        return Create(proposed, active, done);
+            Proposed = counts.GetValueOrDefault(WorkStatusCategory.Proposed, 0),
+            Active = counts.GetValueOrDefault(WorkStatusCategory.Active, 0),
+            Done = counts.GetValueOrDefault(WorkStatusCategory.Done, 0)
+        };
     }
 
     public static WorkItemProgressRollupDto Create(List<WorkItemProgressRollupDto> rollups)
     {
-        int proposed = 0, active = 0, done = 0;
-
-        foreach (var rollup in rollups)
-        {
-            proposed += rollup.Proposed;
-            active += rollup.Active;
-            done += rollup.Done;
-        }
-
         return new WorkItemProgressRollupDto
         {
-            Proposed = proposed,
-            Active = active,
-            Done = done
+            Proposed = rollups.Sum(r => r.Proposed),
+            Active = rollups.Sum(r => r.Active),
+            Done = rollups.Sum(r => r.Done)
         };
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemProjectInfoDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Dtos/WorkItemProjectInfoDto.cs
@@ -1,0 +1,22 @@
+﻿using Moda.Work.Application.WorkProjects.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Dtos;
+public class WorkItemProjectInfoDto : IMapFrom<WorkItem>
+{
+    public Guid Id { get; set; }
+    public required string Key { get; set; }
+    public WorkProjectNavigationDto? Project { get; set; }
+    public WorkProjectNavigationDto? ParentProject { get; set; }
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<WorkItem, WorkItemProjectInfoDto>()
+            .Map(dest => dest.Key, src => src.Key.ToString())
+            .Map(dest => dest.Project, src => src.Project != null
+                ? WorkProjectNavigationDto.From(src.Project)
+                : null)
+            .Map(dest => dest.ParentProject, src => src.ParentProject != null
+                ? WorkProjectNavigationDto.From(src.ParentProject)
+                : null);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetChildWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetChildWorkItemsQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemMetricsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemMetricsQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkItems.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;
 public sealed record GetExternalObjectWorkItemMetricsQuery(Guid ObjectiveId, DateOnly Start, DateOnly End) : IQuery<List<WorkItemProgressDailyRollupDto>>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemMetricsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemMetricsQuery.cs
@@ -4,12 +4,9 @@ using Moda.Work.Application.WorkItems.Dtos;
 namespace Moda.Work.Application.WorkItems.Queries;
 public sealed record GetExternalObjectWorkItemMetricsQuery(Guid ObjectiveId, DateOnly Start, DateOnly End) : IQuery<List<WorkItemProgressDailyRollupDto>>;
 
-internal sealed class GetExternalObjectWorkItemMetricsQueryHandler(IWorkDbContext workDbContext, ILogger<GetExternalObjectWorkItemMetricsQueryHandler> logger) : IQueryHandler<GetExternalObjectWorkItemMetricsQuery, List<WorkItemProgressDailyRollupDto>>
+internal sealed class GetExternalObjectWorkItemMetricsQueryHandler(IWorkDbContext workDbContext) : IQueryHandler<GetExternalObjectWorkItemMetricsQuery, List<WorkItemProgressDailyRollupDto>>
 {
-    private const string AppRequestName = nameof(GetExternalObjectWorkItemMetricsQuery);
-
     private readonly IWorkDbContext _workDbContext = workDbContext;
-    private readonly ILogger<GetExternalObjectWorkItemMetricsQueryHandler> _logger = logger;
 
     public async Task<List<WorkItemProgressDailyRollupDto>> Handle(GetExternalObjectWorkItemMetricsQuery request, CancellationToken cancellationToken)
     {

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
@@ -4,12 +4,9 @@ using Moda.Work.Application.WorkItems.Dtos;
 namespace Moda.Work.Application.WorkItems.Queries;
 public sealed record GetExternalObjectWorkItemsQuery(Guid ObjectId) : IQuery<WorkItemsSummaryDto>;
 
-internal sealed class GetExternalObjectWorkItemsQueryHandler(IWorkDbContext workDbContext, ILogger<GetExternalObjectWorkItemsQueryHandler> logger) : IQueryHandler<GetExternalObjectWorkItemsQuery, WorkItemsSummaryDto>
+internal sealed class GetExternalObjectWorkItemsQueryHandler(IWorkDbContext workDbContext) : IQueryHandler<GetExternalObjectWorkItemsQuery, WorkItemsSummaryDto>
 {
-    private const string AppRequestName = nameof(GetExternalObjectWorkItemsQuery);
-
     private readonly IWorkDbContext _workDbContext = workDbContext;
-    private readonly ILogger<GetExternalObjectWorkItemsQueryHandler> _logger = logger;
 
     public async Task<WorkItemsSummaryDto> Handle(GetExternalObjectWorkItemsQuery request, CancellationToken cancellationToken)
     {

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetExternalObjectWorkItemsQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkItems.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;
 public sealed record GetExternalObjectWorkItemsQuery(Guid ObjectId) : IQuery<WorkItemsSummaryDto>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetProjectWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetProjectWorkItemsQuery.cs
@@ -1,0 +1,22 @@
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Queries;
+
+// TODO: change this to IdOrKey parameter
+public sealed record GetProjectWorkItemsQuery(Guid ProjectId) : IQuery<Result<List<WorkItemListDto>>>;
+
+internal sealed class GetProjectWorkItemsQueryHandler(IWorkDbContext workDbContext)
+    : IQueryHandler<GetProjectWorkItemsQuery, Result<List<WorkItemListDto>>>
+{
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+
+    public async Task<Result<List<WorkItemListDto>>> Handle(GetProjectWorkItemsQuery request, CancellationToken cancellationToken)
+    {
+        return await _workDbContext.WorkItems
+            .Where(i => (i.ProjectId != null && i.ProjectId == request.ProjectId) 
+                || (i.ProjectId == null && i.ParentProjectId != null && i.ParentProjectId == request.ProjectId))
+            .ProjectToType<WorkItemListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetTeamBacklogQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetTeamBacklogQuery.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Domain.Enums.Work;
 using Moda.Organization.Domain.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetTeamDependenciesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetTeamDependenciesQuery.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Domain.Enums.Work;
 using Moda.Common.Domain.Extensions;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemDependenciesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemDependenciesQuery.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq.Expressions;
 using Moda.Common.Domain.Enums.Work;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 using Moda.Work.Application.Workspaces.Models;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemMetricsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemMetricsQuery.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Domain.Enums.Work;
 using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemProjectInfoQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemProjectInfoQuery.cs
@@ -1,0 +1,54 @@
+﻿using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Dtos;
+
+namespace Moda.Work.Application.WorkItems.Queries;
+public sealed record GetWorkItemProjectInfoQuery : IQuery<Result<WorkItemProjectInfoDto?>>
+{
+    public GetWorkItemProjectInfoQuery(Guid workspaceId, WorkItemKey workItemKey)
+    {
+        Id = Guard.Against.NullOrEmpty(workspaceId);
+        WorkItemKey = workItemKey;
+    }
+
+    public GetWorkItemProjectInfoQuery(WorkspaceKey workspaceKey, WorkItemKey workItemKey)
+    {
+        Key = Guard.Against.Default(workspaceKey);
+        WorkItemKey = workItemKey;
+    }
+
+    public Guid? Id { get; }
+    public WorkspaceKey? Key { get; }
+    public WorkItemKey WorkItemKey { get; }
+}
+
+internal sealed class GetWorkItemProjectInfoQueryHandler(IWorkDbContext workDbContext, ILogger<GetWorkItemProjectInfoQueryHandler> logger) : IQueryHandler<GetWorkItemProjectInfoQuery, Result<WorkItemProjectInfoDto?>>
+{
+    private const string AppRequestName = nameof(GetWorkItemProjectInfoQuery);
+
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<GetWorkItemProjectInfoQueryHandler> _logger = logger;
+
+    public async Task<Result<WorkItemProjectInfoDto?>> Handle(GetWorkItemProjectInfoQuery request, CancellationToken cancellationToken)
+    {
+        var query = _workDbContext.WorkItems
+            .Where(w => w.Key == request.WorkItemKey)
+            .AsQueryable();
+
+        if (request.Id.HasValue)
+        {
+            query = query.Where(w => w.WorkspaceId == request.Id);
+        }
+        else if (request.Key is not null)
+        {
+            query = query.Where(w => w.Workspace.Key == request.Key);
+        }
+        else
+        {
+            _logger.LogError("{AppRequestName}: No workspace id or key provided. {@Request}", AppRequestName, request);
+            return Result.Failure<WorkItemProjectInfoDto?>("No valid workspace id or key provided.");
+        }
+
+        return await query.ProjectToType<WorkItemProjectInfoDto>().FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/GetWorkItemsQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/SearchWorkItemsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Queries/SearchWorkItemsQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkItems.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems.Queries;
 public sealed record SearchWorkItemsQuery(string SearchTerm, int Top) : IQuery<Result<IReadOnlyCollection<WorkItemListDto>>>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/WorkItemProgressStateBuilder.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/WorkItemProgressStateBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Domain.Enums.Work;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkItems.Dtos;
 
 namespace Moda.Work.Application.WorkItems;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/ActivateWorkProcessCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/ActivateWorkProcessCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkProcesses.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkProcesses.Commands;
 public sealed record ActivateWorkProcessCommand(Guid Id) : ICommand;
 
 internal sealed class ActivateWorkProcessCommandHandler(IWorkDbContext workDbContext, ILogger<ActivateWorkProcessCommandHandler> logger, IDateTimeProvider dateTimeProvider) : ICommandHandler<ActivateWorkProcessCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/CreateExternalWorkProcessCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/CreateExternalWorkProcessCommandHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Domain.Models;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkProcesses.Commands;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/DeactivateWorkProcessCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/DeactivateWorkProcessCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkProcesses.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkProcesses.Commands;
 public sealed record DeactivateWorkProcessCommand(Guid Id) : ICommand;
 
 internal sealed class DeactivateWorkProcessCommandHandler(IWorkDbContext workDbContext, ILogger<DeactivateWorkProcessCommandHandler> logger, IDateTimeProvider dateTimeProvider) : ICommandHandler<DeactivateWorkProcessCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/UpdateExternalWorkProcessCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Commands/UpdateExternalWorkProcessCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Moda.Common.Application.Interfaces.ExternalWork;
 using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Application.Requests.WorkManagement.Interfaces;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkProcesses.Commands;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/ExternalWorkProcessExistsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/ExternalWorkProcessExistsQuery.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkProcesses.Queries;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkProcesses.Queries;
 public sealed record ExternalWorkProcessExistsQuery(Guid ExternalId) : IQuery<bool>;
 
 internal sealed class ExternalWorkProcessExistsQueryHandler : IQueryHandler<ExternalWorkProcessExistsQuery, bool>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetIntegrationRegistrationsForWorkProcessesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetIntegrationRegistrationsForWorkProcessesQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Domain.Models;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkProcesses.Queries;
 public sealed record GetIntegrationRegistrationsForWorkProcessesQuery(Guid? ExternalId = null) : IQuery<List<IntegrationRegistration<Guid, Guid>>>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetWorkProcessQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetWorkProcessQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkProcesses.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkProcesses.Dtos;
 
 namespace Moda.Work.Application.WorkProcesses.Queries;
 public sealed record GetWorkProcessQuery : IQuery<Result<WorkProcessDto?>>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetWorkProcessSchemesQueryHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetWorkProcessSchemesQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Application.Requests.WorkManagement.Interfaces;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkProcesses.Dtos;
 
 namespace Moda.Work.Application.WorkProcesses.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetWorkProcessesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProcesses/Queries/GetWorkProcessesQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkProcesses.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkProcesses.Dtos;
 
 namespace Moda.Work.Application.WorkProcesses.Queries;
 public sealed record GetWorkProcessesQuery(bool IncludeInactive = false) : IQuery<IReadOnlyList<WorkProcessListDto>>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProjects/Commands/SyncWorkProjectsCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProjects/Commands/SyncWorkProjectsCommand.cs
@@ -1,0 +1,80 @@
+﻿using Moda.Common.Domain.Enums;
+using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
+using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkProjects.Commands;
+public sealed record SyncWorkProjectsCommand(IEnumerable<ISimpleProject> Projects) : ICommand;
+
+internal sealed class SyncWorkProjectsCommandHandler(
+    IWorkDbContext workDbContext,
+    ILogger<SyncWorkProjectsCommandHandler> logger)
+    : ICommandHandler<SyncWorkProjectsCommand>
+{
+    private const string AppRequestName = nameof(SyncWorkProjectsCommand);
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<SyncWorkProjectsCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(SyncWorkProjectsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (request.Projects == null || !request.Projects.Any())
+            {
+                _logger.LogInformation("No projects to sync.");
+                return Result.Success();
+            }
+
+            int createCount = 0;
+            int updateCount = 0;
+            int deleteCount = 0;
+
+            var existingProjects = await _workDbContext.WorkProjects
+                .ToListAsync(cancellationToken);
+
+            var existingIds = existingProjects.Select(x => x.Id).ToHashSet();
+
+            // Handle deletes
+            var deleteIds = existingIds.Except(request.Projects.Select(x => x.Id)).ToList();
+            if (deleteIds.Count != 0)
+            {
+                var projectsToDelete = existingProjects.Where(x => deleteIds.Contains(x.Id)).ToList();
+                _workDbContext.WorkProjects.RemoveRange(projectsToDelete);
+                deleteCount = projectsToDelete.Count;
+            }
+
+            // Handle creates and updates
+            foreach (var project in request.Projects)
+            {
+                var existingProject = existingProjects.FirstOrDefault(x => x.Id == project.Id);
+                if (existingProject == null)
+                {
+                    _logger.LogDebug("Creating new Work project {ProjectId}.", project.Id);
+
+                    var newProject = new WorkProject(project);
+
+                    await _workDbContext.WorkProjects.AddAsync(newProject, cancellationToken);
+                    createCount++;
+                }
+                else
+                {
+                    _logger.LogDebug("Updating existing Work project {ProjectId}.", project.Id);
+
+                    existingProject.UpdateDetails(project);
+                    updateCount++;
+                }
+            }
+
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Successful Work {SystemActionType} for {CreateCount} created, {UpdateCount} updated, and {DeleteCount} deleted projects.",
+                SystemActionType.ServiceDataReplication, createCount, updateCount, deleteCount);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProjects/Dtos/WorkProjectNavigationDto.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProjects/Dtos/WorkProjectNavigationDto.cs
@@ -1,0 +1,21 @@
+﻿using Moda.Common.Application.Dtos;
+
+namespace Moda.Work.Application.WorkProjects.Dtos;
+public sealed record WorkProjectNavigationDto : NavigationDto, IMapFrom<WorkProject>
+{
+    public static WorkProjectNavigationDto From(WorkProject workProject)
+        => new()
+        {
+            Id = workProject.Id,
+            Key = workProject.Key,
+            Name = workProject.Name
+        };
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<WorkProject, WorkProjectNavigationDto>()
+            .Map(dest => dest.Id, src => src.Id)
+            .Map(dest => dest.Key, src => src.Key)
+            .Map(dest => dest.Name, src => src.Name);
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProjects/EventHandlers/ProjectSyncHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkProjects/EventHandlers/ProjectSyncHandler.cs
@@ -1,0 +1,98 @@
+﻿using Moda.Common.Application.Events;
+using Moda.Common.Domain.Enums;
+using Moda.Common.Domain.Events.ProjectPortfolioManagement;
+using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkProjects.EventHandlers;
+internal sealed class ProjectSyncHandler(IWorkDbContext workDbContext, ILogger<ProjectSyncHandler> logger) :
+    IEventNotificationHandler<ProjectCreatedEvent>,
+    IEventNotificationHandler<ProjectDetailsUpdatedEvent>,
+    IEventNotificationHandler<ProjectDeletedEvent>
+{
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+    private readonly ILogger<ProjectSyncHandler> _logger = logger;
+
+    public async Task Handle(EventNotification<ProjectCreatedEvent> notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Handling Work {SystemActionType} for a new Project {ProjectId}.", SystemActionType.ServiceDataReplication, notification.Event.Id);
+        await CreateProject(notification.Event, cancellationToken);
+    }
+
+    public async Task Handle(EventNotification<ProjectDetailsUpdatedEvent> notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Handling Work {SystemActionType} for an updated Project {ProjectId}.", SystemActionType.ServiceDataReplication, notification.Event.Id);
+        await UpdateProject(notification.Event, cancellationToken);
+    }
+
+    public async Task Handle(EventNotification<ProjectDeletedEvent> notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Handling Work {SystemActionType} for a deleted Project {ProjectId}.", SystemActionType.ServiceDataReplication, notification.Event.Id);
+        await DeleteProject(notification.Event, cancellationToken);
+    }
+
+    private async Task CreateProject(ProjectCreatedEvent createdEvent, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (await _workDbContext.WorkProjects.AnyAsync(x => x.Id == createdEvent.Id, cancellationToken))
+            {
+                _logger.LogCritical("Error processing Work {SystemActionType} for a new Project. Project {ProjectId} already exists in the Work system.", SystemActionType.ServiceDataReplication, createdEvent.Id);
+                return;
+            }
+            var project = new WorkProject(createdEvent);
+            await _workDbContext.WorkProjects.AddAsync(project, cancellationToken);
+
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Successful Work {SystemActionType} for the Project {ProjectId} created action.", SystemActionType.ServiceDataReplication, createdEvent.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "Exception handling Work {SystemActionType} for the Project {ProjectId} created action.", SystemActionType.ServiceDataReplication, createdEvent.Id);
+        }
+    }
+
+    private async Task UpdateProject(ProjectDetailsUpdatedEvent updatedEvent, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var existingProject = await _workDbContext.WorkProjects
+                .FirstOrDefaultAsync(x => x.Id == updatedEvent.Id, cancellationToken);
+            if (existingProject == null)
+            {
+                _logger.LogCritical("Error processing Work {SystemActionType} for an updated Project. Project {ProjectId} does not exist in the Work system.", SystemActionType.ServiceDataReplication, updatedEvent.Id);
+                return;
+            }
+            existingProject.UpdateDetails(updatedEvent);
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+            _logger.LogInformation("Successful Work {SystemActionType} for the Project {ProjectId} updated action.", SystemActionType.ServiceDataReplication, updatedEvent.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "Exception handling Work {SystemActionType} for the Project {ProjectId} updated action.", SystemActionType.ServiceDataReplication, updatedEvent.Id);
+        }
+    }
+
+    private async Task DeleteProject(ProjectDeletedEvent deletedEvent, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var existingProject = await _workDbContext.WorkProjects
+                .FirstOrDefaultAsync(x => x.Id == deletedEvent.Id, cancellationToken);
+            if (existingProject == null)
+            {
+                _logger.LogCritical("Error processing Work {SystemActionType} for a deleted Project. Project {ProjectId} does not exist in the Work system.", SystemActionType.ServiceDataReplication, deletedEvent.Id);
+                return;
+            }
+
+            _workDbContext.WorkProjects.Remove(existingProject);
+            await _workDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Successful Work {SystemActionType} for the Project {ProjectId} deleted action.", SystemActionType.ServiceDataReplication, deletedEvent.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogCritical(ex, "Exception handling Work {SystemActionType} for the Project {ProjectId} deleted action.", SystemActionType.ServiceDataReplication, deletedEvent.Id);
+        }
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Commands/CreateWorkStatusCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Commands/CreateWorkStatusCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkStatuses.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkStatuses.Commands;
 public sealed record CreateWorkStatusCommand : ICommand<int>
 {
     public CreateWorkStatusCommand(string name, string? description)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Commands/SyncExternalWorkStatusesCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Commands/SyncExternalWorkStatusesCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Interfaces.ExternalWork;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkStatuses.Validators;
 
 namespace Moda.Work.Application.WorkStatuses.Commands;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Commands/UpdateWorkStatusCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Commands/UpdateWorkStatusCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkStatuses.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkStatuses.Commands;
 public sealed record UpdateWorkStatusCommand : ICommand<int>
 {
     public UpdateWorkStatusCommand(int id, string? description)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Queries/GetWorkStatusQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Queries/GetWorkStatusQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Exceptions;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkStatuses.Dtos;
 
 namespace Moda.Work.Application.WorkStatuses.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Queries/GetWorkStatusesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkStatuses/Queries/GetWorkStatusesQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkStatuses.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkStatuses.Dtos;
 
 namespace Moda.Work.Application.WorkStatuses.Queries;
 public sealed record GetWorkStatusesQuery(bool IncludeInactive = false) : IQuery<IReadOnlyList<WorkStatusDto>>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTeams/EventHandlers/WorkTeamChangeEventHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTeams/EventHandlers/WorkTeamChangeEventHandler.cs
@@ -3,6 +3,7 @@ using Moda.Common.Domain.Enums;
 using Moda.Common.Domain.Events;
 using Moda.Common.Domain.Interfaces.Organization;
 using Moda.Organization.Domain.Models;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkTeams.EventHandlers;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Commands/CreateWorkTypeLevelCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Commands/CreateWorkTypeLevelCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkTypeLevels.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkTypeLevels.Commands;
 public sealed record CreateWorkTypeLevelCommand(string Name, string? Description) : ICommand<int>;
 
 public sealed class CreateWorkTypeLevelCommandValidator : CustomValidator<CreateWorkTypeLevelCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Commands/UpdateWorkTypeLevelCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Commands/UpdateWorkTypeLevelCommand.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkItems.Commands;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkItems.Commands;
 
 namespace Moda.Work.Application.WorkTypeLevels.Commands;
 public sealed record UpdateWorkTypeLevelCommand : ICommand

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Commands/UpdateWorkTypeLevelsOrderCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Commands/UpdateWorkTypeLevelsOrderCommand.cs
@@ -1,4 +1,5 @@
 ﻿using MediatR;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkTypeLevels.Commands;
 public sealed record UpdateWorkTypeLevelsOrderCommand(Dictionary<int, int> Levels) : ICommand;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Queries/GetWorkTypeLevelQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Queries/GetWorkTypeLevelQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkTypeLevels.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkTypeLevels.Dtos;
 
 namespace Moda.Work.Application.WorkTypeLevels.Queries;
 public sealed record GetWorkTypeLevelQuery(int Id) : IQuery<WorkTypeLevelDto?>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Queries/GetWorkTypeLevelsQueryHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypeLevels/Queries/GetWorkTypeLevelsQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Application.Requests.WorkManagement.Interfaces;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.WorkTypeLevels.Queries;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/CreateWorkTypeCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/CreateWorkTypeCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkTypes.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkTypes.Commands;
 public sealed record CreateWorkTypeCommand(string Name, string? Description, int LevelId) : ICommand<int>;
 
 public sealed class CreateWorkTypeCommandValidator : CustomValidator<CreateWorkTypeCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/SyncExternalWorkTypesCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/SyncExternalWorkTypesCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Interfaces.ExternalWork;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkTypes.Validators;
 
 namespace Moda.Work.Application.WorkTypes.Commands;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/UpdateWorkTypeCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Commands/UpdateWorkTypeCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.WorkTypes.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.WorkTypes.Commands;
 public sealed record UpdateWorkTypeCommand(int Id, string? Description, int LevelId) : ICommand<int>;
 
 public sealed class UpdateWorkTypeCommandValidator : CustomValidator<UpdateWorkTypeCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Queries/GetWorkTypeQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Queries/GetWorkTypeQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Exceptions;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkTypes.Dtos;
 
 namespace Moda.Work.Application.WorkTypes.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Queries/GetWorkTypesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkTypes/Queries/GetWorkTypesQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.WorkTypes.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.WorkTypes.Dtos;
 
 namespace Moda.Work.Application.WorkTypes.Queries;
 public sealed record GetWorkTypesQuery : IQuery<IReadOnlyList<WorkTypeDto>>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workflows/Commands/CreateExternalWorkflowCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workflows/Commands/CreateExternalWorkflowCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.Workflows.Dtos;
 using Moda.Work.Application.WorkProcesses.Commands;
 using Moda.Work.Domain.Interfaces;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workflows/Commands/UpdateExternalWorkflowCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workflows/Commands/UpdateExternalWorkflowCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.Workflows.Commands;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/CreateExternalWorkspaceCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/CreateExternalWorkspaceCommandHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Domain.Models;
 using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkProcesses.Commands;
 using Moda.Work.Application.Workspaces.Validators;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/SetExternalViewWorkItemUrlTemplateCommand.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/SetExternalViewWorkItemUrlTemplateCommand.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.Workspaces.Commands;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.Workspaces.Commands;
 public sealed record SetExternalViewWorkItemUrlTemplateCommand(Guid WorkspaceId, string? ExternalViewWorkItemUrlTemplate) : ICommand;
 
 internal sealed class SetExternalViewWorkItemUrlTemplateCommandHandler(IWorkDbContext workDbContext, ILogger<SetExternalViewWorkItemUrlTemplateCommandHandler> logger, IDateTimeProvider dateTimeProvider) : ICommandHandler<SetExternalViewWorkItemUrlTemplateCommand>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/UpdateExternalWorkspaceCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Commands/UpdateExternalWorkspaceCommandHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.Workspaces.Validators;
 
 namespace Moda.Work.Application.Workspaces.Commands;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/ExternalWorkspaceExistsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/ExternalWorkspaceExistsQuery.cs
@@ -1,4 +1,6 @@
-﻿namespace Moda.Work.Application.Workspaces.Queries;
+﻿using Moda.Work.Application.Persistence;
+
+namespace Moda.Work.Application.Workspaces.Queries;
 public sealed record ExternalWorkspaceExistsQuery(Guid ExternalId) : IQuery<bool>;
 
 internal sealed class ExternalWorkspaceExistsQueryHandler : IQueryHandler<ExternalWorkspaceExistsQuery, bool>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspaceMostRecentChangeDateQueryHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspaceMostRecentChangeDateQueryHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.Workspaces.Queries;
 internal sealed class GetWorkspaceMostRecentChangeDateQueryHandler(IWorkDbContext workDbContext, ILogger<GetWorkspaceMostRecentChangeDateQueryHandler> logger) : IQueryHandler<GetWorkspaceMostRecentChangeDateQuery, Result<Instant?>>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspaceQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspaceQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.Workspaces.Dtos;
 
 namespace Moda.Work.Application.Workspaces.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspaceWorkTypesQueryHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspaceWorkTypesQueryHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Moda.Common.Application.Requests.WorkManagement;
 using Moda.Common.Application.Requests.WorkManagement.Interfaces;
+using Moda.Work.Application.Persistence;
 using Moda.Work.Application.WorkTypes.Dtos;
 
 namespace Moda.Work.Application.Workspaces.Queries;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspacesQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/GetWorkspacesQuery.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Work.Application.Workspaces.Dtos;
+﻿using Moda.Work.Application.Persistence;
+using Moda.Work.Application.Workspaces.Dtos;
 
 namespace Moda.Work.Application.Workspaces.Queries;
 public sealed record GetWorkspacesQuery(bool IncludeInactive = false) : IQuery<IReadOnlyList<WorkspaceListDto>>;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/WorkspaceKeyExistsQuery.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/Workspaces/Queries/WorkspaceKeyExistsQuery.cs
@@ -1,4 +1,5 @@
 ﻿using Moda.Common.Models;
+using Moda.Work.Application.Persistence;
 
 namespace Moda.Work.Application.Workspaces.Queries;
 public sealed record WorkspaceKeyExistsQuery : IQuery<bool>

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Interfaces/IWorkItemParentInfo.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Interfaces/IWorkItemParentInfo.cs
@@ -7,4 +7,5 @@ public interface IWorkItemParentInfo
     int? ExternalId { get; }
     WorkTypeTier Tier { get; }
     int LevelOrder { get; }
+    Guid? ProjectId { get; }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
@@ -275,6 +275,13 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable, HasWorkspace
     /// <returns></returns>
     public Result UpdateProjectId(Guid? projectId)
     {
+        Guard.Against.Null(Type?.Level, nameof(Type.Level));
+
+        if (Type.Level.Tier is not WorkTypeTier.Portfolio)
+        {
+            return Result.Failure("Only portfolio tier work items can have a project id.");
+        }
+
         ProjectId = projectId;
 
         TryResetProjectId();

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
@@ -110,6 +110,16 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable, HasWorkspace
     // TODO: other systems will use different types.  How to handle this?
     public double StackRank { get; private set; }
 
+    public Guid? ProjectId { get; private set; }
+
+    public WorkProject? Project { get; private set; }
+
+    public Guid? ParentProjectId { get; private set; }
+
+    public WorkProject? ParentProject { get; private set; }
+
+    public Guid? CurrentProjectId => ProjectId ?? ParentProjectId;
+
     public Instant? ActivatedTimestamp { get; private set; }
 
     public Instant? DoneTimestamp { get; private set; }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
@@ -216,6 +216,8 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable, HasWorkspace
         if (currentWorkType.Level.Tier is not WorkTypeTier.Other)
         {
             ParentProjectId = parentInfo?.ProjectId;
+
+            TryResetProjectId();
         }
 
         return Result.Success();
@@ -273,6 +275,17 @@ public sealed class WorkItem : BaseEntity<Guid>, ISystemAuditable, HasWorkspace
         }
 
         return Result.Success();
+    }
+
+    /// <summary>
+    /// Resets the project id if the parent project id is the same as the work item project id.
+    /// </summary>
+    private void TryResetProjectId()
+    {
+        if (ProjectId.HasValue && ProjectId == ParentProjectId)
+        {
+            ProjectId = null;
+        }
     }
 
     private void SetActivatedTimestamp(Instant? activatedTimestamp, Instant created, Instant? doneTimestamp)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProject.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProject.cs
@@ -1,0 +1,34 @@
+﻿using Moda.Common.Domain.Interfaces.Ppm;
+
+namespace Moda.Work.Domain.Models;
+
+/// <summary>
+/// A copy of the Moda.Common.Domain.Interfaces.Ppm.ISimpleProject interface.  Used to hold basic project information for the work service and db context.
+/// </summary>
+public class WorkProject : ISimpleProject, IHasIdAndKey
+{
+    private WorkProject() { }
+
+    public WorkProject(ISimpleProject project)
+    {
+        Id = project.Id;
+        Key = project.Key;
+        Name = project.Name;
+    }
+
+    public Guid Id { get; private set; }
+    public int Key { get; private set; }
+    public string Name { get; private set; } = default!;
+    public bool IsActive { get; private set; }
+
+    /// <summary>
+    /// Updates the specified project from a PPM ISimpleProject.
+    /// </summary>
+    /// <param name="project"></param>
+    public void Update(ISimpleProject project)
+    {
+        Id = project.Id;
+        Key = project.Key;
+        Name = project.Name;
+    }
+}

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProject.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProject.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Common.Domain.Interfaces.Ppm;
+﻿using Moda.Common.Domain.Events.ProjectPortfolioManagement;
+using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
 
 namespace Moda.Work.Domain.Models;
 
@@ -14,21 +15,23 @@ public class WorkProject : ISimpleProject, IHasIdAndKey
         Id = project.Id;
         Key = project.Key;
         Name = project.Name;
+        Description = project.Description;
     }
 
     public Guid Id { get; private set; }
     public int Key { get; private set; }
     public string Name { get; private set; } = default!;
-    public bool IsActive { get; private set; }
+    public string Description { get; private set; } = default!;
 
     /// <summary>
-    /// Updates the specified project from a PPM ISimpleProject.
+    /// Updates the specified project basic details from a PPM ISimpleProject.
     /// </summary>
     /// <param name="project"></param>
-    public void Update(ISimpleProject project)
+    public void UpdateDetails(ISimpleProject project)
     {
         Id = project.Id;
         Key = project.Key;
         Name = project.Name;
+        Description = project.Description;
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProject.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProject.cs
@@ -1,5 +1,4 @@
-﻿using Moda.Common.Domain.Events.ProjectPortfolioManagement;
-using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
+﻿using Moda.Common.Domain.Interfaces.ProjectPortfolioManagement;
 
 namespace Moda.Work.Domain.Models;
 

--- a/Moda.Services/Moda.Work/tests/Moda.Work.Domain.Tests/Data/WorkItemFaker.cs
+++ b/Moda.Services/Moda.Work/tests/Moda.Work.Domain.Tests/Data/WorkItemFaker.cs
@@ -60,6 +60,9 @@ public class WorkItemFaker : PrivateConstructorFaker<WorkItem>
         RuleFor(x => x.Priority, f => f.Random.Int(1, 4));
         RuleFor(x => x.StackRank, f => f.Random.Double(1000, 100000));
 
+        RuleFor(x => x.ProjectId, f => null);
+        RuleFor(x => x.ParentProjectId, f => null);
+
         RuleFor(x => x.Created, created);
         RuleFor(x => x.CreatedById, f => f.Random.Guid());
         RuleFor(x => x.LastModified, f => f.Date.Recent().AsUtc().ToInstant());
@@ -73,7 +76,7 @@ public class WorkItemFaker : PrivateConstructorFaker<WorkItem>
 
 public static class WorkItemFakerExtensions
 {
-    public static WorkItemFaker WithData(this WorkItemFaker faker, Guid? workspaceId = null, string? title = null, WorkType? type = null, WorkStatus? status = null, WorkStatusCategory? statusCategory = null, Guid? parentId = null, Instant? created = null, Guid? createdById = null, Instant? lastModified = null, Guid? lastModifiedById = null, Guid? assignedToId = null, int? priority = null, double? stackRank = null, Instant? activatedTimestamp = null, Instant? doneTimestamp = null)
+    public static WorkItemFaker WithData(this WorkItemFaker faker, Guid? workspaceId = null, string? title = null, WorkType? type = null, WorkStatus? status = null, WorkStatusCategory? statusCategory = null, Guid? parentId = null, Instant? created = null, Guid? createdById = null, Instant? lastModified = null, Guid? lastModifiedById = null, Guid? assignedToId = null, int? priority = null, double? stackRank = null, Guid? projectId = null, Guid? parentProjectId = null, Instant? activatedTimestamp = null, Instant? doneTimestamp = null)
     {
         if (workspaceId.HasValue) { faker.RuleFor(x => x.WorkspaceId, workspaceId.Value); }
         if (!string.IsNullOrWhiteSpace(title)) { faker.RuleFor(x => x.Title, title); }
@@ -88,6 +91,8 @@ public static class WorkItemFakerExtensions
         if (assignedToId.HasValue) { faker.RuleFor(x => x.AssignedToId, assignedToId.Value); }
         if (priority.HasValue) { faker.RuleFor(x => x.Priority, priority.Value); }
         if (stackRank.HasValue) { faker.RuleFor(x => x.StackRank, stackRank.Value); }
+        if (projectId.HasValue) { faker.RuleFor(x => x.ProjectId, projectId.Value); }
+        if (parentProjectId.HasValue) { faker.RuleFor(x => x.ParentProjectId, parentProjectId.Value); }
         if (activatedTimestamp.HasValue) { faker.RuleFor(x => x.ActivatedTimestamp, activatedTimestamp.Value); }
         if (doneTimestamp.HasValue) { faker.RuleFor(x => x.DoneTimestamp, doneTimestamp.Value); }
 

--- a/Moda.Services/Moda.Work/tests/Moda.Work.Domain.Tests/Sut/Models/WorkItemTests.cs
+++ b/Moda.Services/Moda.Work/tests/Moda.Work.Domain.Tests/Sut/Models/WorkItemTests.cs
@@ -30,23 +30,25 @@ public class WorkItemTests
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
     }
 
     [Fact]
     public void UpdateParent_WithParent_SetNullParent_ShouldSucceed()
     {
         // Arrange
-        var workItem = _workItemFaker.WithData(parentId: Guid.NewGuid()).Generate();
+        var workItem = _workItemFaker.WithData(parentId: Guid.NewGuid(), parentProjectId: Guid.NewGuid()).Generate();
         IWorkItemParentInfo? parentInfo = null;
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
     }
 
     [Fact]
@@ -56,14 +58,15 @@ public class WorkItemTests
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var epicWorkType = _workTypeFaker.AsEpic().Generate();
         var workItem = _workItemFaker.WithData(type: storyWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
         workItem.ParentId.Should().Be(parentInfo.Id);
+        workItem.ParentProjectId.Should().BeNull();
     }
 
     [Fact]
@@ -72,15 +75,19 @@ public class WorkItemTests
         // Arrange
         var featureWorkType = _workTypeFaker.AsFeature().Generate();
         var epicWorkType = _workTypeFaker.AsEpic().Generate();
-        var workItem = _workItemFaker.WithData(type: featureWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order);
+        var projectId = Guid.NewGuid();
+        var workItem = _workItemFaker.WithData(type: featureWorkType, projectId: projectId).Generate();
+        var parentProjectId = Guid.NewGuid();
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order, parentProjectId);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
         workItem.ParentId.Should().Be(parentInfo.Id);
+        workItem.ParentProjectId.Should().Be(parentProjectId);
+        workItem.ProjectId.Should().Be(projectId);
     }
 
     [Fact]
@@ -89,14 +96,15 @@ public class WorkItemTests
         // Arrange
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var workItem = _workItemFaker.WithData(type: storyWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -107,14 +115,15 @@ public class WorkItemTests
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var otherWorkType = _workTypeFaker.AsOther().Generate();
         var workItem = _workItemFaker.WithData(type: storyWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -125,14 +134,15 @@ public class WorkItemTests
         var featureWorkType = _workTypeFaker.AsFeature().Generate();
         var otherWorkType = _workTypeFaker.AsOther().Generate();
         var workItem = _workItemFaker.WithData(type: featureWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -143,14 +153,15 @@ public class WorkItemTests
         var featureWorkType = _workTypeFaker.AsFeature().Generate();
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var workItem = _workItemFaker.WithData(type: featureWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -160,14 +171,15 @@ public class WorkItemTests
         // Arrange
         var featureWorkType = _workTypeFaker.AsFeature().Generate();
         var workItem = _workItemFaker.WithData(type: featureWorkType).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, featureWorkType.Level!.Tier, featureWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, featureWorkType.Level!.Tier, featureWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().BeNull();
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("The parent must be a higher level than the work item.");
     }
 
@@ -178,14 +190,15 @@ public class WorkItemTests
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var epicWorkType = _workTypeFaker.AsEpic().Generate();
         var workItem = _workItemFaker.WithData(type: storyWorkType, parentId: Guid.NewGuid()).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order, Guid.NewGuid());
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
         workItem.ParentId.Should().Be(parentInfo.Id);
+        workItem.ParentProjectId.Should().Be(parentInfo.ProjectId);
     }
 
     [Fact]
@@ -195,14 +208,15 @@ public class WorkItemTests
         var featureWorkType = _workTypeFaker.AsFeature().Generate();
         var epicWorkType = _workTypeFaker.AsEpic().Generate();
         var workItem = _workItemFaker.WithData(type: featureWorkType, parentId: Guid.NewGuid()).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order, Guid.NewGuid());
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsSuccess);
+        result.IsSuccess.Should().BeTrue();
         workItem.ParentId.Should().Be(parentInfo.Id);
+        workItem.ParentProjectId.Should().Be(parentInfo.ProjectId);
     }
 
     [Fact]
@@ -211,15 +225,17 @@ public class WorkItemTests
         // Arrange
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var expectedParentId = Guid.NewGuid();
-        var workItem = _workItemFaker.WithData(type: storyWorkType, parentId: expectedParentId).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
+        var expectedParentProjectId = Guid.NewGuid();
+        var workItem = _workItemFaker.WithData(type: storyWorkType, parentId: expectedParentId, parentProjectId: expectedParentProjectId).Generate();
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().Be(expectedParentId);
+        workItem.ParentProjectId.Should().Be(expectedParentProjectId);
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -230,15 +246,17 @@ public class WorkItemTests
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var otherWorkType = _workTypeFaker.AsOther().Generate();
         var expectedParentId = Guid.NewGuid();
-        var workItem = _workItemFaker.WithData(type: storyWorkType, parentId: expectedParentId).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
+        var expectedParentProjectId = Guid.NewGuid();
+        var workItem = _workItemFaker.WithData(type: storyWorkType, parentId: expectedParentId, parentProjectId: expectedParentProjectId).Generate();
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().Be(expectedParentId);
+        workItem.ParentProjectId.Should().Be(expectedParentProjectId);
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -250,14 +268,15 @@ public class WorkItemTests
         var otherWorkType = _workTypeFaker.AsOther().Generate();
         var expectedParentId = Guid.NewGuid();
         var workItem = _workItemFaker.WithData(type: featureWorkType, parentId: expectedParentId).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, otherWorkType.Level!.Tier, otherWorkType.Level.Order, Guid.NewGuid());
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().Be(expectedParentId);
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -269,14 +288,15 @@ public class WorkItemTests
         var storyWorkType = _workTypeFaker.AsStory().Generate();
         var expectedParentId = Guid.NewGuid();
         var workItem = _workItemFaker.WithData(type: featureWorkType, parentId: expectedParentId).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, storyWorkType.Level!.Tier, storyWorkType.Level.Order, Guid.NewGuid());
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().Be(expectedParentId);
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Only portfolio tier work items can be parents.");
     }
 
@@ -287,14 +307,15 @@ public class WorkItemTests
         var featureWorkType = _workTypeFaker.AsFeature().Generate();
         var expectedParentId = Guid.NewGuid();
         var workItem = _workItemFaker.WithData(type: featureWorkType, parentId: expectedParentId).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, featureWorkType.Level!.Tier, featureWorkType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, featureWorkType.Level!.Tier, featureWorkType.Level.Order, Guid.NewGuid());
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().Be(expectedParentId);
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("The parent must be a higher level than the work item.");
     }
 
@@ -309,28 +330,19 @@ public class WorkItemTests
 
         var expectedParentId = Guid.NewGuid();
         var workItem = _workItemFaker.WithData(type: workItemType, parentId: expectedParentId).Generate();
-        var parentInfo = new MockParentInfo(Guid.NewGuid(), 123456, parentType.Level!.Tier, parentType.Level.Order);
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, parentType.Level!.Tier, parentType.Level.Order, Guid.NewGuid());
 
         // Act
         var result = workItem.UpdateParent(parentInfo, workItem.Type);
 
         // Assert
-        Assert.True(result.IsFailure);
+        result.IsFailure.Should().BeTrue();
         workItem.ParentId.Should().Be(expectedParentId);
+        workItem.ParentProjectId.Should().BeNull();
         result.Error.Should().Be("Unable to set the work item parent without the type and level.");
     }
 
     #endregion UpdateParent
 
-    public sealed record MockParentInfo(Guid Id, int? ExternalId, WorkTypeTier Tier, int LevelOrder) : IWorkItemParentInfo;
-    public sealed record MockBadParentInfo : IWorkItemParentInfo
-    {
-        public Guid Id { get; set; }
-
-        public int? ExternalId { get; set; }
-
-        public WorkTypeTier Tier { get; set; }
-
-        public int LevelOrder { get; set; }
-    }
+    public sealed record TestParentInfo(Guid Id, int? ExternalId, WorkTypeTier Tier, int LevelOrder, Guid? ProjectId = null) : IWorkItemParentInfo;
 }

--- a/Moda.Services/Moda.Work/tests/Moda.Work.Domain.Tests/Sut/Models/WorkItemTests.cs
+++ b/Moda.Services/Moda.Work/tests/Moda.Work.Domain.Tests/Sut/Models/WorkItemTests.cs
@@ -220,6 +220,46 @@ public class WorkItemTests
     }
 
     [Fact]
+    public void UpdateParent_FeatureWithProjectId_SetEpicParentWithDifferentProjectId_ShouldSucceed()
+    {
+        // Arrange
+        var featureWorkType = _workTypeFaker.AsFeature().Generate();
+        var epicWorkType = _workTypeFaker.AsEpic().Generate();
+        var featureProjectId = Guid.NewGuid();
+        var workItem = _workItemFaker.WithData(type: featureWorkType, parentId: Guid.NewGuid(), projectId: featureProjectId).Generate();
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order, Guid.NewGuid());
+
+        // Act
+        var result = workItem.UpdateParent(parentInfo, workItem.Type);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        workItem.ParentId.Should().Be(parentInfo.Id);
+        workItem.ParentProjectId.Should().Be(parentInfo.ProjectId);
+        workItem.ProjectId.Should().Be(featureProjectId);
+    }
+
+    [Fact]
+    public void UpdateParent_FeatureWithProjectId_SetEpicParentWithSameProjectId_ShouldSucceed()
+    {
+        // Arrange
+        var featureWorkType = _workTypeFaker.AsFeature().Generate();
+        var epicWorkType = _workTypeFaker.AsEpic().Generate();
+        var projectId = Guid.NewGuid();
+        var workItem = _workItemFaker.WithData(type: featureWorkType, parentId: Guid.NewGuid(), projectId: projectId).Generate();
+        var parentInfo = new TestParentInfo(Guid.NewGuid(), 123456, epicWorkType.Level!.Tier, epicWorkType.Level.Order, projectId);
+
+        // Act
+        var result = workItem.UpdateParent(parentInfo, workItem.Type);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        workItem.ParentId.Should().Be(parentInfo.Id);
+        workItem.ParentProjectId.Should().Be(projectId);
+        workItem.ProjectId.Should().BeNull();
+    }
+
+    [Fact]
     public void UpdateParent_StoryWithParent_SetStoryParent_ShouldFail()
     {
         // Arrange

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Admin/BackgroundJobsController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Admin/BackgroundJobsController.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using Hangfire;
 using Moda.Common.Application.BackgroundJobs;
 using Moda.Common.Application.Enums;
 using Moda.Web.Api.Extensions;
@@ -73,6 +72,9 @@ public class BackgroundJobsController : ControllerBase
                 break;
             case BackgroundJobType.StrategicThemesSync:
                 _jobService.Enqueue(() => jobManager.RunSyncStrategicThemes(cancellationToken));
+                break;
+            case BackgroundJobType.ProjectsSync:
+                _jobService.Enqueue(() => jobManager.RunSyncProjects(cancellationToken));
                 break;
             default:
                 _logger.LogWarning("Unknown job type {jobType} requested", jobType);

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
@@ -175,7 +175,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
     [OpenApiOperation("Update the project for a work item.", "")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult> UpdateProjectId(Guid id, string workItemKey, [FromBody] UpdateWorkItemProjectRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult> UpdateWorkItemProject(Guid id, string workItemKey, [FromBody] UpdateWorkItemProjectRequest request, CancellationToken cancellationToken)
     {
         if (workItemKey != request.WorkItemKey)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
@@ -1,4 +1,5 @@
-﻿using Moda.Common.Extensions;
+﻿using CSharpFunctionalExtensions;
+using Moda.Common.Extensions;
 using Moda.Web.Api.Extensions;
 using Moda.Web.Api.Models.Work.Workspaces;
 using Moda.Work.Application.WorkItems.Commands;
@@ -170,17 +171,18 @@ public class WorkspacesController(ISender sender) : ControllerBase
                 : NotFound();
     }
 
-    [HttpPut("{id}/work-items/{workItemKey}/update-project")]
+    [HttpPut("{id}/work-items/{workItemId}/update-project")]
     [MustHavePermission(ApplicationAction.ManageProjectWorkItems, ApplicationResource.Projects)]
     [OpenApiOperation("Update the project for a work item.", "")]
     [ProducesResponseType(StatusCodes.Status204NoContent)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
-    public async Task<ActionResult> UpdateWorkItemProject(Guid id, string workItemKey, [FromBody] UpdateWorkItemProjectRequest request, CancellationToken cancellationToken)
+    public async Task<ActionResult> UpdateWorkItemProject(Guid id, Guid workItemId, [FromBody] UpdateWorkItemProjectRequest request, CancellationToken cancellationToken)
     {
-        if (workItemKey != request.WorkItemKey)
+        if (workItemId != request.WorkItemId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
         var result = await _sender.Send(request.ToUpdateWorkItemProjectCommand(), cancellationToken);
+
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));

--- a/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
+++ b/Moda.Web/src/Moda.Web.Api/Controllers/Work/WorkspacesController.cs
@@ -1,6 +1,7 @@
 ﻿using Moda.Common.Extensions;
 using Moda.Web.Api.Extensions;
 using Moda.Web.Api.Models.Work.Workspaces;
+using Moda.Work.Application.WorkItems.Commands;
 using Moda.Work.Application.WorkItems.Dtos;
 using Moda.Work.Application.WorkItems.Queries;
 using Moda.Work.Application.Workspaces.Commands;
@@ -134,6 +135,22 @@ public class WorkspacesController(ISender sender) : ControllerBase
             : result.Value is not null
                 ? result.Value
                 : NotFound();
+    }
+
+    [HttpPut("{id}/work-items/{workItemKey}/update-project")]
+    [MustHavePermission(ApplicationAction.ManageProjectWorkItems, ApplicationResource.Projects)]
+    [OpenApiOperation("Update the project for a work item.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> UpdateProjectId(Guid id, string workItemKey, [FromBody] UpdateWorkItemProjectRequest request, CancellationToken cancellationToken)
+    {
+        if (workItemKey != request.WorkItemKey)
+            return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
+
+        var result = await _sender.Send(request.ToUpdateWorkItemProjectCommand(), cancellationToken);
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
     [HttpGet("{idOrKey}/work-items/{workItemKey}/children")]

--- a/Moda.Web/src/Moda.Web.Api/Interfaces/IJobManager.cs
+++ b/Moda.Web/src/Moda.Web.Api/Interfaces/IJobManager.cs
@@ -8,4 +8,5 @@ public interface IJobManager
     Task RunSyncAzureDevOpsBoards(SyncType syncType, CancellationToken cancellationToken);
     Task RunSyncTeamsWithGraphTables(CancellationToken cancellationToken);
     Task RunSyncStrategicThemes(CancellationToken cancellationToken);
+    Task RunSyncProjects(CancellationToken cancellationToken);
 }

--- a/Moda.Web/src/Moda.Web.Api/Models/Work/Workspaces/UpdateWorkItemProjectRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Work/Workspaces/UpdateWorkItemProjectRequest.cs
@@ -1,0 +1,31 @@
+﻿using Moda.Work.Application.WorkItems.Commands;
+using Moda.Work.Domain.Models;
+
+namespace Moda.Web.Api.Models.Work.Workspaces;
+
+public class UpdateWorkItemProjectRequest
+{
+    public string WorkItemKey { get; set; } = default!;
+    public Guid? ProjectId { get; set; }
+
+    public UpdateWorkItemProjectCommand ToUpdateWorkItemProjectCommand()
+    {
+        return new UpdateWorkItemProjectCommand(new WorkItemKey(WorkItemKey), ProjectId);
+    }
+}
+
+public sealed class UpdateWorkItemProjectRequestValidator : CustomValidator<UpdateWorkItemProjectRequest>
+{
+    public UpdateWorkItemProjectRequestValidator()
+    {
+        RuleFor(c => c.WorkItemKey)
+            .NotEmpty()
+            .MaximumLength(256);
+
+        When(x => x.ProjectId.HasValue, () =>
+        {
+            RuleFor(x => x.ProjectId)
+                .NotEmpty();
+        });
+    }
+}

--- a/Moda.Web/src/Moda.Web.Api/Models/Work/Workspaces/UpdateWorkItemProjectRequest.cs
+++ b/Moda.Web/src/Moda.Web.Api/Models/Work/Workspaces/UpdateWorkItemProjectRequest.cs
@@ -1,16 +1,15 @@
 ﻿using Moda.Work.Application.WorkItems.Commands;
-using Moda.Work.Domain.Models;
 
 namespace Moda.Web.Api.Models.Work.Workspaces;
 
 public class UpdateWorkItemProjectRequest
 {
-    public string WorkItemKey { get; set; } = default!;
+    public Guid WorkItemId { get; set; }
     public Guid? ProjectId { get; set; }
 
     public UpdateWorkItemProjectCommand ToUpdateWorkItemProjectCommand()
     {
-        return new UpdateWorkItemProjectCommand(new WorkItemKey(WorkItemKey), ProjectId);
+        return new UpdateWorkItemProjectCommand(WorkItemId, ProjectId);
     }
 }
 
@@ -18,9 +17,8 @@ public sealed class UpdateWorkItemProjectRequestValidator : CustomValidator<Upda
 {
     public UpdateWorkItemProjectRequestValidator()
     {
-        RuleFor(c => c.WorkItemKey)
-            .NotEmpty()
-            .MaximumLength(256);
+        RuleFor(c => c.WorkItemId)
+            .NotEmpty();
 
         When(x => x.ProjectId.HasValue, () =>
         {

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -15491,6 +15491,14 @@
             "type": "number",
             "format": "double"
           },
+          "project": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkProjectNavigationDto"
+              }
+            ]
+          },
           "externalViewWorkItemUrl": {
             "type": "string",
             "nullable": true
@@ -15578,6 +15586,17 @@
                 "type": "string"
               }
             }
+          }
+        ]
+      },
+      "WorkProjectNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
           }
         ]
       },
@@ -17261,6 +17280,14 @@
             "format": "date-time",
             "nullable": true
           },
+          "project": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkProjectNavigationDto"
+              }
+            ]
+          },
           "externalViewWorkItemUrl": {
             "type": "string",
             "nullable": true
@@ -18375,6 +18402,14 @@
             "type": "integer",
             "format": "int32",
             "nullable": true
+          },
+          "project": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkProjectNavigationDto"
+              }
+            ]
           },
           "externalViewWorkItemUrl": {
             "type": "string",

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -3319,6 +3319,69 @@
         ]
       }
     },
+    "/api/ppm/projects/{id}/work-items": {
+      "get": {
+        "tags": [
+          "Projects"
+        ],
+        "summary": "Get work items for a project.",
+        "operationId": "Projects_GetProjectWorkItems",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkItemListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/ppm/strategic-initiatives": {
       "get": {
         "tags": [
@@ -13930,6 +13993,181 @@
           }
         }
       },
+      "WorkItemListDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "key",
+          "title",
+          "workspace",
+          "type",
+          "status",
+          "statusCategory",
+          "stackRank"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "workspace": {
+            "$ref": "#/components/schemas/WorkspaceNavigationDto"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "statusCategory": {
+            "$ref": "#/components/schemas/SimpleNavigationDto"
+          },
+          "parent": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkItemNavigationDto"
+              }
+            ]
+          },
+          "team": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkTeamNavigationDto"
+              }
+            ]
+          },
+          "assignedTo": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/EmployeeNavigationDto"
+              }
+            ]
+          },
+          "stackRank": {
+            "type": "number",
+            "format": "double"
+          },
+          "project": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkProjectNavigationDto"
+              }
+            ]
+          },
+          "externalViewWorkItemUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "WorkspaceNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDtoOfGuidAndString"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
+      },
+      "NavigationDtoOfGuidAndString": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "key",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "minLength": 1,
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "string",
+            "minLength": 1
+          },
+          "name": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      },
+      "WorkItemNavigationDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "key",
+          "title",
+          "workspaceKey"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "workspaceKey": {
+            "type": "string"
+          },
+          "externalViewWorkItemUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "WorkTeamNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "WorkProjectNavigationDto": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NavigationDto"
+          },
+          {
+            "type": "object",
+            "additionalProperties": false
+          }
+        ]
+      },
       "StrategicInitiativeDetailsDto": {
         "type": "object",
         "additionalProperties": false,
@@ -15424,181 +15662,6 @@
             "format": "int32"
           }
         }
-      },
-      "WorkItemListDto": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "key",
-          "title",
-          "workspace",
-          "type",
-          "status",
-          "statusCategory",
-          "stackRank"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "guid",
-            "nullable": false,
-            "example": "00000000-0000-0000-0000-000000000000"
-          },
-          "key": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "workspace": {
-            "$ref": "#/components/schemas/WorkspaceNavigationDto"
-          },
-          "type": {
-            "type": "string"
-          },
-          "status": {
-            "type": "string"
-          },
-          "statusCategory": {
-            "$ref": "#/components/schemas/SimpleNavigationDto"
-          },
-          "parent": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/WorkItemNavigationDto"
-              }
-            ]
-          },
-          "team": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/WorkTeamNavigationDto"
-              }
-            ]
-          },
-          "assignedTo": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/EmployeeNavigationDto"
-              }
-            ]
-          },
-          "stackRank": {
-            "type": "number",
-            "format": "double"
-          },
-          "project": {
-            "nullable": true,
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/WorkProjectNavigationDto"
-              }
-            ]
-          },
-          "externalViewWorkItemUrl": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "WorkspaceNavigationDto": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NavigationDtoOfGuidAndString"
-          },
-          {
-            "type": "object",
-            "additionalProperties": false
-          }
-        ]
-      },
-      "NavigationDtoOfGuidAndString": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "key",
-          "name"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "guid",
-            "minLength": 1,
-            "nullable": false,
-            "example": "00000000-0000-0000-0000-000000000000"
-          },
-          "key": {
-            "type": "string",
-            "minLength": 1
-          },
-          "name": {
-            "type": "string",
-            "minLength": 1
-          }
-        }
-      },
-      "WorkItemNavigationDto": {
-        "type": "object",
-        "additionalProperties": false,
-        "required": [
-          "id",
-          "key",
-          "title",
-          "workspaceKey"
-        ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "guid",
-            "nullable": false,
-            "example": "00000000-0000-0000-0000-000000000000"
-          },
-          "key": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "workspaceKey": {
-            "type": "string"
-          },
-          "externalViewWorkItemUrl": {
-            "type": "string",
-            "nullable": true
-          }
-        }
-      },
-      "WorkTeamNavigationDto": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NavigationDto"
-          },
-          {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "type": {
-                "type": "string"
-              }
-            }
-          }
-        ]
-      },
-      "WorkProjectNavigationDto": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/NavigationDto"
-          },
-          {
-            "type": "object",
-            "additionalProperties": false
-          }
-        ]
       },
       "WorkItemProgressDailyRollupDto": {
         "allOf": [

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -7766,6 +7766,72 @@
         ]
       }
     },
+    "/api/work/workspaces/{idOrKey}/work-items/{workItemKey}/project-info": {
+      "get": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get a work item's project info.",
+        "operationId": "Workspaces_GetWorkItemProjectInfo",
+        "parameters": [
+          {
+            "name": "idOrKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "workItemKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkItemProjectInfoDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/work/workspaces/{id}/work-items/{workItemKey}/update-project": {
       "put": {
         "tags": [
@@ -17418,6 +17484,41 @@
           "externalViewWorkItemUrl": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "WorkItemProjectInfoDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "key"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "string"
+          },
+          "project": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkProjectNavigationDto"
+              }
+            ]
+          },
+          "parentProject": {
+            "nullable": true,
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/WorkProjectNavigationDto"
+              }
+            ]
           }
         }
       },

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -7832,7 +7832,7 @@
         ]
       }
     },
-    "/api/work/workspaces/{id}/work-items/{workItemKey}/update-project": {
+    "/api/work/workspaces/{id}/work-items/{workItemId}/update-project": {
       "put": {
         "tags": [
           "Workspaces"
@@ -7853,11 +7853,14 @@
             "x-position": 1
           },
           {
-            "name": "workItemKey",
+            "name": "workItemId",
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
             },
             "x-position": 2
           }
@@ -17526,14 +17529,15 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "workItemKey"
+          "workItemId"
         ],
         "properties": {
-          "workItemKey": {
+          "workItemId": {
             "type": "string",
-            "maxLength": 256,
+            "format": "guid",
             "minLength": 1,
-            "nullable": false
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
           },
           "projectId": {
             "type": "string",

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -7766,6 +7766,70 @@
         ]
       }
     },
+    "/api/work/workspaces/{id}/work-items/{workItemKey}/update-project": {
+      "put": {
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Update the project for a work item.",
+        "operationId": "Workspaces_UpdateProjectId",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "workItemKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWorkItemProjectRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "Bearer": []
+          }
+        ]
+      }
+    },
     "/api/work/workspaces/{idOrKey}/work-items/{workItemKey}/children": {
       "get": {
         "tags": [
@@ -17354,6 +17418,27 @@
           "externalViewWorkItemUrl": {
             "type": "string",
             "nullable": true
+          }
+        }
+      },
+      "UpdateWorkItemProjectRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "workItemKey"
+        ],
+        "properties": {
+          "workItemKey": {
+            "type": "string",
+            "maxLength": 256,
+            "minLength": 1,
+            "nullable": false
+          },
+          "projectId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": true,
+            "example": "00000000-0000-0000-0000-000000000000"
           }
         }
       },

--- a/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
+++ b/Moda.Web/src/Moda.Web.Api/wwwroot/api/v1/specification.json
@@ -7838,7 +7838,7 @@
           "Workspaces"
         ],
         "summary": "Update the project for a work item.",
-        "operationId": "Workspaces_UpdateProjectId",
+        "operationId": "Workspaces_UpdateWorkItemProject",
         "parameters": [
           {
             "name": "id",

--- a/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -65,10 +65,9 @@ const TeamDetailsPage = (props: { params: Promise<{ key: number }> }) => {
   const [risksQueryEnabled, setRisksQueryEnabled] = useState<boolean>(false)
   const [includeClosedRisks, setIncludeClosedRisks] = useState<boolean>(false)
 
-  const { hasClaim } = useAuth()
-  const canUpdateTeam = hasClaim('Permission', 'Permissions.Teams.Update')
-  const canManageTeamMemberships = hasClaim(
-    'Permission',
+  const { hasPermissionClaim } = useAuth()
+  const canUpdateTeam = hasPermissionClaim('Permissions.Teams.Update')
+  const canManageTeamMemberships = hasPermissionClaim(
     'Permissions.Teams.ManageTeamMemberships',
   )
 

--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/[objectiveKey]/manage-planning-interval-objective-work-items-form.tsx
@@ -63,6 +63,11 @@ const workItemColDefs: ColDef<WorkItemListDto>[] = [
     headerName: 'Parent Key',
     width: 125,
   },
+  {
+    field: 'project.name',
+    headerName: 'Project',
+    width: 200,
+  },
 ]
 
 const leftColDefs = [...asDraggableColDefs(workItemColDefs)]

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/projects/[key]/page.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/projects/[key]/page.tsx
@@ -4,7 +4,10 @@ import { PageActions, PageTitle } from '@/src/components/common'
 import useAuth from '@/src/components/contexts/auth'
 import { authorizePage } from '@/src/components/hoc'
 import { useAppDispatch, useDocumentTitle } from '@/src/hooks'
-import { useGetProjectQuery } from '@/src/store/features/ppm/projects-api'
+import {
+  useGetProjectQuery,
+  useGetProjectWorkItemsQuery,
+} from '@/src/store/features/ppm/projects-api'
 import { Alert, Card, MenuProps } from 'antd'
 import { notFound, usePathname, useRouter } from 'next/navigation'
 import { use, useCallback, useEffect, useMemo, useState } from 'react'
@@ -18,9 +21,11 @@ import {
 import { BreadcrumbItem, setBreadcrumbRoute } from '@/src/store/breadcrumbs'
 import { ItemType } from 'antd/es/menu/interface'
 import { ProjectStatusAction } from '../_components/change-project-status-form'
+import { WorkItemsGrid } from '@/src/components/common/work'
 
 enum ProjectTabs {
   Details = 'details',
+  WorkItems = 'workItems',
 }
 
 enum ProjectAction {
@@ -63,6 +68,13 @@ const ProjectDetailsPage = (props: { params: Promise<{ key: number }> }) => {
     refetch: refetchProject,
   } = useGetProjectQuery(key)
 
+  const {
+    data: workItemsData,
+    isLoading: workItemsDataIsLoading,
+    error: workItemsDataError,
+    refetch: refetchWorkItemsData,
+  } = useGetProjectWorkItemsQuery(projectData?.id, { skip: !projectData?.id })
+
   useEffect(() => {
     if (!projectData) return
 
@@ -94,9 +106,21 @@ const ProjectDetailsPage = (props: { params: Promise<{ key: number }> }) => {
         label: 'Details',
         content: <ProjectDetails project={projectData} />,
       },
+      {
+        key: ProjectTabs.WorkItems,
+        tab: 'Work Items',
+        content: (
+          <WorkItemsGrid
+            workItems={workItemsData}
+            isLoading={workItemsDataIsLoading}
+            refetch={refetchWorkItemsData}
+            hideProjectColumn={true}
+          />
+        ),
+      },
     ]
     return pageTabs
-  }, [projectData])
+  }, [projectData, refetchWorkItemsData, workItemsData, workItemsDataIsLoading])
 
   // doesn't trigger on first render
   const onTabChange = useCallback((tabKey) => {

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
@@ -42,6 +42,15 @@ const WorkItemDetails = ({ workItem }: WorkItemDetailsProps) => {
             'No Parent'
           )}
         </Item>
+        <Item label="Project">
+          {workItem.project ? (
+            <Link href={`/ppm/projects/${workItem.project.key}`}>
+              {workItem.project.name}
+            </Link>
+          ) : (
+            'No Parent'
+          )}
+        </Item>
         <Item label="Assigned To">
           {workItem.assignedTo ? (
             <Link href={`/organizations/employees/${workItem.assignedTo.key}`}>

--- a/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/_components/edit-workitem-project-form.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/work/workspaces/_components/edit-workitem-project-form.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+import useAuth from '@/src/components/contexts/auth'
+import { useMessage } from '@/src/components/contexts/messaging'
+import { UpdateWorkItemProjectRequest } from '@/src/services/moda-api'
+import { useGetProjectOptionsQuery } from '@/src/store/features/ppm/projects-api'
+import {
+  useGetWorkItemProjectInfoQuery,
+  useUpdateWorkItemProjectMutation,
+} from '@/src/store/features/work-management/workspace-api'
+import { toFormErrors } from '@/src/utils'
+import { Form, Modal, Select, Space, Typography } from 'antd'
+import { useCallback, useEffect, useState } from 'react'
+
+const { Item } = Form
+const { Text } = Typography
+
+export interface EditWorkItemProjectFormProps {
+  workItemId: string
+  workItemKey: string
+  workspaceId: string
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface EditWorkItemProjectFormValues {
+  projectId: string
+}
+
+const mapToRequestValues = (
+  values: EditWorkItemProjectFormValues,
+  workItemId: string,
+): UpdateWorkItemProjectRequest => {
+  return {
+    workItemId: workItemId,
+    projectId: values.projectId,
+  }
+}
+
+const EditWorkItemProjectForm = (props: EditWorkItemProjectFormProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [isValid, setIsValid] = useState(false)
+  const [form] = Form.useForm<EditWorkItemProjectFormValues>()
+  const formValues = Form.useWatch([], form)
+
+  const messageApi = useMessage()
+
+  const [updateWorkItemProject] = useUpdateWorkItemProjectMutation()
+
+  const {
+    data: workItemProjectInfoData,
+    isLoading,
+    error,
+  } = useGetWorkItemProjectInfoQuery({
+    idOrKey: props.workspaceId,
+    workItemKey: props.workItemKey,
+  })
+
+  const {
+    data: projectOptions,
+    isLoading: projectOptionsIsLoading,
+    error: projectOptionsError,
+  } = useGetProjectOptionsQuery()
+
+  const { hasPermissionClaim } = useAuth()
+  const canManageProjectWorkItems = hasPermissionClaim(
+    'Permissions.Projects.ManageProjectWorkItems',
+  )
+
+  const mapToFormValues = useCallback(
+    (projectId: string | null) => {
+      form.setFieldsValue({
+        projectId: projectId,
+      })
+    },
+    [form],
+  )
+
+  const update = async (
+    values: EditWorkItemProjectFormValues,
+    workItemId: string,
+    workItemKey: string,
+    workspaceId: string,
+  ) => {
+    try {
+      const request = mapToRequestValues(values, workItemId)
+
+      const response = await updateWorkItemProject({
+        workspaceId: workspaceId,
+        request: request,
+        cacheKey: workItemKey,
+      })
+
+      if (response.error) {
+        throw response.error
+      }
+
+      messageApi.success('Work item project updated successfully.')
+      return true
+    } catch (error) {
+      console.error('update error', error)
+      if (error.status === 422 && error.errors) {
+        const formErrors = toFormErrors(error.errors)
+        form.setFields(formErrors)
+        messageApi.error('Correct the validation error(s) to continue.')
+      } else {
+        messageApi.error(
+          error.detail ??
+            'An error occurred while updating the work item. Please try again.',
+        )
+      }
+      return false
+    }
+  }
+
+  const handleOk = async () => {
+    setIsSaving(true)
+    try {
+      const values = await form.validateFields()
+      if (
+        await update(
+          values,
+          props.workItemId,
+          props.workItemKey,
+          props.workspaceId,
+        )
+      ) {
+        setIsOpen(false)
+        form.resetFields()
+        props.onFormComplete()
+      }
+    } catch (error) {
+      console.error('handleOk error', error)
+      messageApi.error(
+        'An error occurred while updating the work item. Please try again.',
+      )
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const handleCancel = useCallback(() => {
+    setIsOpen(false)
+    form.resetFields()
+    props.onFormCancel()
+  }, [form, props])
+
+  useEffect(() => {
+    if (!workItemProjectInfoData) return
+    if (canManageProjectWorkItems) {
+      setIsOpen(true)
+      const projectId =
+        workItemProjectInfoData.project?.id ??
+        workItemProjectInfoData.parentProject?.id
+      mapToFormValues(projectId)
+    } else {
+      props.onFormCancel()
+      messageApi.error(
+        'You do not have permission to update the project on work items.',
+      )
+    }
+  }, [
+    canManageProjectWorkItems,
+    mapToFormValues,
+    messageApi,
+    props,
+    workItemProjectInfoData,
+  ])
+
+  useEffect(() => {
+    if (error || projectOptionsError) {
+      console.error(error ?? projectOptionsError)
+      messageApi.error(
+        error.detail ??
+          projectOptionsError.detail ??
+          'An error occurred while loading form data. Please try again.',
+      )
+    }
+  }, [error, messageApi, projectOptionsError])
+
+  useEffect(() => {
+    form.validateFields({ validateOnly: true }).then(
+      () => setIsValid(true && form.isFieldsTouched()),
+      () => setIsValid(false),
+    )
+  }, [form, formValues])
+
+  const projectSourceText =
+    workItemProjectInfoData &&
+    (workItemProjectInfoData.project
+      ? 'The work item is currently overriding the Parent Project.  Clear and save to inherit the Parent Project.'
+      : workItemProjectInfoData.parentProject
+        ? 'The work item is currently is inheriting the Project from its Parent. Select a Project and save to override.'
+        : 'The work item is currently not associated with any project.')
+
+  return (
+    <>
+      <Modal
+        title="Edit Project"
+        open={isOpen}
+        width={'60vw'}
+        onOk={handleOk}
+        okButtonProps={{ disabled: !isValid }}
+        okText="Save"
+        confirmLoading={isSaving}
+        onCancel={handleCancel}
+        maskClosable={false}
+        keyboard={false} // disable esc key to close modal
+        destroyOnClose={true}
+      >
+        <Space direction="vertical">
+          {projectSourceText && <Text italic>{projectSourceText}</Text>}
+          <Form
+            form={form}
+            size="small"
+            layout="vertical"
+            name="edit-workitem-project-form"
+          >
+            <Item
+              name="projectId"
+              label="Project"
+              rules={[
+                {
+                  required: !workItemProjectInfoData?.project,
+                  message: 'Project is required',
+                },
+              ]}
+            >
+              <Select
+                allowClear
+                options={projectOptions ?? []}
+                placeholder="Select Project"
+              />
+            </Item>
+          </Form>
+        </Space>
+      </Modal>
+    </>
+  )
+}
+
+export default EditWorkItemProjectForm

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/moda-grid-cell-renderers.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/moda-grid-cell-renderers.tsx
@@ -138,13 +138,21 @@ export const PortfolioLinkCellRenderer = ({
 }
 
 export interface ProjectLinkCellRendererProps {
-  data: NavigationDto
+  data: NavigationDto | { project: NavigationDto | null } | null
 }
+
 export const ProjectLinkCellRenderer = ({
   data,
 }: ProjectLinkCellRendererProps) => {
   if (!data) return null
-  return <Link href={`/ppm/projects/${data.key}`}>{data.name}</Link>
+
+  // Handle both direct NavigationDto and nested project cases
+  const projectData = 'project' in data ? data.project : data
+  if (!projectData) return null
+
+  return (
+    <Link href={`/ppm/projects/${projectData.key}`}>{projectData.name}</Link>
+  )
 }
 
 export interface RowMenuCellRendererProps {

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
@@ -6,7 +6,10 @@ import { ColDef } from 'ag-grid-community'
 import Link from 'next/link'
 import { useCallback, useMemo } from 'react'
 import { ExportOutlined } from '@ant-design/icons'
-import { NestedTeamNameLinkCellRenderer } from '../moda-grid-cell-renderers'
+import {
+  NestedTeamNameLinkCellRenderer,
+  ProjectLinkCellRenderer,
+} from '../moda-grid-cell-renderers'
 import {
   workItemKeyComparator,
   workStatusCategoryComparator,
@@ -120,6 +123,12 @@ const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
         field: 'assignedTo.name',
         headerName: 'Assigned To',
         cellRenderer: AssignedToLinkCellRenderer,
+      },
+      {
+        field: 'project.name',
+        headerName: 'Project',
+        width: 300,
+        cellRenderer: ProjectLinkCellRenderer,
       },
     ],
     [props.hideTeamColumn],

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-items-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-items-grid.tsx
@@ -19,6 +19,7 @@ export interface WorkItemsGridProps {
   workItems: WorkItemListDto[]
   isLoading: boolean
   refetch: () => void
+  hideProjectColumn?: boolean
 }
 
 const WorkItemLinkCellRenderer = ({ value, data }) => {
@@ -125,6 +126,7 @@ const WorkItemsGrid = (props: WorkItemsGridProps) => {
         field: 'project.name',
         headerName: 'Project',
         width: 300,
+        hide: props.hideProjectColumn,
         cellRenderer: ProjectLinkCellRenderer,
       },
     ],

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-items-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/work/work-items-grid.tsx
@@ -6,7 +6,10 @@ import { ColDef } from 'ag-grid-community'
 import Link from 'next/link'
 import { useCallback, useMemo } from 'react'
 import { ExportOutlined } from '@ant-design/icons'
-import { NestedTeamNameLinkCellRenderer } from '../moda-grid-cell-renderers'
+import {
+  NestedTeamNameLinkCellRenderer,
+  ProjectLinkCellRenderer,
+} from '../moda-grid-cell-renderers'
 import {
   workItemKeyComparator,
   workStatusCategoryComparator,
@@ -117,6 +120,12 @@ const WorkItemsGrid = (props: WorkItemsGridProps) => {
         field: 'assignedTo.name',
         headerName: 'Assigned To',
         cellRenderer: AssignedToLinkCellRenderer,
+      },
+      {
+        field: 'project.name',
+        headerName: 'Project',
+        width: 300,
+        cellRenderer: ProjectLinkCellRenderer,
       },
     ],
     [],

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9655,14 +9655,14 @@ export class WorkspacesClient {
     /**
      * Update the project for a work item.
      */
-    updateWorkItemProject(id: string, workItemKey: string, request: UpdateWorkItemProjectRequest, cancelToken?: CancelToken): Promise<void> {
-        let url_ = this.baseUrl + "/api/work/workspaces/{id}/work-items/{workItemKey}/update-project";
+    updateWorkItemProject(id: string, workItemId: string, request: UpdateWorkItemProjectRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/work/workspaces/{id}/work-items/{workItemId}/update-project";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
         url_ = url_.replace("{id}", encodeURIComponent("" + id));
-        if (workItemKey === undefined || workItemKey === null)
-            throw new Error("The parameter 'workItemKey' must be defined.");
-        url_ = url_.replace("{workItemKey}", encodeURIComponent("" + workItemKey));
+        if (workItemId === undefined || workItemId === null)
+            throw new Error("The parameter 'workItemId' must be defined.");
+        url_ = url_.replace("{workItemId}", encodeURIComponent("" + workItemId));
         url_ = url_.replace(/[?&]$/, "");
 
         const content_ = JSON.stringify(request);
@@ -16372,7 +16372,7 @@ export interface WorkItemProjectInfoDto {
 }
 
 export interface UpdateWorkItemProjectRequest {
-    workItemKey: string;
+    workItemId: string;
     projectId?: string | undefined;
 }
 

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9655,7 +9655,7 @@ export class WorkspacesClient {
     /**
      * Update the project for a work item.
      */
-    updateProjectId(id: string, workItemKey: string, request: UpdateWorkItemProjectRequest, cancelToken?: CancelToken): Promise<void> {
+    updateWorkItemProject(id: string, workItemKey: string, request: UpdateWorkItemProjectRequest, cancelToken?: CancelToken): Promise<void> {
         let url_ = this.baseUrl + "/api/work/workspaces/{id}/work-items/{workItemKey}/update-project";
         if (id === undefined || id === null)
             throw new Error("The parameter 'id' must be defined.");
@@ -9684,11 +9684,11 @@ export class WorkspacesClient {
                 throw _error;
             }
         }).then((_response: AxiosResponse) => {
-            return this.processUpdateProjectId(_response);
+            return this.processUpdateWorkItemProject(_response);
         });
     }
 
-    protected processUpdateProjectId(response: AxiosResponse): Promise<void> {
+    protected processUpdateWorkItemProject(response: AxiosResponse): Promise<void> {
         const status = response.status;
         let _headers: any = {};
         if (response.headers && typeof response.headers === "object") {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9582,6 +9582,77 @@ export class WorkspacesClient {
     }
 
     /**
+     * Get a work item's project info.
+     */
+    getWorkItemProjectInfo(idOrKey: string, workItemKey: string, cancelToken?: CancelToken): Promise<WorkItemProjectInfoDto> {
+        let url_ = this.baseUrl + "/api/work/workspaces/{idOrKey}/work-items/{workItemKey}/project-info";
+        if (idOrKey === undefined || idOrKey === null)
+            throw new Error("The parameter 'idOrKey' must be defined.");
+        url_ = url_.replace("{idOrKey}", encodeURIComponent("" + idOrKey));
+        if (workItemKey === undefined || workItemKey === null)
+            throw new Error("The parameter 'workItemKey' must be defined.");
+        url_ = url_.replace("{workItemKey}", encodeURIComponent("" + workItemKey));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetWorkItemProjectInfo(_response);
+        });
+    }
+
+    protected processGetWorkItemProjectInfo(response: AxiosResponse): Promise<WorkItemProjectInfoDto> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<WorkItemProjectInfoDto>(result200);
+
+        } else if (status === 404) {
+            const _responseText = response.data;
+            let result404: any = null;
+            let resultData404  = _responseText;
+            result404 = JSON.parse(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<WorkItemProjectInfoDto>(null as any);
+    }
+
+    /**
      * Update the project for a work item.
      */
     updateProjectId(id: string, workItemKey: string, request: UpdateWorkItemProjectRequest, cancelToken?: CancelToken): Promise<void> {
@@ -16291,6 +16362,13 @@ export interface WorkItemDetailsDto {
     doneTimestamp?: Date | undefined;
     project?: WorkProjectNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
+}
+
+export interface WorkItemProjectInfoDto {
+    id: string;
+    key: string;
+    project?: WorkProjectNavigationDto | undefined;
+    parentProject?: WorkProjectNavigationDto | undefined;
 }
 
 export interface UpdateWorkItemProjectRequest {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -4369,6 +4369,74 @@ export class ProjectsClient {
         }
         return Promise.resolve<void>(null as any);
     }
+
+    /**
+     * Get work items for a project.
+     */
+    getProjectWorkItems(id: string, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
+        let url_ = this.baseUrl + "/api/ppm/projects/{id}/work-items";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetProjectWorkItems(_response);
+        });
+    }
+
+    protected processGetProjectWorkItems(response: AxiosResponse): Promise<WorkItemListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = JSON.parse(resultData200);
+            return Promise.resolve<WorkItemListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 404) {
+            const _responseText = response.data;
+            let result404: any = null;
+            let resultData404  = _responseText;
+            result404 = JSON.parse(resultData404);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<WorkItemListDto[]>(null as any);
+    }
 }
 
 export class StrategicInitiativesClient {
@@ -15347,6 +15415,46 @@ export interface UpdateProjectRequest {
     strategicThemeIds?: string[] | undefined;
 }
 
+export interface WorkItemListDto {
+    id: string;
+    key: string;
+    title: string;
+    workspace: WorkspaceNavigationDto;
+    type: string;
+    status: string;
+    statusCategory: SimpleNavigationDto;
+    parent?: WorkItemNavigationDto | undefined;
+    team?: WorkTeamNavigationDto | undefined;
+    assignedTo?: EmployeeNavigationDto | undefined;
+    stackRank: number;
+    project?: WorkProjectNavigationDto | undefined;
+    externalViewWorkItemUrl?: string | undefined;
+}
+
+export interface NavigationDtoOfGuidAndString {
+    id: string;
+    key: string;
+    name: string;
+}
+
+export interface WorkspaceNavigationDto extends NavigationDtoOfGuidAndString {
+}
+
+export interface WorkItemNavigationDto {
+    id: string;
+    key: string;
+    title: string;
+    workspaceKey: string;
+    externalViewWorkItemUrl?: string | undefined;
+}
+
+export interface WorkTeamNavigationDto extends NavigationDto {
+    type?: string;
+}
+
+export interface WorkProjectNavigationDto extends NavigationDto {
+}
+
 export interface StrategicInitiativeDetailsDto {
     id: string;
     key: number;
@@ -15720,46 +15828,6 @@ export interface WorkItemProgressRollupDto {
     active: number;
     done: number;
     total: number;
-}
-
-export interface WorkItemListDto {
-    id: string;
-    key: string;
-    title: string;
-    workspace: WorkspaceNavigationDto;
-    type: string;
-    status: string;
-    statusCategory: SimpleNavigationDto;
-    parent?: WorkItemNavigationDto | undefined;
-    team?: WorkTeamNavigationDto | undefined;
-    assignedTo?: EmployeeNavigationDto | undefined;
-    stackRank: number;
-    project?: WorkProjectNavigationDto | undefined;
-    externalViewWorkItemUrl?: string | undefined;
-}
-
-export interface NavigationDtoOfGuidAndString {
-    id: string;
-    key: string;
-    name: string;
-}
-
-export interface WorkspaceNavigationDto extends NavigationDtoOfGuidAndString {
-}
-
-export interface WorkItemNavigationDto {
-    id: string;
-    key: string;
-    title: string;
-    workspaceKey: string;
-    externalViewWorkItemUrl?: string | undefined;
-}
-
-export interface WorkTeamNavigationDto extends NavigationDto {
-    type?: string;
-}
-
-export interface WorkProjectNavigationDto extends NavigationDto {
 }
 
 export interface WorkItemProgressDailyRollupDto extends WorkItemProgressRollupDto {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -9582,6 +9582,70 @@ export class WorkspacesClient {
     }
 
     /**
+     * Update the project for a work item.
+     */
+    updateProjectId(id: string, workItemKey: string, request: UpdateWorkItemProjectRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/work/workspaces/{id}/work-items/{workItemKey}/update-project";
+        if (id === undefined || id === null)
+            throw new Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (workItemKey === undefined || workItemKey === null)
+            throw new Error("The parameter 'workItemKey' must be defined.");
+        url_ = url_.replace("{workItemKey}", encodeURIComponent("" + workItemKey));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateProjectId(_response);
+        });
+    }
+
+    protected processUpdateProjectId(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = JSON.parse(resultData400);
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Get a work item's child work items.
      */
     getChildWorkItems(idOrKey: string, workItemKey: string, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
@@ -16227,6 +16291,11 @@ export interface WorkItemDetailsDto {
     doneTimestamp?: Date | undefined;
     project?: WorkProjectNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
+}
+
+export interface UpdateWorkItemProjectRequest {
+    workItemKey: string;
+    projectId?: string | undefined;
 }
 
 export interface ScopedDependencyDto {

--- a/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/services/moda-api.ts
@@ -15734,6 +15734,7 @@ export interface WorkItemListDto {
     team?: WorkTeamNavigationDto | undefined;
     assignedTo?: EmployeeNavigationDto | undefined;
     stackRank: number;
+    project?: WorkProjectNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
 }
 
@@ -15756,6 +15757,9 @@ export interface WorkItemNavigationDto {
 
 export interface WorkTeamNavigationDto extends NavigationDto {
     type?: string;
+}
+
+export interface WorkProjectNavigationDto extends NavigationDto {
 }
 
 export interface WorkItemProgressDailyRollupDto extends WorkItemProgressRollupDto {
@@ -16153,6 +16157,7 @@ export interface WorkItemDetailsDto {
     lastModifiedBy?: EmployeeNavigationDto | undefined;
     activatedTimestamp?: Date | undefined;
     doneTimestamp?: Date | undefined;
+    project?: WorkProjectNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
 }
 
@@ -16431,6 +16436,7 @@ export interface WorkItemBacklogItemDto {
     created: Date;
     rank: number;
     parentRank?: number | undefined;
+    project?: WorkProjectNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
     stackRank: number;
 }

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/projects-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/projects-api.ts
@@ -6,6 +6,7 @@ import {
   ProjectListDto,
   ProjectDetailsDto,
   UpdateProjectRequest,
+  WorkItemListDto,
 } from '@/src/services/moda-api'
 import { QueryTags } from '../query-tags'
 
@@ -146,6 +147,21 @@ export const projectsApi = apiSlice.injectEndpoints({
         ]
       },
     }),
+    getProjectWorkItems: builder.query<WorkItemListDto[], string>({
+      queryFn: async (id) => {
+        try {
+          const data = await getProjectsClient().getProjectWorkItems(id)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result) => [
+        QueryTags.WorkItem,
+        ...result.map(({ key }) => ({ type: QueryTags.ProjectWorkItems, key })),
+      ],
+    }),
   }),
 })
 
@@ -158,4 +174,5 @@ export const {
   useCompleteProjectMutation,
   useCancelProjectMutation,
   useDeleteProjectMutation,
+  useGetProjectWorkItemsQuery,
 } = projectsApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/projects-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/ppm/projects-api.ts
@@ -9,6 +9,7 @@ import {
   WorkItemListDto,
 } from '@/src/services/moda-api'
 import { QueryTags } from '../query-tags'
+import { BaseOptionType } from 'antd/es/select'
 
 export const projectsApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
@@ -162,6 +163,25 @@ export const projectsApi = apiSlice.injectEndpoints({
         ...result.map(({ key }) => ({ type: QueryTags.ProjectWorkItems, key })),
       ],
     }),
+    getProjectOptions: builder.query<BaseOptionType[], void>({
+      queryFn: async () => {
+        try {
+          const portfolios = await getProjectsClient().getProjects(null)
+
+          const data: BaseOptionType[] = portfolios
+            .sort((a, b) => a.name.localeCompare(b.name))
+            .map((category) => ({
+              label: category.name,
+              value: category.id,
+            }))
+
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+    }),
   }),
 })
 
@@ -175,4 +195,5 @@ export const {
   useCancelProjectMutation,
   useDeleteProjectMutation,
   useGetProjectWorkItemsQuery,
+  useGetProjectOptionsQuery,
 } = projectsApi

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/query-tags.ts
@@ -39,6 +39,7 @@ export enum QueryTags {
   PortfolioProjects = 'Ppm.Portfolio.Project',
   PortfolioStrategicInitiatives = 'Ppm.Portfolio.StrategicInitiatives',
   Project = 'Ppm.Project',
+  ProjectWorkItems = 'Ppm.Project.WorkItems',
   StrategicInitiative = 'Ppm.StrategicInitiative',
   StrategicInitiativeKpi = 'Ppm.StrategicInitiativeKpi',
   StrategicInitiativeKpiCheckpoint = 'Ppm.StrategicInitiativeKpiCheckpoint',

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -69,10 +69,11 @@ export const workspaceApi = apiSlice.injectEndpoints({
     >({
       queryFn: async (request) => {
         try {
-          await getWorkspacesClient().setExternalUrlTemplates(
+          const data = await getWorkspacesClient().setExternalUrlTemplates(
             request.workspaceId,
             request.externalUrlTemplatesRequest,
           )
+          return { data }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -136,15 +137,20 @@ export const workspaceApi = apiSlice.injectEndpoints({
     }),
     updateWorkItemProject: builder.mutation<
       void,
-      { workspaceIdOrKey: string; request: UpdateWorkItemProjectRequest }
+      {
+        workspaceId: string
+        request: UpdateWorkItemProjectRequest
+        cacheKey: string
+      }
     >({
-      queryFn: async ({ workspaceIdOrKey, request }) => {
+      queryFn: async ({ workspaceId, request }) => {
         try {
-          await getWorkspacesClient().updateWorkItemProject(
-            workspaceIdOrKey,
-            request.workItemKey,
+          const data = await getWorkspacesClient().updateWorkItemProject(
+            workspaceId,
+            request.workItemId,
             request,
           )
+          return { data }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -152,8 +158,8 @@ export const workspaceApi = apiSlice.injectEndpoints({
       },
       invalidatesTags: (result, error, arg) => [
         // TODO: there are a few more tags that need to be invalidated here
-        { type: QueryTags.WorkItem, id: arg.request.workItemKey },
-        { type: QueryTags.WorkItemChildren, id: arg.request.workItemKey },
+        { type: QueryTags.WorkItem, id: arg.cacheKey },
+        { type: QueryTags.WorkItemChildren, id: arg.cacheKey },
       ],
     }),
     getChildWorkItems: builder.query<
@@ -249,6 +255,7 @@ export const {
   useGetWorkItemsQuery,
   useGetWorkItemQuery,
   useGetWorkItemProjectInfoQuery,
+  useUpdateWorkItemProjectMutation,
   useGetChildWorkItemsQuery,
   useGetWorkItemDependenciesQuery,
   useGetWorkItemMetricsQuery,

--- a/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/store/features/work-management/workspace-api.ts
@@ -4,9 +4,11 @@ import { QueryTags } from '../query-tags'
 import {
   ScopedDependencyDto,
   SetExternalUrlTemplatesRequest,
+  UpdateWorkItemProjectRequest,
   WorkItemDetailsDto,
   WorkItemListDto,
   WorkItemProgressDailyRollupDto,
+  WorkItemProjectInfoDto,
   WorkspaceDto,
   WorkspaceListDto,
 } from '@/src/services/moda-api'
@@ -112,6 +114,48 @@ export const workspaceApi = apiSlice.injectEndpoints({
         { type: QueryTags.WorkItem, id: arg.workItemKey }, // typically arg is the key
       ],
     }),
+    getWorkItemProjectInfo: builder.query<
+      WorkItemProjectInfoDto,
+      GetWorkItemRequest
+    >({
+      queryFn: async (request: GetWorkItemRequest) => {
+        try {
+          const data = await getWorkspacesClient().getWorkItemProjectInfo(
+            request.idOrKey,
+            request.workItemKey,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        { type: QueryTags.WorkItem, id: arg.workItemKey }, // typically arg is the key
+      ],
+    }),
+    updateWorkItemProject: builder.mutation<
+      void,
+      { workspaceIdOrKey: string; request: UpdateWorkItemProjectRequest }
+    >({
+      queryFn: async ({ workspaceIdOrKey, request }) => {
+        try {
+          await getWorkspacesClient().updateWorkItemProject(
+            workspaceIdOrKey,
+            request.workItemKey,
+            request,
+          )
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [
+        // TODO: there are a few more tags that need to be invalidated here
+        { type: QueryTags.WorkItem, id: arg.request.workItemKey },
+        { type: QueryTags.WorkItemChildren, id: arg.request.workItemKey },
+      ],
+    }),
     getChildWorkItems: builder.query<
       WorkItemListDto[],
       GetChildWorkItemsRequest
@@ -204,6 +248,7 @@ export const {
   useGetWorkspaceQuery,
   useGetWorkItemsQuery,
   useGetWorkItemQuery,
+  useGetWorkItemProjectInfoQuery,
   useGetChildWorkItemsQuery,
   useGetWorkItemDependenciesQuery,
   useGetWorkItemMetricsQuery,


### PR DESCRIPTION
- Setting up the new WorkProject model and DB config.
- Added basic events for PPM Project.  Added a new WorkProject model that will be used to maintain basic Project info for the Work domain.  Added a Project sync and handlers to keep data in-sync.
- Updated the WorkItem sync process to update the ParentProjectId when parent work items change.
- Updated the work queries and views to include project.
- Added a new query and API to get work items linked to a project.  Added a work items grid tab to the project details page.
- Updated the work item ProjectId override to reset when the ParentProjectId matches the ProjectId.
- Added a command and API endpoint to update a work items project id.
- Added a new query and API endpoint to get a work item's current project info.
- Added a new form to update the project on a work item.