### PR TITLE
Feature/change guid id strategy

### DIFF
--- a/Moda.Common/src/Moda.Common.Domain/Data/BaseAuditableEntity.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Data/BaseAuditableEntity.cs
@@ -3,3 +3,11 @@
 public abstract class BaseAuditableEntity<TId> : BaseEntity<TId>, ISystemAuditable
 {
 }
+
+public abstract class BaseAuditableEntity : BaseAuditableEntity<Guid>
+{
+    protected BaseAuditableEntity()
+    {
+        Id = Guid.CreateVersion7();
+    }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Data/BaseEntity.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Data/BaseEntity.cs
@@ -52,3 +52,11 @@ public abstract class BaseEntity<TId> : IEntity<TId>
         _postPersistenceActions.Clear();
     }
 }
+
+public abstract class BaseEntity : BaseEntity<Guid>
+{
+    protected BaseEntity()
+    {
+        Id = Guid.CreateVersion7();
+    }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Data/BaseSoftDeletableEntity.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Data/BaseSoftDeletableEntity.cs
@@ -19,3 +19,11 @@ public abstract class BaseSoftDeletableEntity<TId> : BaseAuditableEntity<TId>, I
     /// </summary>
     public bool IsDeleted { get; set; } = false;
 }
+
+public abstract class BaseSoftDeletableEntity : BaseSoftDeletableEntity<Guid>
+{
+    protected BaseSoftDeletableEntity()
+    {
+        Id = Guid.CreateVersion7();
+    }
+}

--- a/Moda.Common/src/Moda.Common.Domain/Employees/Employee.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Employees/Employee.cs
@@ -6,7 +6,7 @@ using Moda.Common.Models;
 using NodaTime;
 
 namespace Moda.Common.Domain.Employees;
