### PR TITLE
Feature/drop applicationuser objectid

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260420011623_Drop-ApplicationUser-ObjectId.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260420011623_Drop-ApplicationUser-ObjectId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260420011623_Drop-ApplicationUser-ObjectId")]
+    partial class DropApplicationUserObjectId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260420011623_Drop-ApplicationUser-ObjectId.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260420011623_Drop-ApplicationUser-ObjectId.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class DropApplicationUserObjectId : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "ObjectId",
+            schema: "Identity",
+            table: "Users");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "ObjectId",
+            schema: "Identity",
+            table: "Users",
+            type: "nvarchar(256)",
+            maxLength: 256,
+            nullable: true);
+
+        // Rehydrate ObjectId from the active Entra UserIdentity row so that
+        // rolling back this migration together with the PR1 code restores a
+        // working lookup. Without this the old ObjectId-based lookups would
+        // find no users after a rollback.
+        migrationBuilder.Sql(@"
+                UPDATE u
+                SET u.[ObjectId] = ui.[ProviderSubject]
+                FROM [Identity].[Users] u
+                INNER JOIN [Identity].[UserIdentities] ui
+                    ON ui.[UserId] = u.[Id]
+                   AND ui.[IsActive] = 1
+                   AND ui.[Provider] = 'MicrosoftEntraId';
+            ");
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/ApplicationUser.cs
@@ -9,7 +9,6 @@ public class ApplicationUser : IdentityUser
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
     public bool IsActive { get; set; }
-    public string? ObjectId { get; set; }
     public Guid? EmployeeId { get; set; }
     public Employee? Employee { get; set; }
     public Instant? LastActivityAt { get; set; }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/IUserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/IUserIdentityStore.cs
@@ -20,6 +20,14 @@ internal interface IUserIdentityStore : IScopedService
     Task<bool> ExistsActive(string userId, string provider, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns a dictionary mapping <c>UserId</c> to the <c>ProviderSubject</c> of
+    /// their active identity row for the given provider. Used by batch processes
+    /// that need to correlate users to an external identifier (e.g., employee
+    /// records keyed by the Entra <c>oid</c>).
+    /// </summary>
+    Task<IReadOnlyDictionary<string, string>> GetActiveSubjectsByProvider(string provider, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Marks every active row for a user as inactive, setting <c>UnlinkedAt</c> and
     /// the given <c>unlinkReason</c>. Used to enforce the "exactly one active identity
     /// per user at rest" invariant when a new identity is being linked.

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
@@ -49,6 +49,14 @@ internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
             cancellationToken);
     }
 
+    public async Task<IReadOnlyDictionary<string, string>> GetActiveSubjectsByProvider(string provider, CancellationToken cancellationToken = default)
+    {
+        return await _db.UserIdentities
+            .AsNoTracking()
+            .Where(ui => ui.IsActive && ui.Provider == provider)
+            .ToDictionaryAsync(ui => ui.UserId, ui => ui.ProviderSubject, cancellationToken);
+    }
+
     public async Task<int> DeactivateAllActive(string userId, Instant unlinkedAt, string unlinkReason, CancellationToken cancellationToken = default)
     {
         var active = await _db.UserIdentities

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserIdentityStore.cs
@@ -1,10 +1,11 @@
 ﻿using Microsoft.Data.SqlClient;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using NodaTime;
 
 namespace Wayd.Infrastructure.Identity;
 
-internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
+internal sealed class UserIdentityStore(WaydDbContext db, ILogger<UserIdentityStore> logger) : IUserIdentityStore
 {
     // SQL Server error numbers for unique-constraint / duplicate-key violations.
     // 2627 = unique constraint, 2601 = unique index. We treat either as "another
@@ -14,6 +15,7 @@ internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
     private const int SqlUniqueIndexErrorNumber = 2601;
 
     private readonly WaydDbContext _db = db;
+    private readonly ILogger<UserIdentityStore> _logger = logger;
 
     public Task<UserIdentity?> FindActive(string provider, string? tenantId, string subject, CancellationToken cancellationToken = default)
     {
@@ -51,10 +53,32 @@ internal sealed class UserIdentityStore(WaydDbContext db) : IUserIdentityStore
 
     public async Task<IReadOnlyDictionary<string, string>> GetActiveSubjectsByProvider(string provider, CancellationToken cancellationToken = default)
     {
-        return await _db.UserIdentities
+        // The "at most one active identity per user+provider" invariant is
+        // enforced in application code, not at the schema level — so defensively
+        // group here rather than letting ToDictionaryAsync throw if a bad row
+        // slips through. Duplicates are logged and the latest-linked row wins,
+        // so a batch sync can complete on otherwise-healthy users.
+        var rows = await _db.UserIdentities
             .AsNoTracking()
             .Where(ui => ui.IsActive && ui.Provider == provider)
-            .ToDictionaryAsync(ui => ui.UserId, ui => ui.ProviderSubject, cancellationToken);
+            .Select(ui => new { ui.UserId, ui.ProviderSubject, ui.LinkedAt })
+            .ToListAsync(cancellationToken);
+
+        var result = new Dictionary<string, string>(rows.Count);
+        foreach (var group in rows.GroupBy(r => r.UserId))
+        {
+            if (group.Count() > 1)
+            {
+                _logger.LogWarning(
+                    "UserIdentity invariant violation: user {UserId} has {Count} active identities for provider {Provider}. Using most recently linked row.",
+                    group.Key, group.Count(), provider);
+            }
+
+            var winner = group.OrderByDescending(r => r.LinkedAt).First();
+            result[group.Key] = winner.ProviderSubject;
+        }
+
+        return result;
     }
 
     public async Task<int> DeactivateAllActive(string userId, Instant unlinkedAt, string unlinkReason, CancellationToken cancellationToken = default)

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -449,14 +449,20 @@ internal partial class UserService
             // External employee records are keyed by the Entra oid, which lives in
             // the user's active MicrosoftEntraId UserIdentity row.
             var entraSubjectsByUserId = await _userIdentityStore.GetActiveSubjectsByProvider(LoginProviders.MicrosoftEntraId, cancellationToken);
+            // Pre-index by EmployeeNumber so per-user lookup is O(1) instead of scanning
+            // the full employees list for every user. Last-wins on duplicate numbers —
+            // matches the old FirstOrDefault behavior since duplicates would have been
+            // unreachable anyway.
+            var employeeIdByNumber = employees
+                .GroupBy(e => e.EmployeeNumber)
+                .ToDictionary(g => g.Key, g => g.Last().Id);
 
             foreach (var user in users)
             {
                 if (!entraSubjectsByUserId.TryGetValue(user.Id, out var entraSubject))
                     continue;
 
-                var employeeId = employees.Where(e => e.EmployeeNumber == entraSubject).Select(e => (Guid?)e.Id ?? null).FirstOrDefault();
-                if (!employeeId.HasValue)
+                if (!employeeIdByNumber.TryGetValue(entraSubject, out var employeeId))
                     continue;
 
                 user.EmployeeId = employeeId;
@@ -478,26 +484,45 @@ internal partial class UserService
     public async Task<Result> SyncUsersFromEmployeeRecords(List<IExternalEmployee> externalEmployees, CancellationToken cancellationToken)
     {
         // Only sync users who have an active Entra identity — that's what pairs them
-        // with an external employee record (keyed by Entra oid).
-        var entraSubjectsByUserId = await _userIdentityStore.GetActiveSubjectsByProvider(LoginProviders.MicrosoftEntraId, cancellationToken);
-        if (entraSubjectsByUserId.Count == 0)
-            return Result.Success();
-
+        // with an external employee record (keyed by Entra oid). Filter server-side
+        // via an EXISTS subquery against UserIdentities so we don't have to round-
+        // trip user IDs in an IN (...) list, which hits the 2100-parameter SQL
+        // Server limit past a few thousand users.
         var users = await _userManager.Users
-            .Where(u => entraSubjectsByUserId.Keys.Contains(u.Id))
+            .Where(u => _db.UserIdentities.Any(ui =>
+                ui.UserId == u.Id &&
+                ui.IsActive &&
+                ui.Provider == LoginProviders.MicrosoftEntraId))
             .ToListAsync(cancellationToken);
 
         _logger.LogDebug("{UserCount} users found with an active Entra identity.", users.Count);
         if (users.Count == 0)
             return Result.Success();
 
+        // Second query — just the subject map for the users we actually need to
+        // correlate. Still cheap because it's filtered by active + provider.
+        var entraSubjectsByUserId = await _userIdentityStore.GetActiveSubjectsByProvider(LoginProviders.MicrosoftEntraId, cancellationToken);
+
+        // Pre-index by EmployeeNumber so per-user correlation is O(1) instead of
+        // scanning the full externalEmployees list for every user.
+        var employeesByNumber = externalEmployees
+            .GroupBy(e => e.EmployeeNumber)
+            .ToDictionary(g => g.Key, g => g.Last());
+
         foreach (var user in users)
         {
-            var entraSubject = entraSubjectsByUserId[user.Id];
-            var employee = externalEmployees.FirstOrDefault(e => e.EmployeeNumber == entraSubject);
+            if (!entraSubjectsByUserId.TryGetValue(user.Id, out var entraSubject))
+            {
+                // Edge case: user's identity was deactivated between the two queries.
+                continue;
+            }
+
+            var employee = employeesByNumber.GetValueOrDefault(entraSubject);
             if (employee is null)
             {
-                _logger.LogWarning("Employee with Id {EmployeeId} not found.", user.EmployeeId);
+                _logger.LogWarning(
+                    "No external employee record matched Entra subject {EntraSubject} for user {UserId}.",
+                    entraSubject, user.Id);
                 continue;
             }
 

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -127,7 +127,7 @@ internal partial class UserService
         }
 
         var user = await _userManager.FindByNameAsync(username);
-        if (user is not null && !string.IsNullOrWhiteSpace(user.ObjectId))
+        if (user is not null && await _userIdentityStore.ExistsActive(user.Id, LoginProviders.MicrosoftEntraId))
         {
             _logger.LogError("Username or Email {Username} not valid", username);
             throw new InternalServerException($"Username {username} is already taken.");
@@ -136,7 +136,7 @@ internal partial class UserService
         if (user is null)
         {
             user = await _userManager.FindByEmailAsync(email);
-            if (user is not null && !string.IsNullOrWhiteSpace(user.ObjectId))
+            if (user is not null && await _userIdentityStore.ExistsActive(user.Id, LoginProviders.MicrosoftEntraId))
             {
                 _logger.LogError("Email {email} is already taken.", email);
                 throw new InternalServerException($"Email {email} is already taken.");
@@ -148,7 +148,9 @@ internal partial class UserService
         IdentityResult? result;
         if (user is not null)
         {
-            user.ObjectId = principal.GetObjectId();
+            // Existing user — linking them to Entra. The UserIdentity row is inserted
+            // downstream by EnsureEntraIdentityRowAsync, which also deactivates any
+            // prior active identity (e.g., a Wayd local identity being migrated to SSO).
             result = await _userManager.UpdateAsync(user);
 
             await _events.PublishAsync(new ApplicationUserUpdatedEvent(user.Id, _dateTimeProvider.Now));
@@ -166,7 +168,6 @@ internal partial class UserService
 
             user = new ApplicationUser
             {
-                ObjectId = principalObjectId,
                 FirstName = principal.FindFirstValue(ClaimTypes.GivenName) ?? Guard.Against.NullOrWhiteSpace(adUser?.GivenName),
                 LastName = principal.FindFirstValue(ClaimTypes.Surname) ?? Guard.Against.NullOrWhiteSpace(adUser?.Surname),
                 Email = email,
@@ -445,9 +446,16 @@ internal partial class UserService
         if (users.Count != 0)
         {
             var employees = await _sender.Send(new GetEmployeeNumberMapQuery(), cancellationToken);
+            // External employee records are keyed by the Entra oid, which lives in
+            // the user's active MicrosoftEntraId UserIdentity row.
+            var entraSubjectsByUserId = await _userIdentityStore.GetActiveSubjectsByProvider(LoginProviders.MicrosoftEntraId, cancellationToken);
+
             foreach (var user in users)
             {
-                var employeeId = employees.Where(e => e.EmployeeNumber == user.ObjectId).Select(e => (Guid?)e.Id ?? null).FirstOrDefault();
+                if (!entraSubjectsByUserId.TryGetValue(user.Id, out var entraSubject))
+                    continue;
+
+                var employeeId = employees.Where(e => e.EmployeeNumber == entraSubject).Select(e => (Guid?)e.Id ?? null).FirstOrDefault();
                 if (!employeeId.HasValue)
                     continue;
 
@@ -469,15 +477,24 @@ internal partial class UserService
 
     public async Task<Result> SyncUsersFromEmployeeRecords(List<IExternalEmployee> externalEmployees, CancellationToken cancellationToken)
     {
-        var users = await _userManager.Users.Where(u => u.ObjectId != null).ToListAsync(cancellationToken);
+        // Only sync users who have an active Entra identity — that's what pairs them
+        // with an external employee record (keyed by Entra oid).
+        var entraSubjectsByUserId = await _userIdentityStore.GetActiveSubjectsByProvider(LoginProviders.MicrosoftEntraId, cancellationToken);
+        if (entraSubjectsByUserId.Count == 0)
+            return Result.Success();
 
-        _logger.LogDebug("{UserCount} users found with EmployeeId.", users.Count);
+        var users = await _userManager.Users
+            .Where(u => entraSubjectsByUserId.Keys.Contains(u.Id))
+            .ToListAsync(cancellationToken);
+
+        _logger.LogDebug("{UserCount} users found with an active Entra identity.", users.Count);
         if (users.Count == 0)
             return Result.Success();
 
         foreach (var user in users)
         {
-            var employee = externalEmployees.FirstOrDefault(e => e.EmployeeNumber == user.ObjectId);
+            var entraSubject = entraSubjectsByUserId[user.Id];
+            var employee = externalEmployees.FirstOrDefault(e => e.EmployeeNumber == entraSubject);
             if (employee is null)
             {
                 _logger.LogWarning("Employee with Id {EmployeeId} not found.", user.EmployeeId);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
@@ -15,8 +15,6 @@ public class ApplicationUserConfig : IEntityTypeConfiguration<ApplicationUser>
         builder.HasIndex(u => u.Id)
             .IncludeProperties(e => new { e.UserName, e.EmployeeId, e.Email, e.FirstName, e.LastName });
 
-        builder.Property(u => u.ObjectId).HasMaxLength(256);
-
         builder.Property(u => u.FirstName).HasMaxLength(100);
         builder.Property(u => u.LastName).HasMaxLength(100);
         builder.Property(u => u.PhoneNumber).HasMaxLength(20);

--- a/docs/contributing/specs/identity-model-refactor.mdx
+++ b/docs/contributing/specs/identity-model-refactor.mdx
@@ -139,16 +139,17 @@ WHERE LoginProvider = 'MicrosoftEntraId' AND ObjectId IS NULL;
 
 ### PR 2 — Drop `ObjectId` from `ApplicationUser`
 
-Tiny cleanup PR once PR 1 has been stable in prod for a release cycle (a week or two).
+Removes the now-unused `ObjectId` column and rewires the remaining callers that still referenced it. Safe to ship in the same release as PR 1, or in a follow-up release after a soak period — the code paths are independent.
 
 **Scope:**
 
-- Remove `ObjectId` property from `ApplicationUser`.
-- Remove from `ApplicationUserConfig` (`IdentityConfiguration.cs`).
-- Migration: drop the column.
-- Clean up references (e.g., `SyncUsersFromEmployeeRecords`, `UpdateMissingEmployeeIds` which read `ObjectId` today — they need to read from the `UserIdentity` row instead, or be rewritten to use a different employee correlation).
+- Remove `ObjectId` property from `ApplicationUser` and the mapping in `ApplicationUserConfig` (`IdentityConfiguration.cs`).
+- Migration `Drop-ApplicationUser-ObjectId`: drops the column; `Down` re-adds the column and rehydrates it from the active `MicrosoftEntraId` `UserIdentity` rows so rollback is non-destructive.
+- Rewire the username/email-taken guards in `CreateOrUpdateFromPrincipalAsync` to check `IUserIdentityStore.ExistsActive(userId, MicrosoftEntraId)` instead of inspecting `ObjectId`.
+- Remove the three `user.ObjectId = ...` writes in the principal-link path — the `UserIdentity` row is written by `EnsureEntraIdentityRowAsync` downstream.
+- Rewire `UpdateMissingEmployeeIds` and `SyncUsersFromEmployeeRecords` (which correlated external employee records by matching `ObjectId` to `EmployeeNumber`) to use a new `IUserIdentityStore.GetActiveSubjectsByProvider(provider)` batch lookup. Pulls the Entra subject from the user's active identity row.
 
-**Rollback:** harder. Restoring the column requires re-backfilling from `UserIdentity`. Hence the one-release gap after PR 1 to be sure.
+**Rollback:** revert the code. The migration's `Down` re-creates the column and re-populates it from `UserIdentity.ProviderSubject` for active Entra identities, so the old `ObjectId`-based lookups would work unchanged if PR 1 were also reverted.
 
 ### PR 3 — Token exchange + Wayd JWT with permission claims (multi-PR effort on its own)
 


### PR DESCRIPTION
## PR title

`Remove ObjectId column from ApplicationUser`

## Description

### Summary
- Removes the now-unused `ObjectId` column from `ApplicationUser` and rewires the remaining callers that still referenced it.
- Completes the identity-model consolidation started in PR 1 — every read and write of Entra identity information now flows through `UserIdentity` via `IUserIdentityStore`.
- No behavior changes visible to end users. Safe to ship in the same release as PR 1, or in a follow-up release after a soak period.

### Why
After PR 1 (#545), `ObjectId` was a write-only column in production code paths — kept around as a rollback safety net while the new `UserIdentity`-based lookups baked. This PR removes the column and rewires the handful of remaining `ObjectId` readers that weren't on the hot auth path:

- Username/email-taken guards in the Entra principal-link flow.
- Employee-correlation batch jobs (`UpdateMissingEmployeeIds`, `SyncUsersFromEmployeeRecords`) that use the Entra `oid` to match external employee records.

Leaving the column in place indefinitely leaves dead state in the schema and a trap for future readers who might assume it's still meaningful.

### What's in this PR
- **`ApplicationUser.ObjectId` removed** + `ApplicationUserConfig` mapping removed from `IdentityConfiguration.cs`.
- **Migration `Drop-ApplicationUser-ObjectId`**:
  - `Up`: drops the column.
  - `Down`: re-adds the column *and* rehydrates it from each user's active `MicrosoftEntraId` `UserIdentity.ProviderSubject`. Makes rollback non-destructive — combined with reverting PR 1's code, the old `ObjectId`-based lookups would resolve correctly.
- **`CreateOrUpdateFromPrincipalAsync`** ([UserService.CreateUpdate.cs](Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs)):
  - Username/email-taken guards now check `IUserIdentityStore.ExistsActive(userId, MicrosoftEntraId)` instead of inspecting `ObjectId`. That was the actual intent of the old code — "is this user already linked to Entra?"
  - Removed the three `user.ObjectId = ...` writes (the new-user, existing-user-link, and property-initializer paths). The `UserIdentity` row is written downstream by `EnsureEntraIdentityRowAsync`, which hasn't changed.
- **`UpdateMissingEmployeeIds`** and **`SyncUsersFromEmployeeRecords`** — rewired from `u.ObjectId == EmployeeNumber` correlation to a new batch lookup.
- **New store method:** `IUserIdentityStore.GetActiveSubjectsByProvider(provider)` — returns a `UserId → ProviderSubject` dictionary for users with an active identity for the given provider. Used by the two employee-correlation methods to avoid N+1 queries.
- **Spec updated**: [docs/contributing/specs/identity-model-refactor.mdx](docs/contributing/specs/identity-model-refactor.mdx) PR 2 section rewritten to reflect what landed (scope, rollback, release coupling with PR 1).

### What's intentionally *not* in this PR
- **No logic changes to the Entra or local login paths** beyond removing dead `ObjectId` writes. Both flows already resolved via `UserIdentity` after PR 1.
- **No changes to `LoginProvider` on `ApplicationUser`** — still retained as a "primary provider" indicator. Could be removed in a future cleanup if it proves to drift from `UserIdentity`, but not today.
- **No token exchange or frontend changes.** That's PR 3's scope.

### Risk and rollback
- **Blast radius:** schema + three code sites (all inside `UserService.CreateUpdate.cs`). No API contract changes, no UI changes.
- **Rollback:** `dotnet ef migrations update <previous>` re-creates the column and populates it from `UserIdentity` via the `Down` migration's rehydration SQL. If PR 1's code is also reverted, the old `ObjectId`-based lookups resolve users correctly. No data loss.
- **Deploy-window skew:** during rollout, old app instances running against the new schema would fail on queries like `Where(u => u.ObjectId != null)` (in `SyncUsersFromEmployeeRecords`). Wayd applies migrations on app startup via `InitializeDatabases()`, which keeps the window effectively zero — but worth knowing about if the deploy model ever changes.

### Release coupling with PR 1
Safe to ship in the **same release** as PR 1, despite the earlier plan to hold a release cycle:

- After PR 1 merged, `ObjectId` became write-only in production code paths. The `DROP COLUMN` removes a column that nothing was reading.
- The `Down` migration's rehydration makes rollback genuinely non-destructive — the "keep a column as a safety net" rationale is mostly moot.
- Migrations run in timestamp order, so PR 1's backfill completes before PR 2's drop, inside the same deploy.

If you'd rather keep them separate for review/soak purposes, that's also fine — no correctness reason to require it.

### Test plan
- [x] `dotnet build Wayd.slnx` clean
- [x] `dotnet test Wayd.slnx` — all test projects green (Infrastructure: 70, Architecture: 65, full solution ~1,900 tests)
- [x] Migration applies cleanly against a dev database (verified via NSwag build hook, which boots the API and runs migrations)
- [x] Docs link-checker passes (`npx jest src/services/docs.test.ts` — 663 tests)
- [ ] Verify in staging: existing Entra users can still log in, local users unaffected, employee-correlation batch jobs still correlate correctly (spot-check via Settings → User Management UI)

### Follow-ups
- PR 3: Token exchange endpoint + Wayd JWT with permission claims (multi-PR effort; fixes the "Loading Permissions" 10-second delay).
- PR 4: Admin-initiated tenant migration UI + rebind logic.

See [docs/contributing/specs/identity-model-refactor.mdx](docs/contributing/specs/identity-model-refactor.mdx) for the full sequenced plan.
