### PR TITLE
Feature/update identity schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,6 +139,8 @@ Two methods, configured per user via `LoginProvider`:
 
 Key files: `Wayd.Infrastructure/Auth/Local/TokenService.cs`, `wayd.web.reactclient/src/components/contexts/auth/auth-context.tsx`
 
+**Ongoing refactor:** the identity model (how users link to login providers) is being generalized. See [docs/contributing/specs/identity-model-refactor.mdx](docs/contributing/specs/identity-model-refactor.mdx) — multi-PR spec covering a `UserIdentity` table, multi-provider support (Entra + Auth0), tenant-migration history, and a future token-exchange flow.
+
 ### Feature Flags
 
 Microsoft.FeatureManagement — defined in code, stored in database, managed via Settings UI.

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260419201300_Add-UserIdentities-Table.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260419201300_Add-UserIdentities-Table.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419201300_Add-UserIdentities-Table")]
+    partial class AddUserIdentitiesTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260419201300_Add-UserIdentities-Table.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260419201300_Add-UserIdentities-Table.cs
@@ -1,0 +1,117 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddUserIdentitiesTable : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "UserIdentities",
+            schema: "Identity",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                UserId = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: false),
+                Provider = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: false),
+                ProviderTenantId = table.Column<string>(type: "nvarchar(100)", maxLength: 100, nullable: true),
+                ProviderSubject = table.Column<string>(type: "nvarchar(256)", maxLength: 256, nullable: false),
+                IsActive = table.Column<bool>(type: "bit", nullable: false),
+                LinkedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                UnlinkedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                UnlinkReason = table.Column<string>(type: "nvarchar(50)", maxLength: 50, nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_UserIdentities", x => x.Id);
+                table.ForeignKey(
+                    name: "FK_UserIdentities_Users_UserId",
+                    column: x => x.UserId,
+                    principalSchema: "Identity",
+                    principalTable: "Users",
+                    principalColumn: "Id",
+                    onDelete: ReferentialAction.Cascade);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_UserIdentities_UserId",
+            schema: "Identity",
+            table: "UserIdentities",
+            column: "UserId");
+
+        migrationBuilder.CreateIndex(
+            name: "UX_UserIdentities_Provider_Tenant_Subject_Active",
+            schema: "Identity",
+            table: "UserIdentities",
+            columns: new[] { "Provider", "ProviderTenantId", "ProviderSubject" },
+            unique: true,
+            filter: "[IsActive] = 1");
+
+        // Backfill: one UserIdentity row per existing ApplicationUser.
+        //   - Entra users (LoginProvider = 'MicrosoftEntraId' AND ObjectId IS NOT NULL)
+        //     get a row keyed by ObjectId (ProviderTenantId is left NULL; the next
+        //     login populates it via the null-tid upgrade path in UserService).
+        //   - Local ('Wayd') users get a row keyed by ApplicationUser.Id — the stable
+        //     identifier. Usernames are mutable; ApplicationUser.Id is not.
+        // NEWID() is acceptable here because each row is inserted once and the PK is
+        // never referenced by FK (UserId is the link back to the user).
+        migrationBuilder.Sql(@"
+                INSERT INTO [Identity].[UserIdentities]
+                    ([Id], [UserId], [Provider], [ProviderTenantId], [ProviderSubject],
+                     [IsActive], [LinkedAt], [UnlinkedAt], [UnlinkReason])
+                SELECT NEWID(), [Id], 'MicrosoftEntraId', NULL, [ObjectId],
+                       1, SYSUTCDATETIME(), NULL, NULL
+                FROM [Identity].[Users]
+                WHERE [LoginProvider] = 'MicrosoftEntraId' AND [ObjectId] IS NOT NULL;
+
+                INSERT INTO [Identity].[UserIdentities]
+                    ([Id], [UserId], [Provider], [ProviderTenantId], [ProviderSubject],
+                     [IsActive], [LinkedAt], [UnlinkedAt], [UnlinkReason])
+                SELECT NEWID(), [Id], 'Wayd', NULL, [Id],
+                       1, SYSUTCDATETIME(), NULL, NULL
+                FROM [Identity].[Users]
+                WHERE [LoginProvider] = 'Wayd';
+            ");
+
+        // Post-migration assertion: every user who can currently authenticate must
+        // have a matching active UserIdentity row. We deliberately exclude two
+        // legitimate pre-state cases so the migration doesn't fail on them:
+        //   - Entra users who have never logged in (ObjectId IS NULL): the row is
+        //     written on their first SSO login via the EnsureEntraIdentityRow path.
+        //   - Users with an unrecognized LoginProvider value: these are data-quality
+        //     outliers that should be investigated separately, not blocking here.
+        migrationBuilder.Sql(@"
+                DECLARE @Missing int;
+                SELECT @Missing = COUNT(*)
+                FROM [Identity].[Users] u
+                LEFT JOIN [Identity].[UserIdentities] ui
+                    ON ui.[UserId] = u.[Id] AND ui.[IsActive] = 1
+                WHERE ui.[Id] IS NULL
+                  AND (
+                        (u.[LoginProvider] = 'MicrosoftEntraId' AND u.[ObjectId] IS NOT NULL)
+                     OR (u.[LoginProvider] = 'Wayd')
+                      );
+
+                IF @Missing > 0
+                BEGIN
+                    DECLARE @Msg nvarchar(200) = CONCAT(
+                        'UserIdentity backfill incomplete: ', @Missing,
+                        ' authenticable ApplicationUser row(s) have no active UserIdentity. ',
+                        'Investigate before proceeding.');
+                    THROW 50000, @Msg, 1;
+                END
+            ");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "UserIdentities",
+            schema: "Identity");
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs
@@ -61,15 +61,7 @@ internal class TokenService(
             throw new UnauthorizedException("Your account has been deactivated. Please contact an administrator.");
         }
 
-        // Require an active UserIdentity row for the Wayd provider. Uniform with
-        // the Entra flow and enables "disable local login for this user" without
-        // a new flag — an admin can deactivate the identity row instead.
-        var hasActiveIdentity = await _userIdentityStore.ExistsActive(user.Id, LoginProviders.Wayd, cancellationToken);
-        if (!hasActiveIdentity)
-        {
-            _logger.LogWarning("Login failed: user {UserName} has no active Wayd identity.", command.UserName);
-            throw new UnauthorizedException("Invalid credentials.");
-        }
+        await EnsureActiveWaydIdentityAsync(user, command.UserName, cancellationToken);
 
         return await GenerateTokensAndUpdateUser(user);
     }
@@ -99,7 +91,27 @@ internal class TokenService(
             throw new UnauthorizedException("Invalid or expired refresh token.");
         }
 
+        // Deactivating a UserIdentity must also stop in-flight sessions, not just new
+        // logins. Without this check a user whose local identity was revoked could
+        // keep minting fresh access tokens via refresh until the refresh-token TTL
+        // (days) elapsed.
+        await EnsureActiveWaydIdentityAsync(user, user.UserName ?? userId, cancellationToken);
+
         return await GenerateTokensAndUpdateUser(user);
+    }
+
+    private async Task EnsureActiveWaydIdentityAsync(ApplicationUser user, string usernameForLogging, CancellationToken cancellationToken)
+    {
+        // Requires an active UserIdentity row for the Wayd provider. Enables
+        // "disable local login for this user" by deactivating the identity row —
+        // no new flag needed. Applied on both login and refresh so revocation takes
+        // effect immediately on the next refresh, not when the refresh token expires.
+        var hasActiveIdentity = await _userIdentityStore.ExistsActive(user.Id, LoginProviders.Wayd, cancellationToken);
+        if (!hasActiveIdentity)
+        {
+            _logger.LogWarning("Authentication failed: user {UserName} has no active Wayd identity.", usernameForLogging);
+            throw new UnauthorizedException("Invalid credentials.");
+        }
     }
 
     private async Task<TokenResponse> GenerateTokensAndUpdateUser(ApplicationUser user)

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Wayd.Common.Application.Identity;
 using Wayd.Common.Application.Identity.Tokens;
+using Wayd.Infrastructure.Identity;
 
 namespace Wayd.Infrastructure.Auth.Local;
 