-public sealed class Employee : BaseSoftDeletableEntity<Guid>, IActivatable, IHasIdAndKey
+public sealed class Employee : BaseSoftDeletableEntity, IActivatable, IHasIdAndKey
 {
     private readonly List<Employee> _directReports = [];
 

--- a/Moda.Common/src/Moda.Common.Domain/Identity/PersonalAccessToken.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Identity/PersonalAccessToken.cs
@@ -8,7 +8,7 @@ namespace Moda.Common.Domain.Identity;
 /// <summary>
 /// Represents a personal access token used for API authentication.
 /// </summary>
-public sealed class PersonalAccessToken : BaseAuditableEntity<Guid>
+public sealed class PersonalAccessToken : BaseAuditableEntity
 {
     private PersonalAccessToken() { }
 

--- a/Moda.Common/src/Moda.Common.Domain/Models/Goals/Objective.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Models/Goals/Objective.cs
@@ -8,7 +8,7 @@ using NodaTime;
 namespace Moda.Goals.Domain.Models;
 
 // TODO make a BaseObjective to inherit Objective and KeyResult from
-public class Objective : BaseSoftDeletableEntity<Guid>, IHasIdAndKey
+public class Objective : BaseSoftDeletableEntity, IHasIdAndKey
 {
     private string _name = default!;
     private string? _description;

--- a/Moda.Common/src/Moda.Common.Domain/Models/KeyPerformanceIndicators/Kpi.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Models/KeyPerformanceIndicators/Kpi.cs
@@ -8,7 +8,7 @@ namespace Moda.Common.Domain.Models.KeyPerformanceIndicators;
 /// <summary>
 /// Represents the common properties and behavior for a Key Performance Indicator (KPI).
 /// </summary>
-public abstract class Kpi : BaseAuditableEntity<Guid>, IHasIdAndKey
+public abstract class Kpi : BaseAuditableEntity, IHasIdAndKey
 {
     protected string _name = default!;
     protected string? _description;

--- a/Moda.Common/src/Moda.Common.Domain/Models/KeyPerformanceIndicators/KpiCheckpoint.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Models/KeyPerformanceIndicators/KpiCheckpoint.cs
@@ -8,7 +8,7 @@ namespace Moda.Common.Domain.Models.KeyPerformanceIndicators;
 /// <summary>
 /// Represents the common properties and behavior for a KPI checkpoint (expected progress checkpoint).
 /// </summary>
-public abstract class KpiCheckpoint : BaseAuditableEntity<Guid>
+public abstract class KpiCheckpoint : BaseAuditableEntity
 {
     protected string _dateLabel = default!;
 

--- a/Moda.Common/src/Moda.Common.Domain/Models/KeyPerformanceIndicators/KpiMeasurement.cs
+++ b/Moda.Common/src/Moda.Common.Domain/Models/KeyPerformanceIndicators/KpiMeasurement.cs
@@ -8,7 +8,7 @@ namespace Moda.Common.Domain.Models.KeyPerformanceIndicators;
 /// <summary>
 /// Represents the common properties and behavior for a KPI measurement (check-in).  This class is intended to be immutable.
 /// </summary>
-public abstract class KpiMeasurement : BaseAuditableEntity<Guid>
+public abstract class KpiMeasurement : BaseAuditableEntity
 {
     protected string? _notes;
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Auditing/Trail.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Auditing/Trail.cs
@@ -2,7 +2,7 @@
 
 namespace Moda.Infrastructure.Auditing;
 
-public sealed class Trail : BaseEntity<Guid>
+public sealed class Trail : BaseEntity
 {
     public required string UserId { get; set; }
     public string? Type { get; set; }

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/AppIntegrationConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/AppIntegrationConfiguration.cs
@@ -28,6 +28,7 @@ public class ConnectionConfig : IEntityTypeConfiguration<Connection>
         builder.HasIndex(c => new { c.IsActive, c.IsDeleted })
             .HasFilter("[IsDeleted] = 0");
 
+        builder.Property(c => c.Id).ValueGeneratedNever();
         builder.Property(c => c.Name).IsRequired().HasMaxLength(128);
         builder.Property(c => c.Description).HasMaxLength(1024);
         builder.Property(w => w.Connector).IsRequired()

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/AuditingConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/AuditingConfiguration.cs
@@ -13,7 +13,7 @@ public class AuditTrailConfig : IEntityTypeConfiguration<Trail>
         builder.HasIndex(x => x.UserId);
         builder.HasIndex(x => x.PrimaryKey);
 
-        builder.Property(x => x.Id).ValueGeneratedOnAdd();
+        builder.Property(x => x.Id).ValueGeneratedNever();
         builder.Property(x => x.UserId).IsRequired().HasMaxLength(450);
         builder.Property(x => x.Type).HasMaxLength(32).HasColumnType("varchar");
         builder.Property(x => x.SchemaName).HasMaxLength(64).HasColumnType("varchar");

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/CommonConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/CommonConfiguration.cs
@@ -29,6 +29,7 @@ public class EmployeeConfig : IEntityTypeConfiguration<Employee>
         builder.HasIndex(e => e.Email)
             .IncludeProperties(e => new { e.Id });
 
+        builder.Property(e => e.Id).ValueGeneratedNever();
         builder.Property(e => e.Key).ValueGeneratedOnAdd();
 
         builder.Property(e => e.EmployeeNumber).HasMaxLength(256).IsRequired();

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/GoalsConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/GoalsConfiguration.cs
@@ -27,6 +27,7 @@ public class ObjectiveConfiguration : IEntityTypeConfiguration<Objective>
             .IncludeProperties(o => new { o.Id, o.Key, o.Name, o.Type, o.Status, o.OwnerId, o.Order })
             .HasFilter("[IsDeleted] = 0");
 
+        builder.Property(o => o.Id).ValueGeneratedNever();
         builder.Property(o => o.Key).ValueGeneratedOnAdd();
 
         builder.Property(o => o.Name).IsRequired().HasMaxLength(256);

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/HealthConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/HealthConfiguration.cs
@@ -18,6 +18,7 @@ public class HealthCheckConfiguration : IEntityTypeConfiguration<HealthCheck>
         builder.HasIndex(h => h.ObjectId)
             .IncludeProperties(o => new { o.Id });
 
+        builder.Property(h => h.Id).ValueGeneratedNever();
         builder.Property(h => h.ObjectId).IsRequired();
 
         builder.Property(h => h.Context).IsRequired()

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
@@ -152,6 +152,7 @@ public class PersonalAccessTokenConfig : IEntityTypeConfiguration<PersonalAccess
             .HasDatabaseName("IX_PersonalAccessTokens_TokenIdentifier_RevokedAt_ExpiresAt");
 
         // Properties
+        builder.Property(p => p.Id).ValueGeneratedNever();
         builder.Property(p => p.Name)
             .HasMaxLength(100)
             .IsRequired();

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/LinksConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/LinksConfiguration.cs
@@ -16,6 +16,7 @@ public class LinkConfiguration : IEntityTypeConfiguration<Link>
         builder.HasIndex(o => o.ObjectId)
             .IncludeProperties(o => new { o.Id, o.Name, o.Url });
 
+        builder.Property(o => o.Id).ValueGeneratedNever();
         builder.Property(o => o.ObjectId).IsRequired();
         builder.Property(o => o.Name).IsRequired().HasMaxLength(128);
         builder.Property(o => o.Url).IsRequired();

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/OrganizationConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/OrganizationConfiguration.cs
@@ -34,6 +34,7 @@ public class BaseTeamConfig : IEntityTypeConfiguration<BaseTeam>
         builder.HasIndex(o => new { o.IsActive, o.IsDeleted })
             .HasFilter("[IsDeleted] = 0");
 
+        builder.Property(o => o.Id).ValueGeneratedNever();
         builder.Property(o => o.Key).ValueGeneratedOnAdd();
 
         builder.Property(o => o.Name).IsRequired().HasMaxLength(128);
@@ -84,6 +85,7 @@ public class TeamMembershipConfig : IEntityTypeConfiguration<TeamMembership>
             .HasFilter("[IsDeleted] = 0");
 
         // Value Objects
+        builder.Property(m => m.Id).ValueGeneratedNever();
         builder.ComplexProperty(m => m.DateRange, options =>
         {
             options.Property(d => d.Start).HasColumnName("Start").IsRequired();
@@ -121,6 +123,8 @@ public class TeamOperatingModelConfig : IEntityTypeConfiguration<TeamOperatingMo
             .IncludeProperties(m => new { m.Id, m.Methodology, m.SizingMethod })
             .HasFilter("[End] IS NULL")
             .HasDatabaseName("IX_TeamOperatingModels_TeamId_Current");
+
+        builder.Property(m => m.Id).ValueGeneratedNever();
 
         // Enums
         builder.Property(m => m.Methodology)

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/OrganizationGraphConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/OrganizationGraphConfiguration.cs
@@ -16,6 +16,7 @@ public class TeamNodeConfig : IEntityTypeConfiguration<TeamNode>
         builder.HasAlternateKey(o => o.Key);
 
         // Properties
+        builder.Property(o => o.Id).ValueGeneratedNever();
         builder.Property(o => o.Key);
         builder.Property(o => o.Name).IsRequired().HasMaxLength(128);
         builder.Property(o => o.Code).IsRequired()
@@ -60,7 +61,7 @@ public class TeamMembershipEdgeConfig : IEntityTypeConfiguration<TeamMembershipE
         builder.HasKey(e => e.Id);
 
         // Properties
-        builder.Property(m => m.Id).ValueGeneratedOnAdd();
+        builder.Property(m => m.Id).ValueGeneratedNever();
         builder.Property(m => m.StartDate).IsRequired();
         builder.Property(m => m.EndDate);
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/PlanningConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/PlanningConfiguration.cs
@@ -55,8 +55,6 @@ public class PlanningTeamConfig : IEntityTypeConfiguration<PlanningTeam>
             .WithOne(t => t.Team)
             .HasForeignKey(t => t.TeamId)
             .OnDelete(DeleteBehavior.Cascade);
-
-        // Ignore
     }
 }
 
@@ -77,6 +75,7 @@ public class PlanningIntervalConfig : IEntityTypeConfiguration<PlanningInterval>
         builder.HasIndex(p => p.Name)
             .IsUnique();
 
+        builder.Property(p => p.Id).ValueGeneratedNever();
         builder.Property(p => p.Key).ValueGeneratedOnAdd();
 
         builder.Property(p => p.Name).HasMaxLength(128).IsRequired();
@@ -115,6 +114,7 @@ public class PlanningIntervalIterationConfig : IEntityTypeConfiguration<Planning
             .IncludeProperties(i => new { i.Id, i.Key, i.Name, i.Category })
             .HasFilter("[IsDeleted] = 0");
 
+        builder.Property(i => i.Id).ValueGeneratedNever();
         builder.Property(i => i.Key).ValueGeneratedOnAdd();
 
         builder.Property(i => i.Name).HasMaxLength(128).IsRequired();
@@ -165,6 +165,7 @@ public class PlanningIntervalObjectiveConfig : IEntityTypeConfiguration<Planning
             .IncludeProperties(o => new { o.Id, o.Key, o.PlanningIntervalId, o.Type, o.IsStretch })
             .HasFilter("[IsDeleted] = 0");
 
+        builder.Property(o => o.Id).ValueGeneratedNever();
         builder.Property(o => o.Key).ValueGeneratedOnAdd();
 
         builder.Property(o => o.ObjectiveId).IsRequired();
@@ -198,8 +199,6 @@ public class PlanningIntervalObjectiveConfig : IEntityTypeConfiguration<Planning
             .WithOne()
             .HasForeignKey<SimpleHealthCheck>(h => h.ObjectId)
             .OnDelete(DeleteBehavior.Cascade);
-
-        // Ignore
     }
 }
 
@@ -249,6 +248,7 @@ public class RiskConfig : IEntityTypeConfiguration<Risk>
         builder.HasIndex(r => new { r.TeamId, r.IsDeleted })
             .HasFilter("[IsDeleted] = 0");
 
+        builder.Property(r => r.Id).ValueGeneratedNever();
         builder.Property(r => r.Key).ValueGeneratedOnAdd();
 
         builder.Property(r => r.Summary).HasMaxLength(256).IsRequired();
@@ -317,6 +317,7 @@ public class RoadmapConfig : IEntityTypeConfiguration<Roadmap>
         builder.HasIndex(r => r.Visibility)
             .IncludeProperties(r => new { r.Id, r.Key, r.Name });
 
+        builder.Property(r => r.Id).ValueGeneratedNever();
         builder.Property(r => r.Key).ValueGeneratedOnAdd();
 
         builder.Property(r => r.Name).HasMaxLength(128).IsRequired();
@@ -389,6 +390,7 @@ public class BaseRoadmapItemConfiguration : IEntityTypeConfiguration<BaseRoadmap
         builder.HasIndex(ri => ri.RoadmapId);
 
         // Properties
+        builder.Property(ri => ri.Id).ValueGeneratedNever();
         builder.Property(ri => ri.Name).HasMaxLength(128).IsRequired();
         builder.Property(ri => ri.Description).HasMaxLength(2048);
 
@@ -468,6 +470,7 @@ public class IterationConfig : IEntityTypeConfiguration<Iteration>
         builder.HasAlternateKey(i => i.Key);
 
         // Properties
+        builder.Property(i => i.Id).ValueGeneratedNever();
         builder.Property(i => i.Key).ValueGeneratedOnAdd();
         builder.Property(i => i.Name).HasMaxLength(256).IsRequired();
 
@@ -558,6 +561,7 @@ public class PlanningIntervalIterationSprintConfig : IEntityTypeConfiguration<Pl
             .IsUnique()
             .IncludeProperties(s => new { s.PlanningIntervalId, s.PlanningIntervalIterationId });
 
+        builder.Property(s => s.Id).ValueGeneratedNever();
         builder.Property(s => s.PlanningIntervalId).IsRequired();
         builder.Property(s => s.PlanningIntervalIterationId).IsRequired();
         builder.Property(s => s.SprintId).IsRequired();
@@ -636,6 +640,7 @@ public class PokerSessionConfig : IEntityTypeConfiguration<PokerSession>
 
         builder.HasIndex(s => s.Key);
 
+        builder.Property(s => s.Id).ValueGeneratedNever();
         builder.Property(s => s.Key).ValueGeneratedOnAdd();
         builder.Property(s => s.Name).IsRequired().HasMaxLength(256);
         builder.Property(s => s.EstimationScaleId).IsRequired();
@@ -680,6 +685,7 @@ public class PokerRoundConfig : IEntityTypeConfiguration<PokerRound>
 
         builder.HasIndex(r => r.PokerSessionId);
 
+        builder.Property(r => r.Id).ValueGeneratedNever();
         builder.Property(r => r.PokerSessionId).IsRequired();
         builder.Property(r => r.Label).HasMaxLength(512);
         builder.Property(r => r.Status).IsRequired()
@@ -710,6 +716,7 @@ public class PokerVoteConfig : IEntityTypeConfiguration<PokerVote>
 
         builder.HasIndex(v => new { v.PokerRoundId, v.ParticipantId }).IsUnique();
 
+        builder.Property(v => v.Id).ValueGeneratedNever();
         builder.Property(v => v.PokerRoundId).IsRequired();
         builder.Property(v => v.ParticipantId)
             .IsRequired()

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/ProjectPortfolioManagementConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/ProjectPortfolioManagementConfiguration.cs
@@ -70,6 +70,7 @@ public class ProjectPortfolioConfiguration : IEntityTypeConfiguration<ProjectPor
 
         builder.HasIndex(p => p.Status);
 
+        builder.Property(p => p.Id).ValueGeneratedNever();
         builder.Property(p => p.Key).ValueGeneratedOnAdd();
         builder.Property(p => p.Name).HasMaxLength(128).IsRequired();
         builder.Property(p => p.Description).HasMaxLength(1024).IsRequired();
@@ -119,6 +120,7 @@ public class ProgramConfiguration : IEntityTypeConfiguration<Program>
 
         builder.HasIndex(p => p.Status);
 
+        builder.Property(p => p.Id).ValueGeneratedNever();
         builder.Property(p => p.Key).ValueGeneratedOnAdd();
         builder.Property(p => p.Name).HasMaxLength(128).IsRequired();
         builder.Property(p => p.Description).HasMaxLength(2048).IsRequired();
@@ -166,6 +168,7 @@ public class ProjectConfiguration : IEntityTypeConfiguration<Project>
 
         builder.HasIndex(p => p.Status);
 
+        builder.Property(p => p.Id).ValueGeneratedNever();
         builder.Property(p => p.Name).HasMaxLength(128).IsRequired();
         builder.Property(p => p.Description).HasMaxLength(4096).IsRequired();
         builder.Property(p => p.BusinessCase).HasMaxLength(4096);
@@ -240,6 +243,7 @@ public class StrategicInitiativeConfiguration : IEntityTypeConfiguration<Strateg
 
         builder.HasIndex(i => i.Status);
 
+        builder.Property(i => i.Id).ValueGeneratedNever();
         builder.Property(i => i.Key).ValueGeneratedOnAdd();
         builder.Property(i => i.Name).HasMaxLength(128).IsRequired();
         builder.Property(i => i.Description).HasMaxLength(2048).IsRequired();
@@ -280,6 +284,7 @@ public class StrategicInitiativeKpiConfiguration : IEntityTypeConfiguration<Stra
 
         builder.HasIndex(k => k.StrategicInitiativeId);
 
+        builder.Property(k => k.Id).ValueGeneratedNever();
         builder.Property(k => k.Key).ValueGeneratedOnAdd();
         builder.Property(k => k.Name).HasMaxLength(64).IsRequired();
         builder.Property(k => k.Description).HasMaxLength(512);
@@ -322,6 +327,7 @@ public class StrategicInitiativeKpiCheckpointConfiguration : IEntityTypeConfigur
 
         builder.HasIndex(k => k.KpiId);
 
+        builder.Property(k => k.Id).ValueGeneratedNever();
         builder.Property(k => k.TargetValue).IsRequired();
         builder.Property(k => k.AtRiskValue);
         builder.Property(k => k.CheckpointDate).IsRequired();
@@ -340,6 +346,7 @@ public class StrategicInitiativeKpiMeasurementConfiguration : IEntityTypeConfigu
 
         builder.HasIndex(m => m.KpiId);
 
+        builder.Property(m => m.Id).ValueGeneratedNever();
         builder.Property(m => m.ActualValue).IsRequired();
         builder.Property(m => m.MeasurementDate).IsRequired();
         builder.Property(m => m.Note).HasMaxLength(1024);
@@ -695,6 +702,7 @@ public class ProjectTaskConfiguration : IEntityTypeConfiguration<ProjectTask>
         builder.HasIndex(t => t.Key)
             .IsUnique();
 
+        builder.Property(t => t.Id).ValueGeneratedNever();
         builder.HasIndex(t => t.Number);
         builder.HasIndex(t => t.ProjectId);
         builder.HasIndex(t => t.ParentId);
@@ -787,6 +795,7 @@ public class ProjectTaskDependencyConfiguration : IEntityTypeConfiguration<Proje
 
         builder.HasKey(d => d.Id);
 
+        builder.Property(d => d.Id).ValueGeneratedNever();
         builder.HasIndex(d => d.PredecessorId);
         builder.HasIndex(d => d.SuccessorId);
         builder.HasIndex(d => d.RemovedOn);

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/StrategicManagementConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/StrategicManagementConfiguration.cs
@@ -18,6 +18,7 @@ public class StrategicThemeConfig : IEntityTypeConfiguration<StrategicTheme>
 
         builder.HasIndex(s => s.State);
 
+        builder.Property(s => s.Id).ValueGeneratedNever();
         builder.Property(s => s.Key).ValueGeneratedOnAdd();
         builder.Property(s => s.Name).HasMaxLength(64).IsRequired();
         builder.Property(s => s.Description).HasMaxLength(1024).IsRequired();
@@ -40,6 +41,7 @@ public class StrategyConfig : IEntityTypeConfiguration<Strategy>
 
         builder.HasIndex(s => s.Status);
 
+        builder.Property(s => s.Id).ValueGeneratedNever();
         builder.Property(s => s.Key).ValueGeneratedOnAdd();
         builder.Property(s => s.Name).HasMaxLength(1024).IsRequired();
         builder.Property(s => s.Description).HasMaxLength(3072);
@@ -69,6 +71,7 @@ public class VisionConfig : IEntityTypeConfiguration<Vision>
 
         builder.HasIndex(s => s.State);
 
+        builder.Property(s => s.Id).ValueGeneratedNever();
         builder.Property(s => s.Key).ValueGeneratedOnAdd();
         builder.Property(s => s.Description).HasMaxLength(3072).IsRequired();
 

--- a/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Moda.Infrastructure/src/Moda.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -159,6 +159,7 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             .HasColumnType("varchar")
             .HasMaxLength(64);
 
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(w => w.Title).IsRequired().HasMaxLength(256);
         builder.Property(w => w.StatusCategory).IsRequired()
             .HasConversion<EnumConverter<WorkStatusCategory>>()
@@ -322,6 +323,7 @@ public class WorkItemLinkConfig : IEntityTypeConfiguration<WorkItemLink>
             .HasFilter("[RemovedOn] IS NULL AND [LinkType] = 'Dependency'");
 
         // Properties
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(w => w.LinkType).IsRequired()
             .HasConversion<EnumConverter<WorkItemLinkType>>()
             .HasColumnType("varchar")
@@ -435,6 +437,7 @@ public class WorkProcessConfig : IEntityTypeConfiguration<WorkProcess>
         builder.Property(w => w.Key).ValueGeneratedOnAdd();
 
         // Properties
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(w => w.Name).HasMaxLength(128).IsRequired();
         builder.Property(w => w.Description).HasMaxLength(1024);
 
@@ -474,6 +477,7 @@ public class WorkProcessSchemeConfig : IEntityTypeConfiguration<WorkProcessSchem
             .HasFilter("[IsDeleted] = 0");
 
         // Properties
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(w => w.WorkProcessId);
         builder.Property(w => w.WorkTypeId);
         builder.Property(w => w.WorkflowId);
@@ -540,6 +544,7 @@ public class WorkspaceConfig : IEntityTypeConfiguration<Workspace>
             .HasFilter("[IsDeleted] = 0");
 
         // Properties
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(w => w.Key).IsRequired()
             .HasConversion(
                 w => w.Value,
@@ -730,6 +735,7 @@ public class WorkflowConfig : IEntityTypeConfiguration<Workflow>
             .HasFilter("[IsDeleted] = 0");
 
         // Properties
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(p => p.Key).ValueGeneratedOnAdd();
         builder.Property(w => w.Name).IsRequired().HasMaxLength(128);
         builder.Property(w => w.Description).HasMaxLength(1024);
@@ -770,6 +776,7 @@ public class WorkflowSchemeConfig : IEntityTypeConfiguration<WorkflowScheme>
             .HasFilter("[IsDeleted] = 0");
 
         // Properties
+        builder.Property(w => w.Id).ValueGeneratedNever();
         builder.Property(w => w.WorkStatusCategory).IsRequired()
             .HasConversion<EnumConverter<WorkStatusCategory>>()
             .HasColumnType("varchar")

--- a/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/Connection.cs
+++ b/Moda.Services/Moda.AppIntegration/src/Moda.AppIntegration.Domain/Models/Connection.cs
@@ -3,7 +3,7 @@ using Moda.Common.Domain.Enums.AppIntegrations;
 using Moda.Common.Extensions;
 
 namespace Moda.AppIntegration.Domain.Models;
-public abstract class Connection : BaseSoftDeletableEntity<Guid>, IActivatable
+public abstract class Connection : BaseSoftDeletableEntity, IActivatable
 {
     /// <summary>
     /// The name of the connection.

--- a/Moda.Services/Moda.Health/src/Moda.Health/Models/HealthCheck.cs
+++ b/Moda.Services/Moda.Health/src/Moda.Health/Models/HealthCheck.cs
@@ -10,7 +10,7 @@ using NodaTime;
 
 namespace Moda.Health.Models;
 
-public sealed class HealthCheck : BaseSoftDeletableEntity<Guid>, IHealthCheck
+public sealed class HealthCheck : BaseSoftDeletableEntity, IHealthCheck
 {
     private HealthCheck() { }
 

--- a/Moda.Services/Moda.Links/src/Moda.Links/Models/Link.cs
+++ b/Moda.Services/Moda.Links/src/Moda.Links/Models/Link.cs
@@ -4,7 +4,7 @@ using Moda.Common.Domain.Data;
 
 namespace Moda.Links.Models;
 
-public sealed class Link : BaseEntity<Guid>
+public sealed class Link : BaseEntity
 {
     private string _name = default!;
     private string _url = default!;

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Domain/Models/BaseMembership.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Domain/Models/BaseMembership.cs
@@ -3,7 +3,7 @@ using Moda.Organization.Domain.Enums;
 using NodaTime;
 
 namespace Moda.Organization.Domain.Models;
-public abstract class BaseMembership : BaseSoftDeletableEntity<Guid>
+public abstract class BaseMembership : BaseSoftDeletableEntity
 {
     private MembershipDateRange _dateRange = default!;
 

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Domain/Models/BaseTeam.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Domain/Models/BaseTeam.cs
@@ -7,7 +7,7 @@ using Moda.Common.Extensions;
 using NodaTime;
 
 namespace Moda.Organization.Domain.Models;
-public abstract class BaseTeam : BaseSoftDeletableEntity<Guid>, ISimpleTeam, IHasIdAndKey
+public abstract class BaseTeam : BaseSoftDeletableEntity, ISimpleTeam, IHasIdAndKey
 {
     private string _name = null!;
     private TeamCode _code = null!;

--- a/Moda.Services/Moda.Organization/src/Moda.Organization.Domain/Models/TeamOperatingModel.cs
+++ b/Moda.Services/Moda.Organization/src/Moda.Organization.Domain/Models/TeamOperatingModel.cs
@@ -8,7 +8,7 @@ namespace Moda.Organization.Domain.Models;
 /// Represents the operating model for a team, defining how the team works
 /// (methodology and sizing method) for a specific date range.
 /// </summary>
-public sealed class TeamOperatingModel : BaseAuditableEntity<Guid>
+public sealed class TeamOperatingModel : BaseAuditableEntity
 {
     private TeamOperatingModel() { }
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Iterations/Iteration.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Iterations/Iteration.cs
@@ -16,7 +16,7 @@ namespace Moda.Planning.Domain.Models.Iterations;
 /// </summary>
 /// <remarks>An iteration is characterized by its name, type, state, date range, and ownership information.  This class
 /// provides methods for creating and updating iterations, as well as managing associated metadata.</remarks>
-public class Iteration : BaseAuditableEntity<Guid>, IHasIdAndKey, ISimpleIteration
+public class Iteration : BaseAuditableEntity, IHasIdAndKey, ISimpleIteration
 {
     private readonly List<KeyValueObjectMetadata> _externalMetadata = [];
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningInterval.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningInterval.cs
@@ -9,7 +9,7 @@ using Moda.Planning.Domain.Models.Iterations;
 using NodaTime;
 
 namespace Moda.Planning.Domain.Models;
-public class PlanningInterval : BaseSoftDeletableEntity<Guid>, ILocalSchedule, INavigable
+public class PlanningInterval : BaseSoftDeletableEntity, ILocalSchedule, INavigable
 {
     private readonly List<PlanningIntervalTeam> _teams = [];
     private readonly List<PlanningIntervalIteration> _iterations = [];

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningIntervalIteration.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningIntervalIteration.cs
@@ -7,7 +7,7 @@ using Moda.Planning.Domain.Interfaces;
 using NodaTime;
 
 namespace Moda.Planning.Domain.Models;
-public sealed class PlanningIntervalIteration : BaseSoftDeletableEntity<Guid>, ILocalSchedule, INavigable
+public sealed class PlanningIntervalIteration : BaseSoftDeletableEntity, ILocalSchedule, INavigable
 {
     private readonly List<PlanningIntervalIterationSprint> _iterationSprints = [];
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningIntervalIterationSprint.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningIntervalIterationSprint.cs
@@ -3,7 +3,7 @@ using Moda.Planning.Domain.Models.Iterations;
 
 namespace Moda.Planning.Domain.Models;
 
-public sealed class PlanningIntervalIterationSprint : BaseAuditableEntity<Guid>
+public sealed class PlanningIntervalIterationSprint : BaseAuditableEntity
 {
     private PlanningIntervalIterationSprint() { }
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningIntervalObjective.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningIntervalObjective.cs
@@ -3,7 +3,7 @@ using Moda.Common.Domain.Interfaces;
 using Moda.Planning.Domain.Enums;
 
 namespace Moda.Planning.Domain.Models;
-public class PlanningIntervalObjective : BaseSoftDeletableEntity<Guid>, IHasIdAndKey
+public class PlanningIntervalObjective : BaseSoftDeletableEntity, IHasIdAndKey
 {
     private PlanningIntervalObjective() { }
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningPoker/PokerRound.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningPoker/PokerRound.cs
@@ -5,7 +5,7 @@ using NodaTime;
 
 namespace Moda.Planning.Domain.Models.PlanningPoker;
 
-public class PokerRound : BaseEntity<Guid>
+public class PokerRound : BaseEntity
 {
     private readonly List<PokerVote> _votes = [];
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningPoker/PokerSession.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningPoker/PokerSession.cs
@@ -7,7 +7,7 @@ using NodaTime;
 
 namespace Moda.Planning.Domain.Models.PlanningPoker;
 
-public class PokerSession : BaseAuditableEntity<Guid>, IHasIdAndKey
+public class PokerSession : BaseAuditableEntity, IHasIdAndKey
 {
     private readonly List<PokerRound> _rounds = [];
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningPoker/PokerVote.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/PlanningPoker/PokerVote.cs
@@ -4,7 +4,7 @@ using NodaTime;
 
 namespace Moda.Planning.Domain.Models.PlanningPoker;
 
-public class PokerVote : BaseEntity<Guid>
+public class PokerVote : BaseEntity
 {
     private PokerVote() { }
 

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Risk.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Risk.cs
@@ -6,7 +6,7 @@ using Moda.Planning.Domain.Enums;
 using NodaTime;
 
 namespace Moda.Planning.Domain.Models;
-public class Risk : BaseSoftDeletableEntity<Guid>, IHasIdAndKey
+public class Risk : BaseSoftDeletableEntity, IHasIdAndKey
 {
     private string _summary = default!;
     private string? _description;

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Roadmaps/BaseRoadmapItem.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Roadmaps/BaseRoadmapItem.cs
@@ -4,7 +4,7 @@ using Moda.Common.Domain.Interfaces;
 using Moda.Planning.Domain.Enums;
 
 namespace Moda.Planning.Domain.Models.Roadmaps;
-public abstract class BaseRoadmapItem : BaseAuditableEntity<Guid>
+public abstract class BaseRoadmapItem : BaseAuditableEntity
 {
     private string _name = default!;
     private string? _description;

--- a/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Roadmaps/Roadmap.cs
+++ b/Moda.Services/Moda.Planning/src/Moda.Planning.Domain/Models/Roadmaps/Roadmap.cs
@@ -8,7 +8,7 @@ using Moda.Planning.Domain.Interfaces.Roadmaps;
 using OneOf;
 
 namespace Moda.Planning.Domain.Models.Roadmaps;
-public class Roadmap : BaseAuditableEntity<Guid>, ILocalSchedule, IHasIdAndKey
+public class Roadmap : BaseAuditableEntity, ILocalSchedule, IHasIdAndKey
 {
     private readonly bool _objectConstruction = false;
     private string _name = default!;

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Program.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Program.cs
@@ -10,7 +10,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents a program consisting of related projects within a portfolio, designed to achieve strategic objectives.
 /// </summary>
-public sealed class Program : BaseAuditableEntity<Guid>, IHasIdAndKey, ISimpleProgram
+public sealed class Program : BaseAuditableEntity, IHasIdAndKey, ISimpleProgram
 {
     private readonly HashSet<RoleAssignment<ProgramRole>> _roles = [];
     private readonly HashSet<Project> _projects = [];

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Project.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/Project.cs
@@ -12,7 +12,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents an individual project within a portfolio or program.
 /// </summary>
-public sealed class Project : BaseAuditableEntity<Guid>, IHasIdAndKey<ProjectKey>, ISimpleProject
+public sealed class Project : BaseAuditableEntity, IHasIdAndKey<ProjectKey>, ISimpleProject
 {
     private readonly HashSet<RoleAssignment<ProjectRole>> _roles = [];
     private readonly HashSet<StrategicThemeTag<Project>> _strategicThemeTags = [];

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectLifecycle.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectLifecycle.cs
@@ -8,7 +8,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// Represents a project lifecycle template that defines the ordered phases a project goes through.
 /// Lifecycles enforce consistency across projects by standardizing the top-level planning structure.
 /// </summary>
-public sealed class ProjectLifecycle : BaseAuditableEntity<Guid>, IHasIdAndKey
+public sealed class ProjectLifecycle : BaseAuditableEntity, IHasIdAndKey
 {
     private readonly List<ProjectLifecyclePhase> _phases = [];
 
@@ -16,7 +16,6 @@ public sealed class ProjectLifecycle : BaseAuditableEntity<Guid>, IHasIdAndKey
 
     private ProjectLifecycle(string name, string description)
     {
-        Id = Guid.CreateVersion7();
         Name = name;
         Description = description;
         State = ProjectLifecycleState.Proposed;

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectLifecyclePhase.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectLifecyclePhase.cs
@@ -6,13 +6,12 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents a phase definition within a project lifecycle template.
 /// </summary>
-public sealed class ProjectLifecyclePhase : BaseAuditableEntity<Guid>
+public sealed class ProjectLifecyclePhase : BaseAuditableEntity
 {
     private ProjectLifecyclePhase() { }
 
     internal ProjectLifecyclePhase(Guid projectLifecycleId, string name, string description, int order)
     {
-        Id = Guid.CreateVersion7();
         ProjectLifecycleId = projectLifecycleId;
         Name = name;
         Description = description;

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectPhase.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectPhase.cs
@@ -9,7 +9,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// Represents a phase instance on a project, created from a project lifecycle phase template.
 /// Phases provide the top-level structure for a project's plan and group related tasks.
 /// </summary>
-public sealed class ProjectPhase : BaseAuditableEntity<Guid>
+public sealed class ProjectPhase : BaseAuditableEntity
 {
     private readonly HashSet<RoleAssignment<ProjectPhaseRole>> _roles = [];
 
@@ -17,7 +17,6 @@ public sealed class ProjectPhase : BaseAuditableEntity<Guid>
 
     private ProjectPhase(Guid projectId, ProjectLifecyclePhase lifecyclePhase)
     {
-        Id = Guid.CreateVersion7();
         ProjectId = projectId;
         ProjectLifecyclePhaseId = lifecyclePhase.Id;
         Name = lifecyclePhase.Name;

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectPortfolio.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectPortfolio.cs
@@ -11,7 +11,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents a collection of projects or programs that are managed together to achieve strategic results.
 /// </summary>
-public sealed class ProjectPortfolio : BaseAuditableEntity<Guid>, IHasIdAndKey
+public sealed class ProjectPortfolio : BaseAuditableEntity, IHasIdAndKey
 {
     private const string ReadOnlyErrorMessage = "Project Portfolio is readonly and cannot be updated.";
 

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectTask.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectTask.cs
@@ -11,7 +11,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents a task within a project with hierarchical structure and dependency management.
 /// </summary>
-public sealed class ProjectTask : BaseAuditableEntity<Guid>, IHasIdAndKey<ProjectTaskKey>, IHasProject
+public sealed class ProjectTask : BaseAuditableEntity, IHasIdAndKey<ProjectTaskKey>, IHasProject
 {
     private readonly List<ProjectTask> _children = [];
     private readonly HashSet<RoleAssignment<TaskRole>> _roles = [];

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectTaskDependency.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/ProjectTaskDependency.cs
@@ -6,7 +6,7 @@ namespace Moda.ProjectPortfolioManagement.Domain.Models;
 /// <summary>
 /// Represents a dependency relationship between two project tasks.
 /// </summary>
-public sealed class ProjectTaskDependency : BaseAuditableEntity<Guid>
+public sealed class ProjectTaskDependency : BaseAuditableEntity
 {
     private ProjectTaskDependency() { }
 

--- a/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/StrategicInitiatives/StrategicInitiative.cs
+++ b/Moda.Services/Moda.ProjectPortfolioManagement/src/Moda.ProjectPortfolioManagement.Domain/Models/StrategicInitiatives/StrategicInitiative.cs
@@ -5,7 +5,7 @@ using Moda.ProjectPortfolioManagement.Domain.Enums;
 
 namespace Moda.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 
-public sealed class StrategicInitiative : BaseAuditableEntity<Guid>, IHasIdAndKey
+public sealed class StrategicInitiative : BaseAuditableEntity, IHasIdAndKey
 {
     private readonly HashSet<RoleAssignment<StrategicInitiativeRole>> _roles = [];
     private readonly HashSet<StrategicInitiativeKpi> _kpis = [];

--- a/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Domain/Models/StrategicTheme.cs
+++ b/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Domain/Models/StrategicTheme.cs
@@ -10,7 +10,7 @@ namespace Moda.StrategicManagement.Domain.Models;
 /// <summary>
 /// Represents a high-level focus area or priority that guides related initiatives.
 /// </summary>
-public sealed class StrategicTheme : BaseAuditableEntity<Guid>, IHasIdAndKey, IStrategicThemeData
+public sealed class StrategicTheme : BaseAuditableEntity, IHasIdAndKey, IStrategicThemeData
 {
     private string _name = default!;
     private string _description = default!;

--- a/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Domain/Models/Strategy.cs
+++ b/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Domain/Models/Strategy.cs
@@ -7,7 +7,7 @@ namespace Moda.StrategicManagement.Domain.Models;
 /// <summary>
 /// Represents a strategic plan or initiative to achieve organizational goals.
 /// </summary>
-public sealed class Strategy : BaseAuditableEntity<Guid>, IHasIdAndKey
+public sealed class Strategy : BaseAuditableEntity, IHasIdAndKey
 {
     private string _name = default!;
     private string? _description;

--- a/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Domain/Models/Vision.cs
+++ b/Moda.Services/Moda.StrategicManagement/src/Moda.StrategicManagement.Domain/Models/Vision.cs
@@ -9,7 +9,7 @@ namespace Moda.StrategicManagement.Domain.Models;
 /// Represents the overarching purpose and direction of the organization.
 /// Operates independently of the Strategy entity, allowing flexibility for different organizational use cases.
 /// </summary>
-public sealed class Vision : BaseAuditableEntity<Guid>, IHasIdAndKey
+public sealed class Vision : BaseAuditableEntity, IHasIdAndKey
 {
     private string _description = default!;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
@@ -225,7 +225,7 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
                                 iterationId,
                                 externalWorkItem.ActivatedTimestamp,
                                 externalWorkItem.DoneTimestamp,
-                                CreateExtendedPropsIfNeeded(null, externalWorkItem.ExternalTeamIdentifier)
+                                externalWorkItem.ExternalTeamIdentifier
                             );
                             newWorkItems.Add(workItem);
 
@@ -434,14 +434,9 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
         return new EmployeeIds(createdById, lastModifiedById, assignedToId);
     }
 
-    private static WorkItemExtended? CreateExtendedPropsIfNeeded(Guid? workItemId, string? externalTeamIdentifier)
+    private static WorkItemExtended? CreateExtendedPropsIfNeeded(Guid workItemId, string? externalTeamIdentifier)
     {
-        if (string.IsNullOrWhiteSpace(externalTeamIdentifier))
-            return null;
-
-        return workItemId.HasValue
-            ? WorkItemExtended.Create(workItemId.Value, externalTeamIdentifier)
-            : WorkItemExtended.Create(externalTeamIdentifier);
+        return WorkItemExtended.Create(workItemId, externalTeamIdentifier);
     }
 
     private async Task MapMissingParents(Workspace workspace, Dictionary<int, int> missingParents, CancellationToken cancellationToken)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItem.cs
@@ -7,7 +7,7 @@ using NodaTime;
 
 namespace Moda.Work.Domain.Models;
 
-public sealed class WorkItem : BaseAuditableEntity<Guid>, IHasWorkspace, IHasOptionalWorkTeam
+public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalWorkTeam
 {
     private readonly List<WorkItem> _children = [];
     private readonly List<WorkItemHierarchy> _outboundHierarchyHistory = []; // source links
@@ -20,7 +20,7 @@ public sealed class WorkItem : BaseAuditableEntity<Guid>, IHasWorkspace, IHasOpt
 
     private WorkItem() { }
 
-    private WorkItem(WorkItemKey key, string title, Guid workspaceId, int? externalId, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, WorkItemExtended? extendedProps)
+    private WorkItem(WorkItemKey key, string title, Guid workspaceId, int? externalId, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, string? externalTeamIdentifier)
     {
         Key = key;
         Title = title;
@@ -42,7 +42,7 @@ public sealed class WorkItem : BaseAuditableEntity<Guid>, IHasWorkspace, IHasOpt
 
         ActivatedTimestamp = activatedTimestamp;
         DoneTimestamp = doneTimestamp;
-        ExtendedProps = extendedProps;
+        ExtendedProps = WorkItemExtended.Create(Id, externalTeamIdentifier);
 
         var result = UpdateParent(parentInfo, workType);
         if (result.IsFailure)
@@ -363,7 +363,7 @@ public sealed class WorkItem : BaseAuditableEntity<Guid>, IHasWorkspace, IHasOpt
         return Result.Success();
     }
 
-    public static WorkItem CreateExternal(Workspace workspace, int externalId, string title, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, WorkItemExtended? extendedProps)
+    public static WorkItem CreateExternal(Workspace workspace, int externalId, string title, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, string? externalTeamIdentifier)
     {
         Guard.Against.Null(workspace, nameof(workspace));
         Guard.Against.Null(workType, nameof(workType));
@@ -374,7 +374,7 @@ public sealed class WorkItem : BaseAuditableEntity<Guid>, IHasWorkspace, IHasOpt
         }
 
         var key = new WorkItemKey(workspace.Key, externalId);
-        return new WorkItem(key, title, workspace.Id, externalId, workType, statusId, statusCategory, parentInfo, teamId, created, createdById, lastModified, lastModifiedById, assignedToId, priority, stackRank, storyPoints, iterationId, activatedTimestamp, doneTimestamp, extendedProps);
+        return new WorkItem(key, title, workspace.Id, externalId, workType, statusId, statusCategory, parentInfo, teamId, created, createdById, lastModified, lastModifiedById, assignedToId, priority, stackRank, storyPoints, iterationId, activatedTimestamp, doneTimestamp, externalTeamIdentifier);
 
         //var result = workspace.AddWorkItem(workItem);  // this is handled in the handler for performance reasons
     }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemExtended.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemExtended.cs
@@ -11,10 +11,6 @@ public sealed class WorkItemExtended
         ExternalTeamIdentifier = iterationPath;
     }
 
-    private WorkItemExtended(string? iterationPath)
-        : this(Guid.Empty, iterationPath) // the guid is empty when the work item is not yet created. EF will fill it in.
-    { }
-
     /// <summary>
     /// Work Item Id
     /// </summary>
@@ -27,17 +23,10 @@ public sealed class WorkItemExtended
         ExternalTeamIdentifier = workItemExtended?.ExternalTeamIdentifier;
     }
 
-    public static WorkItemExtended? Create(string? externalTeamIdentifier)
-    {
-        return string.IsNullOrWhiteSpace(externalTeamIdentifier) 
-            ? null 
-            : new WorkItemExtended(externalTeamIdentifier);
-    }
-
     public static WorkItemExtended? Create(Guid id, string? externalTeamIdentifier)
     {
-        return string.IsNullOrWhiteSpace(externalTeamIdentifier) 
-            ? null 
+        return string.IsNullOrWhiteSpace(externalTeamIdentifier)
+            ? null
             : new WorkItemExtended(id, externalTeamIdentifier);
     }
 }

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemLink.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemLink.cs
@@ -6,7 +6,7 @@ using NodaTime;
 
 namespace Moda.Work.Domain.Models;
 
-public abstract class WorkItemLink : BaseAuditableEntity<Guid>
+public abstract class WorkItemLink : BaseAuditableEntity
 {
     private string? _comment;
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemRevision.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemRevision.cs
@@ -5,7 +5,7 @@ namespace Moda.Work.Domain.Models;
 /// <summary>
 /// The work item revision is a change record for a work item.
 /// </summary>
-public sealed class WorkItemRevision : BaseEntity<Guid>, ISoftDelete
+public sealed class WorkItemRevision : BaseEntity, ISoftDelete
 {
     private readonly List<WorkItemRevisionChange> _changes = new();
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemRevisionChange.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkItemRevisionChange.cs
@@ -5,7 +5,7 @@ namespace Moda.Work.Domain.Models;
 /// <summary>
 /// A specific field change within a work item revision.
 /// </summary>
-public sealed class WorkItemRevisionChange : BaseEntity<Guid>, ISoftDelete
+public sealed class WorkItemRevisionChange : BaseEntity, ISoftDelete
 {
     private WorkItemRevisionChange() { }
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcess.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcess.cs
@@ -11,7 +11,7 @@ namespace Moda.Work.Domain.Models;
 /// </summary>
 /// <seealso cref="Moda.Common.Domain.Data.BaseSoftDeletableEntity&lt;System.Guid&gt;" />
 /// <seealso cref="Moda.Common.Domain.Interfaces.IActivatable" />
-public sealed class WorkProcess : BaseSoftDeletableEntity<Guid>, IActivatable, IHasIdAndKey
+public sealed class WorkProcess : BaseSoftDeletableEntity, IActivatable, IHasIdAndKey
 {
     private string _name = null!;
     private string? _description;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcess.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcess.cs
@@ -9,7 +9,7 @@ namespace Moda.Work.Domain.Models;
 /// The work process defines a set of work process configurations that can be used
 /// within a workspace. A work process can be used in many workspaces.
 /// </summary>
-/// <seealso cref="Moda.Common.Domain.Data.BaseSoftDeletableEntity&lt;System.Guid&gt;" />
+/// <seealso cref="Moda.Common.Domain.Data.BaseSoftDeletableEntity" />
 /// <seealso cref="Moda.Common.Domain.Interfaces.IActivatable" />
 public sealed class WorkProcess : BaseSoftDeletableEntity, IActivatable, IHasIdAndKey
 {
@@ -162,9 +162,7 @@ public sealed class WorkProcess : BaseSoftDeletableEntity, IActivatable, IHasIdA
         if (_schemes.Any(s => s.WorkTypeId == workTypeId))
             return Result.Failure("The work type is already associated to this work process.");
 
-        WorkProcessScheme scheme = Id == Guid.Empty
-            ? WorkProcessScheme.CreateExternal(this, workTypeId, workflowId, isActive)
-            : WorkProcessScheme.CreateExternal(Id, workTypeId, workflowId, isActive);
+        WorkProcessScheme scheme = WorkProcessScheme.CreateExternal(Id, workTypeId, workflowId, isActive);
 
         _schemes.Add(scheme);
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcessScheme.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcessScheme.cs
@@ -4,7 +4,7 @@ using NodaTime;
 
 namespace Moda.Work.Domain.Models;
 
-public sealed class WorkProcessScheme : BaseSoftDeletableEntity<Guid>, IActivatable
+public sealed class WorkProcessScheme : BaseSoftDeletableEntity, IActivatable
 {
     private WorkProcessScheme() { }
 

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcessScheme.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkProcessScheme.cs
@@ -14,13 +14,6 @@ public sealed class WorkProcessScheme : BaseSoftDeletableEntity, IActivatable
         WorkTypeId = workTypeId;
         WorkflowId = workflowId;
     }
-    internal WorkProcessScheme(WorkProcess workProcess, int workTypeId, Guid? workflowId)
-    {
-        WorkProcess = workProcess;
-        WorkTypeId = workTypeId;
-        WorkflowId = workflowId;
-    }
-
     public Guid WorkProcessId { get; }
     public WorkProcess? WorkProcess { get; private set; }
     public int WorkTypeId { get; }
@@ -78,25 +71,6 @@ public sealed class WorkProcessScheme : BaseSoftDeletableEntity, IActivatable
         Guard.Against.Default(workflowId, nameof(workflowId));
 
         var scheme = new WorkProcessScheme(workProcessId, workTypeId, workflowId);
-
-        // external work process schemes do not have to be active when they are first created in Moda
-        if (scheme.IsActive != isActive)
-            scheme.IsActive = isActive;
-
-        return scheme;
-    }
-
-    /// <summary>
-    /// Used when creating a new external work process scheme and work process together.  EF will set the WorkProcessId when the work process is saved.
-    /// </summary>
-    /// <param name="workProcess"></param>
-    /// <param name="workTypeId"></param>
-    /// <param name="workflowId"></param>
-    /// <param name="isActive"></param>
-    /// <returns></returns>
-    internal static WorkProcessScheme CreateExternal(WorkProcess workProcess, int workTypeId, Guid workflowId, bool isActive)
-    {
-        var scheme = new WorkProcessScheme(workProcess, workTypeId, workflowId);
 
         // external work process schemes do not have to be active when they are first created in Moda
         if (scheme.IsActive != isActive)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/Workflow.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/Workflow.cs
@@ -12,7 +12,7 @@ namespace Moda.Work.Domain.Models;
 /// </summary>
 /// <seealso cref="Moda.Common.Domain.Data.BaseSoftDeletableEntity&lt;System.Guid&gt;" />
 /// <seealso cref="Moda.Common.Domain.Interfaces.IActivatable" />
-public sealed class Workflow : BaseSoftDeletableEntity<Guid>, IActivatable, IHasIdAndKey
+public sealed class Workflow : BaseSoftDeletableEntity, IActivatable, IHasIdAndKey
 {
     private readonly List<WorkflowScheme> _schemes = [];
     private string _name = null!;

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkflowScheme.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/WorkflowScheme.cs
@@ -4,7 +4,7 @@ using NodaTime;
 
 namespace Moda.Work.Domain.Models;
 
-public sealed class WorkflowScheme : BaseSoftDeletableEntity<Guid>, IActivatable
+public sealed class WorkflowScheme : BaseSoftDeletableEntity, IActivatable
 {
     private WorkflowScheme() { }
     internal WorkflowScheme(Guid workflowId, int workStatusId, WorkStatusCategory workStatusCategory, int order)

--- a/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/Workspace.cs
+++ b/Moda.Services/Moda.Work/src/Moda.Work.Domain/Models/Workspace.cs
@@ -15,7 +15,7 @@ namespace Moda.Work.Domain.Models;
 /// process. It supports operations such as adding and removing work items, updating workspace properties, and managing
 /// activation and deactivation states. Workspaces can be either owned internally or managed externally, with optional
 /// support for external work item URL templates.</remarks>
-public sealed class Workspace : BaseSoftDeletableEntity<Guid>, IActivatable<WorkspaceActivatableArgs, Instant>, IHasWorkspaceIdAndKey
+public sealed class Workspace : BaseSoftDeletableEntity, IActivatable<WorkspaceActivatableArgs, Instant>, IHasWorkspaceIdAndKey
 {
     private WorkspaceKey _key = null!;
     private string _name = null!;


### PR DESCRIPTION
Switched from relying on the database to generate Guid based Id's to allowing classes to generate them via Guid.CreateVersion7().
- Add non-generic base entity classes with Guid keys
- Refactor: Remove Guid generics from entity base classes
- Set all entity Ids to ValueGeneratedNever in EF configs