### PR TITLE
Bug/create project task failing

### DIFF
--- a/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/_components/roadmap-items-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/planning/roadmaps/_components/roadmap-items-grid.tsx
@@ -27,7 +27,7 @@ import {
   usePatchRoadmapItemMutation,
   useUpdateRoadmapActivityPlacementMutation,
 } from '@/src/store/features/planning/roadmaps-api'
-import { FC, ReactNode, useRef, useState } from 'react'
+import { FC, ReactNode, useCallback, useMemo, useRef, useState } from 'react'
 import EditRoadmapActivityForm from './edit-roadmap-activity-form'
 import DeleteRoadmapItemForm from './delete-roadmap-item-form'
 import EditRoadmapTimeboxForm from './edit-roadmap-timebox-form'
@@ -144,425 +144,455 @@ const RoadmapItemsGrid: FC<RoadmapItemsGridProps> = ({
 
   const enableDragAndDrop = isRoadmapManager
 
-  const onEditItem = (item: RoadmapItemTreeNode) => {
+  const onEditItem = useCallback((item: RoadmapItemTreeNode) => {
     setSelectedItemId(item.id)
     if (item.type === 'Activity') {
       setOpenUpdateRoadmapActivityForm(true)
     } else if (item.type === 'Timebox') {
       setOpenUpdateRoadmapTimeboxForm(true)
     }
-  }
+  }, [])
 
-  const onDeleteItem = (item: RoadmapItemTreeNode) => {
+  const onDeleteItem = useCallback((item: RoadmapItemTreeNode) => {
     setSelectedItemId(item.id)
     setOpenDeleteRoadmapItemForm(true)
-  }
+  }, [])
 
-  const treeData = roadmapItemsIsLoading
-    ? []
-    : roadmapItemsData.map((item) => mapToTreeNode(item))
+  const treeData = useMemo(() => {
+    if (roadmapItemsIsLoading) return []
+    return roadmapItemsData.map((item) => mapToTreeNode(item))
+  }, [roadmapItemsData, roadmapItemsIsLoading])
 
-  const roadmapActivityMoveValidator: MoveValidator<RoadmapItemTreeNode> = (
-    activeNode,
-    targetParentNode,
-    targetParentId,
-  ) => {
-    // Only activities can be dragged
-    if (activeNode.node.type !== 'Activity') {
-      return { canMove: false, reason: 'Only activities can be reordered' }
-    }
-    const result = defaultMoveValidator(
-      activeNode,
-      targetParentNode,
-      targetParentId,
-    )
-    if (!result.canMove) return result
-    // Activities can only be dropped into other activities or root
-    if (targetParentNode && targetParentNode.type !== 'Activity') {
-      return {
-        canMove: false,
-        reason: 'Activities can only be placed under other activities',
+  const roadmapActivityMoveValidator: MoveValidator<RoadmapItemTreeNode> =
+    useCallback((activeNode, targetParentNode, targetParentId) => {
+      // Only activities can be dragged
+      if (activeNode.node.type !== 'Activity') {
+        return { canMove: false, reason: 'Only activities can be reordered' }
       }
-    }
-    return { canMove: true }
-  }
-
-  const handleNodeMove = async (
-    nodeId: string,
-    parentId: string | null,
-    order: number,
-  ) => {
-    try {
-      await updateActivityPlacement({
-        request: {
-          roadmapId,
-          itemId: nodeId,
-          parentId: parentId ?? undefined,
-          order,
-        },
-      }).unwrap()
-      refreshRoadmapItems()
-    } catch (error: any) {
-      messageApi.error(
-        error?.data?.detail ||
-          'Failed to reorganize activity. Please try again.',
+      const result = defaultMoveValidator(
+        activeNode,
+        targetParentNode,
+        targetParentId,
       )
-    }
-  }
-
-  const createDraftRoadmapItem = (draft: DraftItem): RoadmapItemTreeNode => ({
-    id: draft.id,
-    name: '',
-    type: 'Activity',
-    $type: 'activity',
-    parentId: draft.parentId ?? null,
-    start: null,
-    end: null,
-    date: null,
-    color: null,
-    children: [],
-  })
-
-  const handleSaveRoadmapItem = async (
-    itemId: string,
-    updates: Record<string, any>,
-  ): Promise<boolean> => {
-    const isDraft = itemId.startsWith('draft-')
-
-    try {
-      if (isDraft) {
-        const draft = draftsRef.current.find((d) => d.id === itemId)
-        if (!draft) return false
-
-        const itemType =
-          updates.itemType === 'timebox' ? 'timebox' : 'activity'
-        const request:
-          | CreateRoadmapActivityRequest
-          | CreateRoadmapTimeboxRequest = {
-          $type: itemType,
-          roadmapId,
-          parentId: draft.parentId,
-          name: updates.name || '',
-          start: updates.start,
-          end: updates.end,
-          ...(itemType === 'activity' ? { color: updates.color } : {}),
-        } as CreateRoadmapActivityRequest | CreateRoadmapTimeboxRequest
-
-        const response = await createRoadmapItem(request)
-        if (response.error) throw response.error
-      } else {
-        const item = findNodeById(
-          treeData,
-          itemId,
-        ) as RoadmapItemTreeNode | null
-        if (!item) return false
-
-        const patchOperations: Array<{
-          op: 'replace' | 'add' | 'remove'
-          path: string
-          value?: any
-        }> = []
-
-        if (updates.name !== undefined) {
-          patchOperations.push({
-            op: 'replace',
-            path: '/name',
-            value: updates.name,
-          })
+      if (!result.canMove) return result
+      // Activities can only be dropped into other activities or root
+      if (targetParentNode && targetParentNode.type !== 'Activity') {
+        return {
+          canMove: false,
+          reason: 'Activities can only be placed under other activities',
         }
-        if (updates.start !== undefined) {
-          patchOperations.push({
-            op: 'replace',
-            path: item.type === 'Milestone' ? '/date' : '/start',
-            value: updates.start,
-          })
-        }
-        if (updates.end !== undefined && item.type !== 'Milestone') {
-          patchOperations.push({
-            op: 'replace',
-            path: '/end',
-            value: updates.end,
-          })
-        }
-        if (updates.color !== undefined) {
-          patchOperations.push({
-            op: 'replace',
-            path: '/color',
-            value: updates.color,
-          })
-        }
+      }
+      return { canMove: true }
+    }, [])
 
-        if (patchOperations.length === 0) return true
-
-        await patchRoadmapItem({
-          roadmapId,
-          itemId,
-          patchOperations,
+  const handleNodeMove = useCallback(
+    async (nodeId: string, parentId: string | null, order: number) => {
+      try {
+        await updateActivityPlacement({
+          request: {
+            roadmapId,
+            itemId: nodeId,
+            parentId: parentId ?? undefined,
+            order,
+          },
         }).unwrap()
+        refreshRoadmapItems()
+      } catch (error: any) {
+        messageApi.error(
+          error?.data?.detail ||
+            'Failed to reorganize activity. Please try again.',
+        )
       }
+    },
+    [roadmapId, updateActivityPlacement, refreshRoadmapItems, messageApi],
+  )
 
-      setFieldErrors({})
-      messageApi.success(
-        isDraft
-          ? updates.itemType === 'timebox'
-            ? 'Roadmap timebox created successfully.'
-            : 'Roadmap activity created successfully.'
-          : 'Roadmap item updated successfully.',
-      )
-      refreshRoadmapItems()
-      return true
-    } catch (error: any) {
-      const status = error?.status ?? error?.data?.status
-      const errors = error?.errors ?? error?.data?.errors
-      const detail = error?.detail ?? error?.data?.detail
+  const createDraftRoadmapItem = useCallback(
+    (draft: DraftItem): RoadmapItemTreeNode => ({
+      id: draft.id,
+      name: '',
+      type: 'Activity',
+      $type: 'activity',
+      parentId: draft.parentId ?? null,
+      start: null,
+      end: null,
+      date: null,
+      color: null,
+      children: [],
+    }),
+    [],
+  )
 
-      if (status === 422 && errors) {
-        const errorMap: Record<string, string> = {}
-        const errorFields: string[] = []
-        Object.entries(errors).forEach(([key, messages]) => {
-          const apiField = key.charAt(0).toLowerCase() + key.slice(1)
-          const fieldName =
-            apiField === 'type' || apiField === '$type'
-              ? 'itemType'
-              : apiField === 'date'
-                ? 'start'
-                : apiField
-          errorMap[fieldName] = Array.isArray(messages)
-            ? String(messages[0] ?? '')
-            : String(messages)
-          errorFields.push(fieldName)
-        })
-        setFieldErrors(errorMap)
+  const handleSaveRoadmapItem = useCallback(
+    async (itemId: string, updates: Record<string, any>): Promise<boolean> => {
+      const isDraft = itemId.startsWith('draft-')
 
-        setTimeout(() => {
-          const fieldToColumn: Record<string, string> = {
-            itemType: 'type',
-            type: 'type',
+      try {
+        if (isDraft) {
+          const draft = draftsRef.current.find((d) => d.id === itemId)
+          if (!draft) return false
+
+          const itemType =
+            updates.itemType === 'timebox' ? 'timebox' : 'activity'
+          const request:
+            | CreateRoadmapActivityRequest
+            | CreateRoadmapTimeboxRequest = {
+            $type: itemType,
+            roadmapId,
+            parentId: draft.parentId,
+            name: updates.name || '',
+            start: updates.start,
+            end: updates.end,
+            ...(itemType === 'activity' ? { color: updates.color } : {}),
+          } as CreateRoadmapActivityRequest | CreateRoadmapTimeboxRequest
+
+          const response = await createRoadmapItem(request)
+          if (response.error) throw response.error
+        } else {
+          const item = findNodeById(
+            treeData,
+            itemId,
+          ) as RoadmapItemTreeNode | null
+          if (!item) return false
+
+          const patchOperations: Array<{
+            op: 'replace' | 'add' | 'remove'
+            path: string
+            value?: any
+          }> = []
+
+          if (updates.name !== undefined) {
+            patchOperations.push({
+              op: 'replace',
+              path: '/name',
+              value: updates.name,
+            })
+          }
+          if (updates.start !== undefined) {
+            patchOperations.push({
+              op: 'replace',
+              path: item.type === 'Milestone' ? '/date' : '/start',
+              value: updates.start,
+            })
+          }
+          if (updates.end !== undefined && item.type !== 'Milestone') {
+            patchOperations.push({
+              op: 'replace',
+              path: '/end',
+              value: updates.end,
+            })
+          }
+          if (updates.color !== undefined) {
+            patchOperations.push({
+              op: 'replace',
+              path: '/color',
+              value: updates.color,
+            })
           }
 
-          let focused = false
-          for (const errorField of errorFields) {
-            const columnId = fieldToColumn[errorField] ?? errorField
-            const cellElement = document.querySelector(
-              `[data-cell-id="${itemId}-${columnId}"]`,
-            )
-            if (!cellElement) continue
+          if (patchOperations.length === 0) return true
 
-            const input = cellElement.querySelector(
-              'input, .ant-select, .ant-picker',
-            ) as HTMLElement | null
-            if (input) {
-              input.focus()
-              focused = true
-              break
+          await patchRoadmapItem({
+            roadmapId,
+            itemId,
+            patchOperations,
+          }).unwrap()
+        }
+
+        setFieldErrors({})
+        messageApi.success(
+          isDraft
+            ? updates.itemType === 'timebox'
+              ? 'Roadmap timebox created successfully.'
+              : 'Roadmap activity created successfully.'
+            : 'Roadmap item updated successfully.',
+        )
+        refreshRoadmapItems()
+        return true
+      } catch (error: any) {
+        const status = error?.status ?? error?.data?.status
+        const errors = error?.errors ?? error?.data?.errors
+        const detail = error?.detail ?? error?.data?.detail
+
+        if (status === 422 && errors) {
+          const errorMap: Record<string, string> = {}
+          const errorFields: string[] = []
+          Object.entries(errors).forEach(([key, messages]) => {
+            const apiField = key.charAt(0).toLowerCase() + key.slice(1)
+            const fieldName =
+              apiField === 'type' || apiField === '$type'
+                ? 'itemType'
+                : apiField === 'date'
+                  ? 'start'
+                  : apiField
+            errorMap[fieldName] = Array.isArray(messages)
+              ? String(messages[0] ?? '')
+              : String(messages)
+            errorFields.push(fieldName)
+          })
+          setFieldErrors(errorMap)
+
+          setTimeout(() => {
+            const fieldToColumn: Record<string, string> = {
+              itemType: 'type',
+              type: 'type',
             }
-          }
 
-          if (!focused) {
-            const cellElement = document.querySelector(
-              `[data-cell-id="${itemId}-name"]`,
-            )
-            const input = cellElement?.querySelector(
-              'input',
-            ) as HTMLElement | null
-            input?.focus()
-          }
-        }, 0)
+            let focused = false
+            for (const errorField of errorFields) {
+              const columnId = fieldToColumn[errorField] ?? errorField
+              const cellElement = document.querySelector(
+                `[data-cell-id="${itemId}-${columnId}"]`,
+              )
+              if (!cellElement) continue
 
-        messageApi.error('Correct the validation error(s) to continue.')
+              const input = cellElement.querySelector(
+                'input, .ant-select, .ant-picker',
+              ) as HTMLElement | null
+              if (input) {
+                input.focus()
+                focused = true
+                break
+              }
+            }
+
+            if (!focused) {
+              const cellElement = document.querySelector(
+                `[data-cell-id="${itemId}-name"]`,
+              )
+              const input = cellElement?.querySelector(
+                'input',
+              ) as HTMLElement | null
+              input?.focus()
+            }
+          }, 0)
+
+          messageApi.error('Correct the validation error(s) to continue.')
+          return false
+        }
+
+        messageApi.error(
+          detail ??
+            `An error occurred while ${isDraft ? 'creating' : 'updating'} the roadmap item. Please try again.`,
+        )
         return false
       }
+    },
+    [
+      createRoadmapItem,
+      messageApi,
+      patchRoadmapItem,
+      refreshRoadmapItems,
+      roadmapId,
+      treeData,
+    ],
+  )
 
-      messageApi.error(
-        detail ??
-          `An error occurred while ${isDraft ? 'creating' : 'updating'} the roadmap item. Please try again.`,
-      )
-      return false
-    }
-  }
+  const getFormValues = useCallback(
+    (rowId: string, data: RoadmapItemTreeNode[]) => {
+      const item = findNodeById(data, rowId) as RoadmapItemTreeNode | null
+      const isDraft = rowId.startsWith('draft-')
 
-  const getFormValues = (rowId: string, data: RoadmapItemTreeNode[]) => {
-    const item = findNodeById(data, rowId) as RoadmapItemTreeNode | null
-    const isDraft = rowId.startsWith('draft-')
-
-    if (isDraft || !item) {
-      return {
-        name: '',
-        itemType: 'activity',
-        start: null,
-        end: null,
-        color: null,
+      if (isDraft || !item) {
+        return {
+          name: '',
+          itemType: 'activity',
+          start: null,
+          end: null,
+          color: null,
+        }
       }
-    }
 
-    return {
-      name: item.name,
-      itemType: item.$type,
-      start:
-        item.type === 'Milestone'
-          ? item.date
-            ? dayjs(item.date)
-            : null
-          : item.start
-            ? dayjs(item.start)
-            : null,
-      end: item.end ? dayjs(item.end) : null,
-      color: item.color ?? null,
-    }
-  }
+      return {
+        name: item.name,
+        itemType: item.$type,
+        start:
+          item.type === 'Milestone'
+            ? item.date
+              ? dayjs(item.date)
+              : null
+            : item.start
+              ? dayjs(item.start)
+              : null,
+        end: item.end ? dayjs(item.end) : null,
+        color: item.color ?? null,
+      }
+    },
+    [],
+  )
 
-  const computeChanges = (
-    rowId: string,
-    formValues: Record<string, any>,
-    _data: RoadmapItemTreeNode[],
-  ) => {
-    if (!rowId.startsWith('draft-')) return null
+  const computeChanges = useCallback(
+    (
+      rowId: string,
+      formValues: Record<string, any>,
+      _data: RoadmapItemTreeNode[],
+    ) => {
+      if (!rowId.startsWith('draft-')) return null
 
-    const values = formValues as any
-    return {
-      name: values.name || '',
-      itemType: values.itemType || 'activity',
-      start: values.start ? values.start.format('YYYY-MM-DD') : null,
-      end: values.end ? values.end.format('YYYY-MM-DD') : null,
-      color: values.color ?? null,
-    }
-  }
+      const values = formValues as any
+      return {
+        name: values.name || '',
+        itemType: values.itemType || 'activity',
+        start: values.start ? values.start.format('YYYY-MM-DD') : null,
+        end: values.end ? values.end.format('YYYY-MM-DD') : null,
+        color: values.color ?? null,
+      }
+    },
+    [],
+  )
 
-  const computeRoadmapItemChanges = (
-    rowId: string,
-    formValues: Record<string, any>,
-    data: RoadmapItemTreeNode[],
-  ) => {
-    if (rowId.startsWith('draft-')) {
-      return computeChanges(rowId, formValues, data)
-    }
+  const computeRoadmapItemChanges = useCallback(
+    (
+      rowId: string,
+      formValues: Record<string, any>,
+      data: RoadmapItemTreeNode[],
+    ) => {
+      if (rowId.startsWith('draft-')) {
+        return computeChanges(rowId, formValues, data)
+      }
 
-    const item = findNodeById(data, rowId) as RoadmapItemTreeNode | null
-    if (!item) return null
+      const item = findNodeById(data, rowId) as RoadmapItemTreeNode | null
+      if (!item) return null
 
-    const values = formValues as any
-    const updates: Record<string, any> = {}
-    let hasChanges = false
+      const values = formValues as any
+      const updates: Record<string, any> = {}
+      let hasChanges = false
 
-    if (values.name !== item.name) {
-      updates.name = values.name
-      hasChanges = true
-    }
-
-    const currentStart =
-      item.type === 'Milestone'
-        ? item.date
-          ? dayjs(item.date).format('YYYY-MM-DD')
-          : null
-        : item.start
-          ? dayjs(item.start).format('YYYY-MM-DD')
-          : null
-    const nextStart = values.start ? values.start.format('YYYY-MM-DD') : null
-    if (nextStart !== currentStart) {
-      updates.start = nextStart
-      hasChanges = true
-    }
-
-    if (item.type !== 'Milestone') {
-      const currentEnd = item.end
-        ? dayjs(item.end).format('YYYY-MM-DD')
-        : null
-      const nextEnd = values.end ? values.end.format('YYYY-MM-DD') : null
-      if (nextEnd !== currentEnd) {
-        updates.end = nextEnd
+      if (values.name !== item.name) {
+        updates.name = values.name
         hasChanges = true
       }
-    }
 
-    const currentColor = item.color ?? null
-    const nextColor = values.color ?? null
-    if (nextColor !== currentColor) {
-      updates.color = nextColor
-      hasChanges = true
-    }
-
-    return hasChanges ? updates : null
-  }
-
-  const validateFields = (rowId: string, formValues: Record<string, any>) => {
-    if (!rowId.startsWith('draft-')) return {}
-
-    const errors: Record<string, string> = {}
-    const name = String(formValues.name ?? '').trim()
-    const start = formValues.start
-    const end = formValues.end
-
-    if (!name) {
-      errors.name = 'Name is required.'
-    }
-
-    if (!start || !end) {
-      const message = 'Start and end dates are required.'
-      errors.start = message
-      errors.end = message
-    } else if (!dayjs(start).isBefore(dayjs(end), 'day')) {
-      errors.end = 'End date must be after start date.'
-    }
-
-    return errors
-  }
-
-  const validateRoadmapItemFields = (
-    rowId: string,
-    formValues: Record<string, any>,
-  ) => {
-    if (rowId.startsWith('draft-')) {
-      return validateFields(rowId, formValues)
-    }
-
-    const item = findNodeById(treeData, rowId) as RoadmapItemTreeNode | null
-    if (!item) return {}
-
-    const errors: Record<string, string> = {}
-    const name = String(formValues.name ?? '').trim()
-    const start = formValues.start
-    const end = formValues.end
-
-    if (!name) {
-      errors.name = 'Name is required.'
-    }
-
-    if (item.type === 'Milestone') {
-      if (!start) {
-        errors.start = 'Date is required.'
+      const currentStart =
+        item.type === 'Milestone'
+          ? item.date
+            ? dayjs(item.date).format('YYYY-MM-DD')
+            : null
+          : item.start
+            ? dayjs(item.start).format('YYYY-MM-DD')
+            : null
+      const nextStart = values.start ? values.start.format('YYYY-MM-DD') : null
+      if (nextStart !== currentStart) {
+        updates.start = nextStart
+        hasChanges = true
       }
+
+      if (item.type !== 'Milestone') {
+        const currentEnd = item.end
+          ? dayjs(item.end).format('YYYY-MM-DD')
+          : null
+        const nextEnd = values.end ? values.end.format('YYYY-MM-DD') : null
+        if (nextEnd !== currentEnd) {
+          updates.end = nextEnd
+          hasChanges = true
+        }
+      }
+
+      const currentColor = item.color ?? null
+      const nextColor = values.color ?? null
+      if (nextColor !== currentColor) {
+        updates.color = nextColor
+        hasChanges = true
+      }
+
+      return hasChanges ? updates : null
+    },
+    [computeChanges],
+  )
+
+  const validateFields = useCallback(
+    (rowId: string, formValues: Record<string, any>) => {
+      if (!rowId.startsWith('draft-')) return {}
+
+      const errors: Record<string, string> = {}
+      const name = String(formValues.name ?? '').trim()
+      const start = formValues.start
+      const end = formValues.end
+
+      if (!name) {
+        errors.name = 'Name is required.'
+      }
+
+      if (!start || !end) {
+        const message = 'Start and end dates are required.'
+        errors.start = message
+        errors.end = message
+      } else if (!dayjs(start).isBefore(dayjs(end), 'day')) {
+        errors.end = 'End date must be after start date.'
+      }
+
       return errors
-    }
+    },
+    [],
+  )
 
-    if (!start || !end) {
-      const message = 'Start and end dates are required.'
-      errors.start = message
-      errors.end = message
-    } else if (!dayjs(start).isBefore(dayjs(end), 'day')) {
-      errors.end = 'End date must be after start date.'
-    }
+  const validateRoadmapItemFields = useCallback(
+    (rowId: string, formValues: Record<string, any>) => {
+      if (rowId.startsWith('draft-')) {
+        return validateFields(rowId, formValues)
+      }
 
-    return errors
-  }
+      const item = findNodeById(treeData, rowId) as RoadmapItemTreeNode | null
+      if (!item) return {}
 
-  const columns = (ctx: TreeGridColumnContext) =>
-    getRoadmapItemsGridColumns({
+      const errors: Record<string, string> = {}
+      const name = String(formValues.name ?? '').trim()
+      const start = formValues.start
+      const end = formValues.end
+
+      if (!name) {
+        errors.name = 'Name is required.'
+      }
+
+      if (item.type === 'Milestone') {
+        if (!start) {
+          errors.start = 'Date is required.'
+        }
+        return errors
+      }
+
+      if (!start || !end) {
+        const message = 'Start and end dates are required.'
+        errors.start = message
+        errors.end = message
+      } else if (!dayjs(start).isBefore(dayjs(end), 'day')) {
+        errors.end = 'End date must be after start date.'
+      }
+
+      return errors
+    },
+    [treeData, validateFields],
+  )
+
+  const columns = useCallback(
+    (ctx: TreeGridColumnContext) =>
+      getRoadmapItemsGridColumns({
+        isRoadmapManager,
+        selectedRowId: ctx.selectedRowId,
+        onEditItem,
+        onDeleteItem,
+        handleSaveRoadmapItem,
+        getFieldError: ctx.getFieldError,
+        handleKeyDown: ctx.handleKeyDown,
+        openRoadmapItemDrawer,
+        typeFilterOptions: TYPE_FILTER_OPTIONS,
+        isDragEnabled: ctx.isDragEnabled,
+        enableDragAndDrop,
+        addDraftItemAsChild: ctx.addDraftAsChild,
+        canCreateItems: ctx.canCreateDraft,
+        createTypeOptions: CREATE_TYPE_OPTIONS,
+        isSelectedDraftActivity: selectedDraftItemType !== 'timebox',
+      }),
+    [
       isRoadmapManager,
-      selectedRowId: ctx.selectedRowId,
+      openRoadmapItemDrawer,
       onEditItem,
       onDeleteItem,
       handleSaveRoadmapItem,
-      getFieldError: ctx.getFieldError,
-      handleKeyDown: ctx.handleKeyDown,
-      openRoadmapItemDrawer,
-      typeFilterOptions: TYPE_FILTER_OPTIONS,
-      isDragEnabled: ctx.isDragEnabled,
       enableDragAndDrop,
-      addDraftItemAsChild: ctx.addDraftAsChild,
-      canCreateItems: ctx.canCreateDraft,
-      createTypeOptions: CREATE_TYPE_OPTIONS,
-      isSelectedDraftActivity: selectedDraftItemType !== 'timebox',
-    })
+      selectedDraftItemType,
+    ],
+  )
 
   const onUpdateRoadmapActivityFormClosed = (wasSaved: boolean) => {
     setOpenUpdateRoadmapActivityForm(false)

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/projects/_components/project-plan-table.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/projects/_components/project-plan-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ProjectPlanNodeDto } from '@/src/services/moda-api'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import dayjs from 'dayjs'
 
 import { useMessage } from '@/src/components/contexts/messaging'
@@ -33,7 +33,6 @@ import {
 } from '@/src/store/features/ppm/project-tasks-api'
 import { useGetEmployeeOptionsQuery } from '@/src/store/features/organizations/employee-api'
 import { usePatchProjectPhaseMutation } from '@/src/store/features/ppm/projects-api'
-import { useState } from 'react'
 import { Form } from 'antd'
 
 interface ProjectPlanTableProps {
@@ -80,7 +79,10 @@ const ProjectPlanTable = ({
   const { data: taskTypeOptions = [] } = useGetTaskTypeOptionsQuery()
   const { data: employeeOptions = [] } = useGetEmployeeOptionsQuery(false)
 
-  const milestoneTypeValue = taskTypeOptions.find((opt) => opt.label === 'Milestone')?.value
+  const milestoneTypeValue = useMemo(
+    () => taskTypeOptions.find((opt) => opt.label === 'Milestone')?.value,
+    [taskTypeOptions],
+  )
 
   const [patchProjectTask] = usePatchProjectTaskMutation()
   const [patchProjectPhase] = usePatchProjectPhaseMutation()
@@ -157,514 +159,563 @@ const ProjectPlanTable = ({
     watchedPlannedStart,
   ])
 
-  const taskTypeFilterOptions = taskTypeOptions
+  const taskTypeFilterOptions = useMemo(
+    () =>
+      taskTypeOptions
         .map((o: any) => {
           const label = (o?.label ?? '') as string
           return label ? { label, value: label } : null
         })
-        .filter(Boolean)
+        .filter(Boolean),
+    [taskTypeOptions],
+  )
 
-  const taskStatusFilterOptions = taskStatusOptions
+  const taskStatusFilterOptions = useMemo(
+    () =>
+      taskStatusOptions
         .map((o: any) => {
           const label = (o?.label ?? '') as string
           return label ? { label, value: label } : null
         })
-        .filter(Boolean)
+        .filter(Boolean),
+    [taskStatusOptions],
+  )
 
-  const taskPriorityFilterOptions = taskPriorityOptions
+  const taskPriorityFilterOptions = useMemo(
+    () =>
+      taskPriorityOptions
         .map((o: any) => {
           const label = (o?.label ?? '') as string
           return label ? { label, value: label } : null
         })
-        .filter(Boolean)
+        .filter(Boolean),
+    [taskPriorityOptions],
+  )
 
-  const createDraftProjectTask = (draft: DraftItem): ProjectPlanNodeDto => ({
-    id: draft.id,
-    nodeType: 'Task',
-    key: '',
-    wbs: '',
-    name: '',
-    type: { id: 1, name: 'Task' },
-    status: { id: 1, name: 'Not Started' },
-    priority: { id: 2, name: 'Medium' },
-    assignees: [],
-    progress: 0,
-    order: draft.order,
-    children: [],
-  })
+  const createDraftProjectTask = useCallback(
+    (draft: DraftItem): ProjectPlanNodeDto => ({
+      id: draft.id,
+      nodeType: 'Task',
+      key: '',
+      wbs: '',
+      name: '',
+      type: { id: 1, name: 'Task' },
+      status: { id: 1, name: 'Not Started' },
+      priority: { id: 2, name: 'Medium' },
+      assignees: [],
+      progress: 0,
+      order: draft.order,
+      children: [],
+    }),
+    [],
+  )
 
-  const isPhaseNode = (node: ProjectPlanNodeDto | null | undefined) =>
-    node?.nodeType === 'Phase'
+  const isPhaseNode = useCallback(
+    (node: ProjectPlanNodeDto | null | undefined) => node?.nodeType === 'Phase',
+    [],
+  )
 
-  const projectTaskMoveValidator: MoveValidator<ProjectPlanNodeDto> = (
-    activeNode,
-    targetParentNode,
-    targetParentId,
-  ) => {
-    // Phases cannot be moved
-    if (isPhaseNode(activeNode.node)) {
-      return { canMove: false, reason: 'Phases cannot be moved' }
-    }
-    const result = defaultMoveValidator(
-      activeNode,
-      targetParentNode,
-      targetParentId,
-    )
-    if (!result.canMove) return result
-    if (targetParentNode?.type?.name === 'Milestone') {
-      return {
-        canMove: false,
-        reason: 'Milestones cannot have child tasks',
-      }
-    }
-    return { canMove: true }
-  }
-
-  const handleNodeMove = async (
-    nodeId: string,
-    parentId: string | null,
-    order: number,
-    overNodeId?: string,
-    overIndex?: number,
-  ) => {
-    let resolvedParentId = parentId
-
-    // When parentId is null (task dropped at root level), resolve to
-    // the nearest phase above the drop position in the flat tree.
-    if (resolvedParentId === null && overNodeId) {
-      const flatten = (nodes: ProjectPlanNodeDto[]): ProjectPlanNodeDto[] => {
-        const result: ProjectPlanNodeDto[] = []
-        for (const node of nodes) {
-          result.push(node)
-          if (node.children?.length) {
-            result.push(...flatten(node.children))
+  const projectTaskMoveValidator: MoveValidator<ProjectPlanNodeDto> =
+    useCallback(
+      (activeNode, targetParentNode, targetParentId) => {
+        // Phases cannot be moved
+        if (isPhaseNode(activeNode.node)) {
+          return { canMove: false, reason: 'Phases cannot be moved' }
+        }
+        const result = defaultMoveValidator(
+          activeNode,
+          targetParentNode,
+          targetParentId,
+        )
+        if (!result.canMove) return result
+        if (targetParentNode?.type?.name === 'Milestone') {
+          return {
+            canMove: false,
+            reason: 'Milestones cannot have child tasks',
           }
         }
-        return result
-      }
-      const flat = flatten(tasks)
-      const activeIdx = flat.findIndex((n) => n.id === nodeId)
-      const overIdx = overIndex ?? flat.findIndex((n) => n.id === overNodeId)
-      const isDraggingUp = activeIdx > overIdx
+        return { canMove: true }
+      },
+      [isPhaseNode],
+    )
 
-      // Scan backwards from over index to find the nearest phase
-      let nearestPhaseId: string | null = null
-      for (let i = Math.min(overIdx, flat.length - 1); i >= 0; i--) {
-        if (flat[i].nodeType === 'Phase') {
-          nearestPhaseId = flat[i].id
-          break
+  const handleNodeMove = useCallback(
+    async (
+      nodeId: string,
+      parentId: string | null,
+      order: number,
+      overNodeId?: string,
+      overIndex?: number,
+    ) => {
+      let resolvedParentId = parentId
+
+      // When parentId is null (task dropped at root level), resolve to
+      // the nearest phase above the drop position in the flat tree.
+      if (resolvedParentId === null && overNodeId) {
+        const flatten = (nodes: ProjectPlanNodeDto[]): ProjectPlanNodeDto[] => {
+          const result: ProjectPlanNodeDto[] = []
+          for (const node of nodes) {
+            result.push(node)
+            if (node.children?.length) {
+              result.push(...flatten(node.children))
+            }
+          }
+          return result
         }
-      }
+        const flat = flatten(tasks)
+        const activeIdx = flat.findIndex((n) => n.id === nodeId)
+        const overIdx = overIndex ?? flat.findIndex((n) => n.id === overNodeId)
+        const isDraggingUp = activeIdx > overIdx
 
-      if (nearestPhaseId) {
-        // If dragging up and the nearest phase is the task's current phase,
-        // use the phase above it instead (the user intends to leave this phase)
-        const activeNode = flat[activeIdx]
-        if (isDraggingUp && activeNode?.projectPhaseId === nearestPhaseId) {
-          const phases = flat.filter((n) => n.nodeType === 'Phase')
-          const phaseIdx = phases.findIndex((p) => p.id === nearestPhaseId)
-          if (phaseIdx > 0) {
-            resolvedParentId = phases[phaseIdx - 1].id
+        // Scan backwards from over index to find the nearest phase
+        let nearestPhaseId: string | null = null
+        for (let i = Math.min(overIdx, flat.length - 1); i >= 0; i--) {
+          if (flat[i].nodeType === 'Phase') {
+            nearestPhaseId = flat[i].id
+            break
+          }
+        }
+
+        if (nearestPhaseId) {
+          // If dragging up and the nearest phase is the task's current phase,
+          // use the phase above it instead (the user intends to leave this phase)
+          const activeNode = flat[activeIdx]
+          if (isDraggingUp && activeNode?.projectPhaseId === nearestPhaseId) {
+            const phases = flat.filter((n) => n.nodeType === 'Phase')
+            const phaseIdx = phases.findIndex((p) => p.id === nearestPhaseId)
+            if (phaseIdx > 0) {
+              resolvedParentId = phases[phaseIdx - 1].id
+            } else {
+              resolvedParentId = nearestPhaseId
+            }
           } else {
             resolvedParentId = nearestPhaseId
           }
-        } else {
-          resolvedParentId = nearestPhaseId
         }
       }
-    }
 
-    if (!resolvedParentId) {
-      messageApi.warning('Tasks must be placed within a phase')
-      return
-    }
+      if (!resolvedParentId) {
+        messageApi.warning('Tasks must be placed within a phase')
+        return
+      }
 
-    try {
-      await updateProjectTaskPlacement({
-        projectIdOrKey: projectKey,
-        id: nodeId,
-        request: {
-          taskId: nodeId,
-          parentId: resolvedParentId,
-          order,
-        },
-      }).unwrap()
-      await refetch()
-    } catch (error: any) {
-      messageApi.error(
-        error?.data?.detail || 'Failed to move task. Please try again.',
-      )
-    }
-  }
+      try {
+        await updateProjectTaskPlacement({
+          projectIdOrKey: projectKey,
+          id: nodeId,
+          request: {
+            taskId: nodeId,
+            parentId: resolvedParentId,
+            order,
+          },
+        }).unwrap()
+        await refetch()
+      } catch (error: any) {
+        messageApi.error(
+          error?.data?.detail || 'Failed to move task. Please try again.',
+        )
+      }
+    },
+    [projectKey, tasks, updateProjectTaskPlacement, refetch, messageApi],
+  )
 
-  const handleTaskError = (
-    error: any,
-    taskId: string,
-    fallbackMessage: string,
-  ): false => {
-    const status = error?.status ?? error?.data?.status
-    const errors = error?.errors ?? error?.data?.errors
-    const detail = error?.detail ?? error?.data?.detail
+  const handleTaskError = useCallback(
+    (error: any, taskId: string, fallbackMessage: string): false => {
+      const status = error?.status ?? error?.data?.status
+      const errors = error?.errors ?? error?.data?.errors
+      const detail = error?.detail ?? error?.data?.detail
 
-    if (status === 422 && errors) {
-      const errorMap: Record<string, string> = {}
-      const errorFields: string[] = []
-      Object.entries(errors).forEach(([key, messages]) => {
-        const fieldName = key.charAt(0).toLowerCase() + key.slice(1)
-        errorMap[fieldName] = Array.isArray(messages) ? messages[0] : messages
-        errorFields.push(fieldName)
-      })
-      setFieldErrors(errorMap)
+      if (status === 422 && errors) {
+        const errorMap: Record<string, string> = {}
+        const errorFields: string[] = []
+        Object.entries(errors).forEach(([key, messages]) => {
+          const fieldName = key.charAt(0).toLowerCase() + key.slice(1)
+          errorMap[fieldName] = Array.isArray(messages) ? messages[0] : messages
+          errorFields.push(fieldName)
+        })
+        setFieldErrors(errorMap)
 
-      setTimeout(() => {
-        let focused = false
-        for (const errorField of errorFields) {
-          const columnId =
-            errorField === 'plannedDate'
-              ? 'plannedStart'
-              : errorField.replace(/Id$/, '')
-          const cellElement = document.querySelector(
-            `[data-cell-id="${taskId}-${columnId}"]`,
-          )
-          if (cellElement) {
-            const input = cellElement.querySelector(
-              'input, .ant-select',
-            ) as HTMLElement
-            if (input) {
-              input.focus()
-              focused = true
-              break
+        setTimeout(() => {
+          let focused = false
+          for (const errorField of errorFields) {
+            const columnId =
+              errorField === 'plannedDate'
+                ? 'plannedStart'
+                : errorField.replace(/Id$/, '')
+            const cellElement = document.querySelector(
+              `[data-cell-id="${taskId}-${columnId}"]`,
+            )
+            if (cellElement) {
+              const input = cellElement.querySelector(
+                'input, .ant-select',
+              ) as HTMLElement
+              if (input) {
+                input.focus()
+                focused = true
+                break
+              }
             }
           }
-        }
-        if (!focused) {
-          const cellElement = document.querySelector(
-            `[data-cell-id="${taskId}-name"]`,
-          )
-          if (cellElement) {
-            const input = cellElement.querySelector('input') as HTMLElement
-            input?.focus()
+          if (!focused) {
+            const cellElement = document.querySelector(
+              `[data-cell-id="${taskId}-name"]`,
+            )
+            if (cellElement) {
+              const input = cellElement.querySelector('input') as HTMLElement
+              input?.focus()
+            }
           }
-        }
-      }, 0)
+        }, 0)
 
-      messageApi.error('Correct the validation error(s) to continue.')
-    } else {
-      messageApi.error(detail ?? fallbackMessage)
-    }
-    return false
-  }
-
-  const handleUpdateTask = async (
-    taskId: string,
-    updates: Partial<any>,
-  ): Promise<boolean> => {
-    if (!projectKey) return false
-
-    const isDraft = taskId.startsWith('draft-')
-
-    if (isDraft) {
-      try {
-        const draft = draftsRef.current.find((d) => d.id === taskId)
-        if (!draft) return false
-
-        const request: any = {
-          name: updates.name || '',
-          typeId: updates.typeId || 1,
-          statusId: updates.statusId || 1,
-          priorityId: updates.priorityId || 2,
-          assigneeIds: updates.assigneeIds || [],
-          progress: updates.progress,
-          parentId: draft.parentId,
-          plannedStart: updates.plannedStart,
-          plannedEnd: updates.plannedEnd,
-          plannedDate: updates.plannedDate,
-          estimatedEffortHours: updates.estimatedEffortHours,
-        }
-
-        const response = await createProjectTask({
-          projectIdOrKey: projectKey,
-          request,
-        })
-
-        if (response.error) throw response.error
-
-        messageApi.success(`Task created: ${response.data.key}`)
-        await refetch()
-        return true
-      } catch (error: any) {
-        return handleTaskError(
-          error,
-          taskId,
-          'An error occurred while creating the project task. Please try again.',
-        )
+        messageApi.error('Correct the validation error(s) to continue.')
+      } else {
+        messageApi.error(detail ?? fallbackMessage)
       }
-    } else {
-      const node = findNodeById(
-        tasks || [],
-        taskId,
-      ) as ProjectPlanNodeDto | null
-      if (!node) return false
+      return false
+    },
+    [messageApi, setFieldErrors],
+  )
 
-      try {
-        if (isPhaseNode(node)) {
-          const patchOperations = buildProjectPhasePatchOperations(updates)
-          const response = await patchProjectPhase({
-            projectId,
-            phaseId: taskId,
-            patchOperations,
-            cacheKey: taskId,
-          })
-          if (response.error) throw response.error
-        } else {
-          const patchOperations = buildProjectTaskPatchOperations(updates)
-          const response = await patchProjectTask({
+  const handleUpdateTask = useCallback(
+    async (taskId: string, updates: Partial<any>): Promise<boolean> => {
+      if (!projectKey) return false
+
+      const isDraft = taskId.startsWith('draft-')
+
+      if (isDraft) {
+        try {
+          const draft = draftsRef.current.find((d) => d.id === taskId)
+          if (!draft) return false
+
+          const request: any = {
+            name: updates.name || '',
+            typeId: updates.typeId || 1,
+            statusId: updates.statusId || 1,
+            priorityId: updates.priorityId || 2,
+            assigneeIds: updates.assigneeIds || [],
+            progress: updates.progress,
+            parentId: draft.parentId,
+            plannedStart: updates.plannedStart,
+            plannedEnd: updates.plannedEnd,
+            plannedDate: updates.plannedDate,
+            estimatedEffortHours: updates.estimatedEffortHours,
+          }
+
+          const response = await createProjectTask({
             projectIdOrKey: projectKey,
-            taskId,
-            patchOperations,
-            cacheKey: taskId,
+            request,
           })
-          if (response.error) throw response.error
-        }
-        await refetch()
-        return true
-      } catch (error: any) {
-        const entityName = isPhaseNode(node) ? 'phase' : 'task'
-        return handleTaskError(
-          error,
-          taskId,
-          `An error occurred while updating the project ${entityName}. Please try again.`,
-        )
-      }
-    }
-  }
 
-  const handleEditTask = (task: any) => {
+          if (response.error) throw response.error
+
+          messageApi.success(`Task created: ${response.data.key}`)
+          await refetch()
+          return true
+        } catch (error: any) {
+          return handleTaskError(
+            error,
+            taskId,
+            'An error occurred while creating the project task. Please try again.',
+          )
+        }
+      } else {
+        const node = findNodeById(
+          tasks || [],
+          taskId,
+        ) as ProjectPlanNodeDto | null
+        if (!node) return false
+
+        try {
+          if (isPhaseNode(node)) {
+            const patchOperations = buildProjectPhasePatchOperations(updates)
+            const response = await patchProjectPhase({
+              projectId,
+              phaseId: taskId,
+              patchOperations,
+              cacheKey: taskId,
+            })
+            if (response.error) throw response.error
+          } else {
+            const patchOperations = buildProjectTaskPatchOperations(updates)
+            const response = await patchProjectTask({
+              projectIdOrKey: projectKey,
+              taskId,
+              patchOperations,
+              cacheKey: taskId,
+            })
+            if (response.error) throw response.error
+          }
+          await refetch()
+          return true
+        } catch (error: any) {
+          const entityName = isPhaseNode(node) ? 'phase' : 'task'
+          return handleTaskError(
+            error,
+            taskId,
+            `An error occurred while updating the project ${entityName}. Please try again.`,
+          )
+        }
+      }
+    },
+    [
+      messageApi,
+      projectId,
+      projectKey,
+      refetch,
+      tasks,
+      patchProjectTask,
+      patchProjectPhase,
+      createProjectTask,
+      handleTaskError,
+      isPhaseNode,
+    ],
+  )
+
+  const handleEditTask = useCallback((task: any) => {
     setSelectedTaskId(task.id)
     setOpenEditTaskForm(true)
-  }
+  }, [])
 
-  const handleEditPhase = (phase: any) => {
+  const handleEditPhase = useCallback((phase: any) => {
     setSelectedPhaseId(phase.id)
     setOpenEditPhaseForm(true)
-  }
+  }, [])
 
-  const handleDeleteTask = (task: any) => {
+  const handleDeleteTask = useCallback((task: any) => {
     setSelectedTaskId(task.id)
     setOpenDeleteTaskForm(true)
-  }
+  }, [])
 
-  const onEditTaskFormClosed = (wasSaved: boolean) => {
-    setOpenEditTaskForm(false)
-    setSelectedTaskId(undefined)
-    if (wasSaved) refetch()
-  }
+  const onEditTaskFormClosed = useCallback(
+    (wasSaved: boolean) => {
+      setOpenEditTaskForm(false)
+      setSelectedTaskId(undefined)
+      if (wasSaved) refetch()
+    },
+    [refetch],
+  )
 
-  const onDeleteTaskFormClosed = (wasDeleted: boolean) => {
-    setOpenDeleteTaskForm(false)
-    setSelectedTaskId(undefined)
-    if (wasDeleted) refetch()
-  }
+  const onDeleteTaskFormClosed = useCallback(
+    (wasDeleted: boolean) => {
+      setOpenDeleteTaskForm(false)
+      setSelectedTaskId(undefined)
+      if (wasDeleted) refetch()
+    },
+    [refetch],
+  )
 
-  const onCreateTaskFormClosed = (wasSaved: boolean) => {
-    setOpenCreateTaskForm(false)
-    if (wasSaved) refetch()
-  }
+  const onCreateTaskFormClosed = useCallback(
+    (wasSaved: boolean) => {
+      setOpenCreateTaskForm(false)
+      if (wasSaved) refetch()
+    },
+    [refetch],
+  )
 
-  const getFormValues = (rowId: string, data: ProjectPlanNodeDto[]) => {
-    const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
-    const isDraft = rowId.startsWith('draft-')
+  const getFormValues = useCallback(
+    (rowId: string, data: ProjectPlanNodeDto[]) => {
+      const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
+      const isDraft = rowId.startsWith('draft-')
 
-    if (isDraft || !task) {
-      return {
-        name: '',
-        typeId: 1,
-        statusId: 1,
-        priorityId: 2,
-        assigneeIds: [],
-        progress: 0,
-        plannedStart: null,
-        plannedEnd: null,
-        plannedDate: null,
-        estimatedEffortHours: null,
+      if (isDraft || !task) {
+        return {
+          name: '',
+          typeId: 1,
+          statusId: 1,
+          priorityId: 2,
+          assigneeIds: [],
+          progress: 0,
+          plannedStart: null,
+          plannedEnd: null,
+          plannedDate: null,
+          estimatedEffortHours: null,
+        }
       }
-    }
 
-    // Phase rows: limited fields
-    if (isPhaseNode(task)) {
+      // Phase rows: limited fields
+      if (isPhaseNode(task)) {
+        return {
+          statusId: task.status?.id,
+          assigneeIds: task.assignees?.map((a) => a.id) ?? [],
+          plannedStart: task.start ? dayjs(task.start) : null,
+          plannedEnd: task.end ? dayjs(task.end) : null,
+          progress: task.progress,
+        }
+      }
+
       return {
+        name: task.name,
+        typeId: task.type?.id,
         statusId: task.status?.id,
+        priorityId: task.priority?.id,
         assigneeIds: task.assignees?.map((a) => a.id) ?? [],
+        progress: task.progress,
         plannedStart: task.start ? dayjs(task.start) : null,
         plannedEnd: task.end ? dayjs(task.end) : null,
-        progress: task.progress,
+        plannedDate: task.plannedDate ? dayjs(task.plannedDate) : null,
+        estimatedEffortHours: task.estimatedEffortHours,
       }
-    }
+    },
+    [isPhaseNode],
+  )
 
-    return {
-      name: task.name,
-      typeId: task.type?.id,
-      statusId: task.status?.id,
-      priorityId: task.priority?.id,
-      assigneeIds: task.assignees?.map((a) => a.id) ?? [],
-      progress: task.progress,
-      plannedStart: task.start ? dayjs(task.start) : null,
-      plannedEnd: task.end ? dayjs(task.end) : null,
-      plannedDate: task.plannedDate ? dayjs(task.plannedDate) : null,
-      estimatedEffortHours: task.estimatedEffortHours,
-    }
-  }
+  const computeChanges = useCallback(
+    (
+      rowId: string,
+      formValues: Record<string, any>,
+      data: ProjectPlanNodeDto[],
+    ) => {
+      const isDraft = rowId.startsWith('draft-')
+      const values = formValues as any
+      const completedStatusValue = taskStatusOptions.find(
+        (opt) => opt.label === 'Completed',
+      )?.value
+      const isCompleted = values.statusId === completedStatusValue
 
-  const computeChanges = (
-    rowId: string,
-    formValues: Record<string, any>,
-    data: ProjectPlanNodeDto[],
-  ) => {
-    const isDraft = rowId.startsWith('draft-')
-    const values = formValues as any
-    const completedStatusValue = taskStatusOptions.find(
-      (opt) => opt.label === 'Completed',
-    )?.value
-    const isCompleted = values.statusId === completedStatusValue
-
-    if (isDraft) {
-      const updates: Record<string, any> = {
-        name: values.name || '',
-        typeId: values.typeId,
-        statusId: values.statusId,
-        priorityId: values.priorityId,
-        assigneeIds: values.assigneeIds ?? [],
+      if (isDraft) {
+        const updates: Record<string, any> = {
+          name: values.name || '',
+          typeId: values.typeId,
+          statusId: values.statusId,
+          priorityId: values.priorityId,
+          assigneeIds: values.assigneeIds ?? [],
+        }
+        if (isSelectedRowMilestone) {
+          updates.plannedStart = null
+          updates.plannedEnd = null
+          updates.plannedDate = values.plannedDate
+            ? values.plannedDate.format('YYYY-MM-DD')
+            : null
+          updates.progress = null
+          updates.estimatedEffortHours = null
+        } else {
+          updates.plannedStart = values.plannedStart
+            ? values.plannedStart.format('YYYY-MM-DD')
+            : null
+          updates.plannedEnd = values.plannedEnd
+            ? values.plannedEnd.format('YYYY-MM-DD')
+            : null
+          updates.plannedDate = null
+          updates.progress = isCompleted ? 100 : (values.progress ?? 0)
+          updates.estimatedEffortHours = values.estimatedEffortHours
+            ? Number(values.estimatedEffortHours)
+            : null
+        }
+        return updates
       }
-      if (isSelectedRowMilestone) {
-        updates.plannedStart = null
-        updates.plannedEnd = null
-        updates.plannedDate = values.plannedDate
-          ? values.plannedDate.format('YYYY-MM-DD')
-          : null
-        updates.progress = null
-        updates.estimatedEffortHours = null
-      } else {
-        updates.plannedStart = values.plannedStart
-          ? values.plannedStart.format('YYYY-MM-DD')
-          : null
-        updates.plannedEnd = values.plannedEnd
-          ? values.plannedEnd.format('YYYY-MM-DD')
-          : null
-        updates.plannedDate = null
-        updates.progress = isCompleted ? 100 : (values.progress ?? 0)
+
+      const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
+      if (!task) return null
+
+      const updates: Record<string, any> = {}
+      let hasChanges = false
+
+      if (values.name !== task.name) {
+        updates.name = values.name
+        hasChanges = true
+      }
+      if (values.statusId !== task.status?.id) {
+        updates.statusId = values.statusId
+        hasChanges = true
+      }
+      if (values.priorityId !== task.priority?.id) {
+        updates.priorityId = values.priorityId
+        hasChanges = true
+      }
+
+      const taskAssigneeIds = task.assignees?.map((a) => a.id) ?? []
+      const formAssigneeIds = values.assigneeIds ?? []
+      const assigneesChanged =
+        taskAssigneeIds.length !== formAssigneeIds.length ||
+        !taskAssigneeIds.every((id: string) => formAssigneeIds.includes(id))
+      if (assigneesChanged) {
+        updates.assigneeIds = formAssigneeIds
+        hasChanges = true
+      }
+
+      const taskPlannedStart = task.start
+        ? String(task.start).split('T')[0]
+        : null
+      const plannedStartFormatted = values.plannedStart
+        ? values.plannedStart.format('YYYY-MM-DD')
+        : null
+      if (plannedStartFormatted !== taskPlannedStart) {
+        updates.plannedStart = plannedStartFormatted
+        hasChanges = true
+      }
+
+      const taskPlannedEnd = task.end ? String(task.end).split('T')[0] : null
+      const plannedEndFormatted = values.plannedEnd
+        ? values.plannedEnd.format('YYYY-MM-DD')
+        : null
+      if (plannedEndFormatted !== taskPlannedEnd) {
+        updates.plannedEnd = plannedEndFormatted
+        hasChanges = true
+      }
+
+      const taskPlannedDate = task.plannedDate
+        ? String(task.plannedDate).split('T')[0]
+        : null
+      const plannedDateFormatted = values.plannedDate
+        ? values.plannedDate.format('YYYY-MM-DD')
+        : null
+      if (plannedDateFormatted !== taskPlannedDate) {
+        updates.plannedDate = plannedDateFormatted
+        hasChanges = true
+      }
+
+      const effectiveProgress = isCompleted ? 100 : values.progress
+      if (effectiveProgress !== task.progress) {
+        updates.progress = effectiveProgress
+        hasChanges = true
+      }
+
+      if (values.estimatedEffortHours !== task.estimatedEffortHours) {
         updates.estimatedEffortHours = values.estimatedEffortHours
           ? Number(values.estimatedEffortHours)
           : null
+        hasChanges = true
       }
-      return updates
-    }
 
-    const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
-    if (!task) return null
+      return hasChanges ? updates : null
+    },
+    [isSelectedRowMilestone, taskStatusOptions],
+  )
 
-    const updates: Record<string, any> = {}
-    let hasChanges = false
+  const validateFields = useCallback(
+    (rowId: string, formValues: Record<string, any>) => {
+      const isDraft = rowId.startsWith('draft-')
+      const task = findNodeById(tasks, rowId) as ProjectPlanNodeDto | null
+      const isMilestone = isDraft
+        ? isSelectedRowMilestone
+        : task?.type?.name === 'Milestone'
 
-    if (values.name !== task.name) {
-      updates.name = values.name
-      hasChanges = true
-    }
-    if (values.statusId !== task.status?.id) {
-      updates.statusId = values.statusId
-      hasChanges = true
-    }
-    if (values.priorityId !== task.priority?.id) {
-      updates.priorityId = values.priorityId
-      hasChanges = true
-    }
+      if (isMilestone) return {}
 
-    const taskAssigneeIds = task.assignees?.map((a) => a.id) ?? []
-    const formAssigneeIds = values.assigneeIds ?? []
-    const assigneesChanged =
-      taskAssigneeIds.length !== formAssigneeIds.length ||
-      !taskAssigneeIds.every((id: string) => formAssigneeIds.includes(id))
-    if (assigneesChanged) {
-      updates.assigneeIds = formAssigneeIds
-      hasChanges = true
-    }
+      const errors: Record<string, string> = {}
+      const hasPlannedStart = Boolean(formValues.plannedStart)
+      const hasPlannedEnd = Boolean(formValues.plannedEnd)
 
-    const taskPlannedStart = task.start
-      ? String(task.start).split('T')[0]
-      : null
-    const plannedStartFormatted = values.plannedStart
-      ? values.plannedStart.format('YYYY-MM-DD')
-      : null
-    if (plannedStartFormatted !== taskPlannedStart) {
-      updates.plannedStart = plannedStartFormatted
-      hasChanges = true
-    }
-
-    const taskPlannedEnd = task.end ? String(task.end).split('T')[0] : null
-    const plannedEndFormatted = values.plannedEnd
-      ? values.plannedEnd.format('YYYY-MM-DD')
-      : null
-    if (plannedEndFormatted !== taskPlannedEnd) {
-      updates.plannedEnd = plannedEndFormatted
-      hasChanges = true
-    }
-
-    const taskPlannedDate = task.plannedDate
-      ? String(task.plannedDate).split('T')[0]
-      : null
-    const plannedDateFormatted = values.plannedDate
-      ? values.plannedDate.format('YYYY-MM-DD')
-      : null
-    if (plannedDateFormatted !== taskPlannedDate) {
-      updates.plannedDate = plannedDateFormatted
-      hasChanges = true
-    }
-
-    const effectiveProgress = isCompleted ? 100 : values.progress
-    if (effectiveProgress !== task.progress) {
-      updates.progress = effectiveProgress
-      hasChanges = true
-    }
-
-    if (values.estimatedEffortHours !== task.estimatedEffortHours) {
-      updates.estimatedEffortHours = values.estimatedEffortHours
-        ? Number(values.estimatedEffortHours)
-        : null
-      hasChanges = true
-    }
-
-    return hasChanges ? updates : null
-  }
-
-  const validateFields = (rowId: string, formValues: Record<string, any>) => {
-    const isDraft = rowId.startsWith('draft-')
-    const task = findNodeById(tasks, rowId) as ProjectPlanNodeDto | null
-    const isMilestone = isDraft
-      ? isSelectedRowMilestone
-      : task?.type?.name === 'Milestone'
-
-    if (isMilestone) return {}
-
-    const errors: Record<string, string> = {}
-    const hasPlannedStart = Boolean(formValues.plannedStart)
-    const hasPlannedEnd = Boolean(formValues.plannedEnd)
-
-    if (hasPlannedStart !== hasPlannedEnd) {
-      const message =
-        'Planned Start and Planned End must both have a value or both be empty.'
-      errors.plannedStart = message
-      errors.plannedEnd = message
-    }
-
-    if (hasPlannedStart && hasPlannedEnd) {
-      const plannedStart = dayjs(formValues.plannedStart)
-      const plannedEnd = dayjs(formValues.plannedEnd)
-      if (plannedEnd.isBefore(plannedStart, 'day')) {
-        errors.plannedEnd = 'Planned End cannot be earlier than Planned Start.'
+      if (hasPlannedStart !== hasPlannedEnd) {
+        const message =
+          'Planned Start and Planned End must both have a value or both be empty.'
+        errors.plannedStart = message
+        errors.plannedEnd = message
       }
-    }
 
-    return errors
-  }
+      if (hasPlannedStart && hasPlannedEnd) {
+        const plannedStart = dayjs(formValues.plannedStart)
+        const plannedEnd = dayjs(formValues.plannedEnd)
+        if (plannedEnd.isBefore(plannedStart, 'day')) {
+          errors.plannedEnd =
+            'Planned End cannot be earlier than Planned Start.'
+        }
+      }
+
+      return errors
+    },
+    [isSelectedRowMilestone, tasks],
+  )
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/app/ppm/projects/_components/project-plan-table.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/app/ppm/projects/_components/project-plan-table.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ProjectPlanNodeDto } from '@/src/services/moda-api'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import dayjs from 'dayjs'
 
 import { useMessage } from '@/src/components/contexts/messaging'
@@ -80,7 +80,10 @@ const ProjectPlanTable = ({
   const { data: taskTypeOptions = [] } = useGetTaskTypeOptionsQuery()
   const { data: employeeOptions = [] } = useGetEmployeeOptionsQuery(false)
 
-  const milestoneTypeValue = taskTypeOptions.find((opt) => opt.label === 'Milestone')?.value
+  const milestoneTypeValue = useMemo(
+    () => taskTypeOptions.find((opt) => opt.label === 'Milestone')?.value,
+    [taskTypeOptions],
+  )
 
   const [patchProjectTask] = usePatchProjectTaskMutation()
   const [patchProjectPhase] = usePatchProjectPhaseMutation()
@@ -157,514 +160,563 @@ const ProjectPlanTable = ({
     watchedPlannedStart,
   ])
 
-  const taskTypeFilterOptions = taskTypeOptions
+  const taskTypeFilterOptions = useMemo(
+    () =>
+      taskTypeOptions
         .map((o: any) => {
           const label = (o?.label ?? '') as string
           return label ? { label, value: label } : null
         })
-        .filter(Boolean)
+        .filter(Boolean),
+    [taskTypeOptions],
+  )
 
-  const taskStatusFilterOptions = taskStatusOptions
+  const taskStatusFilterOptions = useMemo(
+    () =>
+      taskStatusOptions
         .map((o: any) => {
           const label = (o?.label ?? '') as string
           return label ? { label, value: label } : null
         })
-        .filter(Boolean)
+        .filter(Boolean),
+    [taskStatusOptions],
+  )
 
-  const taskPriorityFilterOptions = taskPriorityOptions
+  const taskPriorityFilterOptions = useMemo(
+    () =>
+      taskPriorityOptions
         .map((o: any) => {
           const label = (o?.label ?? '') as string
           return label ? { label, value: label } : null
         })
-        .filter(Boolean)
+        .filter(Boolean),
+    [taskPriorityOptions],
+  )
 
-  const createDraftProjectTask = (draft: DraftItem): ProjectPlanNodeDto => ({
-    id: draft.id,
-    nodeType: 'Task',
-    key: '',
-    wbs: '',
-    name: '',
-    type: { id: 1, name: 'Task' },
-    status: { id: 1, name: 'Not Started' },
-    priority: { id: 2, name: 'Medium' },
-    assignees: [],
-    progress: 0,
-    order: draft.order,
-    children: [],
-  })
+  const createDraftProjectTask = useCallback(
+    (draft: DraftItem): ProjectPlanNodeDto => ({
+      id: draft.id,
+      nodeType: 'Task',
+      key: '',
+      wbs: '',
+      name: '',
+      type: { id: 1, name: 'Task' },
+      status: { id: 1, name: 'Not Started' },
+      priority: { id: 2, name: 'Medium' },
+      assignees: [],
+      progress: 0,
+      order: draft.order,
+      children: [],
+    }),
+    [],
+  )
 
-  const isPhaseNode = (node: ProjectPlanNodeDto | null | undefined) =>
-    node?.nodeType === 'Phase'
+  const isPhaseNode = useCallback(
+    (node: ProjectPlanNodeDto | null | undefined) => node?.nodeType === 'Phase',
+    [],
+  )
 
-  const projectTaskMoveValidator: MoveValidator<ProjectPlanNodeDto> = (
-    activeNode,
-    targetParentNode,
-    targetParentId,
-  ) => {
-    // Phases cannot be moved
-    if (isPhaseNode(activeNode.node)) {
-      return { canMove: false, reason: 'Phases cannot be moved' }
-    }
-    const result = defaultMoveValidator(
-      activeNode,
-      targetParentNode,
-      targetParentId,
-    )
-    if (!result.canMove) return result
-    if (targetParentNode?.type?.name === 'Milestone') {
-      return {
-        canMove: false,
-        reason: 'Milestones cannot have child tasks',
-      }
-    }
-    return { canMove: true }
-  }
-
-  const handleNodeMove = async (
-    nodeId: string,
-    parentId: string | null,
-    order: number,
-    overNodeId?: string,
-    overIndex?: number,
-  ) => {
-    let resolvedParentId = parentId
-
-    // When parentId is null (task dropped at root level), resolve to
-    // the nearest phase above the drop position in the flat tree.
-    if (resolvedParentId === null && overNodeId) {
-      const flatten = (nodes: ProjectPlanNodeDto[]): ProjectPlanNodeDto[] => {
-        const result: ProjectPlanNodeDto[] = []
-        for (const node of nodes) {
-          result.push(node)
-          if (node.children?.length) {
-            result.push(...flatten(node.children))
+  const projectTaskMoveValidator: MoveValidator<ProjectPlanNodeDto> =
+    useCallback(
+      (activeNode, targetParentNode, targetParentId) => {
+        // Phases cannot be moved
+        if (isPhaseNode(activeNode.node)) {
+          return { canMove: false, reason: 'Phases cannot be moved' }
+        }
+        const result = defaultMoveValidator(
+          activeNode,
+          targetParentNode,
+          targetParentId,
+        )
+        if (!result.canMove) return result
+        if (targetParentNode?.type?.name === 'Milestone') {
+          return {
+            canMove: false,
+            reason: 'Milestones cannot have child tasks',
           }
         }
-        return result
-      }
-      const flat = flatten(tasks)
-      const activeIdx = flat.findIndex((n) => n.id === nodeId)
-      const overIdx = overIndex ?? flat.findIndex((n) => n.id === overNodeId)
-      const isDraggingUp = activeIdx > overIdx
+        return { canMove: true }
+      },
+      [isPhaseNode],
+    )
 
-      // Scan backwards from over index to find the nearest phase
-      let nearestPhaseId: string | null = null
-      for (let i = Math.min(overIdx, flat.length - 1); i >= 0; i--) {
-        if (flat[i].nodeType === 'Phase') {
-          nearestPhaseId = flat[i].id
-          break
+  const handleNodeMove = useCallback(
+    async (
+      nodeId: string,
+      parentId: string | null,
+      order: number,
+      overNodeId?: string,
+      overIndex?: number,
+    ) => {
+      let resolvedParentId = parentId
+
+      // When parentId is null (task dropped at root level), resolve to
+      // the nearest phase above the drop position in the flat tree.
+      if (resolvedParentId === null && overNodeId) {
+        const flatten = (nodes: ProjectPlanNodeDto[]): ProjectPlanNodeDto[] => {
+          const result: ProjectPlanNodeDto[] = []
+          for (const node of nodes) {
+            result.push(node)
+            if (node.children?.length) {
+              result.push(...flatten(node.children))
+            }
+          }
+          return result
         }
-      }
+        const flat = flatten(tasks)
+        const activeIdx = flat.findIndex((n) => n.id === nodeId)
+        const overIdx = overIndex ?? flat.findIndex((n) => n.id === overNodeId)
+        const isDraggingUp = activeIdx > overIdx
 
-      if (nearestPhaseId) {
-        // If dragging up and the nearest phase is the task's current phase,
-        // use the phase above it instead (the user intends to leave this phase)
-        const activeNode = flat[activeIdx]
-        if (isDraggingUp && activeNode?.projectPhaseId === nearestPhaseId) {
-          const phases = flat.filter((n) => n.nodeType === 'Phase')
-          const phaseIdx = phases.findIndex((p) => p.id === nearestPhaseId)
-          if (phaseIdx > 0) {
-            resolvedParentId = phases[phaseIdx - 1].id
+        // Scan backwards from over index to find the nearest phase
+        let nearestPhaseId: string | null = null
+        for (let i = Math.min(overIdx, flat.length - 1); i >= 0; i--) {
+          if (flat[i].nodeType === 'Phase') {
+            nearestPhaseId = flat[i].id
+            break
+          }
+        }
+
+        if (nearestPhaseId) {
+          // If dragging up and the nearest phase is the task's current phase,
+          // use the phase above it instead (the user intends to leave this phase)
+          const activeNode = flat[activeIdx]
+          if (isDraggingUp && activeNode?.projectPhaseId === nearestPhaseId) {
+            const phases = flat.filter((n) => n.nodeType === 'Phase')
+            const phaseIdx = phases.findIndex((p) => p.id === nearestPhaseId)
+            if (phaseIdx > 0) {
+              resolvedParentId = phases[phaseIdx - 1].id
+            } else {
+              resolvedParentId = nearestPhaseId
+            }
           } else {
             resolvedParentId = nearestPhaseId
           }
-        } else {
-          resolvedParentId = nearestPhaseId
         }
       }
-    }
 
-    if (!resolvedParentId) {
-      messageApi.warning('Tasks must be placed within a phase')
-      return
-    }
+      if (!resolvedParentId) {
+        messageApi.warning('Tasks must be placed within a phase')
+        return
+      }
 
-    try {
-      await updateProjectTaskPlacement({
-        projectIdOrKey: projectKey,
-        id: nodeId,
-        request: {
-          taskId: nodeId,
-          parentId: resolvedParentId,
-          order,
-        },
-      }).unwrap()
-      await refetch()
-    } catch (error: any) {
-      messageApi.error(
-        error?.data?.detail || 'Failed to move task. Please try again.',
-      )
-    }
-  }
+      try {
+        await updateProjectTaskPlacement({
+          projectIdOrKey: projectKey,
+          id: nodeId,
+          request: {
+            taskId: nodeId,
+            parentId: resolvedParentId,
+            order,
+          },
+        }).unwrap()
+        await refetch()
+      } catch (error: any) {
+        messageApi.error(
+          error?.data?.detail || 'Failed to move task. Please try again.',
+        )
+      }
+    },
+    [projectKey, tasks, updateProjectTaskPlacement, refetch, messageApi],
+  )
 
-  const handleTaskError = (
-    error: any,
-    taskId: string,
-    fallbackMessage: string,
-  ): false => {
-    const status = error?.status ?? error?.data?.status
-    const errors = error?.errors ?? error?.data?.errors
-    const detail = error?.detail ?? error?.data?.detail
+  const handleTaskError = useCallback(
+    (error: any, taskId: string, fallbackMessage: string): false => {
+      const status = error?.status ?? error?.data?.status
+      const errors = error?.errors ?? error?.data?.errors
+      const detail = error?.detail ?? error?.data?.detail
 
-    if (status === 422 && errors) {
-      const errorMap: Record<string, string> = {}
-      const errorFields: string[] = []
-      Object.entries(errors).forEach(([key, messages]) => {
-        const fieldName = key.charAt(0).toLowerCase() + key.slice(1)
-        errorMap[fieldName] = Array.isArray(messages) ? messages[0] : messages
-        errorFields.push(fieldName)
-      })
-      setFieldErrors(errorMap)
+      if (status === 422 && errors) {
+        const errorMap: Record<string, string> = {}
+        const errorFields: string[] = []
+        Object.entries(errors).forEach(([key, messages]) => {
+          const fieldName = key.charAt(0).toLowerCase() + key.slice(1)
+          errorMap[fieldName] = Array.isArray(messages) ? messages[0] : messages
+          errorFields.push(fieldName)
+        })
+        setFieldErrors(errorMap)
 
-      setTimeout(() => {
-        let focused = false
-        for (const errorField of errorFields) {
-          const columnId =
-            errorField === 'plannedDate'
-              ? 'plannedStart'
-              : errorField.replace(/Id$/, '')
-          const cellElement = document.querySelector(
-            `[data-cell-id="${taskId}-${columnId}"]`,
-          )
-          if (cellElement) {
-            const input = cellElement.querySelector(
-              'input, .ant-select',
-            ) as HTMLElement
-            if (input) {
-              input.focus()
-              focused = true
-              break
+        setTimeout(() => {
+          let focused = false
+          for (const errorField of errorFields) {
+            const columnId =
+              errorField === 'plannedDate'
+                ? 'plannedStart'
+                : errorField.replace(/Id$/, '')
+            const cellElement = document.querySelector(
+              `[data-cell-id="${taskId}-${columnId}"]`,
+            )
+            if (cellElement) {
+              const input = cellElement.querySelector(
+                'input, .ant-select',
+              ) as HTMLElement
+              if (input) {
+                input.focus()
+                focused = true
+                break
+              }
             }
           }
-        }
-        if (!focused) {
-          const cellElement = document.querySelector(
-            `[data-cell-id="${taskId}-name"]`,
-          )
-          if (cellElement) {
-            const input = cellElement.querySelector('input') as HTMLElement
-            input?.focus()
+          if (!focused) {
+            const cellElement = document.querySelector(
+              `[data-cell-id="${taskId}-name"]`,
+            )
+            if (cellElement) {
+              const input = cellElement.querySelector('input') as HTMLElement
+              input?.focus()
+            }
           }
-        }
-      }, 0)
+        }, 0)
 
-      messageApi.error('Correct the validation error(s) to continue.')
-    } else {
-      messageApi.error(detail ?? fallbackMessage)
-    }
-    return false
-  }
-
-  const handleUpdateTask = async (
-    taskId: string,
-    updates: Partial<any>,
-  ): Promise<boolean> => {
-    if (!projectKey) return false
-
-    const isDraft = taskId.startsWith('draft-')
-
-    if (isDraft) {
-      try {
-        const draft = draftsRef.current.find((d) => d.id === taskId)
-        if (!draft) return false
-
-        const request: any = {
-          name: updates.name || '',
-          typeId: updates.typeId || 1,
-          statusId: updates.statusId || 1,
-          priorityId: updates.priorityId || 2,
-          assigneeIds: updates.assigneeIds || [],
-          progress: updates.progress,
-          parentId: draft.parentId,
-          plannedStart: updates.plannedStart,
-          plannedEnd: updates.plannedEnd,
-          plannedDate: updates.plannedDate,
-          estimatedEffortHours: updates.estimatedEffortHours,
-        }
-
-        const response = await createProjectTask({
-          projectIdOrKey: projectKey,
-          request,
-        })
-
-        if (response.error) throw response.error
-
-        messageApi.success(`Task created: ${response.data.key}`)
-        await refetch()
-        return true
-      } catch (error: any) {
-        return handleTaskError(
-          error,
-          taskId,
-          'An error occurred while creating the project task. Please try again.',
-        )
+        messageApi.error('Correct the validation error(s) to continue.')
+      } else {
+        messageApi.error(detail ?? fallbackMessage)
       }
-    } else {
-      const node = findNodeById(
-        tasks || [],
-        taskId,
-      ) as ProjectPlanNodeDto | null
-      if (!node) return false
+      return false
+    },
+    [messageApi, setFieldErrors],
+  )
 
-      try {
-        if (isPhaseNode(node)) {
-          const patchOperations = buildProjectPhasePatchOperations(updates)
-          const response = await patchProjectPhase({
-            projectId,
-            phaseId: taskId,
-            patchOperations,
-            cacheKey: taskId,
-          })
-          if (response.error) throw response.error
-        } else {
-          const patchOperations = buildProjectTaskPatchOperations(updates)
-          const response = await patchProjectTask({
+  const handleUpdateTask = useCallback(
+    async (taskId: string, updates: Partial<any>): Promise<boolean> => {
+      if (!projectKey) return false
+
+      const isDraft = taskId.startsWith('draft-')
+
+      if (isDraft) {
+        try {
+          const draft = draftsRef.current.find((d) => d.id === taskId)
+          if (!draft) return false
+
+          const request: any = {
+            name: updates.name || '',
+            typeId: updates.typeId || 1,
+            statusId: updates.statusId || 1,
+            priorityId: updates.priorityId || 2,
+            assigneeIds: updates.assigneeIds || [],
+            progress: updates.progress,
+            parentId: draft.parentId,
+            plannedStart: updates.plannedStart,
+            plannedEnd: updates.plannedEnd,
+            plannedDate: updates.plannedDate,
+            estimatedEffortHours: updates.estimatedEffortHours,
+          }
+
+          const response = await createProjectTask({
             projectIdOrKey: projectKey,
-            taskId,
-            patchOperations,
-            cacheKey: taskId,
+            request,
           })
-          if (response.error) throw response.error
-        }
-        await refetch()
-        return true
-      } catch (error: any) {
-        const entityName = isPhaseNode(node) ? 'phase' : 'task'
-        return handleTaskError(
-          error,
-          taskId,
-          `An error occurred while updating the project ${entityName}. Please try again.`,
-        )
-      }
-    }
-  }
 
-  const handleEditTask = (task: any) => {
+          if (response.error) throw response.error
+
+          messageApi.success(`Task created: ${response.data.key}`)
+          await refetch()
+          return true
+        } catch (error: any) {
+          return handleTaskError(
+            error,
+            taskId,
+            'An error occurred while creating the project task. Please try again.',
+          )
+        }
+      } else {
+        const node = findNodeById(
+          tasks || [],
+          taskId,
+        ) as ProjectPlanNodeDto | null
+        if (!node) return false
+
+        try {
+          if (isPhaseNode(node)) {
+            const patchOperations = buildProjectPhasePatchOperations(updates)
+            const response = await patchProjectPhase({
+              projectId,
+              phaseId: taskId,
+              patchOperations,
+              cacheKey: taskId,
+            })
+            if (response.error) throw response.error
+          } else {
+            const patchOperations = buildProjectTaskPatchOperations(updates)
+            const response = await patchProjectTask({
+              projectIdOrKey: projectKey,
+              taskId,
+              patchOperations,
+              cacheKey: taskId,
+            })
+            if (response.error) throw response.error
+          }
+          await refetch()
+          return true
+        } catch (error: any) {
+          const entityName = isPhaseNode(node) ? 'phase' : 'task'
+          return handleTaskError(
+            error,
+            taskId,
+            `An error occurred while updating the project ${entityName}. Please try again.`,
+          )
+        }
+      }
+    },
+    [
+      messageApi,
+      projectId,
+      projectKey,
+      refetch,
+      tasks,
+      patchProjectTask,
+      patchProjectPhase,
+      createProjectTask,
+      handleTaskError,
+      isPhaseNode,
+    ],
+  )
+
+  const handleEditTask = useCallback((task: any) => {
     setSelectedTaskId(task.id)
     setOpenEditTaskForm(true)
-  }
+  }, [])
 
-  const handleEditPhase = (phase: any) => {
+  const handleEditPhase = useCallback((phase: any) => {
     setSelectedPhaseId(phase.id)
     setOpenEditPhaseForm(true)
-  }
+  }, [])
 
-  const handleDeleteTask = (task: any) => {
+  const handleDeleteTask = useCallback((task: any) => {
     setSelectedTaskId(task.id)
     setOpenDeleteTaskForm(true)
-  }
+  }, [])
 
-  const onEditTaskFormClosed = (wasSaved: boolean) => {
-    setOpenEditTaskForm(false)
-    setSelectedTaskId(undefined)
-    if (wasSaved) refetch()
-  }
+  const onEditTaskFormClosed = useCallback(
+    (wasSaved: boolean) => {
+      setOpenEditTaskForm(false)
+      setSelectedTaskId(undefined)
+      if (wasSaved) refetch()
+    },
+    [refetch],
+  )
 
-  const onDeleteTaskFormClosed = (wasDeleted: boolean) => {
-    setOpenDeleteTaskForm(false)
-    setSelectedTaskId(undefined)
-    if (wasDeleted) refetch()
-  }
+  const onDeleteTaskFormClosed = useCallback(
+    (wasDeleted: boolean) => {
+      setOpenDeleteTaskForm(false)
+      setSelectedTaskId(undefined)
+      if (wasDeleted) refetch()
+    },
+    [refetch],
+  )
 
-  const onCreateTaskFormClosed = (wasSaved: boolean) => {
-    setOpenCreateTaskForm(false)
-    if (wasSaved) refetch()
-  }
+  const onCreateTaskFormClosed = useCallback(
+    (wasSaved: boolean) => {
+      setOpenCreateTaskForm(false)
+      if (wasSaved) refetch()
+    },
+    [refetch],
+  )
 
-  const getFormValues = (rowId: string, data: ProjectPlanNodeDto[]) => {
-    const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
-    const isDraft = rowId.startsWith('draft-')
+  const getFormValues = useCallback(
+    (rowId: string, data: ProjectPlanNodeDto[]) => {
+      const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
+      const isDraft = rowId.startsWith('draft-')
 
-    if (isDraft || !task) {
-      return {
-        name: '',
-        typeId: 1,
-        statusId: 1,
-        priorityId: 2,
-        assigneeIds: [],
-        progress: 0,
-        plannedStart: null,
-        plannedEnd: null,
-        plannedDate: null,
-        estimatedEffortHours: null,
+      if (isDraft || !task) {
+        return {
+          name: '',
+          typeId: 1,
+          statusId: 1,
+          priorityId: 2,
+          assigneeIds: [],
+          progress: 0,
+          plannedStart: null,
+          plannedEnd: null,
+          plannedDate: null,
+          estimatedEffortHours: null,
+        }
       }
-    }
 
-    // Phase rows: limited fields
-    if (isPhaseNode(task)) {
+      // Phase rows: limited fields
+      if (isPhaseNode(task)) {
+        return {
+          statusId: task.status?.id,
+          assigneeIds: task.assignees?.map((a) => a.id) ?? [],
+          plannedStart: task.start ? dayjs(task.start) : null,
+          plannedEnd: task.end ? dayjs(task.end) : null,
+          progress: task.progress,
+        }
+      }
+
       return {
+        name: task.name,
+        typeId: task.type?.id,
         statusId: task.status?.id,
+        priorityId: task.priority?.id,
         assigneeIds: task.assignees?.map((a) => a.id) ?? [],
+        progress: task.progress,
         plannedStart: task.start ? dayjs(task.start) : null,
         plannedEnd: task.end ? dayjs(task.end) : null,
-        progress: task.progress,
+        plannedDate: task.plannedDate ? dayjs(task.plannedDate) : null,
+        estimatedEffortHours: task.estimatedEffortHours,
       }
-    }
+    },
+    [isPhaseNode],
+  )
 
-    return {
-      name: task.name,
-      typeId: task.type?.id,
-      statusId: task.status?.id,
-      priorityId: task.priority?.id,
-      assigneeIds: task.assignees?.map((a) => a.id) ?? [],
-      progress: task.progress,
-      plannedStart: task.start ? dayjs(task.start) : null,
-      plannedEnd: task.end ? dayjs(task.end) : null,
-      plannedDate: task.plannedDate ? dayjs(task.plannedDate) : null,
-      estimatedEffortHours: task.estimatedEffortHours,
-    }
-  }
+  const computeChanges = useCallback(
+    (
+      rowId: string,
+      formValues: Record<string, any>,
+      data: ProjectPlanNodeDto[],
+    ) => {
+      const isDraft = rowId.startsWith('draft-')
+      const values = formValues as any
+      const completedStatusValue = taskStatusOptions.find(
+        (opt) => opt.label === 'Completed',
+      )?.value
+      const isCompleted = values.statusId === completedStatusValue
 
-  const computeChanges = (
-    rowId: string,
-    formValues: Record<string, any>,
-    data: ProjectPlanNodeDto[],
-  ) => {
-    const isDraft = rowId.startsWith('draft-')
-    const values = formValues as any
-    const completedStatusValue = taskStatusOptions.find(
-      (opt) => opt.label === 'Completed',
-    )?.value
-    const isCompleted = values.statusId === completedStatusValue
-
-    if (isDraft) {
-      const updates: Record<string, any> = {
-        name: values.name || '',
-        typeId: values.typeId,
-        statusId: values.statusId,
-        priorityId: values.priorityId,
-        assigneeIds: values.assigneeIds ?? [],
+      if (isDraft) {
+        const updates: Record<string, any> = {
+          name: values.name || '',
+          typeId: values.typeId,
+          statusId: values.statusId,
+          priorityId: values.priorityId,
+          assigneeIds: values.assigneeIds ?? [],
+        }
+        if (isSelectedRowMilestone) {
+          updates.plannedStart = null
+          updates.plannedEnd = null
+          updates.plannedDate = values.plannedDate
+            ? values.plannedDate.format('YYYY-MM-DD')
+            : null
+          updates.progress = null
+          updates.estimatedEffortHours = null
+        } else {
+          updates.plannedStart = values.plannedStart
+            ? values.plannedStart.format('YYYY-MM-DD')
+            : null
+          updates.plannedEnd = values.plannedEnd
+            ? values.plannedEnd.format('YYYY-MM-DD')
+            : null
+          updates.plannedDate = null
+          updates.progress = isCompleted ? 100 : (values.progress ?? 0)
+          updates.estimatedEffortHours = values.estimatedEffortHours
+            ? Number(values.estimatedEffortHours)
+            : null
+        }
+        return updates
       }
-      if (isSelectedRowMilestone) {
-        updates.plannedStart = null
-        updates.plannedEnd = null
-        updates.plannedDate = values.plannedDate
-          ? values.plannedDate.format('YYYY-MM-DD')
-          : null
-        updates.progress = null
-        updates.estimatedEffortHours = null
-      } else {
-        updates.plannedStart = values.plannedStart
-          ? values.plannedStart.format('YYYY-MM-DD')
-          : null
-        updates.plannedEnd = values.plannedEnd
-          ? values.plannedEnd.format('YYYY-MM-DD')
-          : null
-        updates.plannedDate = null
-        updates.progress = isCompleted ? 100 : (values.progress ?? 0)
+
+      const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
+      if (!task) return null
+
+      const updates: Record<string, any> = {}
+      let hasChanges = false
+
+      if (values.name !== task.name) {
+        updates.name = values.name
+        hasChanges = true
+      }
+      if (values.statusId !== task.status?.id) {
+        updates.statusId = values.statusId
+        hasChanges = true
+      }
+      if (values.priorityId !== task.priority?.id) {
+        updates.priorityId = values.priorityId
+        hasChanges = true
+      }
+
+      const taskAssigneeIds = task.assignees?.map((a) => a.id) ?? []
+      const formAssigneeIds = values.assigneeIds ?? []
+      const assigneesChanged =
+        taskAssigneeIds.length !== formAssigneeIds.length ||
+        !taskAssigneeIds.every((id: string) => formAssigneeIds.includes(id))
+      if (assigneesChanged) {
+        updates.assigneeIds = formAssigneeIds
+        hasChanges = true
+      }
+
+      const taskPlannedStart = task.start
+        ? String(task.start).split('T')[0]
+        : null
+      const plannedStartFormatted = values.plannedStart
+        ? values.plannedStart.format('YYYY-MM-DD')
+        : null
+      if (plannedStartFormatted !== taskPlannedStart) {
+        updates.plannedStart = plannedStartFormatted
+        hasChanges = true
+      }
+
+      const taskPlannedEnd = task.end ? String(task.end).split('T')[0] : null
+      const plannedEndFormatted = values.plannedEnd
+        ? values.plannedEnd.format('YYYY-MM-DD')
+        : null
+      if (plannedEndFormatted !== taskPlannedEnd) {
+        updates.plannedEnd = plannedEndFormatted
+        hasChanges = true
+      }
+
+      const taskPlannedDate = task.plannedDate
+        ? String(task.plannedDate).split('T')[0]
+        : null
+      const plannedDateFormatted = values.plannedDate
+        ? values.plannedDate.format('YYYY-MM-DD')
+        : null
+      if (plannedDateFormatted !== taskPlannedDate) {
+        updates.plannedDate = plannedDateFormatted
+        hasChanges = true
+      }
+
+      const effectiveProgress = isCompleted ? 100 : values.progress
+      if (effectiveProgress !== task.progress) {
+        updates.progress = effectiveProgress
+        hasChanges = true
+      }
+
+      if (values.estimatedEffortHours !== task.estimatedEffortHours) {
         updates.estimatedEffortHours = values.estimatedEffortHours
           ? Number(values.estimatedEffortHours)
           : null
+        hasChanges = true
       }
-      return updates
-    }
 
-    const task = findNodeById(data, rowId) as ProjectPlanNodeDto | null
-    if (!task) return null
+      return hasChanges ? updates : null
+    },
+    [isSelectedRowMilestone, taskStatusOptions],
+  )
 
-    const updates: Record<string, any> = {}
-    let hasChanges = false
+  const validateFields = useCallback(
+    (rowId: string, formValues: Record<string, any>) => {
+      const isDraft = rowId.startsWith('draft-')
+      const task = findNodeById(tasks, rowId) as ProjectPlanNodeDto | null
+      const isMilestone = isDraft
+        ? isSelectedRowMilestone
+        : task?.type?.name === 'Milestone'
 
-    if (values.name !== task.name) {
-      updates.name = values.name
-      hasChanges = true
-    }
-    if (values.statusId !== task.status?.id) {
-      updates.statusId = values.statusId
-      hasChanges = true
-    }
-    if (values.priorityId !== task.priority?.id) {
-      updates.priorityId = values.priorityId
-      hasChanges = true
-    }
+      if (isMilestone) return {}
 
-    const taskAssigneeIds = task.assignees?.map((a) => a.id) ?? []
-    const formAssigneeIds = values.assigneeIds ?? []
-    const assigneesChanged =
-      taskAssigneeIds.length !== formAssigneeIds.length ||
-      !taskAssigneeIds.every((id: string) => formAssigneeIds.includes(id))
-    if (assigneesChanged) {
-      updates.assigneeIds = formAssigneeIds
-      hasChanges = true
-    }
+      const errors: Record<string, string> = {}
+      const hasPlannedStart = Boolean(formValues.plannedStart)
+      const hasPlannedEnd = Boolean(formValues.plannedEnd)
 
-    const taskPlannedStart = task.start
-      ? String(task.start).split('T')[0]
-      : null
-    const plannedStartFormatted = values.plannedStart
-      ? values.plannedStart.format('YYYY-MM-DD')
-      : null
-    if (plannedStartFormatted !== taskPlannedStart) {
-      updates.plannedStart = plannedStartFormatted
-      hasChanges = true
-    }
-
-    const taskPlannedEnd = task.end ? String(task.end).split('T')[0] : null
-    const plannedEndFormatted = values.plannedEnd
-      ? values.plannedEnd.format('YYYY-MM-DD')
-      : null
-    if (plannedEndFormatted !== taskPlannedEnd) {
-      updates.plannedEnd = plannedEndFormatted
-      hasChanges = true
-    }
-
-    const taskPlannedDate = task.plannedDate
-      ? String(task.plannedDate).split('T')[0]
-      : null
-    const plannedDateFormatted = values.plannedDate
-      ? values.plannedDate.format('YYYY-MM-DD')
-      : null
-    if (plannedDateFormatted !== taskPlannedDate) {
-      updates.plannedDate = plannedDateFormatted
-      hasChanges = true
-    }
-
-    const effectiveProgress = isCompleted ? 100 : values.progress
-    if (effectiveProgress !== task.progress) {
-      updates.progress = effectiveProgress
-      hasChanges = true
-    }
-
-    if (values.estimatedEffortHours !== task.estimatedEffortHours) {
-      updates.estimatedEffortHours = values.estimatedEffortHours
-        ? Number(values.estimatedEffortHours)
-        : null
-      hasChanges = true
-    }
-
-    return hasChanges ? updates : null
-  }
-
-  const validateFields = (rowId: string, formValues: Record<string, any>) => {
-    const isDraft = rowId.startsWith('draft-')
-    const task = findNodeById(tasks, rowId) as ProjectPlanNodeDto | null
-    const isMilestone = isDraft
-      ? isSelectedRowMilestone
-      : task?.type?.name === 'Milestone'
-
-    if (isMilestone) return {}
-
-    const errors: Record<string, string> = {}
-    const hasPlannedStart = Boolean(formValues.plannedStart)
-    const hasPlannedEnd = Boolean(formValues.plannedEnd)
-
-    if (hasPlannedStart !== hasPlannedEnd) {
-      const message =
-        'Planned Start and Planned End must both have a value or both be empty.'
-      errors.plannedStart = message
-      errors.plannedEnd = message
-    }
-
-    if (hasPlannedStart && hasPlannedEnd) {
-      const plannedStart = dayjs(formValues.plannedStart)
-      const plannedEnd = dayjs(formValues.plannedEnd)
-      if (plannedEnd.isBefore(plannedStart, 'day')) {
-        errors.plannedEnd = 'Planned End cannot be earlier than Planned Start.'
+      if (hasPlannedStart !== hasPlannedEnd) {
+        const message =
+          'Planned Start and Planned End must both have a value or both be empty.'
+        errors.plannedStart = message
+        errors.plannedEnd = message
       }
-    }
 
-    return errors
-  }
+      if (hasPlannedStart && hasPlannedEnd) {
+        const plannedStart = dayjs(formValues.plannedStart)
+        const plannedEnd = dayjs(formValues.plannedEnd)
+        if (plannedEnd.isBefore(plannedStart, 'day')) {
+          errors.plannedEnd =
+            'Planned End cannot be earlier than Planned Start.'
+        }
+      }
+
+      return errors
+    },
+    [isSelectedRowMilestone, tasks],
+  )
 
   return (
     <>

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/tree-grid/tree-grid.tsx
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/tree-grid/tree-grid.tsx
@@ -5,8 +5,10 @@ import {
   Fragment,
   type ChangeEvent,
   type Ref,
+  useCallback,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
   ReactElement,
@@ -142,19 +144,22 @@ function TreeGridInner<T extends TreeNode>(
   const [internalFieldErrors, setInternalFieldErrors] =
     useState<Record<string, string>>(EMPTY_FIELD_ERRORS)
   const fieldErrors = externalFieldErrors ?? internalFieldErrors
-  const setFieldErrors = (errors: Record<string, string>) => {
-    if (onFieldErrorsChange) {
-      onFieldErrorsChange(errors)
-    } else {
-      setInternalFieldErrors(errors)
-    }
-  }
+  const setFieldErrors = useCallback(
+    (errors: Record<string, string>) => {
+      if (onFieldErrorsChange) {
+        onFieldErrorsChange(errors)
+      } else {
+        setInternalFieldErrors(errors)
+      }
+    },
+    [onFieldErrorsChange],
+  )
 
   // ─── Draft management ────────────────────────────────────
-  const dataWithDrafts =
-    !createDraftNode || draftTasks.length === 0
-      ? data
-      : mergeDraftsIntoTree(data, draftTasks, createDraftNode)
+  const dataWithDrafts = useMemo(() => {
+    if (!createDraftNode || draftTasks.length === 0) return data
+    return mergeDraftsIntoTree(data, draftTasks, createDraftNode)
+  }, [data, draftTasks, createDraftNode])
 
   // ─── Editing hook ────────────────────────────────────────
   const canEdit = editingConfig?.canEdit ?? false
@@ -220,72 +225,107 @@ function TreeGridInner<T extends TreeNode>(
   const canCreateDraft =
     canEdit && !isEditing && draftTasks.length === 0 && !!createDraftNode
 
-  const addDraft = (parentId?: string): string | null => {
-    if (!canCreateDraft) return null
+  const addDraft = useCallback(
+    (parentId?: string): string | null => {
+      if (!canCreateDraft) return null
 
-    draftCounterRef.current += 1
-    const newDraft: DraftItem = {
-      id: `${draftPrefix}${Date.now()}-${draftCounterRef.current}`,
-      parentId,
-      order: 0,
-    }
-    setDraftTasks((prev) => {
-      const next = [...prev, newDraft]
-      onDraftsChange?.(next)
-      return next
-    })
-
-    // Ensure parent is expanded when adding a child draft
-    if (parentId && tableRef.current) {
-      const rows = tableRef.current.getRowModel().rows
-      const parentRow = rows.find((r: any) => r.original.id === parentId)
-      if (parentRow && !parentRow.getIsExpanded()) {
-        parentRow.toggleExpanded()
+      draftCounterRef.current += 1
+      const newDraft: DraftItem = {
+        id: `${draftPrefix}${Date.now()}-${draftCounterRef.current}`,
+        parentId,
+        order: 0,
       }
-    }
+      setDraftTasks((prev) => {
+        const next = [...prev, newDraft]
+        onDraftsChange?.(next)
+        return next
+      })
 
-    // Defer selection so the draft row renders first (unselected),
-    // then a second render mounts the editable input for focusing.
-    requestAnimationFrame(() => {
-      setTimeout(() => {
-        setSelectedRowId(newDraft.id)
-        setSelectedCellId(`${newDraft.id}-name`)
-      }, 50)
-    })
+      // Ensure parent is expanded when adding a child draft
+      if (parentId && tableRef.current) {
+        const rows = tableRef.current.getRowModel().rows
+        const parentRow = rows.find((r: any) => r.original.id === parentId)
+        if (parentRow && !parentRow.getIsExpanded()) {
+          parentRow.toggleExpanded()
+        }
+      }
 
-    return newDraft.id
-  }
+      // Defer selection so the draft row renders first (unselected),
+      // then a second render mounts the editable input for focusing.
+      requestAnimationFrame(() => {
+        setTimeout(() => {
+          setSelectedRowId(newDraft.id)
+          setSelectedCellId(`${newDraft.id}-name`)
+        }, 50)
+      })
 
-  const addDraftAtRoot = () => addDraft()
+      return newDraft.id
+    },
+    [
+      canCreateDraft,
+      draftPrefix,
+      onDraftsChange,
+      setSelectedRowId,
+      setSelectedCellId,
+      tableRef,
+    ],
+  )
 
-  const addDraftAsChild = (parentId: string) => addDraft(parentId)
+  const addDraftAtRoot = useCallback(() => addDraft(), [addDraft])
+
+  const addDraftAsChild = useCallback(
+    (parentId: string) => addDraft(parentId),
+    [addDraft],
+  )
 
   // ─── Column context ──────────────────────────────────────
   const dragEnabledBase =
     enableDragAndDrop && !!onNodeMove && !isLoading && !isEditing
 
-  const dragEnabledForColumns =
-    dragEnabledBase &&
-    !(!!searchValue || columnFilters.length > 0 || sorting.length > 0)
+  const columnContext: TreeGridColumnContext = useMemo(() => {
+    const dragEnabledForColumns =
+      dragEnabledBase &&
+      !(!!searchValue || columnFilters.length > 0 || sorting.length > 0)
 
-  const columnContext: TreeGridColumnContext = {
+    return {
+      selectedRowId,
+      handleKeyDown,
+      createSelectInputKeyDown,
+      getFieldError,
+      editableColumns,
+      isDragEnabled: dragEnabledForColumns,
+      canCreateDraft,
+      addDraftAtRoot,
+      addDraftAsChild,
+    }
+  }, [
+    searchValue,
+    columnFilters.length,
+    sorting.length,
     selectedRowId,
     handleKeyDown,
     createSelectInputKeyDown,
     getFieldError,
     editableColumns,
-    isDragEnabled: dragEnabledForColumns,
+    dragEnabledBase,
     canCreateDraft,
     addDraftAtRoot,
     addDraftAsChild,
-  }
+  ])
 
   // ─── Resolved columns ───────────────────────────────────
-  const columns =
-    typeof columnsProp === 'function' ? columnsProp(columnContext) : columnsProp
+  const columns = useMemo(() => {
+    if (typeof columnsProp === 'function') {
+      return columnsProp(columnContext)
+    }
+    return columnsProp
+  }, [columnsProp, columnContext])
 
   // ─── Flattened tree for DnD ──────────────────────────────
-  const flattenedNodes = flattenTree(dataWithDrafts)
+  const flattenedNodes = useMemo(
+    () => flattenTree(dataWithDrafts),
+    [dataWithDrafts],
+  )
 
   // ─── DnD setup ───────────────────────────────────────────
   const sensors = useSensors(
@@ -295,65 +335,74 @@ function TreeGridInner<T extends TreeNode>(
     useSensor(KeyboardSensor),
   )
 
-  const handleDragStart = (event: DragStartEvent) => {
-    setDraggedNodeId(event.active.id as string)
-    setSelectedRowId(null)
-  }
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      setDraggedNodeId(event.active.id as string)
+      setSelectedRowId(null)
+    },
+    [setSelectedRowId],
+  )
 
-  const handleDragEnd = async (event: DragEndEvent) => {
-    const { active, over, delta } = event
-    setDraggedNodeId(null)
+  const handleDragEnd = useCallback(
+    async (event: DragEndEvent) => {
+      const { active, over, delta } = event
+      setDraggedNodeId(null)
 
-    if (!over || !onNodeMove) return
+      if (!over || !onNodeMove) return
 
-    const horizontalOffset = delta.x
-    const hasHorizontalMovement =
-      Math.abs(horizontalOffset) >= INDENTATION_WIDTH / 2
+      const horizontalOffset = delta.x
+      const hasHorizontalMovement =
+        Math.abs(horizontalOffset) >= INDENTATION_WIDTH / 2
 
-    if (active.id === over.id && !hasHorizontalMovement) return
+      if (active.id === over.id && !hasHorizontalMovement) return
 
-    const projection = getProjection(
-      flattenedNodes,
-      active.id as string,
-      over.id as string,
-      horizontalOffset,
-      INDENTATION_WIDTH,
-      moveValidator,
-    )
-
-    if (!projection.canDrop) {
-      onMoveRejected?.(
-        projection.reason || 'Cannot move item to this location',
+      const projection = getProjection(
+        flattenedNodes,
+        active.id as string,
+        over.id as string,
+        horizontalOffset,
+        INDENTATION_WIDTH,
+        moveValidator,
       )
-      return
-    }
 
-    const overIndex = flattenedNodes.findIndex((t) => t.node.id === over.id)
-    const newOrder = calculateOrderInParent(
-      flattenedNodes,
-      active.id as string,
-      overIndex,
-      projection.parentId,
-    )
+      if (!projection.canDrop) {
+        onMoveRejected?.(
+          projection.reason || 'Cannot move item to this location',
+        )
+        return
+      }
 
-    try {
-      await onNodeMove(active.id as string, projection.parentId, newOrder, over.id as string, overIndex)
-    } catch (error) {
-      onMoveRejected?.(
-        error instanceof Error ? error.message : 'Failed to move item',
+      const overIndex = flattenedNodes.findIndex((t) => t.node.id === over.id)
+      const newOrder = calculateOrderInParent(
+        flattenedNodes,
+        active.id as string,
+        overIndex,
+        projection.parentId,
       )
-    }
-  }
 
-  const handleDragCancel = (_event: DragCancelEvent) => {
+      try {
+        await onNodeMove(active.id as string, projection.parentId, newOrder, over.id as string, overIndex)
+      } catch (error) {
+        onMoveRejected?.(
+          error instanceof Error ? error.message : 'Failed to move item',
+        )
+      }
+    },
+    [flattenedNodes, moveValidator, onNodeMove, onMoveRejected],
+  )
+
+  const handleDragCancel = useCallback((_event: DragCancelEvent) => {
     setDraggedNodeId(null)
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur()
     }
-  }
+  }, [])
 
   // ─── TanStack table ─────────────────────────────────────
-  const totalRowCount = countTreeNodes(data) + draftTasks.length
+  const totalRowCount = useMemo(
+    () => countTreeNodes(data) + draftTasks.length,
+    [data, draftTasks.length],
+  )
 
   // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table does not yet support React Compiler
   const table = useReactTable({
@@ -401,18 +450,18 @@ function TreeGridInner<T extends TreeNode>(
   // ─── Toolbar wiring ──────────────────────────────────────
   const visibleColumnCount = table.getVisibleLeafColumns().length
 
-  const onSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const onSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setSearchValue(e.target.value)
-  }
+  }, [])
 
-  const onClearFilters = () => {
+  const onClearFilters = useCallback(() => {
     setSearchValue('')
     setSorting([])
     setColumnFilters([])
     setTextFilterDraftValues({})
     filterDebounceTimersRef.current.forEach((timer) => clearTimeout(timer))
     filterDebounceTimersRef.current.clear()
-  }
+  }, [])
 
   const hasActiveFilters =
     !!searchValue || columnFilters.length > 0 || sorting.length > 0
@@ -445,44 +494,47 @@ function TreeGridInner<T extends TreeNode>(
     }
   }, [])
 
-  const handleTextFilterChange = (
-    e: ChangeEvent<HTMLInputElement>,
-    columnId: string,
-    setFilterValue: (value: string | undefined) => void,
-    filterInputId: string,
-  ) => {
-    const next = e.target.value
-    setTextFilterDraftValues((prev) => ({
-      ...prev,
-      [columnId]: next,
-    }))
+  const handleTextFilterChange = useCallback(
+    (
+      e: ChangeEvent<HTMLInputElement>,
+      columnId: string,
+      setFilterValue: (value: string | undefined) => void,
+      filterInputId: string,
+    ) => {
+      const next = e.target.value
+      setTextFilterDraftValues((prev) => ({
+        ...prev,
+        [columnId]: next,
+      }))
 
-    const existingTimer = filterDebounceTimersRef.current.get(columnId)
-    if (existingTimer) {
-      clearTimeout(existingTimer)
-    }
+      const existingTimer = filterDebounceTimersRef.current.get(columnId)
+      if (existingTimer) {
+        clearTimeout(existingTimer)
+      }
 
-    const timer = setTimeout(() => {
-      setFilterValue(next ? next : undefined)
-      setTextFilterDraftValues((prev) => {
-        if (!(columnId in prev)) return prev
-        const updated = { ...prev }
-        delete updated[columnId]
-        return updated
-      })
-      filterDebounceTimersRef.current.delete(columnId)
-    }, FILTER_DEBOUNCE_MS)
-    filterDebounceTimersRef.current.set(columnId, timer)
+      const timer = setTimeout(() => {
+        setFilterValue(next ? next : undefined)
+        setTextFilterDraftValues((prev) => {
+          if (!(columnId in prev)) return prev
+          const updated = { ...prev }
+          delete updated[columnId]
+          return updated
+        })
+        filterDebounceTimersRef.current.delete(columnId)
+      }, FILTER_DEBOUNCE_MS)
+      filterDebounceTimersRef.current.set(columnId, timer)
 
-    pendingFilterFocusRef.current = {
-      inputId: filterInputId,
-      selectionStart: e.target.selectionStart,
-      selectionEnd: e.target.selectionEnd,
-    }
-  }
+      pendingFilterFocusRef.current = {
+        inputId: filterInputId,
+        selectionStart: e.target.selectionStart,
+        selectionEnd: e.target.selectionEnd,
+      }
+    },
+    [],
+  )
 
   // ─── CSV export ──────────────────────────────────────────
-  const onExportCsv = () => {
+  const onExportCsv = useCallback(() => {
     const exportableColumns = columns.filter((col: any) => {
       const meta = col.meta as TreeGridColumnMeta | undefined
       if (meta?.enableExport === false) return false
@@ -519,7 +571,7 @@ function TreeGridInner<T extends TreeNode>(
 
     const csv = generateCsv(headers, rows)
     downloadCsvWithTimestamp(csv, csvFileName)
-  }
+  }, [table, columns, csvFileName])
 
   // ─── Ref handle ──────────────────────────────────────────
   useImperativeHandle(ref, () => ({
@@ -528,16 +580,19 @@ function TreeGridInner<T extends TreeNode>(
   }))
 
   // ─── Row/cell click handlers ────────────────────────────
-  const handleRowClickWithContext = (e: React.MouseEvent, rowId: string) => {
-    void handleRowClick(e, {
-      rowId,
-      isEditableColumn: (columnId) => editableColumns.includes(columnId),
-      getClickedColumnId: (target) =>
-        target.closest('td')?.getAttribute('data-column-id') ?? null,
-    })
-  }
+  const handleRowClickWithContext = useCallback(
+    (e: React.MouseEvent, rowId: string) => {
+      void handleRowClick(e, {
+        rowId,
+        isEditableColumn: (columnId) => editableColumns.includes(columnId),
+        getClickedColumnId: (target) =>
+          target.closest('td')?.getAttribute('data-column-id') ?? null,
+      })
+    },
+    [handleRowClick, editableColumns],
+  )
 
-  const handleCellClick = (e: React.MouseEvent) => {
+  const handleCellClick = useCallback((e: React.MouseEvent) => {
     const target = e.target as HTMLElement
     if (
       target.closest('input') ||
@@ -547,7 +602,7 @@ function TreeGridInner<T extends TreeNode>(
     ) {
       e.stopPropagation()
     }
-  }
+  }, [])
 
   // ─── Resolved leftSlot ──────────────────────────────────
   const resolvedLeftSlot =

--- a/Moda.Web/src/moda.web.reactclient/src/components/common/tree-grid/use-tree-grid-editing.ts
+++ b/Moda.Web/src/moda.web.reactclient/src/components/common/tree-grid/use-tree-grid-editing.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { TreeNode, TreeGridEditingConfig, RowClickArgs } from './types'
 
 /**
@@ -66,210 +66,225 @@ export function useTreeGridEditing<T extends TreeNode>(
   })
 
   // Resolve editable columns for a given row (or the currently selected row)
-  const resolveEditableColumns = (rowId: string | null) => {
-    if (typeof editableColumnIds === 'function') {
-      return editableColumnIds(rowId)
-    }
-    return editableColumnIds
-  }
+  const resolveEditableColumns = useCallback(
+    (rowId: string | null) => {
+      if (typeof editableColumnIds === 'function') {
+        return editableColumnIds(rowId)
+      }
+      return editableColumnIds
+    },
+    [editableColumnIds],
+  )
 
   // Resolve editable columns (may be static or dynamic based on selected row)
-  const editableColumns = resolveEditableColumns(selectedRowId)
+  const editableColumns = useMemo(
+    () => resolveEditableColumns(selectedRowId),
+    [resolveEditableColumns, selectedRowId],
+  )
 
-  const getFieldError = (fieldName: string): string | undefined => {
-    return fieldErrors[fieldName]
-  }
+  const getFieldError = useCallback(
+    (fieldName: string): string | undefined => {
+      return fieldErrors[fieldName]
+    },
+    [fieldErrors],
+  )
 
   // Focus management using MutationObserver for DOM stability
-  const focusCellById = useCallback((cellId: string) => {
-    focusObserverRef.current?.disconnect()
-    focusObserverRef.current = null
-    const requestToken = ++focusRequestTokenRef.current
+  const focusCellById = useCallback(
+    (cellId: string) => {
+      focusObserverRef.current?.disconnect()
+      focusObserverRef.current = null
+      const requestToken = ++focusRequestTokenRef.current
 
-    let columnId = ''
-    for (const col of cellIdColumnMatchOrder) {
-      if (cellId.endsWith(`-${col}`)) {
-        columnId = col
-        break
-      }
-    }
-
-    const isActiveElementInsideCell = () => {
-      const active = document.activeElement as HTMLElement | null
-      const activeCellId = active
-        ?.closest?.('[data-cell-id]')
-        ?.getAttribute('data-cell-id')
-      return activeCellId === cellId
-    }
-
-    const getActiveCellId = () => {
-      const active = document.activeElement as HTMLElement | null
-      return active
-        ?.closest?.('[data-cell-id]')
-        ?.getAttribute('data-cell-id')
-    }
-
-    const tryFocus = (attempt: number) => {
-      if (focusRequestTokenRef.current !== requestToken) {
-        return
-      }
-
-      let cellElement: Element | null = null
-      const allCells = document.querySelectorAll('[data-cell-id]')
-      for (const cell of allCells) {
-        if (cell.getAttribute('data-cell-id') === cellId) {
-          cellElement = cell
+      let columnId = ''
+      for (const col of cellIdColumnMatchOrder) {
+        if (cellId.endsWith(`-${col}`)) {
+          columnId = col
           break
         }
       }
 
-      if (cellElement) {
-        const cellElementNode = cellElement as HTMLElement
-        cellElementNode.scrollIntoView({
-          block: 'nearest',
-          inline: 'nearest',
-        })
+      const isActiveElementInsideCell = () => {
+        const active = document.activeElement as HTMLElement | null
+        const activeCellId = active
+          ?.closest?.('[data-cell-id]')
+          ?.getAttribute('data-cell-id')
+        return activeCellId === cellId
+      }
 
-        let input: HTMLElement | null = null
+      const getActiveCellId = () => {
+        const active = document.activeElement as HTMLElement | null
+        return active
+          ?.closest?.('[data-cell-id]')
+          ?.getAttribute('data-cell-id')
+      }
 
-        // Try DatePicker first
-        const picker = cellElement.querySelector('.ant-picker') as
-          | HTMLElement
-          | null
-        const pickerInput = cellElement.querySelector(
-          '.ant-picker-input > input',
-        ) as HTMLElement | null
+      const tryFocus = (attempt: number) => {
+        if (focusRequestTokenRef.current !== requestToken) {
+          return
+        }
 
-        if (picker && pickerInput) {
-          picker.focus()
-          input = pickerInput
-        } else {
-          // Try Select
-          const selectInput = cellElement.querySelector(
-            'input.ant-select-input',
+        let cellElement: Element | null = null
+        const allCells = document.querySelectorAll('[data-cell-id]')
+        for (const cell of allCells) {
+          if (cell.getAttribute('data-cell-id') === cellId) {
+            cellElement = cell
+            break
+          }
+        }
+
+        if (cellElement) {
+          const cellElementNode = cellElement as HTMLElement
+          cellElementNode.scrollIntoView({
+            block: 'nearest',
+            inline: 'nearest',
+          })
+
+          let input: HTMLElement | null = null
+
+          // Try DatePicker first
+          const picker = cellElement.querySelector('.ant-picker') as
+            | HTMLElement
+            | null
+          const pickerInput = cellElement.querySelector(
+            '.ant-picker-input > input',
           ) as HTMLElement | null
-          if (selectInput) {
-            input = selectInput
+
+          if (picker && pickerInput) {
+            picker.focus()
+            input = pickerInput
           } else {
-            // Try regular input
-            input = cellElement.querySelector('input')
-          }
-        }
-
-        if (!input) {
-          input = cellElement.querySelector('.ant-picker')
-        }
-
-        if (!input) {
-          input = cellElement.querySelector(
-            '[data-color-picker-focus]',
-          ) as HTMLElement | null
-        }
-
-        if (!input) {
-          input = cellElement.querySelector(
-            '.ant-color-picker-trigger',
-          ) as HTMLElement | null
-        }
-
-        if (input instanceof HTMLElement) {
-          input.focus()
-          if (input instanceof HTMLInputElement) {
-            input.select()
+            // Try Select
+            const selectInput = cellElement.querySelector(
+              'input.ant-select-input',
+            ) as HTMLElement | null
+            if (selectInput) {
+              input = selectInput
+            } else {
+              // Try regular input
+              input = cellElement.querySelector('input')
+            }
           }
 
-          if (!isActiveElementInsideCell()) {
-            if (attempt < 12) {
-              setTimeout(() => tryFocus(attempt + 1), 20)
+          if (!input) {
+            input = cellElement.querySelector('.ant-picker')
+          }
+
+          if (!input) {
+            input = cellElement.querySelector(
+              '[data-color-picker-focus]',
+            ) as HTMLElement | null
+          }
+
+          if (!input) {
+            input = cellElement.querySelector(
+              '.ant-color-picker-trigger',
+            ) as HTMLElement | null
+          }
+
+          if (input instanceof HTMLElement) {
+            input.focus()
+            if (input instanceof HTMLInputElement) {
+              input.select()
+            }
+
+            if (!isActiveElementInsideCell()) {
+              if (attempt < 12) {
+                setTimeout(() => tryFocus(attempt + 1), 20)
+              }
+              return
+            }
+
+            // DatePicker inputs can be re-mounted during state updates.
+            // Re-check shortly after and re-focus if focus was lost.
+            if (picker && pickerInput) {
+              setTimeout(() => {
+                if (!isActiveElementInsideCell()) {
+                  const activeCellId = getActiveCellId()
+                  if (activeCellId && activeCellId !== cellId) {
+                    return
+                  }
+                  tryFocus(6)
+                }
+              }, 40)
             }
             return
           }
+        }
 
-          // DatePicker inputs can be re-mounted during state updates.
-          // Re-check shortly after and re-focus if focus was lost.
-          if (picker && pickerInput) {
-            setTimeout(() => {
-              if (!isActiveElementInsideCell()) {
-                const activeCellId = getActiveCellId()
-                if (activeCellId && activeCellId !== cellId) {
-                  return
-                }
-                tryFocus(6)
-              }
-            }, 40)
-          }
-          return
+        if (attempt < 12) {
+          setTimeout(() => tryFocus(attempt + 1), 20)
         }
       }
 
-      if (attempt < 12) {
-        setTimeout(() => tryFocus(attempt + 1), 20)
-      }
-    }
-
-    // Use MutationObserver to wait for DOM stability before focusing
-    const cellEl = document.querySelector(`[data-cell-id="${cellId}"]`)
-    const observeTarget = cellEl?.closest('tr') ?? document.body
-    let stabilityTimer: ReturnType<typeof setTimeout> | null = null
-    const observer = new MutationObserver(() => {
-      if (stabilityTimer) clearTimeout(stabilityTimer)
+      // Use MutationObserver to wait for DOM stability before focusing
+      const cellEl = document.querySelector(`[data-cell-id="${cellId}"]`)
+      const observeTarget = cellEl?.closest('tr') ?? document.body
+      let stabilityTimer: ReturnType<typeof setTimeout> | null = null
+      const observer = new MutationObserver(() => {
+        if (stabilityTimer) clearTimeout(stabilityTimer)
+        stabilityTimer = setTimeout(() => {
+          observer.disconnect()
+          focusObserverRef.current = null
+          tryFocus(0)
+        }, 50)
+      })
+      focusObserverRef.current = observer
+      observer.observe(observeTarget, {
+        childList: true,
+        subtree: true,
+      })
+      // Kick off the timer in case there are no mutations
       stabilityTimer = setTimeout(() => {
         observer.disconnect()
-        focusObserverRef.current = null
         tryFocus(0)
       }, 50)
-    })
-    focusObserverRef.current = observer
-    observer.observe(observeTarget, {
-      childList: true,
-      subtree: true,
-    })
-    // Kick off the timer in case there are no mutations
-    stabilityTimer = setTimeout(() => {
-      observer.disconnect()
-      tryFocus(0)
-    }, 50)
-  }, [cellIdColumnMatchOrder])
+    },
+    [cellIdColumnMatchOrder],
+  )
 
   // Save form changes for a row
-  const saveFormChanges = useCallback(async (rowId: string) => {
-    try {
-      // Run client-side validation if provided
-      if (validateFieldsRef.current) {
-        const validationErrors = validateFieldsRef.current(
-          rowId,
-          form.getFieldsValue(),
-        )
-        if (Object.keys(validationErrors).length > 0) {
-          setFieldErrorsRef.current(validationErrors)
-          return false
+  const saveFormChanges = useCallback(
+    async (rowId: string) => {
+      try {
+        // Run client-side validation if provided
+        if (validateFieldsRef.current) {
+          const validationErrors = validateFieldsRef.current(
+            rowId,
+            form.getFieldsValue(),
+          )
+          if (Object.keys(validationErrors).length > 0) {
+            setFieldErrorsRef.current(validationErrors)
+            return false
+          }
         }
+
+        await form.validateFields()
+
+        const formValues = form.getFieldsValue()
+
+        // Clear any prior inline errors once local validation passes
+        if (Object.keys(fieldErrorsRef.current).length > 0) {
+          setFieldErrorsRef.current({})
+        }
+
+        // Use domain-specific change detection
+        const changes = computeChangesRef.current(rowId, formValues, data)
+        if (changes === null) {
+          return true // No changes, nothing to save
+        }
+
+        setIsSaving(true)
+        const success = await onSaveRef.current(rowId, changes)
+        setIsSaving(false)
+        return Boolean(success)
+      } catch {
+        setIsSaving(false)
+        return false
       }
-
-      await form.validateFields()
-
-      const formValues = form.getFieldsValue()
-
-      // Clear any prior inline errors once local validation passes
-      if (Object.keys(fieldErrorsRef.current).length > 0) {
-        setFieldErrorsRef.current({})
-      }
-
-      // Use domain-specific change detection
-      const changes = computeChangesRef.current(rowId, formValues, data)
-      if (changes === null) {
-        return true // No changes, nothing to save
-      }
-
-      setIsSaving(true)
-      const success = await onSaveRef.current(rowId, changes)
-      setIsSaving(false)
-      return Boolean(success)
-    } catch {
-      setIsSaving(false)
-      return false
-    }
-  }, [data, form])
+    },
+    [data, form],
+  )
 
   // Initialize form when row selection changes
   useEffect(() => {
@@ -428,229 +443,249 @@ export function useTreeGridEditing<T extends TreeNode>(
   ])
 
   // Per-cell keyboard handler
-  const handleKeyDown = async (e: React.KeyboardEvent, rowId: string, columnId: string) => {
-    if (!selectedRowId || !tableRef.current) return
+  const handleKeyDown = useCallback(
+    async (e: React.KeyboardEvent, rowId: string, columnId: string) => {
+      if (!selectedRowId || !tableRef.current) return
 
-    if (isSaving) {
-      e.preventDefault()
-      return
-    }
-
-    const rows = tableRef.current.getRowModel().rows
-    const currentRowIndex = rows.findIndex(
-      (r: any) => r.original.id === rowId,
-    )
-    if (currentRowIndex === -1) return
-
-    const currentColIndex = editableColumns.indexOf(columnId)
-    if (currentColIndex === -1) return
-
-    let nextRowId: string | null = null
-    let nextColId: string | null = null
-
-    switch (e.key) {
-      case 'Enter':
-        if (
-          document.querySelector(
-            '.ant-select-dropdown:not(.ant-select-dropdown-hidden), .ant-picker-dropdown:not(.ant-picker-dropdown-hidden)',
-          )
-        ) {
-          return
-        }
+      if (isSaving) {
         e.preventDefault()
-        {
-          const saved = await saveFormChanges(selectedRowId)
-          if (saved) {
-            if (currentRowIndex < rows.length - 1) {
+        return
+      }
+
+      const rows = tableRef.current.getRowModel().rows
+      const currentRowIndex = rows.findIndex(
+        (r: any) => r.original.id === rowId,
+      )
+      if (currentRowIndex === -1) return
+
+      const currentColIndex = editableColumns.indexOf(columnId)
+      if (currentColIndex === -1) return
+
+      let nextRowId: string | null = null
+      let nextColId: string | null = null
+
+      switch (e.key) {
+        case 'Enter':
+          if (
+            document.querySelector(
+              '.ant-select-dropdown:not(.ant-select-dropdown-hidden), .ant-picker-dropdown:not(.ant-picker-dropdown-hidden)',
+            )
+          ) {
+            return
+          }
+          e.preventDefault()
+          {
+            const saved = await saveFormChanges(selectedRowId)
+            if (saved) {
+              if (currentRowIndex < rows.length - 1) {
+                nextRowId = rows[currentRowIndex + 1].original.id
+                const targetCols = resolveEditableColumns(nextRowId)
+                nextColId = targetCols[0]
+                setSelectedRowId(nextRowId)
+                setSelectedCellId(`${nextRowId}-${nextColId}`)
+              } else {
+                setSelectedRowId(null)
+                setSelectedCellId(null)
+              }
+            }
+          }
+          return
+
+        case 'ArrowUp':
+          if (
+            document.querySelector(
+              '.ant-select-dropdown:not(.ant-select-dropdown-hidden), .ant-picker-dropdown:not(.ant-picker-dropdown-hidden)',
+            )
+          ) {
+            return
+          }
+          e.preventDefault()
+          if (currentRowIndex > 0) {
+            nextRowId = rows[currentRowIndex - 1].original.id
+            const targetCols = resolveEditableColumns(nextRowId)
+            nextColId = targetCols[0]
+            await saveFormChanges(selectedRowId)
+            setSelectedRowId(nextRowId)
+            setSelectedCellId(`${nextRowId}-${nextColId}`)
+            return
+          }
+          break
+
+        case 'ArrowDown':
+          if (
+            document.querySelector(
+              '.ant-select-dropdown:not(.ant-select-dropdown-hidden), .ant-picker-dropdown:not(.ant-picker-dropdown-hidden)',
+            )
+          ) {
+            return
+          }
+          e.preventDefault()
+          if (currentRowIndex < rows.length - 1) {
+            nextRowId = rows[currentRowIndex + 1].original.id
+            const targetCols = resolveEditableColumns(nextRowId)
+            nextColId = targetCols.includes(columnId) ? columnId : targetCols[0]
+            await saveFormChanges(selectedRowId)
+            setSelectedRowId(nextRowId)
+            setSelectedCellId(`${nextRowId}-${nextColId}`)
+            return
+          }
+          break
+
+        case 'Escape':
+          e.preventDefault()
+          if (rowId.startsWith(draftPrefix) && onCancelDraftRef.current) {
+            onCancelDraftRef.current(rowId)
+          }
+          setSelectedRowId(null)
+          setSelectedCellId(null)
+          return
+
+        case 'Tab': {
+          e.preventDefault()
+          e.stopPropagation()
+
+          if (document.activeElement instanceof HTMLElement) {
+            document.activeElement.blur()
+          }
+
+          const findNextColInCurrentRow = (
+            startColIdx: number,
+            direction: 1 | -1,
+          ): string | null => {
+            let idx = startColIdx
+            while (idx >= 0 && idx < editableColumns.length) {
+              const col = editableColumns[idx]
+              const cell = document.querySelector(
+                `[data-cell-id="${rowId}-${col}"]`,
+              )
+              if (
+                cell &&
+                cell.querySelector(
+                  'input, .ant-select, .ant-picker, .ant-color-picker, .ant-color-picker-trigger, [data-color-picker-focus]',
+                )
+              ) {
+                return col
+              }
+              idx += direction
+            }
+            return null
+          }
+
+          if (e.shiftKey) {
+            const col = findNextColInCurrentRow(currentColIndex - 1, -1)
+            if (col) {
+              nextColId = col
+              nextRowId = rowId
+            } else if (currentRowIndex > 0) {
+              nextRowId = rows[currentRowIndex - 1].original.id
+              const targetCols = resolveEditableColumns(nextRowId)
+              nextColId = targetCols[targetCols.length - 1]
+            } else {
+              await saveFormChanges(rowId)
+              setSelectedRowId(null)
+              setSelectedCellId(null)
+              return
+            }
+          } else {
+            const col = findNextColInCurrentRow(currentColIndex + 1, 1)
+            if (col) {
+              nextColId = col
+              nextRowId = rowId
+            } else if (currentRowIndex < rows.length - 1) {
               nextRowId = rows[currentRowIndex + 1].original.id
               const targetCols = resolveEditableColumns(nextRowId)
               nextColId = targetCols[0]
-              setSelectedRowId(nextRowId)
-              setSelectedCellId(`${nextRowId}-${nextColId}`)
             } else {
+              await saveFormChanges(rowId)
               setSelectedRowId(null)
               setSelectedCellId(null)
+              return
             }
           }
+          break
         }
-        return
-
-      case 'ArrowUp':
-        if (
-          document.querySelector(
-            '.ant-select-dropdown:not(.ant-select-dropdown-hidden), .ant-picker-dropdown:not(.ant-picker-dropdown-hidden)',
-          )
-        ) {
-          return
-        }
-        e.preventDefault()
-        if (currentRowIndex > 0) {
-          nextRowId = rows[currentRowIndex - 1].original.id
-          const targetCols = resolveEditableColumns(nextRowId)
-          nextColId = targetCols[0]
-          await saveFormChanges(selectedRowId)
-          setSelectedRowId(nextRowId)
-          setSelectedCellId(`${nextRowId}-${nextColId}`)
-          return
-        }
-        break
-
-      case 'ArrowDown':
-        if (
-          document.querySelector(
-            '.ant-select-dropdown:not(.ant-select-dropdown-hidden), .ant-picker-dropdown:not(.ant-picker-dropdown-hidden)',
-          )
-        ) {
-          return
-        }
-        e.preventDefault()
-        if (currentRowIndex < rows.length - 1) {
-          nextRowId = rows[currentRowIndex + 1].original.id
-          const targetCols = resolveEditableColumns(nextRowId)
-          nextColId = targetCols.includes(columnId) ? columnId : targetCols[0]
-          await saveFormChanges(selectedRowId)
-          setSelectedRowId(nextRowId)
-          setSelectedCellId(`${nextRowId}-${nextColId}`)
-          return
-        }
-        break
-
-      case 'Escape':
-        e.preventDefault()
-        if (rowId.startsWith(draftPrefix) && onCancelDraftRef.current) {
-          onCancelDraftRef.current(rowId)
-        }
-        setSelectedRowId(null)
-        setSelectedCellId(null)
-        return
-
-      case 'Tab': {
-        e.preventDefault()
-        e.stopPropagation()
-
-        if (document.activeElement instanceof HTMLElement) {
-          document.activeElement.blur()
-        }
-
-        const findNextColInCurrentRow = (
-          startColIdx: number,
-          direction: 1 | -1,
-        ): string | null => {
-          let idx = startColIdx
-          while (idx >= 0 && idx < editableColumns.length) {
-            const col = editableColumns[idx]
-            const cell = document.querySelector(
-              `[data-cell-id="${rowId}-${col}"]`,
-            )
-            if (
-              cell &&
-              cell.querySelector(
-                'input, .ant-select, .ant-picker, .ant-color-picker, .ant-color-picker-trigger, [data-color-picker-focus]',
-              )
-            ) {
-              return col
-            }
-            idx += direction
-          }
-          return null
-        }
-
-        if (e.shiftKey) {
-          const col = findNextColInCurrentRow(currentColIndex - 1, -1)
-          if (col) {
-            nextColId = col
-            nextRowId = rowId
-          } else if (currentRowIndex > 0) {
-            nextRowId = rows[currentRowIndex - 1].original.id
-            const targetCols = resolveEditableColumns(nextRowId)
-            nextColId = targetCols[targetCols.length - 1]
-          } else {
-            await saveFormChanges(rowId)
-            setSelectedRowId(null)
-            setSelectedCellId(null)
-            return
-          }
-        } else {
-          const col = findNextColInCurrentRow(currentColIndex + 1, 1)
-          if (col) {
-            nextColId = col
-            nextRowId = rowId
-          } else if (currentRowIndex < rows.length - 1) {
-            nextRowId = rows[currentRowIndex + 1].original.id
-            const targetCols = resolveEditableColumns(nextRowId)
-            nextColId = targetCols[0]
-          } else {
-            await saveFormChanges(rowId)
-            setSelectedRowId(null)
-            setSelectedCellId(null)
-            return
-          }
-        }
-        break
-      }
-    }
-
-    if (nextRowId && nextColId) {
-      if (nextRowId !== rowId) {
-        const tabSaved = await saveFormChanges(rowId)
-        if (!tabSaved) return
       }
 
-      setSelectedRowId(nextRowId)
-      setSelectedCellId(`${nextRowId}-${nextColId}`)
-    }
-  }
+      if (nextRowId && nextColId) {
+        if (nextRowId !== rowId) {
+          const tabSaved = await saveFormChanges(rowId)
+          if (!tabSaved) return
+        }
+
+        setSelectedRowId(nextRowId)
+        setSelectedCellId(`${nextRowId}-${nextColId}`)
+      }
+    },
+    [
+      draftPrefix,
+      editableColumns,
+      isSaving,
+      resolveEditableColumns,
+      saveFormChanges,
+      selectedRowId,
+    ],
+  )
 
   // Row click handler
-  const handleRowClick = async (e: React.MouseEvent, args: RowClickArgs) => {
-    if (isSaving || !canEdit) {
-      return
-    }
+  const handleRowClick = useCallback(
+    async (e: React.MouseEvent, args: RowClickArgs) => {
+      if (isSaving || !canEdit) {
+        return
+      }
 
-    const target = e.target as HTMLElement
-    if (
-      target.closest('.ant-select-dropdown') ||
-      target.closest('.ant-picker-dropdown') ||
-      target.closest('.ant-color-picker') ||
-      target.closest('input') ||
-      target.closest('.ant-select-selector') ||
-      target.closest('.ant-color-picker-trigger') ||
-      target.classList.contains('ant-select-item-option-content')
-    ) {
-      return
-    }
+      const target = e.target as HTMLElement
+      if (
+        target.closest('.ant-select-dropdown') ||
+        target.closest('.ant-picker-dropdown') ||
+        target.closest('.ant-color-picker') ||
+        target.closest('input') ||
+        target.closest('.ant-select-selector') ||
+        target.closest('.ant-color-picker-trigger') ||
+        target.classList.contains('ant-select-item-option-content')
+      ) {
+        return
+      }
 
-    if (
-      target.closest('button') ||
-      target.closest('.ant-btn') ||
-      target.closest('.ant-dropdown-trigger') ||
-      target.closest('.ant-dropdown-menu')
-    ) {
-      return
-    }
+      if (
+        target.closest('button') ||
+        target.closest('.ant-btn') ||
+        target.closest('.ant-dropdown-trigger') ||
+        target.closest('.ant-dropdown-menu')
+      ) {
+        return
+      }
 
-    const clickedColumnId = args.getClickedColumnId(target) ?? editableColumns[0]
-    const isEditable = args.isEditableColumn(clickedColumnId)
+      const clickedColumnId = args.getClickedColumnId(target) ?? editableColumns[0]
+      const isEditable = args.isEditableColumn(clickedColumnId)
 
-    if (selectedRowId === args.rowId) {
-      if (isEditable) {
-        const targetCellId = `${args.rowId}-${clickedColumnId}`
-        if (selectedCellId !== targetCellId) {
-          setSelectedCellId(targetCellId)
+      if (selectedRowId === args.rowId) {
+        if (isEditable) {
+          const targetCellId = `${args.rowId}-${clickedColumnId}`
+          if (selectedCellId !== targetCellId) {
+            setSelectedCellId(targetCellId)
+          } else {
+            focusCellById(targetCellId)
+          }
         } else {
-          focusCellById(targetCellId)
+          const targetCellId = `${args.rowId}-${editableColumns[0]}`
+          if (selectedCellId !== targetCellId) {
+            setSelectedCellId(targetCellId)
+          } else {
+            focusCellById(targetCellId)
+          }
+        }
+      } else if (selectedRowId) {
+        const saved = await saveFormChanges(selectedRowId)
+        if (saved) {
+          const targetColumns = resolveEditableColumns(args.rowId)
+          const targetIsEditable = targetColumns.includes(clickedColumnId)
+          setSelectedRowId(args.rowId)
+          const targetCellId = targetIsEditable
+            ? `${args.rowId}-${clickedColumnId}`
+            : `${args.rowId}-${targetColumns[0]}`
+          setSelectedCellId(targetCellId)
         }
       } else {
-        const targetCellId = `${args.rowId}-${editableColumns[0]}`
-        if (selectedCellId !== targetCellId) {
-          setSelectedCellId(targetCellId)
-        } else {
-          focusCellById(targetCellId)
-        }
-      }
-    } else if (selectedRowId) {
-      const saved = await saveFormChanges(selectedRowId)
-      if (saved) {
         const targetColumns = resolveEditableColumns(args.rowId)
         const targetIsEditable = targetColumns.includes(clickedColumnId)
         setSelectedRowId(args.rowId)
@@ -659,16 +694,18 @@ export function useTreeGridEditing<T extends TreeNode>(
           : `${args.rowId}-${targetColumns[0]}`
         setSelectedCellId(targetCellId)
       }
-    } else {
-      const targetColumns = resolveEditableColumns(args.rowId)
-      const targetIsEditable = targetColumns.includes(clickedColumnId)
-      setSelectedRowId(args.rowId)
-      const targetCellId = targetIsEditable
-        ? `${args.rowId}-${clickedColumnId}`
-        : `${args.rowId}-${targetColumns[0]}`
-      setSelectedCellId(targetCellId)
-    }
-  }
+    },
+    [
+      canEdit,
+      editableColumns,
+      focusCellById,
+      isSaving,
+      resolveEditableColumns,
+      saveFormChanges,
+      selectedCellId,
+      selectedRowId,
+    ],
+  )
 
   // Intercept Tab on the Select's inner <input> to prevent rc-select from
   // treating Tab as a selection key (it handles Tab identically to Enter).
@@ -677,19 +714,21 @@ export function useTreeGridEditing<T extends TreeNode>(
   //
   // Because stopPropagation also blocks our own onKeyDown handler on the
   // Select container, we call handleKeyDown directly for Tab events.
-  const createSelectInputKeyDown =
+  const createSelectInputKeyDown = useCallback(
     (rowId: string, columnId: string) =>
-    (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      if (e.key === 'Tab') {
-        e.stopPropagation()
-        // Synthesize the call that stopPropagation blocked
-        handleKeyDown(
-          e as unknown as React.KeyboardEvent,
-          rowId,
-          columnId,
-        )
-      }
-    }
+      (e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        if (e.key === 'Tab') {
+          e.stopPropagation()
+          // Synthesize the call that stopPropagation blocked
+          handleKeyDown(
+            e as unknown as React.KeyboardEvent,
+            rowId,
+            columnId,
+          )
+        }
+      },
+    [handleKeyDown],
+  )
 
   return {
     tableRef,


### PR DESCRIPTION
- Restore useCallback/useMemo in TreeGrid and inline-editing components. Reverts the memoization removal from these four files introduced in 8287cc18 ("Refactor: remove unnecessary useMemo/useCallback hooks").

The React Compiler cannot auto-memoize these components because Form.useWatch creates a cross-component feedback loop:

  1. Parent re-renders (Form.useWatch fires)
  2. Unstable createDraftNode/callback refs → new dataWithDrafts ref
  3. Editing hook useEffect fires (data changed) → form.setFieldsValue
  4. Form.useWatch fires again → infinite render loop → page freeze

The explicit useMemo on dataWithDrafts and useCallback on createDraftNode/saveFormChanges break this cycle. The React Compiler remains enabled and works alongside the manual memoization — this is the recommended approach for cases the compiler cannot resolve.

Affected components:
- TreeGrid (useMemo for dataWithDrafts, useCallback for addDraft/handlers)
- useTreeGridEditing (useCallback for saveFormChanges/focusCellById/etc.)
- ProjectPlanTable (useCallback for createDraftProjectTask/handlers)
- RoadmapItemsGrid (useCallback for createDraftRoadmapItem/handlers)