@@ -15,12 +16,14 @@ internal class TokenService(
     SignInManager<ApplicationUser> signInManager,
     IConfiguration config,
     IDateTimeProvider dateTimeProvider,
+    IUserIdentityStore userIdentityStore,
     ILogger<TokenService> logger) : ITokenService
 {
     private readonly UserManager<ApplicationUser> _userManager = userManager;
     private readonly SignInManager<ApplicationUser> _signInManager = signInManager;
     private readonly IConfiguration _config = config;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+    private readonly IUserIdentityStore _userIdentityStore = userIdentityStore;
     private readonly ILogger<TokenService> _logger = logger;
 
     public async Task<TokenResponse> GetTokenAsync(LoginCommand command, CancellationToken cancellationToken)
@@ -56,6 +59,16 @@ internal class TokenService(
         {
             _logger.LogWarning("Login failed: user {UserName} is inactive.", command.UserName);
             throw new UnauthorizedException("Your account has been deactivated. Please contact an administrator.");
+        }
+
+        // Require an active UserIdentity row for the Wayd provider. Uniform with
+        // the Entra flow and enables "disable local login for this user" without
+        // a new flag — an admin can deactivate the identity row instead.
+        var hasActiveIdentity = await _userIdentityStore.ExistsActive(user.Id, LoginProviders.Wayd, cancellationToken);
+        if (!hasActiveIdentity)
+        {
+            _logger.LogWarning("Login failed: user {UserName} has no active Wayd identity.", command.UserName);
+            throw new UnauthorizedException("Invalid credentials.");
         }
 
         return await GenerateTokensAndUpdateUser(user);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs
@@ -24,4 +24,6 @@ public class ApplicationUser : IdentityUser
     public UserPreferences Preferences { get; set; } = new();
 
     public ICollection<ApplicationUserRole> UserRoles { get; set; } = [];
+
+    public ICollection<UserIdentity> Identities { get; set; } = [];
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/IUserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/IUserIdentityStore.cs
@@ -1,4 +1,6 @@
-﻿namespace Wayd.Infrastructure.Identity;
+﻿using NodaTime;
+
+namespace Wayd.Infrastructure.Identity;
 
 /// <summary>
 /// Narrow seam over <see cref="UserIdentity"/> persistence. Introduced so identity-
@@ -17,7 +19,30 @@ internal interface IUserIdentityStore : IScopedService
 
     Task<bool> ExistsActive(string userId, string provider, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// Marks every active row for a user as inactive, setting <c>UnlinkedAt</c> and
+    /// the given <c>unlinkReason</c>. Used to enforce the "exactly one active identity
+    /// per user at rest" invariant when a new identity is being linked.
+    /// </summary>
+    Task<int> DeactivateAllActive(string userId, Instant unlinkedAt, string unlinkReason, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Conditionally sets <c>ProviderTenantId</c> on a backfilled row — only if the
+    /// row still has a NULL tenant. Returns true if this caller won the race, false
+    /// if another concurrent caller already populated the tenant (in which case the
+    /// caller must re-resolve rather than assume the row is theirs).
+    /// </summary>
+    Task<bool> TryPopulateTenant(Guid identityId, string tenantId, CancellationToken cancellationToken = default);
+
     Task Add(UserIdentity identity, CancellationToken cancellationToken = default);
 
     Task Update(UserIdentity identity, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Runs <paramref name="action"/> inside a database transaction on the
+    /// underlying <c>WaydDbContext</c>. Commits on success, rolls back on throw.
+    /// Used to ensure that multi-step writes touching both <c>ApplicationUser</c>
+    /// (via <c>UserManager</c>) and <c>UserIdentity</c> land atomically.
+    /// </summary>
+    Task ExecuteInTransaction(Func<CancellationToken, Task> action, CancellationToken cancellationToken = default);
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/IUserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/IUserIdentityStore.cs
@@ -1,0 +1,23 @@
+﻿namespace Wayd.Infrastructure.Identity;
+
+/// <summary>
+/// Narrow seam over <see cref="UserIdentity"/> persistence. Introduced so identity-
+/// write paths in <see cref="UserService"/> and <see cref="Auth.Local.TokenService"/>
+/// can be unit-tested without spinning up a full <c>WaydDbContext</c>.
+/// </summary>
+internal interface IUserIdentityStore : IScopedService
+{
+    Task<UserIdentity?> FindActive(string provider, string? tenantId, string subject, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Returns up to two active rows matching (provider, subject) with NULL tenant.
+    /// Used by the Entra null-tid upgrade path to detect ambiguous matches.
+    /// </summary>
+    Task<IReadOnlyList<UserIdentity>> FindActiveByNullTenant(string provider, string subject, CancellationToken cancellationToken = default);
+
+    Task<bool> ExistsActive(string userId, string provider, CancellationToken cancellationToken = default);
+
+    Task Add(UserIdentity identity, CancellationToken cancellationToken = default);
+
+    Task Update(UserIdentity identity, CancellationToken cancellationToken = default);
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentity.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentity.cs
@@ -1,0 +1,33 @@
+using NodaTime;
+
+namespace Wayd.Infrastructure.Identity;
+
+public class UserIdentity
+{
+    public Guid Id { get; set; }
+
+    public string UserId { get; set; } = null!;
+
+    public ApplicationUser? User { get; set; }
+
+    public string Provider { get; set; } = null!;
+
+    public string? ProviderTenantId { get; set; }
+
+    public string ProviderSubject { get; set; } = null!;
+
+    public bool IsActive { get; set; }
+
+    public Instant LinkedAt { get; set; }
+
+    public Instant? UnlinkedAt { get; set; }
+
+    public string? UnlinkReason { get; set; }
+}
+
+public static class UserIdentityUnlinkReasons
+{
+    public const string TenantMigration = "TenantMigration";
+    public const string AdminRevoked = "AdminRevoked";
+    public const string UserUnlinked = "UserUnlinked";
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentity.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentity.cs
@@ -30,4 +30,5 @@ public static class UserIdentityUnlinkReasons
     public const string TenantMigration = "TenantMigration";
     public const string AdminRevoked = "AdminRevoked";
     public const string UserUnlinked = "UserUnlinked";
+    public const string ProviderRelinked = "ProviderRelinked";
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
@@ -1,9 +1,18 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using NodaTime;
 
 namespace Wayd.Infrastructure.Identity;
 
 internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
 {
+    // SQL Server error numbers for unique-constraint / duplicate-key violations.
+    // 2627 = unique constraint, 2601 = unique index. We treat either as "another
+    // concurrent caller inserted the same logical row first" — the caller's goal
+    // (ensure this row exists) is satisfied either way.
+    private const int SqlUniqueConstraintErrorNumber = 2627;
+    private const int SqlUniqueIndexErrorNumber = 2601;
+
     private readonly WaydDbContext _db = db;
 
     public Task<UserIdentity?> FindActive(string provider, string? tenantId, string subject, CancellationToken cancellationToken = default)
@@ -40,15 +49,83 @@ internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
             cancellationToken);
     }
 
+    public async Task<int> DeactivateAllActive(string userId, Instant unlinkedAt, string unlinkReason, CancellationToken cancellationToken = default)
+    {
+        var active = await _db.UserIdentities
+            .Where(ui => ui.UserId == userId && ui.IsActive)
+            .ToListAsync(cancellationToken);
+
+        foreach (var row in active)
+        {
+            row.IsActive = false;
+            row.UnlinkedAt = unlinkedAt;
+            row.UnlinkReason = unlinkReason;
+        }
+
+        if (active.Count > 0)
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+
+        return active.Count;
+    }
+
+    public async Task<bool> TryPopulateTenant(Guid identityId, string tenantId, CancellationToken cancellationToken = default)
+    {
+        // Conditional UPDATE: only succeeds if the row still has a NULL tenant.
+        // Two concurrent logins could both see the backfilled NULL-tenant row; the
+        // one whose UPDATE lands first wins, the other gets 0 rows affected and must
+        // re-resolve (their tenantId might match the now-populated row, or might not).
+        var rowsAffected = await _db.UserIdentities
+            .Where(ui => ui.Id == identityId && ui.ProviderTenantId == null)
+            .ExecuteUpdateAsync(
+                updates => updates.SetProperty(ui => ui.ProviderTenantId, tenantId),
+                cancellationToken);
+
+        return rowsAffected == 1;
+    }
+
     public async Task Add(UserIdentity identity, CancellationToken cancellationToken = default)
     {
         _db.UserIdentities.Add(identity);
-        await _db.SaveChangesAsync(cancellationToken);
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (DbUpdateException ex) when (IsUniqueConstraintViolation(ex))
+        {
+            // A concurrent caller inserted the same (provider, tenant, subject) row
+            // between our caller's ExistsActive check and this insert. The logical
+            // outcome ("a row exists") is achieved, so we swallow and detach the
+            // rejected entity so the context stays usable.
+            _db.Entry(identity).State = EntityState.Detached;
+        }
+    }
+
+    private static bool IsUniqueConstraintViolation(DbUpdateException ex)
+    {
+        return ex.InnerException is SqlException sql &&
+               (sql.Number == SqlUniqueConstraintErrorNumber || sql.Number == SqlUniqueIndexErrorNumber);
     }
 
     public async Task Update(UserIdentity identity, CancellationToken cancellationToken = default)
     {
         _db.UserIdentities.Update(identity);
         await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task ExecuteInTransaction(Func<CancellationToken, Task> action, CancellationToken cancellationToken = default)
+    {
+        await using var tx = await _db.Database.BeginTransactionAsync(cancellationToken);
+        try
+        {
+            await action(cancellationToken);
+            await tx.CommitAsync(cancellationToken);
+        }
+        catch
+        {
+            await tx.RollbackAsync(cancellationToken);
+            throw;
+        }
     }
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Wayd.Infrastructure.Identity;
+
+internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
+{
+    private readonly WaydDbContext _db = db;
+
+    public Task<UserIdentity?> FindActive(string provider, string? tenantId, string subject, CancellationToken cancellationToken = default)
+    {
+        return _db.UserIdentities
+            .Include(ui => ui.User)
+            .FirstOrDefaultAsync(ui =>
+                ui.IsActive &&
+                ui.Provider == provider &&
+                ui.ProviderTenantId == tenantId &&
+                ui.ProviderSubject == subject,
+                cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<UserIdentity>> FindActiveByNullTenant(string provider, string subject, CancellationToken cancellationToken = default)
+    {
+        return await _db.UserIdentities
+            .Include(ui => ui.User)
+            .Where(ui =>
+                ui.IsActive &&
+                ui.Provider == provider &&
+                ui.ProviderTenantId == null &&
+                ui.ProviderSubject == subject)
+            .Take(2)
+            .ToListAsync(cancellationToken);
+    }
+
+    public Task<bool> ExistsActive(string userId, string provider, CancellationToken cancellationToken = default)
+    {
+        return _db.UserIdentities.AnyAsync(ui =>
+            ui.UserId == userId &&
+            ui.IsActive &&
+            ui.Provider == provider,
+            cancellationToken);
+    }
+
+    public async Task Add(UserIdentity identity, CancellationToken cancellationToken = default)
+    {
+        _db.UserIdentities.Add(identity);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+
+    public async Task Update(UserIdentity identity, CancellationToken cancellationToken = default)
+    {
+        _db.UserIdentities.Update(identity);
+        await _db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -15,11 +15,14 @@ namespace Wayd.Infrastructure.Identity;
 internal partial class UserService
 {
     /// <summary>
-    /// This is used when authenticating with AzureAd.
-    /// The local user is retrieved using the objectidentifier claim present in the ClaimsPrincipal.
-    /// If no such claim is found, an InternalServerException is thrown.
-    /// If no user is found with that ObjectId, a new one is created and populated with the values from the ClaimsPrincipal.
-    /// If a role claim is present in the principal, and the user is not yet in that roll, then the user is added to that role.
+    /// Used when authenticating with Microsoft Entra ID.
+    ///
+    /// Resolves the user via the <c>UserIdentity</c> table, keyed by
+    /// (Provider, ProviderTenantId, ProviderSubject) = (MicrosoftEntraId, tid, oid).
+    /// If no active identity matches and exactly one identity matches (MicrosoftEntraId, NULL, oid),
+    /// that row's ProviderTenantId is populated from the token — the one-time upgrade
+    /// path for users backfilled before tenant was persisted.
+    /// If still no match, the user is created and a new UserIdentity row is inserted.
     /// </summary>
     public async Task<(string Id, string? EmployeeId)> GetOrCreateFromPrincipalAsync(ClaimsPrincipal principal)
     {
@@ -30,9 +33,16 @@ internal partial class UserService
             throw new InternalServerException("Invalid objectId");
         }
 
+        string? tenantId = principal.GetTenantId();
+        if (string.IsNullOrWhiteSpace(tenantId))
+        {
+            _logger.LogError("Invalid principal tenantId");
+            throw new InternalServerException("Invalid tenantId");
+        }
+
         var isFirstUser = !await _userManager.Users.AnyAsync();
 
-        var user = await _userManager.Users.Where(u => u.ObjectId == objectId).FirstOrDefaultAsync()
+        var user = await ResolveUserByEntraIdentityAsync(tenantId, objectId)
             ?? await CreateOrUpdateFromPrincipalAsync(principal, isFirstUser);
 
         if (isFirstUser)
@@ -51,6 +61,39 @@ internal partial class UserService
         }
 
         return (user.Id, user.EmployeeId?.ToString());
+    }
+
+    private async Task<ApplicationUser?> ResolveUserByEntraIdentityAsync(string tenantId, string objectId)
+    {
+        var identity = await _userIdentityStore.FindActive(LoginProviders.MicrosoftEntraId, tenantId, objectId);
+        if (identity is not null)
+        {
+            return identity.User;
+        }
+
+        // One-time upgrade path: rows backfilled from ApplicationUser.ObjectId have
+        // ProviderTenantId = NULL. On the user's next login, populate tenant from the
+        // token. If more than one such row matches the subject (extremely unlikely
+        // oid collision across tenants), bail out — do not auto-link.
+        var pending = await _userIdentityStore.FindActiveByNullTenant(LoginProviders.MicrosoftEntraId, objectId);
+
+        if (pending.Count == 0)
+        {
+            return null;
+        }
+
+        if (pending.Count > 1)
+        {
+            _logger.LogError(
+                "Ambiguous tenant upgrade for Entra subject {ObjectId}: {Count} active rows with NULL tenant. Manual resolution required.",
+                objectId, pending.Count);
+            throw new InternalServerException("Identity resolution ambiguous. Contact an administrator.");
+        }
+
+        var row = pending[0];
+        row.ProviderTenantId = tenantId;
+        await _userIdentityStore.Update(row);
+        return row.User;
     }
 
     private async Task<ApplicationUser> CreateOrUpdateFromPrincipalAsync(ClaimsPrincipal principal, bool isFirstUser)
@@ -83,6 +126,8 @@ internal partial class UserService
                 throw new InternalServerException($"Email {email} is already taken.");
             }
         }
+
+        string principalTenantId = principal.GetTenantId() ?? throw new InternalServerException("Principal TenantId is missing or null.");
 
         IdentityResult? result;
         if (user is not null)
@@ -129,7 +174,32 @@ internal partial class UserService
             throw new InternalServerException("Validation Errors Occurred.");
         }
 
+        await EnsureEntraIdentityRowAsync(user.Id, principalTenantId, principalObjectId);
+
         return user;
+    }
+
+    private async Task EnsureEntraIdentityRowAsync(string userId, string tenantId, string objectId)
+    {
+        // Idempotent: inserts an active Entra UserIdentity row if one doesn't already
+        // exist for this user. Covers both new-user creation and the "existing local
+        // user is being linked to Entra" path.
+        var exists = await _userIdentityStore.ExistsActive(userId, LoginProviders.MicrosoftEntraId);
+        if (exists)
+        {
+            return;
+        }
+
+        await _userIdentityStore.Add(new UserIdentity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Provider = LoginProviders.MicrosoftEntraId,
+            ProviderTenantId = tenantId,
+            ProviderSubject = objectId,
+            IsActive = true,
+            LinkedAt = _dateTimeProvider.Now,
+        });
     }
 
     public async Task<Result<string>> CreateAsync(CreateUserCommand command, CancellationToken cancellationToken)
@@ -166,6 +236,24 @@ internal partial class UserService
 
         await _userManager.AddToRoleAsync(user, ApplicationRoles.Basic);
         await _events.PublishAsync(new ApplicationUserCreatedEvent(user.Id, _dateTimeProvider.Now));
+
+        // Wayd (local) users get an identity row immediately, keyed by the stable
+        // ApplicationUser.Id (usernames are mutable). Entra users created by an admin
+        // have no oid/tid yet — the row is inserted on their first SSO login via
+        // EnsureEntraIdentityRowAsync.
+        if (command.LoginProvider == LoginProviders.Wayd)
+        {
+            await _userIdentityStore.Add(new UserIdentity
+            {
+                Id = Guid.NewGuid(),
+                UserId = user.Id,
+                Provider = LoginProviders.Wayd,
+                ProviderTenantId = null,
+                ProviderSubject = user.Id,
+                IsActive = true,
+                LinkedAt = _dateTimeProvider.Now,
+            }, cancellationToken);
+        }
 
         _logger.LogInformation("User {UserId} created successfully.", user.Id);
         return Result.Success(user.Id);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -91,8 +91,24 @@ internal partial class UserService
         }
 
         var row = pending[0];
-        row.ProviderTenantId = tenantId;
-        await _userIdentityStore.Update(row);
+
+        // Conditional UPDATE guards against a concurrent login racing us. If another
+        // login populated the tenant first, TryPopulateTenant returns false and we
+        // re-resolve — the other login may have set a tenant that matches ours (fine,
+        // both users converge on the same row) or a different one (our token has no
+        // matching active row, so we fall into the create path).
+        var won = await _userIdentityStore.TryPopulateTenant(row.Id, tenantId);
+        if (!won)
+        {
+            _logger.LogInformation(
+                "Tenant upgrade for Entra subject {ObjectId} lost the race to a concurrent login; re-resolving.",
+                objectId);
+            return await _userIdentityStore.FindActive(LoginProviders.MicrosoftEntraId, tenantId, objectId)
+                is { } winnerIdentity
+                ? winnerIdentity.User
+                : null;
+        }
+
         return row.User;
     }
 
@@ -181,14 +197,17 @@ internal partial class UserService
 
     private async Task EnsureEntraIdentityRowAsync(string userId, string tenantId, string objectId)
     {
-        // Idempotent: inserts an active Entra UserIdentity row if one doesn't already
-        // exist for this user. Covers both new-user creation and the "existing local
-        // user is being linked to Entra" path.
+        // Idempotent for the new-user case, and enforces the "exactly one active
+        // identity per user" invariant when an existing user is being linked to
+        // Entra (e.g., a Wayd-local user moving to SSO). Any prior active row —
+        // including a Wayd identity — is marked inactive with reason ProviderRelinked.
         var exists = await _userIdentityStore.ExistsActive(userId, LoginProviders.MicrosoftEntraId);
         if (exists)
         {
             return;
         }
+
+        await _userIdentityStore.DeactivateAllActive(userId, _dateTimeProvider.Now, UserIdentityUnlinkReasons.ProviderRelinked);
 
         await _userIdentityStore.Add(new UserIdentity
         {
@@ -223,41 +242,72 @@ internal partial class UserService
             MustChangePassword = command.LoginProvider == LoginProviders.Wayd,
         };
 
-        IdentityResult result = command.LoginProvider == LoginProviders.Wayd
-            ? await _userManager.CreateAsync(user, command.Password!)
-            : await _userManager.CreateAsync(user);
-
-        if (!result.Succeeded)
+        // User creation, role assignment, and the Wayd identity row must land
+        // together. Partial failure — user exists with no active Wayd identity —
+        // would leave a local user who cannot log in (TokenService gates on the
+        // identity row). Run the whole thing in a transaction so any failure rolls
+        // back the user.
+        IdentityResult? result = null;
+        try
         {
-            var errors = string.Join(", ", result.Errors.Select(e => e.Description));
+            await _userIdentityStore.ExecuteInTransaction(async ct =>
+            {
+                result = command.LoginProvider == LoginProviders.Wayd
+                    ? await _userManager.CreateAsync(user, command.Password!)
+                    : await _userManager.CreateAsync(user);
+
+                if (!result.Succeeded)
+                {
+                    // Throw to force rollback. Outer catch swallows this sentinel;
+                    // `result` carries the validation errors back to the caller.
+                    throw new UserCreationRollbackException();
+                }
+
+                await _userManager.AddToRoleAsync(user, ApplicationRoles.Basic);
+
+                // Wayd (local) users get an identity row immediately, keyed by the
+                // stable ApplicationUser.Id (usernames are mutable). Entra users
+                // created by an admin have no oid/tid yet — the row is inserted on
+                // their first SSO login via EnsureEntraIdentityRowAsync.
+                if (command.LoginProvider == LoginProviders.Wayd)
+                {
+                    await _userIdentityStore.Add(new UserIdentity
+                    {
+                        Id = Guid.NewGuid(),
+                        UserId = user.Id,
+                        Provider = LoginProviders.Wayd,
+                        ProviderTenantId = null,
+                        ProviderSubject = user.Id,
+                        IsActive = true,
+                        LinkedAt = _dateTimeProvider.Now,
+                    }, ct);
+                }
+            }, cancellationToken);
+        }
+        catch (UserCreationRollbackException)
+        {
+            // Expected when UserManager.CreateAsync returned a failing IdentityResult
+            // inside the transaction. Fall through — the block below formats the
+            // error response from `result`.
+        }
+
+        if (result is null || !result.Succeeded)
+        {
+            var errors = result is null
+                ? "User creation failed."
+                : string.Join(", ", result.Errors.Select(e => e.Description));
             _logger.LogError("Error creating user: {Errors}", errors);
             return Result.Failure<string>(errors);
         }
 
-        await _userManager.AddToRoleAsync(user, ApplicationRoles.Basic);
+        // Publish after commit so subscribers don't see events for rolled-back users.
         await _events.PublishAsync(new ApplicationUserCreatedEvent(user.Id, _dateTimeProvider.Now));
-
-        // Wayd (local) users get an identity row immediately, keyed by the stable
-        // ApplicationUser.Id (usernames are mutable). Entra users created by an admin
-        // have no oid/tid yet — the row is inserted on their first SSO login via
-        // EnsureEntraIdentityRowAsync.
-        if (command.LoginProvider == LoginProviders.Wayd)
-        {
-            await _userIdentityStore.Add(new UserIdentity
-            {
-                Id = Guid.NewGuid(),
-                UserId = user.Id,
-                Provider = LoginProviders.Wayd,
-                ProviderTenantId = null,
-                ProviderSubject = user.Id,
-                IsActive = true,
-                LinkedAt = _dateTimeProvider.Now,
-            }, cancellationToken);
-        }
 
         _logger.LogInformation("User {UserId} created successfully.", user.Id);
         return Result.Success(user.Id);
     }
+
+    private sealed class UserCreationRollbackException : Exception { }
 
     public async Task UpdateAsync(UpdateUserCommand command, string userId)
     {

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.cs
@@ -18,7 +18,8 @@ internal partial class UserService(
     GraphServiceClient graphServiceClient,
     ISender sender,
     IDateTimeProvider dateTimeProvider,
-    ICurrentUser currentUser) : IUserService
+    ICurrentUser currentUser,
+    IUserIdentityStore userIdentityStore) : IUserService
 {
     private readonly ILogger<UserService> _logger = logger;
     private readonly SignInManager<ApplicationUser> _signInManager = signInManager;
@@ -30,6 +31,7 @@ internal partial class UserService(
     private readonly ISender _sender = sender;
     private readonly ICurrentUser _currentUser = currentUser;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+    private readonly IUserIdentityStore _userIdentityStore = userIdentityStore;
 
     public async Task<IReadOnlyList<UserDetailsDto>> SearchAsync(UserListFilter filter, CancellationToken cancellationToken)
     {

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
@@ -52,6 +52,42 @@ public class ApplicationUserConfig : IEntityTypeConfiguration<ApplicationUser>
     }
 }
 
+public class UserIdentityConfig : IEntityTypeConfiguration<UserIdentity>
+{
+    public void Configure(EntityTypeBuilder<UserIdentity> builder)
+    {
+        builder.ToTable("UserIdentities", SchemaNames.Identity);
+
+        builder.HasKey(ui => ui.Id);
+        builder.Property(ui => ui.Id).ValueGeneratedNever();
+
+        builder.Property(ui => ui.UserId).HasMaxLength(450).IsRequired();
+        builder.Property(ui => ui.Provider).HasMaxLength(50).IsRequired();
+        builder.Property(ui => ui.ProviderTenantId).HasMaxLength(100);
+        builder.Property(ui => ui.ProviderSubject).HasMaxLength(256).IsRequired();
+        builder.Property(ui => ui.IsActive).IsRequired();
+        builder.Property(ui => ui.LinkedAt).IsRequired();
+        builder.Property(ui => ui.UnlinkedAt);
+        builder.Property(ui => ui.UnlinkReason).HasMaxLength(50);
+
+        // One active identity per (provider, tenant, subject). Filtered so inactive
+        // rows don't collide and so NULL tenants (Wayd provider) are handled per
+        // SQL Server filtered-unique-index semantics.
+        builder.HasIndex(ui => new { ui.Provider, ui.ProviderTenantId, ui.ProviderSubject })
+            .IsUnique()
+            .HasFilter("[IsActive] = 1")
+            .HasDatabaseName("UX_UserIdentities_Provider_Tenant_Subject_Active");
+
+        builder.HasIndex(ui => ui.UserId)
+            .HasDatabaseName("IX_UserIdentities_UserId");
+
+        builder.HasOne(ui => ui.User)
+            .WithMany(u => u.Identities)
+            .HasForeignKey(ui => ui.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+
 public class ApplicationRoleConfig : IEntityTypeConfiguration<ApplicationRole>
 {
     public void Configure(EntityTypeBuilder<ApplicationRole> builder)

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Context/WaydDbContext.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Context/WaydDbContext.cs
@@ -41,6 +41,7 @@ public class WaydDbContext : BaseDbContext, IAppIntegrationDbContext, IFeatureMa
     public DbSet<ExternalEmployeeBlacklistItem> ExternalEmployeeBlacklistItems => Set<ExternalEmployeeBlacklistItem>();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => Set<PersonalAccessToken>();
     public DbSet<User> WaydUsers => Set<User>();
+    public DbSet<UserIdentity> UserIdentities => Set<UserIdentity>();
 
     #endregion Common
 

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
@@ -399,6 +399,38 @@ public class TokenServiceTests
             .WithMessage("User account is inactive.");
     }
 
+    [Fact]
+    public async Task RefreshTokenAsync_ShouldThrowUnauthorized_WhenWaydIdentityDeactivatedAfterLogin()
+    {
+        // Simulates admin revocation of the user's local login between issuing the
+        // initial token and the refresh. The refresh must fail — otherwise a revoked
+        // user could keep minting access tokens until the refresh-token TTL elapses.
+        var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
+
+        _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
+        _mockSignInManager.Setup(x => x.CheckPasswordSignInAsync(user, "Password123!", true))
+            .ReturnsAsync(SignInResult.Success);
+        _mockUserManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+        var tokenResponse = await _sut.GetTokenAsync(new LoginCommand("testuser", "Password123!"), TestContext.Current.CancellationToken);
+        var currentRefreshToken = user.RefreshToken;
+
+        _mockUserManager.Setup(x => x.FindByIdAsync("user-1")).ReturnsAsync(user);
+
+        // Deactivate the Wayd identity after the initial token was issued.
+        _mockUserIdentityStore
+            .Setup(s => s.ExistsActive(user.Id, LoginProviders.Wayd, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var refreshCommand = new RefreshTokenCommand(tokenResponse.Token, currentRefreshToken!);
+
+        var act = () => _sut.RefreshTokenAsync(refreshCommand, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<UnauthorizedException>()
+            .WithMessage("Invalid credentials.");
+    }
+
     #endregion
 
     #region GetSettings

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
@@ -24,6 +24,7 @@ public class TokenServiceTests
     private readonly IConfiguration _configuration;
     private readonly TestingDateTimeProvider _dateTimeProvider;
     private readonly Mock<ILogger<TokenService>> _mockLogger;
+    private readonly Mock<IUserIdentityStore> _mockUserIdentityStore;
     private readonly TokenService _sut;
 
     public TokenServiceTests()
@@ -51,12 +52,14 @@ public class TokenServiceTests
 
         _dateTimeProvider = new TestingDateTimeProvider(DateTime.UtcNow);
         _mockLogger = new Mock<ILogger<TokenService>>();
+        _mockUserIdentityStore = new Mock<IUserIdentityStore>();
 
         _sut = new TokenService(
             _mockUserManager.Object,
             _mockSignInManager.Object,
             _configuration,
             _dateTimeProvider,
+            _mockUserIdentityStore.Object,
             _mockLogger.Object);
     }
 
@@ -74,6 +77,13 @@ public class TokenServiceTests
         };
     }
 
+    private void SeedActiveWaydIdentity(string userId)
+    {
+        _mockUserIdentityStore
+            .Setup(s => s.ExistsActive(userId, LoginProviders.Wayd, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+    }
+
     #region GetTokenAsync
 
     [Fact]
@@ -81,6 +91,7 @@ public class TokenServiceTests
     {
         // Arrange
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
         var command = new LoginCommand("testuser", "Password123!");
 
         _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
@@ -113,6 +124,7 @@ public class TokenServiceTests
         var employeeId = Guid.NewGuid();
         var user = CreateLocalUser();
         user.EmployeeId = employeeId;
+        SeedActiveWaydIdentity(user.Id);
         var command = new LoginCommand("testuser", "Password123!");
 
         _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
@@ -216,10 +228,33 @@ public class TokenServiceTests
     }
 
     [Fact]
+    public async Task GetTokenAsync_ShouldThrowUnauthorized_WhenNoActiveWaydIdentity()
+    {
+        // Credentials valid, user active, but the UserIdentity row has been deactivated
+        // (admin-revoked local login). Must fail without issuing a token.
+        var user = CreateLocalUser();
+        _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
+        _mockSignInManager.Setup(x => x.CheckPasswordSignInAsync(user, "Password123!", true))
+            .ReturnsAsync(SignInResult.Success);
+        _mockUserIdentityStore
+            .Setup(s => s.ExistsActive(user.Id, LoginProviders.Wayd, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var command = new LoginCommand("testuser", "Password123!");
+
+        var act = () => _sut.GetTokenAsync(command, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<UnauthorizedException>()
+            .WithMessage("Invalid credentials.");
+        _mockUserManager.Verify(x => x.UpdateAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
     public async Task GetTokenAsync_ShouldUpdateRefreshToken_WhenLoginSucceeds()
     {
         // Arrange
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
         var command = new LoginCommand("testuser", "Password123!");
 
         _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
@@ -245,6 +280,7 @@ public class TokenServiceTests
     {
         // Arrange - first get a valid token
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
         user.RefreshToken = "valid-refresh-token";
         user.RefreshTokenExpiryTime = _dateTimeProvider.Now.ToDateTimeUtc().AddDays(7);
 
@@ -280,6 +316,7 @@ public class TokenServiceTests
     {
         // Arrange - get a valid JWT first
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
         user.RefreshToken = "stored-refresh-token";
         user.RefreshTokenExpiryTime = _dateTimeProvider.Now.ToDateTimeUtc().AddDays(7);
 
@@ -308,6 +345,7 @@ public class TokenServiceTests
     {
         // Arrange
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
 
         _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
         _mockSignInManager.Setup(x => x.CheckPasswordSignInAsync(user, "Password123!", true))
@@ -337,6 +375,7 @@ public class TokenServiceTests
     {
         // Arrange
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
 
         _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
         _mockSignInManager.Setup(x => x.CheckPasswordSignInAsync(user, "Password123!", true))
@@ -374,9 +413,11 @@ public class TokenServiceTests
             _mockSignInManager.Object,
             emptyConfig,
             _dateTimeProvider,
+            _mockUserIdentityStore.Object,
             _mockLogger.Object);
 
         var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
         _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
         _mockSignInManager.Setup(x => x.CheckPasswordSignInAsync(user, "Password123!", true))
             .ReturnsAsync(SignInResult.Success);

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
@@ -55,6 +55,12 @@ public class UserServiceTests
         _mockCurrentUser = new Mock<ICurrentUser>();
         _mockCurrentUser.Setup(x => x.GetUserId()).Returns("current-user-id");
         _mockUserIdentityStore = new Mock<IUserIdentityStore>();
+
+        // Pass-through: tests don't exercise transaction semantics. Invoke the
+        // action directly so CreateAsync behaves as if the transaction succeeded.
+        _mockUserIdentityStore
+            .Setup(s => s.ExecuteInTransaction(It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<CancellationToken>()))
+            .Returns<Func<CancellationToken, Task>, CancellationToken>((action, ct) => action(ct));
     }
 
     private UserService CreateSut()

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
@@ -26,9 +26,11 @@ public class UserServiceTests
     private readonly TestingDateTimeProvider _dateTimeProvider;
     private readonly Mock<ISender> _mockSender;
     private readonly Mock<ICurrentUser> _mockCurrentUser;
+    private readonly Mock<IUserIdentityStore> _mockUserIdentityStore;
 
-    // UserService depends on WaydDbContext and GraphServiceClient which are hard to mock.
-    // We test the methods that primarily use UserManager.
+    // UserService depends on WaydDbContext and GraphServiceClient which are hard to
+    // mock. We test methods that don't require them. UserIdentity writes go through
+    // IUserIdentityStore so they can be verified via Moq.
 
     public UserServiceTests()
     {
@@ -52,13 +54,11 @@ public class UserServiceTests
         _mockSender = new Mock<ISender>();
         _mockCurrentUser = new Mock<ICurrentUser>();
         _mockCurrentUser.Setup(x => x.GetUserId()).Returns("current-user-id");
+        _mockUserIdentityStore = new Mock<IUserIdentityStore>();
     }
 
     private UserService CreateSut()
     {
-        // WaydDbContext and GraphServiceClient are required but not used by the methods we test
-        // (CreateAsync, UpdateAsync, ActivateUserAsync, DeactivateUserAsync, AssignRolesAsync).
-        // We pass null! for them since those methods don't touch them.
         return new UserService(
             _mockLogger.Object,
             _mockSignInManager.Object,
@@ -69,7 +69,8 @@ public class UserServiceTests
             null!, // GraphServiceClient - not used by these methods
             _mockSender.Object,
             _dateTimeProvider,
-            _mockCurrentUser.Object);
+            _mockCurrentUser.Object,
+            _mockUserIdentityStore.Object);
     }
 
     private static ApplicationUser CreateUser(string id = "user-1", string userName = "testuser", bool isActive = true, string loginProvider = LoginProviders.MicrosoftEntraId)
@@ -186,6 +187,96 @@ public class UserServiceTests
         result.Error.Should().Contain("Duplicate username.");
         _mockUserManager.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>()), Times.Never);
         _mockEvents.Verify(x => x.PublishAsync(It.IsAny<ApplicationUserCreatedEvent>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldWriteActiveWaydIdentity_WhenLocalUserCreated()
+    {
+        // Arrange
+        var command = new CreateUserCommand
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            LoginProvider = LoginProviders.Wayd,
+            Password = "Password123!",
+        };
+
+        _mockUserManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), "Password123!"))
+            .ReturnsAsync(IdentityResult.Success);
+        _mockUserManager
+            .Setup(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), ApplicationRoles.Basic))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.CreateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _mockUserIdentityStore.Verify(s => s.Add(
+            It.Is<UserIdentity>(ui =>
+                ui.UserId == result.Value &&
+                ui.Provider == LoginProviders.Wayd &&
+                ui.ProviderTenantId == null &&
+                ui.ProviderSubject == result.Value &&
+                ui.IsActive &&
+                ui.UnlinkedAt == null),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldNotWriteIdentity_WhenEntraAdminProvisionedUser()
+    {
+        // Entra users created by an admin have no oid/tid yet — the identity row
+        // is only written on their first SSO login via the principal flow.
+        var command = new CreateUserCommand
+        {
+            FirstName = "Jane",
+            LastName = "Doe",
+            Email = "jane@example.com",
+            LoginProvider = LoginProviders.MicrosoftEntraId,
+        };
+
+        _mockUserManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>()))
+            .ReturnsAsync(IdentityResult.Success);
+        _mockUserManager
+            .Setup(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), ApplicationRoles.Basic))
+            .ReturnsAsync(IdentityResult.Success);
+
+        var sut = CreateSut();
+
+        await sut.CreateAsync(command, TestContext.Current.CancellationToken);
+
+        _mockUserIdentityStore.Verify(s => s.Add(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ShouldNotWriteIdentity_WhenUserManagerCreateFails()
+    {
+        var command = new CreateUserCommand
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            LoginProvider = LoginProviders.Wayd,
+            Password = "Password123!",
+        };
+
+        _mockUserManager
+            .Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), "Password123!"))
+            .ReturnsAsync(IdentityResult.Failed(new IdentityError { Description = "Duplicate." }));
+
+        var sut = CreateSut();
+
+        var result = await sut.CreateAsync(command, TestContext.Current.CancellationToken);
+
+        result.IsFailure.Should().BeTrue();
+        _mockUserIdentityStore.Verify(s => s.Add(It.IsAny<UserIdentity>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/docs/contributing/configuration.mdx
+++ b/docs/contributing/configuration.mdx
@@ -19,6 +19,10 @@ Wayd.Web/src/Wayd.Web.Api/Configurations/database.json
 
 Wayd supports two authentication providers:
 
+:::info Ongoing refactor
+The identity model that links users to their login providers is being generalized to support multiple OIDC providers, multi-tenant Entra, tenant migrations, and a future token-exchange flow. See [Identity Model Refactor](./specs/identity-model-refactor.mdx) for the multi-PR spec.
+:::
+
 ### Microsoft Entra ID (Azure AD)
 
 Create a `.env` file in the repository root:

--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -26,6 +26,12 @@ Welcome to the Wayd developer documentation. This section covers everything you 
 - [Frontend Development](./frontend.mdx) — Next.js, React, and Ant Design patterns
 - [API Development](./api.mdx) — API endpoint patterns and conventions
 
+## Specs
+
+Multi-PR design specs for in-flight cross-cutting work. These are developer-facing and agent-readable.
+
+- [Identity Model Refactor](./specs/identity-model-refactor.mdx) — Unify the identity model across login providers, support tenant migrations, enable token exchange.
+
 ## Migration
 
 - [Migrating from Moda](./migrating-from-moda.mdx) — One-time steps for developers who had a working local Moda environment before the rename

--- a/docs/contributing/specs/identity-model-refactor.mdx
+++ b/docs/contributing/specs/identity-model-refactor.mdx
@@ -1,0 +1,298 @@
+---
+title: Identity Model Refactor
+description: Multi-PR spec for unifying Wayd's identity model across login providers, supporting tenant migrations, and enabling token exchange.
+sidebar_position: 1
+audience: [developer, agent]
+---
+
+# Identity Model Refactor
+
+This spec coordinates a multi-PR effort to generalize Wayd's identity model so it can support:
+
+1. Multiple OIDC providers side-by-side (Microsoft Entra ID today, Auth0 soon).
+2. Multi-tenant Entra logins where different orgs' tenants are onboarded independently.
+3. History-preserving tenant migrations (e.g., an org moves their users from one Entra tenant to another).
+4. A future token-exchange flow that mints a Wayd JWT carrying permission claims, eliminating the "Loading Permissions" wait on first load after inactivity.
+
+The work is sequenced across several PRs so each is independently shippable and reversible.
+
+## Background
+
+### Today's model
+
+Identity linkage lives as flat columns on [`ApplicationUser`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs):
+
+- `ObjectId` — nullable string, populated from the Entra `oid` claim. Unused by the local (Wayd) provider.
+- `LoginProvider` — `"MicrosoftEntraId"` or `"Wayd"` (see [`LoginProviders`](../../../Wayd.Common/src/Wayd.Common.Application/Identity/LoginProviders.cs)).
+
+Lookups diverge by provider:
+
+- Entra: [`UserService.CreateUpdate.cs:35`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs#L35) — `u.ObjectId == objectId`.
+- Local: [`TokenService.cs:28`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs#L28) — `FindByNameAsync(username)`.
+
+### Why this shape doesn't generalize
+
+- No uniqueness guarantee per provider. `ObjectId` has no index; nothing prevents an Auth0 `sub` colliding with an Entra `oid`.
+- No tenant dimension. Multi-tenant Entra works today by accident (Entra `oid`s are globally unique within Entra). A second OIDC provider breaks that assumption.
+- `ObjectId` is Entra's word. In an OIDC-generic world the field is the `sub` claim.
+- A tenant migration (same human, new tenant → new `tid` + new `oid`) has no clean representation. Overwriting the flat columns loses audit history.
+
+### What's changing
+
+Introduce a `UserIdentity` table — one row per (user, provider-identity) pair — with columns `(Provider, ProviderTenantId, ProviderSubject)`. Every authentication path resolves through the same lookup. History is preserved by marking old rows inactive rather than deleting them.
+
+## Target model
+
+```mermaid
+erDiagram
+    ApplicationUser ||--o{ UserIdentity : has
+    ApplicationUser {
+        string Id PK
+        string UserName
+        string Email
+        string LoginProvider "primary provider (default)"
+        string PendingMigrationTenantId "nullable; staged tenant move"
+    }
+    UserIdentity {
+        guid Id PK
+        string UserId FK
+        string Provider "MicrosoftEntraId | Wayd | Auth0"
+        string ProviderTenantId "Entra tid, Auth0 tenant, null for Wayd"
+        string ProviderSubject "Entra oid, Auth0 sub, ApplicationUser.Id for Wayd"
+        bool IsActive
+        Instant LinkedAt
+        Instant UnlinkedAt "nullable"
+        string UnlinkReason "nullable; TenantMigration | AdminRevoked | UserUnlinked"
+    }
+```
+
+### Invariants
+
+- Unique filtered index: `(Provider, ProviderTenantId, ProviderSubject) WHERE IsActive = 1`. `NULL` tenant values are distinct under SQL Server's filtered unique index semantics.
+- Every `ApplicationUser` has **exactly one** active `UserIdentity` at rest. (Transient second rows may exist mid-transaction during a rebind.)
+- Local users get a row with `Provider = "Wayd"`, `ProviderTenantId = NULL`, `ProviderSubject = ApplicationUser.Id.ToString()`. The stable Wayd user id is the subject — not the username, which is mutable.
+- `ApplicationUser.LoginProvider` is retained as a "default/primary" indicator to avoid churn in code that reads it today. It mirrors the active `UserIdentity.Provider`.
+
+### Unified lookup
+
+```csharp
+var identity = db.UserIdentities.SingleOrDefault(i =>
+    i.IsActive &&
+    i.Provider == provider &&
+    i.ProviderTenantId == tenantId &&
+    i.ProviderSubject == subject);
+```
+
+Every provider — Entra, Auth0, Wayd local — uses the same query. Provider-specific logic is confined to *how the incoming credential is validated* (OIDC token vs. username/password), not how the user is resolved.
+
+## PR sequence
+
+Four PRs, landing in order. Each is independently shippable and reversible.
+
+### PR 1 — Introduce `UserIdentity` table + cutover (invisible)
+
+**Goal:** replace the flat `ObjectId` column with a proper identity table. No behavior changes, no new features. If done right, no user notices.
+
+**Scope:**
+
+- New `UserIdentity` entity, EF config, fluent mapping.
+- Filtered unique index on `(Provider, ProviderTenantId, ProviderSubject) WHERE IsActive = 1`.
+- Migration:
+  - Create `UserIdentity` table.
+  - Backfill: one row per existing `ApplicationUser`:
+    - Entra users (`LoginProvider = "MicrosoftEntraId"`, `ObjectId IS NOT NULL`) → `Provider = "MicrosoftEntraId"`, `ProviderSubject = ObjectId`, `ProviderTenantId = NULL`.
+    - Local users (`LoginProvider = "Wayd"`) → `Provider = "Wayd"`, `ProviderSubject = ApplicationUser.Id`, `ProviderTenantId = NULL`.
+  - Leave `ApplicationUser.ObjectId` in place (rollback safety net).
+- Update lookup sites:
+  - [`UserService.CreateUpdate.cs:35`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs#L35) — query `UserIdentity` by `(Provider, ProviderTenantId, ProviderSubject)`.
+  - [`TokenService.cs:28`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs#L28) — resolve by username → `ApplicationUser`, then assert an active `Wayd` `UserIdentity` row exists. Deactivated row ⇒ deny login.
+- **Null-`tid` upgrade path on Entra login:**
+  - If no match on `(provider, tid, sub)`, fall back to `(provider, sub)` where `ProviderTenantId IS NULL`.
+  - If exactly one row matches, write `tid` into it and proceed.
+  - If more than one row matches (e.g., `oid` collision across tenants — astronomically unlikely but possible), bail out and log. Do **not** auto-link.
+  - Use a transaction with appropriate locking to prevent concurrent-login races from racing each other through the upgrade.
+
+**Out of scope for PR 1:**
+
+- Dropping `ObjectId` from `ApplicationUser`. Keep one release as rollback safety.
+- Removing `ApplicationUser.LoginProvider`.
+- Any admin UI.
+- Tenant migration rebind.
+- Token exchange endpoint.
+
+**Pre-deploy audit queries (must all return 0 before deploy):**
+
+```sql
+-- Any user with an ObjectId but wrong provider tag?
+SELECT COUNT(*) FROM identity.Users
+WHERE ObjectId IS NOT NULL AND LoginProvider <> 'MicrosoftEntraId';
+
+-- Any Entra user missing their ObjectId?
+SELECT COUNT(*) FROM identity.Users
+WHERE LoginProvider = 'MicrosoftEntraId' AND ObjectId IS NULL;
+```
+
+**Post-migration assertion:** every `ApplicationUser` has exactly one active `UserIdentity`. Fail the deploy if not.
+
+**Rollback plan:** revert code. Old `ObjectId`-based lookups work unchanged. `UserIdentity` table sits unused, which is harmless.
+
+**Merge criteria:** logs show the null-`tid` upgrade path populating tenants on normal logins for at least a few days, across both providers. Zero duplicate-user creations. Zero login failures attributable to the new lookup.
+
+### PR 2 — Drop `ObjectId` from `ApplicationUser`
+
+Tiny cleanup PR once PR 1 has been stable in prod for a release cycle (a week or two).
+
+**Scope:**
+
+- Remove `ObjectId` property from [`ApplicationUser`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs).
+- Remove from [`ApplicationUserConfig`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs).
+- Migration: drop the column.
+- Clean up references (e.g., `SyncUsersFromEmployeeRecords`, `UpdateMissingEmployeeIds` which read `ObjectId` today — they need to read from the `UserIdentity` row instead, or be rewritten to use a different employee correlation).
+
+**Rollback:** harder. Restoring the column requires re-backfilling from `UserIdentity`. Hence the one-release gap after PR 1 to be sure.
+
+### PR 3 — Token exchange + Wayd JWT with permission claims (multi-PR effort on its own)
+
+This is the architectural shift that also fixes the 10-second "Loading Permissions" screen. It will likely span several PRs internally.
+
+**Premise:** treat external IdP tokens (Entra, Auth0) as *identity assertions*, not API credentials. The API only ever validates Wayd JWTs.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend (MSAL / auth0-spa-js)
+    participant E as External IdP (Entra / Auth0)
+    participant X as Wayd /auth/exchange
+    participant A as Wayd API
+
+    U->>F: Opens app
+    F->>E: Silent login / redirect
+    E-->>F: IdP id token (iss, tid, sub, email)
+    F->>X: POST /auth/exchange { provider, idToken }
+    X->>X: Validate signature via provider's JWKS
+    X->>X: Lookup UserIdentity (provider, tid, sub)
+    X->>X: Load permissions
+    X-->>F: Wayd JWT (sub=userId, roles, permissions, permissionsVersion)
+    F->>A: API call with Wayd JWT
+    A->>A: Validate Wayd JWT only
+    A-->>F: Response
+```
+
+**Provider registry (backend config):**
+
+```
+{ name, type: "entra" | "auth0" | "oidc-generic",
+  issuer, audience, jwksUri, tenantId?, allowedDomains?, userMappingStrategy }
+```
+
+One config row per onboarded external tenant. Multi-tenant Entra = N rows, one per onboarded org's `tid`. Auth0 = N rows, one per Auth0 tenant.
+
+**Exchange endpoint responsibilities:**
+
+1. Resolve provider config by `iss`.
+2. Fetch/cache provider JWKS. Validate signature, issuer, audience, expiry.
+3. Extract `(ProviderTenantId, ProviderSubject)` per provider's rules (Entra: `tid`, `oid`; Auth0: tenant, `sub`).
+4. Resolve via `UserIdentity` lookup.
+5. Load permissions.
+6. Mint Wayd JWT. Include `permissionsVersion` claim.
+7. Return JWT + refresh token.
+
+**Frontend changes:**
+
+- auth-context no longer calls `useGetUserPermissionsQuery`. Permissions are decoded from Wayd JWT claims.
+- MSAL and Auth0 SDKs both feed `/auth/exchange`. After exchange, the provider SDK is only used to silently refresh the *external* id token when the Wayd JWT refresh flow requires it.
+- "Loading Permissions" screen goes away — claims arrive with the JWT, no extra round-trip.
+- Home-realm discovery (email domain → which provider SDK to initialize) is a new pre-login step if Auth0 is onboarded.
+
+**Permission revocation latency:**
+
+- Short Wayd JWT lifetime (5–15 min) + silent refresh.
+- `permissionsVersion` claim lets the backend force a refresh when permissions change server-side (client compares its cached version to the one it expects; on mismatch, triggers re-exchange).
+
+**JWKS caching:** per-provider with sane TTL. Cold starts must not block logins for seconds.
+
+**Logout:** each provider has its own end-session endpoint. The logout handler dispatches to the right one based on the user's active `UserIdentity.Provider`.
+
+### PR 4 — Admin-initiated tenant migration
+
+Land this just before the org's migration window. Builds on PR 3's exchange endpoint — the rebind lives naturally in the exchange handler.
+
+**Scope:**
+
+- Add `PendingMigrationTenantId` (nullable) to `ApplicationUser`. Migration only, no backfill.
+- Admin UI action on the user detail page: "Migrate to new tenant" — captures target `tid`, sets `PendingMigrationTenantId`. Permissions-gated.
+- Exchange-endpoint migration logic:
+  - On no-match for `(provider, tid, sub)`, check for a user with matching email *and* `PendingMigrationTenantId == token.tid`.
+  - If found, do the transactional rebind in one shot:
+    1. Mark existing active `UserIdentity` row inactive. Set `UnlinkedAt`, `UnlinkReason = "TenantMigration"`.
+    2. Insert new active row with `(provider, token.tid, token.sub)`.
+    3. Clear `PendingMigrationTenantId`.
+  - `UserId` never changes. Every FK downstream (permissions, work items, audit) is preserved.
+- Admin UI: identity-history view on user detail page (read-only list of past + current `UserIdentity` rows with timestamps and reasons). Without this, history's value isn't realized.
+- Cancel action: clear `PendingMigrationTenantId` if staged but not yet completed.
+
+**Test scenarios (non-exhaustive):**
+
+- Admin stages migration, user logs in from new tenant → rebind happens. Old row inactive with correct reason. Downstream FKs untouched.
+- Admin stages migration, user logs in from old tenant → normal login, no rebind, flag still pending.
+- Different user with same email logs in from new tenant → no rebind. Email match scoped to the flagged user only.
+- Concurrent admin writes → last-write-wins on flag, no corruption.
+
+**Out of scope (future extensions):**
+
+- Self-service migration with email verification.
+- Bulk CSV/API migration import.
+
+## Cross-cutting decisions
+
+### Local users in `UserIdentity`
+
+Local (Wayd) users get a row in `UserIdentity` with `ProviderSubject = ApplicationUser.Id`. Two reasons:
+
+1. **Uniformity.** One lookup path for all providers. The exchange endpoint doesn't branch on provider for identity resolution.
+2. **Username mutability.** Usernames will be user-editable in the future. The subject in `UserIdentity` must be immutable — the `ApplicationUser.Id` is the stable identifier. A username rename touches `ApplicationUser.UserName` only; `UserIdentity` is untouched.
+
+The local-login flow still resolves by username first (`FindByNameAsync`), verifies the password, and then asserts that an active `Wayd` `UserIdentity` exists. Step 2 looks redundant today but enables "disable local login for this specific user" as a natural consequence (deactivate the identity row — no new flag, no schema change).
+
+### Why `ApplicationUser.LoginProvider` stays
+
+Redundant in principle (could derive from the active `UserIdentity` row), but keeping it:
+
+- Avoids churn in code that reads it today (e.g., password-change/reset gating).
+- Gives the UI a cheap "primary provider" indicator without joining to `UserIdentity`.
+- Can be removed in a future cleanup PR if it proves to drift from `UserIdentity`.
+
+### Tenant migration history
+
+Every rebind preserves the old `UserIdentity` row (inactive, with `UnlinkedAt` + `UnlinkReason`). This gives:
+
+- An audit trail of which tenant a user used to belong to.
+- Debuggability for "why did this user end up with this `UserId`?"
+- A natural place to record non-migration unlink events (`AdminRevoked`, `UserUnlinked`) if that's ever needed.
+
+### What this does *not* address
+
+- **Account linking** (one Wayd user authenticating via multiple providers simultaneously — e.g., both Entra and Auth0). The schema supports it — multiple active rows per user — but no flow creates that state today. Defer until there's a concrete need.
+- **Auth0 onboarding itself.** PR 1 makes Auth0 a config/provider-registry problem rather than a schema problem; the actual Auth0 integration is downstream of PR 3.
+- **Personal Microsoft accounts.** Out of scope for all four PRs. The email-trust assumptions in migration (PR 4) rely on org-controlled tenants.
+
+## Impact on the "Loading Permissions" delay
+
+The 10-second "Loading Permissions" screen users see on first load after ~24 hours of inactivity is caused by a sequential waterfall in the frontend:
+
+1. MSAL forces a silent token refresh (3–8s when the access token has expired).
+2. RTK Query's permissions fetch (60-second cache, long-gone after 24h) waits for the token refresh.
+3. User profile assembly waits for permissions.
+
+The perf problem is fixed by **PR 3**, not PR 1 or PR 2. Embedding permissions as Wayd JWT claims eliminates step 2 entirely; silent refresh returns a token that already carries everything auth-context needs.
+
+This is called out here because it's often the spark for discussing this work, and it's useful to know which PR actually delivers the fix.
+
+## References
+
+- [`ApplicationUser`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs) — current user entity.
+- [`LoginProviders`](../../../Wayd.Common/src/Wayd.Common.Application/Identity/LoginProviders.cs) — provider constants.
+- [`UserService.CreateUpdate.cs`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs) — Entra lookup + create/update from principal.
+- [`TokenService.cs`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs) — local JWT issuance.
+- [`IdentityConfiguration.cs`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs) — EF Core mapping.
+- [Configuration > Authentication](../configuration.mdx#authentication) — dev-side auth setup.

--- a/docs/contributing/specs/identity-model-refactor.mdx
+++ b/docs/contributing/specs/identity-model-refactor.mdx
@@ -18,28 +18,25 @@ The work is sequenced across several PRs so each is independently shippable and 
 
 ## Background
 
-### Today's model
+### The pre-refactor model (motivation)
 
-Identity linkage lives as flat columns on [`ApplicationUser`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs):
+Before this spec's work began, identity linkage lived as flat columns on `ApplicationUser`:
 
 - `ObjectId` — nullable string, populated from the Entra `oid` claim. Unused by the local (Wayd) provider.
-- `LoginProvider` — `"MicrosoftEntraId"` or `"Wayd"` (see [`LoginProviders`](../../../Wayd.Common/src/Wayd.Common.Application/Identity/LoginProviders.cs)).
+- `LoginProvider` — `"MicrosoftEntraId"` or `"Wayd"`.
 
-Lookups diverge by provider:
+Lookups diverged by provider — the Entra path resolved users via `u.ObjectId == oid`, and the local path via `UserManager.FindByNameAsync(username)`. Those two call sites (in `UserService.CreateUpdate.cs` and `TokenService.cs` respectively) are the anchors PR 1 converts to the unified `UserIdentity` lookup.
 
-- Entra: [`UserService.CreateUpdate.cs:35`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs#L35) — `u.ObjectId == objectId`.
-- Local: [`TokenService.cs:28`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs#L28) — `FindByNameAsync(username)`.
+### Why that shape didn't generalize
 
-### Why this shape doesn't generalize
-
-- No uniqueness guarantee per provider. `ObjectId` has no index; nothing prevents an Auth0 `sub` colliding with an Entra `oid`.
-- No tenant dimension. Multi-tenant Entra works today by accident (Entra `oid`s are globally unique within Entra). A second OIDC provider breaks that assumption.
+- No uniqueness guarantee per provider. `ObjectId` had no index; nothing prevented an Auth0 `sub` from colliding with an Entra `oid`.
+- No tenant dimension. Multi-tenant Entra worked only by accident (Entra `oid`s are globally unique within Entra). A second OIDC provider would break that assumption.
 - `ObjectId` is Entra's word. In an OIDC-generic world the field is the `sub` claim.
-- A tenant migration (same human, new tenant → new `tid` + new `oid`) has no clean representation. Overwriting the flat columns loses audit history.
+- A tenant migration (same human, new tenant → new `tid` + new `oid`) had no clean representation. Overwriting the flat columns loses audit history.
 
-### What's changing
+### What this spec introduces
 
-Introduce a `UserIdentity` table — one row per (user, provider-identity) pair — with columns `(Provider, ProviderTenantId, ProviderSubject)`. Every authentication path resolves through the same lookup. History is preserved by marking old rows inactive rather than deleting them.
+A `UserIdentity` table — one row per (user, provider-identity) pair — with columns `(Provider, ProviderTenantId, ProviderSubject)`. Every authentication path resolves through the same lookup. History is preserved by marking old rows inactive rather than deleting them.
 
 ## Target model
 
@@ -69,7 +66,9 @@ erDiagram
 ### Invariants
 
 - Unique filtered index: `(Provider, ProviderTenantId, ProviderSubject) WHERE IsActive = 1`. `NULL` tenant values are distinct under SQL Server's filtered unique index semantics.
-- Every `ApplicationUser` has **exactly one** active `UserIdentity` at rest. (Transient second rows may exist mid-transaction during a rebind.)
+- **At most one** active `UserIdentity` per `ApplicationUser` at rest. Every user whose account is authenticable has **exactly one**; the general rule allows zero for pre-provisioned-but-not-yet-linked cases (e.g., an admin-created Entra user who has not yet signed in via SSO).
+- The invariant is enforced in application code — not at the schema level — via `IUserIdentityStore.DeactivateAllActive`. Any write path that adds a new active row for a user must first deactivate any prior active rows (setting `UnlinkedAt` + `UnlinkReason = ProviderRelinked` for the relink case, or `TenantMigration` for PR 4's rebind). A database-level check constraint (unique index on `UserId WHERE IsActive = 1`) is an option but has not been added in PR 1 — the store-level enforcement is load-bearing.
+- This deliberately does **not** support multi-provider account linking (one user, multiple active identities). If that becomes a requirement, relaxing the invariant is a forward-compatible schema change; retrofitting the invariant once multiple-active rows exist in prod is much harder.
 - Local users get a row with `Provider = "Wayd"`, `ProviderTenantId = NULL`, `ProviderSubject = ApplicationUser.Id.ToString()`. The stable Wayd user id is the subject — not the username, which is mutable.
 - `ApplicationUser.LoginProvider` is retained as a "default/primary" indicator to avoid churn in code that reads it today. It mirrors the active `UserIdentity.Provider`.
 
@@ -104,8 +103,8 @@ Four PRs, landing in order. Each is independently shippable and reversible.
     - Local users (`LoginProvider = "Wayd"`) → `Provider = "Wayd"`, `ProviderSubject = ApplicationUser.Id`, `ProviderTenantId = NULL`.
   - Leave `ApplicationUser.ObjectId` in place (rollback safety net).
 - Update lookup sites:
-  - [`UserService.CreateUpdate.cs:35`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs#L35) — query `UserIdentity` by `(Provider, ProviderTenantId, ProviderSubject)`.
-  - [`TokenService.cs:28`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs#L28) — resolve by username → `ApplicationUser`, then assert an active `Wayd` `UserIdentity` row exists. Deactivated row ⇒ deny login.
+  - `UserService.CreateUpdate.cs:35` — query `UserIdentity` by `(Provider, ProviderTenantId, ProviderSubject)`.
+  - `TokenService.cs:28` — resolve by username → `ApplicationUser`, then assert an active `Wayd` `UserIdentity` row exists. Deactivated row ⇒ deny login.
 - **Null-`tid` upgrade path on Entra login:**
   - If no match on `(provider, tid, sub)`, fall back to `(provider, sub)` where `ProviderTenantId IS NULL`.
   - If exactly one row matches, write `tid` into it and proceed.
@@ -144,8 +143,8 @@ Tiny cleanup PR once PR 1 has been stable in prod for a release cycle (a week or
 
 **Scope:**
 
-- Remove `ObjectId` property from [`ApplicationUser`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs).
-- Remove from [`ApplicationUserConfig`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs).
+- Remove `ObjectId` property from `ApplicationUser`.
+- Remove from `ApplicationUserConfig` (`IdentityConfiguration.cs`).
 - Migration: drop the column.
 - Clean up references (e.g., `SyncUsersFromEmployeeRecords`, `UpdateMissingEmployeeIds` which read `ObjectId` today — they need to read from the `UserIdentity` row instead, or be rewritten to use a different employee correlation).
 
@@ -290,9 +289,9 @@ This is called out here because it's often the spark for discussing this work, a
 
 ## References
 
-- [`ApplicationUser`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs) — current user entity.
-- [`LoginProviders`](../../../Wayd.Common/src/Wayd.Common.Application/Identity/LoginProviders.cs) — provider constants.
-- [`UserService.CreateUpdate.cs`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs) — Entra lookup + create/update from principal.
-- [`TokenService.cs`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs) — local JWT issuance.
-- [`IdentityConfiguration.cs`](../../../Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs) — EF Core mapping.
+- `Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs` — current user entity.
+- `Wayd.Common/src/Wayd.Common.Application/Identity/LoginProviders.cs` — provider constants.
+- `Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs` — Entra lookup + create/update from principal.
+- `Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs` — local JWT issuance.
+- `Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs` — EF Core mapping.
 - [Configuration > Authentication](../configuration.mdx#authentication) — dev-side auth setup.


### PR DESCRIPTION
## PR title

`Introduce UserIdentity table to unify login-provider identity model`

## Description

### Summary
- Introduces a new `UserIdentity` entity (one row per user + provider-identity pair) as the single source of truth for how a Wayd user links to their login provider.
- Replaces provider-specific lookups (`u.ObjectId == oid` for Entra; `FindByNameAsync` for local) with a uniform query against `(Provider, ProviderTenantId, ProviderSubject)` via a new `IUserIdentityStore` seam.
- Invisible to end users: no behavior changes on login or user creation. Sets up the structural foundation for Auth0, multi-tenant Entra, tenant migrations, and token exchange — see [Identity Model Refactor spec](docs/contributing/specs/identity-model-refactor.mdx).

### Why
Today's identity linkage lives as flat columns on `ApplicationUser` (`ObjectId`, `LoginProvider`). This shape is Entra-specific:
- No uniqueness guarantee per provider — an Auth0 `sub` could collide with an Entra `oid`.
- No tenant dimension — multi-tenant Entra works by accident because Entra `oid`s happen to be globally unique within Entra, and breaks the moment a second OIDC provider is added.
- No way to preserve history when a user's identity changes (e.g., tenant migration overwrites the columns and loses the audit trail).

PR 1 is the smallest increment that fixes this structurally. Later PRs (drop `ObjectId`, token exchange, tenant-migration admin UI) build on it.

### What's in this PR
- **New `UserIdentity` entity** + EF config with a filtered unique index on `(Provider, ProviderTenantId, ProviderSubject) WHERE IsActive = 1`.
- **Migration** `20260419201300_Add-UserIdentities-Table`:
  - Creates the table.
  - Backfills one row per existing user (Entra users keyed by `ObjectId`, local users keyed by `ApplicationUser.Id` — the stable identifier, since usernames will be mutable).
  - Asserts every authenticable user has an active identity row; fails the migration if not.
- **Lookup updates**:
  - [UserService.CreateUpdate.cs](Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs): Entra flow now resolves via `UserIdentity(MicrosoftEntraId, tid, oid)`. Includes a null-`tid` upgrade path — backfilled rows get their tenant populated on the user's next login, with an ambiguity guard for the (astronomically unlikely) `oid` collision case.
  - [TokenService.cs](Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs): local login now gates on an active `Wayd` `UserIdentity` row after password verification.
  - Admin `CreateAsync` writes a `UserIdentity` row for new Wayd (local) users at creation time. Entra users created via admin provisioning get their row on first SSO login.
- **`IUserIdentityStore` seam** — narrow interface over `UserIdentity` persistence so the new logic is unit-testable without a full `WaydDbContext`.
- **Docs**: new multi-PR spec at [docs/contributing/specs/identity-model-refactor.mdx](docs/contributing/specs/identity-model-refactor.mdx) with ER and sequence diagrams. Cross-linked from [configuration.mdx](docs/contributing/configuration.mdx), [docs/contributing/index.mdx](docs/contributing/index.mdx), and CLAUDE.md.

### What's intentionally *not* in this PR
- **`ObjectId` remains on `ApplicationUser`** as a rollback safety net. Removed in a follow-up PR after this has been stable in prod for a release cycle.
- **No token-exchange endpoint or frontend changes.** The "Loading Permissions" 10-second delay is a PR 3 problem, not PR 1.
- **No admin UI for tenant migration.** That's the final PR, landing just before the real tenant-migration window.

### Risk and rollback
- **Blast radius:** schema + two lookup sites. No contract changes, no API changes, no UI changes.
- **Rollback:** revert the code deploy. Old `ObjectId`-based lookups still work unchanged because the column is retained. The new `UserIdentity` table sits unused until the next deploy, which is harmless.
- **Pre-deploy audit queries** (must all return 0 before deploy):
  ```sql
  SELECT COUNT(*) FROM [Identity].[Users] WHERE ObjectId IS NOT NULL AND LoginProvider <> 'MicrosoftEntraId';
  SELECT COUNT(*) FROM [Identity].[Users] WHERE LoginProvider = 'MicrosoftEntraId' AND ObjectId IS NULL AND <user has logged in before>;
  ```
  The migration's built-in assertion will also catch any un-backfilled authenticable users and fail the migration rather than silently proceed.

### Test plan
- [x] `dotnet build Wayd.slnx` clean
- [x] `dotnet test Wayd.slnx` — 1,934 tests passing (including 4 new identity-related tests and 65 architecture tests)
- [x] Migration applies cleanly against a dev database with existing users (verified via NSwag build hook)
- [ ] Verify in a staging environment with mixed Entra + local users that:
  - Existing Entra users can log in (hits null-`tid` upgrade path on first login post-deploy)
  - Existing local users can log in
  - Admin creation of a new local user produces both the `ApplicationUser` and an active `UserIdentity`
  - Admin creation of a new Entra user produces the `ApplicationUser` but *no* identity row until that user's first SSO login
- [ ] Confirm the post-migration assertion catches a deliberately-broken backfill (e.g., a user with a typo in `LoginProvider`)

### Follow-ups
- PR 2: Drop `ObjectId` from `ApplicationUser` (cleanup, after this has been stable one release cycle).
- PR 3: Token exchange endpoint + Wayd JWT with permission claims (multi-PR effort; fixes the "Loading Permissions" 10-second delay).
- PR 4: Admin-initiated tenant migration UI + rebind logic.

See [docs/contributing/specs/identity-model-refactor.mdx](docs/contributing/specs/identity-model-refactor.mdx) for the full sequenced plan.
