### PR TITLE
Feature/auth context exchange cutover

### DIFF
--- a/.iac/wayd/README.md
+++ b/.iac/wayd/README.md
@@ -112,8 +112,6 @@ Override these in the TFC workspace only if the defaults don't fit:
 | `signalr_capacity` | `1` | |
 | `log_analytics_sku` | `PerGB2018` | |
 | `log_analytics_retention_in_days` | `30` | 30 days = free tier; longer incurs cost |
-| `jwt_issuer` | `Wayd` | Local JWT issuer claim |
-| `jwt_audience` | `WaydApi` | Local JWT audience claim |
 | `client_url` | `""` | Optional additional CORS origin |
 | `local_jwt_token_expiration_minutes` | `60` | |
 | `local_jwt_refresh_token_expiration_days` | `7` | |

--- a/.iac/wayd/container-apps.tf
+++ b/.iac/wayd/container-apps.tf
@@ -244,15 +244,10 @@ resource "azurerm_container_app" "wayd_backend" {
         secret_name = "local-jwt-secret"
       }
 
-      env {
-        name  = "SecuritySettings__LocalJwt__Issuer"
-        value = var.jwt_issuer
-      }
-
-      env {
-        name  = "SecuritySettings__LocalJwt__Audience"
-        value = var.jwt_audience
-      }
+      # Issuer and Audience come from security.json baked into the image.
+      # They're JWT claim identifiers — not environment-specific config — and
+      # making them per-env variables invited the kind of defaults-drift bug
+      # that the URI rename caught.
 
       env {
         name  = "SecuritySettings__LocalJwt__TokenExpirationInMinutes"
@@ -279,9 +274,13 @@ resource "azurerm_container_app" "wayd_backend" {
         value = "https://login.microsoftonline.com/common/v2.0"
       }
 
+      # For v2.0 Entra tokens, `aud` is the bare client ID (not the App ID URI
+      # or scope). v1.0 registrations put `api://<clientId>` in `aud` instead.
+      # The value here must match whatever the access token actually carries —
+      # decode a real token at jwt.ms if in doubt.
       env {
         name  = "SecuritySettings__Providers__Entra__Audience"
-        value = var.app_reg_api_scope
+        value = var.api_app_reg_client_id
       }
 
       # Array binding via env vars uses __0, __1, etc. The dynamic block below

--- a/.iac/wayd/variables.tf
+++ b/.iac/wayd/variables.tf
@@ -129,18 +129,6 @@ variable "sql_admin_login" {
   default     = "waydadmin"
 }
 
-variable "jwt_issuer" {
-  type        = string
-  description = "JWT Issuer claim value used by the backend for local (non-AAD) tokens."
-  default     = "Wayd"
-}
-
-variable "jwt_audience" {
-  type        = string
-  description = "JWT Audience claim value used by the backend for local (non-AAD) tokens."
-  default     = "WaydApi"
-}
-
 variable "allow_azure_services_sql_access" {
   type        = bool
   description = "Whether to create a SQL firewall rule allowing all Azure services (0.0.0.0-0.0.0.0) to connect. Useful for dev where the container apps need access; consider disabling for prod in favor of VNet integration."

--- a/README.md
+++ b/README.md
@@ -330,11 +330,11 @@ SecuritySettings__LocalJwt__Secret={strong random secret, at least 32 chars}
 Optional local JWT settings (with defaults):
 
 ```env
-SecuritySettings__LocalJwt__Issuer=Moda
-SecuritySettings__LocalJwt__Audience=ModaApi
 SecuritySettings__LocalJwt__TokenExpirationInMinutes=60
 SecuritySettings__LocalJwt__RefreshTokenExpirationInDays=7
 ```
+
+`Issuer` and `Audience` are JWT claim identifiers sourced from `security.json` — they're not environment-specific and shouldn't be overridden per deploy.
 
 Additionally, by default Wayd logs to the console via Serilog. If you wish to configure any of the other supported sinks (currently Seq, Datadog and Application Insights), provide the appropriate Serilog**Using**x and Serilog**WriteTo**x settings as env vars for your wayd-api container. An example with DataDog (taken from some TF for the `azurerm_container_app` resource type):
 

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Entra/EntraIdTokenValidator.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Entra/EntraIdTokenValidator.cs
@@ -131,17 +131,24 @@ internal sealed class EntraIdTokenValidator : IEntraIdTokenValidator
     /// shapes:
     ///   v1: https://sts.windows.net/{tid}/
     ///   v2: https://login.microsoftonline.com/{tid}/v2.0
-    /// Returns null for issuers that don't match either shape (e.g., the
-    /// personal-accounts issuer, or anything we don't recognize).
+    /// Returns the first path segment if it parses as a GUID, otherwise null.
+    /// <para>
+    /// This is a shape check, not a trust decision — the MSA (personal accounts)
+    /// pseudo-tenant <c>9188040d-6c67-4c5b-b112-36a304b66dad</c> is a real GUID
+    /// and <em>is</em> returned. Keeping personal accounts out is the
+    /// allowlist's job, not this function's. Non-GUID path segments like
+    /// <c>common</c> and <c>organizations</c> return null because they aren't
+    /// tenant IDs in the first place.
+    /// </para>
     /// </summary>
     internal static string? ExtractTenantFromIssuer(string? issuer)
     {
         if (string.IsNullOrWhiteSpace(issuer)) return null;
         if (!Uri.TryCreate(issuer, UriKind.Absolute, out var uri)) return null;
 
-        // The first path segment is the tenant GUID (or 'common' / 'organizations'
-        // / '9188040d-6c67-4c5b-b112-36a304b66dad' for the pseudo-tenants we
-        // don't want to accept).
+        // First path segment is the tenant ID. Filter to GUIDs so non-tenant
+        // authority markers (common, organizations, consumers) don't leak
+        // through as "tenants" the allowlist then has to special-case.
         var segments = uri.Segments
             .Select(s => s.Trim('/'))
             .Where(s => s.Length > 0)

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Entra/EntraIdTokenValidator.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Entra/EntraIdTokenValidator.cs
@@ -82,30 +82,74 @@ internal sealed class EntraIdTokenValidator : IEntraIdTokenValidator
         ClaimsPrincipal principal;
         try
         {
-            var handler = new JwtSecurityTokenHandler();
+            // MapInboundClaims = false keeps JWT short names (tid, iss, sub) on
+            // the principal. The default map rewrites them to long schema URLs
+            // (e.g. http://schemas.microsoft.com/identity/claims/tenantid), which
+            // would break the tid/iss lookups below. Short names are the OIDC
+            // standard; preserving them is what every modern OIDC library does.
+            var handler = new JwtSecurityTokenHandler { MapInboundClaims = false };
             principal = handler.ValidateToken(subjectToken, validationParameters, out _);
         }
-        catch (SecurityTokenException ex)
+        catch (Exception ex) when (ex is SecurityTokenException or ArgumentException)
         {
+            // SecurityTokenException covers signature/audience/lifetime/algorithm
+            // failures. ArgumentException covers malformed-token cases (non-JWT
+            // input, bad base64, etc.) — the handler throws these before it even
+            // reaches the token-validation pipeline.
             _logger.LogWarning(ex, "Entra id token validation failed.");
             throw new UnauthorizedException("Invalid token.");
         }
 
-        // Tenant allowlist — this is the multi-tenant guard. Without an entry here,
-        // an otherwise-valid Entra token from any other org is rejected. Case-
-        // insensitive compare because operators occasionally enter tenant IDs with
-        // mixed case (copy-paste from scripts, docs, etc.); Entra itself always
-        // issues them lowercase, so normalizing to OrdinalIgnoreCase here just
-        // makes misconfiguration debuggable rather than silently broken.
-        var tid = principal.FindFirstValue("tid");
+        // Tenant allowlist — this is the multi-tenant guard. Without an entry
+        // here, an otherwise-valid Entra token from any other org is rejected.
+        // Case-insensitive compare because operators occasionally enter tenant
+        // IDs with mixed case; Entra itself always issues them lowercase.
+        //
+        // We prefer the `tid` claim (standard on org-context tokens) but fall
+        // back to extracting the tenant from `iss` when tid is absent. Personal
+        // Microsoft accounts acting as guests, and some v2.0 edge cases, omit
+        // tid. The issuer is signed along with everything else, so deriving the
+        // tenant from it is just as trustworthy as reading tid directly.
+        var tid =
+            principal.FindFirstValue("tid")
+            ?? ExtractTenantFromIssuer(principal.FindFirstValue("iss"));
+
         if (string.IsNullOrWhiteSpace(tid) ||
             !settings.AllowedTenantIds.Contains(tid, StringComparer.OrdinalIgnoreCase))
         {
-            _logger.LogWarning("Entra id token rejected: tenant {Tid} not in allowlist.", tid ?? "<missing>");
+            _logger.LogWarning(
+                "Entra id token rejected: tenant {Tid} not in allowlist.",
+                tid ?? "<missing>");
             throw new UnauthorizedException("Invalid token.");
         }
 
         return principal;
+    }
+
+    /// <summary>
+    /// Parses the tenant GUID from an Entra issuer URL. Handles both v1 and v2
+    /// shapes:
+    ///   v1: https://sts.windows.net/{tid}/
+    ///   v2: https://login.microsoftonline.com/{tid}/v2.0
+    /// Returns null for issuers that don't match either shape (e.g., the
+    /// personal-accounts issuer, or anything we don't recognize).
+    /// </summary>
+    internal static string? ExtractTenantFromIssuer(string? issuer)
+    {
+        if (string.IsNullOrWhiteSpace(issuer)) return null;
+        if (!Uri.TryCreate(issuer, UriKind.Absolute, out var uri)) return null;
+
+        // The first path segment is the tenant GUID (or 'common' / 'organizations'
+        // / '9188040d-6c67-4c5b-b112-36a304b66dad' for the pseudo-tenants we
+        // don't want to accept).
+        var segments = uri.Segments
+            .Select(s => s.Trim('/'))
+            .Where(s => s.Length > 0)
+            .ToArray();
+        if (segments.Length == 0) return null;
+
+        var candidate = segments[0];
+        return Guid.TryParse(candidate, out _) ? candidate : null;
     }
 
     private EntraSettings GetSettings()

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/LocalJwtSettings.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/LocalJwtSettings.cs
@@ -5,8 +5,8 @@ public sealed class LocalJwtSettings
     public const string SectionName = "SecuritySettings:LocalJwt";
 
     public string Secret { get; set; } = null!;
-    public string Issuer { get; set; } = "Wayd";
-    public string Audience { get; set; } = "WaydApi";
+    public string Issuer { get; set; } = "https://wayd.dev";
+    public string Audience { get; set; } = "https://api.wayd.dev";
     public int TokenExpirationInMinutes { get; set; } = 60;
     public int RefreshTokenExpirationInDays { get; set; } = 7;
 }

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Entra/EntraIdTokenValidatorTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Entra/EntraIdTokenValidatorTests.cs
@@ -1,0 +1,364 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Protocols;
+using Microsoft.IdentityModel.Protocols.OpenIdConnect;
+using Microsoft.IdentityModel.Tokens;
+using Wayd.Common.Application.Exceptions;
+using Wayd.Infrastructure.Auth.Entra;
+
+namespace Wayd.Infrastructure.Tests.Sut.Auth.Entra;
+
+public class EntraIdTokenValidatorTests
+{
+    private const string TestAudience = "api://test-wayd-api";
+    private const string AllowedTenantId = "11111111-1111-1111-1111-111111111111";
+    private const string OtherTenantId = "22222222-2222-2222-2222-222222222222";
+
+    private readonly RsaSecurityKey _signingKey;
+    private readonly SigningCredentials _signingCredentials;
+    private readonly Mock<IConfigurationManager<OpenIdConnectConfiguration>> _mockOidcConfigManager;
+    private readonly CapturingLogger<EntraIdTokenValidator> _logger;
+
+    public EntraIdTokenValidatorTests()
+    {
+        var rsa = RSA.Create(2048);
+        _signingKey = new RsaSecurityKey(rsa) { KeyId = "test-key-1" };
+        _signingCredentials = new SigningCredentials(_signingKey, SecurityAlgorithms.RsaSha256);
+
+        var oidcConfig = new OpenIdConnectConfiguration();
+        oidcConfig.SigningKeys.Add(_signingKey);
+
+        _mockOidcConfigManager = new Mock<IConfigurationManager<OpenIdConnectConfiguration>>();
+        _mockOidcConfigManager
+            .Setup(m => m.GetConfigurationAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(oidcConfig);
+
+        _logger = new CapturingLogger<EntraIdTokenValidator>();
+    }
+
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        public Exception? LastException { get; private set; }
+        public string? LastMessage { get; private set; }
+        IDisposable? ILogger.BeginScope<TState>(TState state) => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+            Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            LastException = exception;
+            LastMessage = formatter(state, exception);
+        }
+    }
+
+    // --- ExtractTenantFromIssuer (pure function) ---
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithV1Issuer_ReturnsTenantGuid()
+    {
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer(
+            $"https://sts.windows.net/{AllowedTenantId}/");
+
+        result.Should().Be(AllowedTenantId);
+    }
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithV2Issuer_ReturnsTenantGuid()
+    {
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer(
+            $"https://login.microsoftonline.com/{AllowedTenantId}/v2.0");
+
+        result.Should().Be(AllowedTenantId);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ExtractTenantFromIssuer_WithNullOrWhitespace_ReturnsNull(string? issuer)
+    {
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer(issuer);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithCommonPseudoTenant_ReturnsNull()
+    {
+        // 'common' is not a real tenant — it's the multi-tenant endpoint marker.
+        // Accepting it would be a major allowlist hole.
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer(
+            "https://login.microsoftonline.com/common/v2.0");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithOrganizationsPseudoTenant_ReturnsNull()
+    {
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer(
+            "https://login.microsoftonline.com/organizations/v2.0");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithPersonalAccountsPseudoTenant_ReturnsTheGuid()
+    {
+        // The MSA (personal account) issuer tenant ID 9188040d-... is a real-looking
+        // GUID — the function returns it. The allowlist is what keeps it out; we do
+        // NOT special-case the MSA tenant here.
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer(
+            "https://login.microsoftonline.com/9188040d-6c67-4c5b-b112-36a304b66dad/v2.0");
+
+        result.Should().Be("9188040d-6c67-4c5b-b112-36a304b66dad");
+    }
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithMalformedUrl_ReturnsNull()
+    {
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer("not a url");
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ExtractTenantFromIssuer_WithEmptyPath_ReturnsNull()
+    {
+        var result = EntraIdTokenValidator.ExtractTenantFromIssuer("https://login.microsoftonline.com");
+
+        result.Should().BeNull();
+    }
+
+    // --- Validate (full pipeline) ---
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_WithEmptyToken_Throws(string? token)
+    {
+        var sut = CreateSut(new[] { AllowedTenantId });
+
+        var act = () => sut.Validate(token!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithEmptyAllowlist_Throws()
+    {
+        // Runtime defense-in-depth: even if startup validation was bypassed, an
+        // empty allowlist at call time must reject.
+        var sut = CreateSut(Array.Empty<string>());
+        var token = BuildToken(tid: AllowedTenantId);
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithOidcDiscoveryFailure_Throws()
+    {
+        _mockOidcConfigManager
+            .Setup(m => m.GetConfigurationAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("network down"));
+
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(tid: AllowedTenantId);
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithValidTokenAndAllowedTenant_ReturnsPrincipal()
+    {
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(tid: AllowedTenantId);
+
+        var principal = await sut.Validate(token, CancellationToken.None);
+
+        principal.Should().NotBeNull();
+        principal.Identity!.IsAuthenticated.Should().BeTrue();
+        principal.FindFirstValue("tid").Should().Be(AllowedTenantId);
+    }
+
+    [Fact]
+    public async Task Validate_WithTenantNotInAllowlist_Throws()
+    {
+        // The core multi-tenant boundary: an otherwise-valid token from a tenant
+        // we haven't onboarded must be rejected.
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(tid: OtherTenantId);
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithNoTidClaim_FallsBackToIssuer()
+    {
+        // Personal accounts and some v2.0 edge cases omit tid. The validator
+        // parses the tenant from the signed iss claim as a fallback.
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(
+            tid: null,
+            issuer: $"https://login.microsoftonline.com/{AllowedTenantId}/v2.0");
+
+        var principal = await sut.Validate(token, CancellationToken.None);
+
+        principal.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Validate_WithNoTidClaimAndCommonIssuer_Throws()
+    {
+        // With no tid AND an unrecognizable issuer, the validator has nothing
+        // to allowlist against and must reject.
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(
+            tid: null,
+            issuer: "https://login.microsoftonline.com/common/v2.0");
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_AllowlistComparisonIsCaseInsensitive()
+    {
+        // Operators occasionally enter tenant IDs with mixed case; Entra itself
+        // always emits them lowercase. Both should match.
+        var sut = CreateSut(new[] { AllowedTenantId.ToUpperInvariant() });
+        var token = BuildToken(tid: AllowedTenantId); // lowercase
+
+        var principal = await sut.Validate(token, CancellationToken.None);
+
+        principal.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Validate_WithWrongAudience_Throws()
+    {
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(tid: AllowedTenantId, audience: "api://some-other-app");
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithExpiredToken_Throws()
+    {
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(
+            tid: AllowedTenantId,
+            expires: DateTime.UtcNow.AddHours(-1));
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithTokenSignedByDifferentKey_Throws()
+    {
+        using var otherRsa = RSA.Create(2048);
+        var otherKey = new RsaSecurityKey(otherRsa) { KeyId = "other-key" };
+        var otherCreds = new SigningCredentials(otherKey, SecurityAlgorithms.RsaSha256);
+
+        var sut = CreateSut(new[] { AllowedTenantId });
+        var token = BuildToken(tid: AllowedTenantId, signingCredentials: otherCreds);
+
+        var act = () => sut.Validate(token, CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    [Fact]
+    public async Task Validate_WithMalformedToken_Throws()
+    {
+        var sut = CreateSut(new[] { AllowedTenantId });
+
+        var act = () => sut.Validate("not.a.jwt", CancellationToken.None);
+
+        await act.Should().ThrowAsync<UnauthorizedException>();
+    }
+
+    // --- Harness ---
+
+    private EntraIdTokenValidator CreateSut(IReadOnlyList<string> allowedTenantIds)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(BuildConfig(allowedTenantIds))
+            .Build();
+
+        return new EntraIdTokenValidator(
+            config,
+            _mockOidcConfigManager.Object,
+            _logger);
+    }
+
+    private static IEnumerable<KeyValuePair<string, string?>> BuildConfig(
+        IReadOnlyList<string> allowedTenantIds)
+    {
+        yield return new("SecuritySettings:Providers:Entra:Enabled", "true");
+        yield return new("SecuritySettings:Providers:Entra:Authority",
+            "https://login.microsoftonline.com/common/v2.0");
+        yield return new("SecuritySettings:Providers:Entra:Audience", TestAudience);
+        yield return new("SecuritySettings:Providers:Entra:ClockSkewSeconds", "60");
+        for (var i = 0; i < allowedTenantIds.Count; i++)
+        {
+            yield return new(
+                $"SecuritySettings:Providers:Entra:AllowedTenantIds:{i}",
+                allowedTenantIds[i]);
+        }
+    }
+
+    private string BuildToken(
+        string? tid,
+        string? issuer = null,
+        string? audience = null,
+        DateTime? expires = null,
+        SigningCredentials? signingCredentials = null)
+    {
+        var claims = new List<Claim> { new("sub", "test-subject") };
+        if (!string.IsNullOrEmpty(tid))
+        {
+            claims.Add(new Claim("tid", tid));
+        }
+
+        var expiresAt = expires ?? DateTime.UtcNow.AddHours(1);
+        // notBefore must be <= expires, but keep it in the past relative to "now"
+        // so the happy-path tests aren't rejected with "not yet valid". For the
+        // expired-token case, both nbf and exp end up in the past — which is what
+        // we want (ValidateLifetime rejects on expiry).
+        var notBefore = expiresAt < DateTime.UtcNow
+            ? expiresAt.AddMinutes(-5)
+            : DateTime.UtcNow.AddMinutes(-5);
+
+        // OutboundClaimTypeMap would rewrite our short claim names (tid, sub)
+        // to schema URLs when serializing — producing a token unlike what Entra
+        // actually emits. Clearing it preserves the real wire shape.
+        var handler = new JwtSecurityTokenHandler();
+        handler.OutboundClaimTypeMap.Clear();
+        var jwt = handler.CreateJwtSecurityToken(
+            issuer: issuer ?? $"https://login.microsoftonline.com/{AllowedTenantId}/v2.0",
+            audience: audience ?? TestAudience,
+            subject: new ClaimsIdentity(claims),
+            notBefore: notBefore,
+            expires: expiresAt,
+            issuedAt: notBefore,
+            signingCredentials: signingCredentials ?? _signingCredentials);
+
+        return handler.WriteToken(jwt);
+    }
+}

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
@@ -19,8 +19,8 @@ namespace Wayd.Infrastructure.Tests.Sut.Auth.Local;
 public class TokenServiceTests
 {
     private const string TestSecret = "ThisIsATestSecretKeyThatIsLongEnoughForHmacSha256!";
-    private const string TestIssuer = "TestWayd";
-    private const string TestAudience = "TestWaydApi";
+    private const string TestIssuer = "https://test.wayd.dev";
+    private const string TestAudience = "https://test.api.wayd.dev";
 
     private readonly Mock<UserManager<ApplicationUser>> _mockUserManager;
     private readonly Mock<SignInManager<ApplicationUser>> _mockSignInManager;

--- a/Wayd.Web/src/Wayd.Web.Api/Configurations/security.json
+++ b/Wayd.Web/src/Wayd.Web.Api/Configurations/security.json
@@ -17,8 +17,8 @@
         },
         "LocalJwt": {
             "Secret": "DEV-ONLY-SECRET-REPLACE-IN-PRODUCTION!!",
-            "Issuer": "Wayd",
-            "Audience": "WaydApi",
+            "Issuer": "https://wayd.dev",
+            "Audience": "https://api.wayd.dev",
             "TokenExpirationInMinutes": 60,
             "RefreshTokenExpirationInDays": 7
         },

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/layout.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/layout.tsx
@@ -5,7 +5,6 @@ import React, {
   memo,
   PropsWithChildren,
   useEffect,
-  useState,
   useSyncExternalStore,
 } from 'react'
 import { Provider } from 'react-redux'
@@ -19,126 +18,26 @@ import { ThemeProvider } from '../components/contexts/theme'
 import { MenuToggleProvider } from '../components/contexts/menu-toggle'
 import { AntdRegistry } from '@ant-design/nextjs-registry'
 import { AuthProvider, msalInstance } from '../components/contexts/auth'
-import {
-  AuthenticatedTemplate,
-  MsalProvider,
-  UnauthenticatedTemplate,
-  useMsal,
-} from '@azure/msal-react'
-import { InteractionStatus } from '@azure/msal-browser'
+import { MsalProvider } from '@azure/msal-react'
 import { MessageProvider } from '../components/contexts/messaging'
 import LoginPage from './login/page'
 import LogoutPage from './logout/page'
-import logoutStyles from './logout/page.module.css'
-// Note: LogoutPage is only used in UnauthenticatedView (after MSAL determines auth state)
 import { usePathname, useRouter } from 'next/navigation'
-import { isLocalAuthActive } from '../services/clients'
+import { isAuthActive } from '../services/clients'
 
 const { Content } = Layout
 const { useBreakpoint } = Grid
 
 const inter = Inter({ subsets: ['latin'] })
 
-/**
- * Shows the appropriate page for unauthenticated users based on route
- */
 const RETURN_URL_KEY = 'wayd.returnUrl'
-
-const UnauthenticatedView = () => {
-  const pathname = usePathname()
-
-  // Show logout page if on logout route
-  if (pathname === '/logout') {
-    return <LogoutPage />
-  }
-
-  // If locally authenticated, don't show login page — AuthProvider handles it
-  if (isLocalAuthActive()) {
-    return null
-  }
-
-  // Preserve the intended URL so login can redirect back after authentication
-  if (pathname && pathname !== '/' && pathname !== '/login') {
-    sessionStorage.setItem(RETURN_URL_KEY, pathname)
-  }
-
-  return <LoginPage />
-}
-
-/**
- * Shows loading state during MSAL initialization (before auth state is determined).
- * Renders null on the first pass to match the server-rendered HTML, then shows
- * the loading UI on the client once mounted (avoids hydration mismatch).
- */
-const MsalInitializingView = () => {
-  const { inProgress } = useMsal()
-  const pathname = usePathname()
-  const isLogoutRoute = pathname === '/logout'
-  const [isMounted, setIsMounted] = useState(false)
-
-  useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  // On the server (and first client render), return null to match SSR output
-  if (!isMounted) return null
-
-  // Only show during MSAL startup - once ready, Auth/Unauth templates take over
-  // Skip for local auth users (MSAL isn't relevant) and users with no cached accounts
-  let hasCachedAccounts = false
-  try {
-    hasCachedAccounts = (msalInstance?.getAllAccounts().length ?? 0) > 0
-  } catch {
-    // MSAL may not be fully initialized yet — treat as no cached accounts
-  }
-  if (
-    inProgress === InteractionStatus.Startup &&
-    !isLocalAuthActive() &&
-    hasCachedAccounts
-  ) {
-    return (
-      <div className={logoutStyles.pageBackground}>
-        <div className={`${logoutStyles.bgCircle} ${logoutStyles.bgCircle1}`} />
-        <div className={`${logoutStyles.bgCircle} ${logoutStyles.bgCircle2}`} />
-        <div className={`${logoutStyles.bgCircle} ${logoutStyles.bgCircle3}`} />
-        <div className={logoutStyles.card}>
-          <div className={logoutStyles.content}>
-            <div className={logoutStyles.logo}>
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img
-                src="/wayd-icon.png"
-                alt="Wayd"
-                className={logoutStyles.logoIcon}
-              />
-              <div className={logoutStyles.logoDivider} />
-              <span className={logoutStyles.logoText}>wayd</span>
-            </div>
-            <div className={logoutStyles.spinnerWrapper}>
-              <LoadingSpinner />
-            </div>
-            <h1 className={logoutStyles.title}>
-              {isLogoutRoute ? 'Signing out...' : 'Loading...'}
-            </h1>
-            <p className={logoutStyles.subtitle}>
-              {isLogoutRoute
-                ? 'Please wait while we sign you out of your account.'
-                : 'Please wait while we initialize the application.'}
-            </p>
-          </div>
-        </div>
-      </div>
-    )
-  }
-
-  return null
-}
 
 const AppContent = memo(({ children }: PropsWithChildren) => {
   const screens = useBreakpoint()
-  const isMobile = !screens.md // md breakpoint is 768px in Ant Design
+  const isMobile = !screens.md
   const router = useRouter()
 
-  // After authentication, redirect to the originally requested URL if one was stored
+  // After authentication, redirect to the originally requested URL if one was stored.
   useEffect(() => {
     const returnUrl = sessionStorage.getItem(RETURN_URL_KEY)
     if (returnUrl) {
@@ -163,40 +62,8 @@ const AppContent = memo(({ children }: PropsWithChildren) => {
 
 AppContent.displayName = 'AppContent'
 
-/**
- * Loading spinner component for SSR fallback
- */
-const LoadingSpinner = () => (
-  <svg
-    className={logoutStyles.spinner}
-    width="48"
-    height="48"
-    viewBox="0 0 24 24"
-    fill="none"
-  >
-    <circle
-      cx="12"
-      cy="12"
-      r="10"
-      stroke="currentColor"
-      strokeWidth="3"
-      strokeLinecap="round"
-      strokeDasharray="31.4 31.4"
-    />
-  </svg>
-)
-
-/**
- * SSR fallback when msalInstance is null (server-side).
- * Renders nothing — the client will immediately hydrate with the MsalProvider branch,
- * which handles its own loading state via MsalInitializingView.
- */
 const SsrFallback = () => null
 
-/**
- * Shared UI provider stack (theme, menu, Ant Design App, messaging).
- * Extracted to avoid duplicating across local auth and MSAL branches.
- */
 const AppProviders = ({ children }: PropsWithChildren) => (
   <ThemeProvider>
     <MenuToggleProvider>
@@ -208,24 +75,29 @@ const AppProviders = ({ children }: PropsWithChildren) => (
 )
 
 /**
- * Auth gate that renders the full app for locally-authenticated users
- * or falls through to MSAL Authenticated/Unauthenticated templates.
+ * Auth gate — single-check on whether a Wayd JWT is in storage. If yes,
+ * render the app; otherwise render the login page (or logout on /logout).
+ *
+ * MSAL state is deliberately not part of the gate decision. Post-PR 3.2 the
+ * Wayd JWT *is* the session; MSAL is just the mechanism the login page uses
+ * to acquire an initial token via /api/auth/exchange. Treating MSAL state as
+ * part of the gate would conflate "has an Entra session cookie" with "logged
+ * in to Wayd" — the source of the logout re-login race that PR 3.2's earlier
+ * revisions hit.
  */
-// useSyncExternalStore helpers for reading localStorage without SSR mismatch.
-// subscribe is a no-op because we only need the value once on mount — the
-// component tree fully remounts on login/logout via window.location.href.
 const subscribeNoop = () => () => {}
-const getLocalAuthSnapshot = () => isLocalAuthActive()
-const getLocalAuthServerSnapshot = () => false
+const getAuthSnapshot = () => isAuthActive()
+const getAuthServerSnapshot = () => false
 
-const LocalOrMsalAuthGate = ({ children }: PropsWithChildren) => {
-  const localAuth = useSyncExternalStore(
+const AuthGate = ({ children }: PropsWithChildren) => {
+  const pathname = usePathname()
+  const auth = useSyncExternalStore(
     subscribeNoop,
-    getLocalAuthSnapshot,
-    getLocalAuthServerSnapshot,
+    getAuthSnapshot,
+    getAuthServerSnapshot,
   )
 
-  if (localAuth) {
+  if (auth) {
     return (
       <AppProviders>
         <AuthProvider>
@@ -235,45 +107,33 @@ const LocalOrMsalAuthGate = ({ children }: PropsWithChildren) => {
     )
   }
 
-  return (
-    <>
-      <AuthenticatedTemplate>
-        <AppProviders>
-          <AuthProvider>
-            <AppContent>{children}</AppContent>
-          </AuthProvider>
-        </AppProviders>
-      </AuthenticatedTemplate>
-      <UnauthenticatedTemplate>
-        <UnauthenticatedView />
-      </UnauthenticatedTemplate>
-    </>
-  )
+  // Preserve the intended URL so login can redirect back after authentication.
+  if (
+    typeof window !== 'undefined' &&
+    pathname &&
+    pathname !== '/' &&
+    pathname !== '/login' &&
+    pathname !== '/logout'
+  ) {
+    sessionStorage.setItem(RETURN_URL_KEY, pathname)
+  }
+
+  if (pathname === '/logout') {
+    return <LogoutPage />
+  }
+
+  return <LoginPage />
 }
 
 const RootLayout = ({ children }: React.PropsWithChildren) => {
-  // Guard against SSR where msalInstance is null - show appropriate page based on route
-  if (!msalInstance) {
-    return (
-      <html lang="en">
-        <head>
-          <meta
-            name="viewport"
-            content="width=device-width, initial-scale=1, viewport-fit=cover"
-          />
-          <link rel="apple-touch-icon" href="/wayd-icon.png" />
-          <meta name="mobile-web-app-capable" content="yes" />
-          <meta
-            name="apple-mobile-web-app-status-bar-style"
-            content="default"
-          />
-        </head>
-        <body className={inter.className}>
-          <SsrFallback />
-        </body>
-      </html>
-    )
-  }
+  // MSAL can't run during SSR (no window). Render the same shell on the server
+  // AND on the first client render, then swap to the MsalProvider tree after
+  // the mount effect fires. This keeps server HTML and first-paint client HTML
+  // identical — required for hydration — while still booting MSAL on the client.
+  const [mounted, setMounted] = React.useState(false)
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
 
   return (
     <html lang="en">
@@ -287,14 +147,17 @@ const RootLayout = ({ children }: React.PropsWithChildren) => {
         <meta name="apple-mobile-web-app-status-bar-style" content="default" />
       </head>
       <body className={inter.className}>
-        <AntdRegistry>
-          <Provider store={store}>
-            <MsalProvider instance={msalInstance}>
-              <LocalOrMsalAuthGate>{children}</LocalOrMsalAuthGate>
-              <MsalInitializingView />
-            </MsalProvider>
-          </Provider>
-        </AntdRegistry>
+        {mounted && msalInstance ? (
+          <AntdRegistry>
+            <Provider store={store}>
+              <MsalProvider instance={msalInstance}>
+                <AuthGate>{children}</AuthGate>
+              </MsalProvider>
+            </Provider>
+          </AntdRegistry>
+        ) : (
+          <SsrFallback />
+        )}
       </body>
     </html>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.test.tsx
@@ -16,14 +16,10 @@ jest.mock('next/navigation', () => ({
 }))
 
 jest.mock('@/src/services/clients', () => ({
-  isLocalAuthActive: () => false,
+  isAuthActive: () => false,
   getAuthClient: jest.fn(),
-  getAuthStorage: () => ({ setItem: jest.fn() }),
   setRememberMe: jest.fn(),
-  LOCAL_AUTH_TOKEN_KEY: 'localAuthToken',
-  LOCAL_AUTH_REFRESH_TOKEN_KEY: 'localAuthRefreshToken',
-  LOCAL_AUTH_TOKEN_EXPIRY_KEY: 'localAuthTokenExpiry',
-  LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY: 'localAuthMustChangePassword',
+  storeAuth: jest.fn(),
 }))
 
 // Controlled return for the capabilities hook — each test sets the response it

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/src/services/clients'
 import { useGetAuthProvidersQuery } from '@/src/store/features/common/auth-providers-api'
 import { LoadingAccount } from '@/src/components/common'
+import { useDocumentTitle } from '@/src/hooks'
 
 const pulseAnimation = `
 @keyframes pulse {
@@ -484,6 +485,7 @@ function LocalLoginTab() {
 }
 
 export default function LoginPage() {
+  useDocumentTitle('Moda Login')
   const isMsalAuthenticated = useIsAuthenticated()
   const { instance, accounts, inProgress } = useMsal()
   const router = useRouter()

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
@@ -1,21 +1,22 @@
 'use client'
 
 import { useMsal, useIsAuthenticated } from '@azure/msal-react'
-import { InteractionStatus } from '@azure/msal-browser'
-import { useEffect, useState } from 'react'
+import {
+  InteractionRequiredAuthError,
+  InteractionStatus,
+} from '@azure/msal-browser'
+import { useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { tokenRequest } from '@/auth-config'
 import styles from './page.module.css'
 import {
-  isLocalAuthActive,
   getAuthClient,
-  getAuthStorage,
+  isAuthActive,
   setRememberMe as persistRememberMe,
-  LOCAL_AUTH_TOKEN_KEY,
-  LOCAL_AUTH_REFRESH_TOKEN_KEY,
-  LOCAL_AUTH_TOKEN_EXPIRY_KEY,
-  LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY,
+  storeAuth,
 } from '@/src/services/clients'
 import { useGetAuthProvidersQuery } from '@/src/store/features/common/auth-providers-api'
+import { LoadingAccount } from '@/src/components/common'
 
 const pulseAnimation = `
 @keyframes pulse {
@@ -409,18 +410,9 @@ function LocalLoginTab() {
         password,
       })
       persistRememberMe(rememberMe)
-      const storage = getAuthStorage()
-      storage.setItem(LOCAL_AUTH_TOKEN_KEY, tokenResponse.token)
-      storage.setItem(LOCAL_AUTH_REFRESH_TOKEN_KEY, tokenResponse.refreshToken)
-      storage.setItem(
-        LOCAL_AUTH_TOKEN_EXPIRY_KEY,
-        new Date(tokenResponse.tokenExpiresAt).toISOString(),
-      )
-      if (tokenResponse.mustChangePassword) {
-        storage.setItem(LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY, 'true')
-      }
-      // Reload to trigger LocalOrMsalAuthGate to pick up the local token.
-      // AppContent will handle redirecting to any stored return URL.
+      storeAuth(tokenResponse)
+      // Full reload so AuthProvider hydrates from the freshly-stored token
+      // and the layout transitions from unauthenticated view to app shell.
       window.location.href = '/'
     } catch (err: any) {
       const message =
@@ -492,7 +484,8 @@ function LocalLoginTab() {
 }
 
 export default function LoginPage() {
-  const isAuthenticated = useIsAuthenticated()
+  const isMsalAuthenticated = useIsAuthenticated()
+  const { instance, accounts, inProgress } = useMsal()
   const router = useRouter()
   const { data: providers } = useGetAuthProvidersQuery()
 
@@ -510,17 +503,96 @@ export default function LoginPage() {
   )
   const activeTab = tabOverride ?? (entraEnabled ? 'microsoft' : 'local')
 
+  // Exchange flow state. The login page owns the MSAL-redirect handling:
+  // when we land here with an active MSAL session but no Wayd JWT, we grab
+  // the access token and POST it to /api/auth/exchange. This is the standard
+  // OIDC callback-route pattern (we just fold it into /login rather than
+  // splitting into /auth/callback).
+  const [exchangeState, setExchangeState] = useState<
+    'idle' | 'running' | 'failed'
+  >('idle')
+  const [exchangeError, setExchangeError] = useState<string | null>(null)
+  const exchangeStartedRef = useRef(false)
+
+  // Already authenticated — bail back to the app. Runs whenever a Wayd JWT
+  // appears in storage (after exchange succeeds, after local login succeeds,
+  // or on fresh page load when a stored token already exists).
   useEffect(() => {
-    if (isAuthenticated || isLocalAuthActive()) {
+    if (isAuthActive()) {
       router.replace('/')
     }
-  }, [isAuthenticated, router])
+  }, [router])
 
-  if (isAuthenticated) {
-    return null
-  }
+  // Exchange-on-MSAL-redirect. When MSAL has an account and we don't have a
+  // Wayd JWT, silently acquire the access token and exchange it. Succeeds →
+  // stores Wayd JWT → effect above navigates away. Fails → shows retry UI.
+  useEffect(() => {
+    if (exchangeStartedRef.current) return
+    if (inProgress !== InteractionStatus.None) return
+    if (isAuthActive()) return
+    if (!isMsalAuthenticated || accounts.length === 0) return
+
+    exchangeStartedRef.current = true
+    // Legitimate side-effect: kicking off the exchange in response to MSAL
+    // returning a usable session. The state updates mark "we're actively
+    // exchanging" for the UI, not an auto-memoizable derivation.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setExchangeState('running')
+    setExchangeError(null)
+
+    const run = async () => {
+      try {
+        const account = instance.getActiveAccount() ?? accounts[0]
+        instance.setActiveAccount(account)
+        const msalResponse = await instance.acquireTokenSilent({
+          ...tokenRequest,
+          account,
+        })
+        const tokenResponse = await getAuthClient().exchange({
+          provider: 'MicrosoftEntraId',
+          subjectToken: msalResponse.accessToken,
+        })
+        storeAuth(tokenResponse)
+        // Full reload so the layout gate re-reads storage and mounts the app.
+        window.location.href = '/'
+      } catch (error) {
+        console.error('[Login] Entra token exchange failed:', error)
+        if (error instanceof InteractionRequiredAuthError) {
+          // A silent acquisition failed because interaction is required.
+          // Signal to the user to click the Microsoft button again; that
+          // triggers a full loginRedirect.
+          setExchangeError(
+            'Sign-in needs to be completed interactively. Please click Sign in with Microsoft again.',
+          )
+        } else {
+          setExchangeError(
+            error instanceof Error
+              ? error.message
+              : 'Sign-in failed. Please try again.',
+          )
+        }
+        setExchangeState('failed')
+      }
+    }
+    run()
+  }, [accounts, inProgress, instance, isMsalAuthenticated])
 
   const showTabs = entraEnabled && localEnabled
+
+  // During exchange, show the shared LoadingAccount screen (spinner + logo +
+  // message) so the transition from Entra redirect → Wayd app matches the
+  // visual language of other loading states in the app.
+  if (exchangeState === 'running') {
+    return <LoadingAccount message="Completing sign-in…" />
+  }
+
+  if (exchangeState === 'failed') {
+    // Show the login UI with an error banner. User can click the Microsoft
+    // button (which triggers loginRedirect) or use email/password.
+    // Note: we deliberately clear MSAL's cached account via a reset so a
+    // subsequent click runs a fresh loginRedirect rather than silent-acquire.
+    // (Left to Microsoft button's natural flow for now — not critical.)
+  }
 
   return (
     <div className={styles.pageBackground}>
@@ -569,6 +641,12 @@ export default function LoginPage() {
             </div>
 
             <h1 className={styles.title}>Welcome</h1>
+
+            {exchangeError && (
+              <div className={styles.errorMessage} role="alert">
+                {exchangeError}
+              </div>
+            )}
 
             {/* Auth method tabs. Hidden when only one provider is enabled —
                 there's no choice to offer. */}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.test.tsx
@@ -95,9 +95,16 @@ import { clearAuth, storeAuth } from '@/src/services/clients'
 
 // --- Test helpers ---
 
+// JWT segments are base64url, not standard base64 — convert btoa's output so
+// tests exercise the same decode path real Wayd tokens hit (`-`/`_` instead of
+// `+`/`/`, stripped padding).
+function base64UrlEncode(value: string): string {
+  return btoa(value).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
 function makeWaydJwt(claims: Record<string, unknown>): string {
-  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
-  const payload = btoa(JSON.stringify(claims))
+  const header = base64UrlEncode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = base64UrlEncode(JSON.stringify(claims))
   return `${header}.${payload}.signature`
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.test.tsx
@@ -1,106 +1,34 @@
 import { render, screen, waitFor, act } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import React, { useImperativeHandle, forwardRef } from 'react'
+import React from 'react'
 
-// Mock LoadingAccount component - must be before imports that use it
-jest.mock('../../common', () => ({
-  LoadingAccount: ({ message }: { message: string }) => (
-    <div data-testid="loading-account">{message}</div>
-  ),
-}))
+// --- Mocks (all before imports) ---
 
-// Mock the page components
-jest.mock('../../../app/unauthorized/page', () => ({
-  __esModule: true,
-  default: () => <div data-testid="unauthorized-page">Unauthorized</div>,
-}))
-
-jest.mock('../../../app/service-unavailable/page', () => ({
-  __esModule: true,
-  default: ({ onRetry }: { onRetry?: () => void }) => (
-    <div data-testid="service-unavailable-page">
-      Service Unavailable
-      {onRetry && (
-        <button onClick={onRetry} data-testid="retry-btn">
-          Retry
-        </button>
-      )}
-    </div>
-  ),
-}))
-
-// Mock next/navigation
-const mockUsePathname = jest.fn()
-jest.mock('next/navigation', () => ({
-  usePathname: () => mockUsePathname(),
-}))
-
-// Mock the permissions API
-const mockUseGetUserPermissionsQuery = jest.fn()
-jest.mock('../../../store/features/user-management/profile-api', () => ({
-  useGetUserPermissionsQuery: (...args: unknown[]) =>
-    mockUseGetUserPermissionsQuery(...args),
-}))
-
-// MSAL mocks
-const mockInstance = {
-  getActiveAccount: jest.fn(),
-  setActiveAccount: jest.fn(),
-  getAllAccounts: jest.fn(),
-  acquireTokenSilent: jest.fn(),
-  acquireTokenPopup: jest.fn(),
-  loginRedirect: jest.fn(),
-  logoutRedirect: jest.fn(),
-  addEventCallback: jest.fn().mockReturnValue('callback-id'),
-  removeEventCallback: jest.fn(),
-}
-
-const mockUseMsal = jest.fn()
-const mockUseIsAuthenticated = jest.fn()
-
-jest.mock('@azure/msal-react', () => ({
-  useMsal: () => mockUseMsal(),
-  useIsAuthenticated: () => mockUseIsAuthenticated(),
-}))
-
-jest.mock('@azure/msal-browser', () => ({
-  PublicClientApplication: jest.fn().mockImplementation(() => ({
-    getActiveAccount: jest.fn(),
-    setActiveAccount: jest.fn(),
-    getAllAccounts: jest.fn().mockReturnValue([]),
-    acquireTokenSilent: jest.fn(),
-    acquireTokenPopup: jest.fn(),
-    loginRedirect: jest.fn(),
-    logoutRedirect: jest.fn(),
-    addEventCallback: jest.fn().mockReturnValue('callback-id'),
-    removeEventCallback: jest.fn(),
-  })),
-  InteractionRequiredAuthError: class InteractionRequiredAuthError extends Error {
-    constructor(message: string) {
-      super(message)
-      this.name = 'InteractionRequiredAuthError'
-    }
-  },
-  EventType: {
-    LOGIN_SUCCESS: 'msal:loginSuccess',
-    ACQUIRE_TOKEN_SUCCESS: 'msal:acquireTokenSuccess',
-    LOGOUT_SUCCESS: 'msal:logoutSuccess',
-    ACTIVE_ACCOUNT_CHANGED: 'msal:activeAccountChanged',
-  },
-}))
-
-// Mock ChangePasswordForm (imported by auth-context for forced password change)
 jest.mock('../../../app/account/profile/change-password-form', () => ({
   __esModule: true,
-  default: ({ onFormComplete, onFormCancel, required }: any) => (
-    <div data-testid="change-password-form" data-required={required}>
-      <button onClick={onFormComplete} data-testid="change-password-complete">Complete</button>
-      <button onClick={onFormCancel} data-testid="change-password-cancel">Cancel</button>
+  default: ({ onFormComplete, onFormCancel }: any) => (
+    <div data-testid="change-password-form">
+      <button onClick={onFormComplete} data-testid="change-password-complete">
+        Complete
+      </button>
+      <button onClick={onFormCancel} data-testid="change-password-cancel">
+        Cancel
+      </button>
     </div>
   ),
 }))
 
-// Mock useTheme (imported by auth-context for themed background)
+// MSAL mock — AuthProvider uses useMsal() to clear the cache on logout. The
+// session-reading behavior we're actually testing doesn't touch MSAL.
+jest.mock('@azure/msal-react', () => ({
+  useMsal: () => ({
+    instance: {
+      setActiveAccount: jest.fn(),
+      clearCache: jest.fn().mockResolvedValue(undefined),
+    },
+  }),
+}))
+
 jest.mock('./../../contexts/theme/use-theme', () => ({
   __esModule: true,
   default: () => ({
@@ -109,1406 +37,270 @@ jest.mock('./../../contexts/theme/use-theme', () => ({
   }),
 }))
 
-// Import after mocks
-import { AuthProvider, _resetRedirectFlag } from './auth-context'
-import useAuth from './use-auth'
-import type { AuthContextType } from './types'
+// In-memory storage for the Wayd JWT. We replace the real services/clients
+// module entirely because clients.ts imports axios + NSwag-generated code,
+// which pulls in too much for a unit test and triggers side effects on module
+// load. The real behavior under test is AuthProvider's session-reading logic.
+const mockStorage = {
+  token: null as string | null,
+  refreshToken: null as string | null,
+  tokenExpiry: null as string | null,
+  mustChangePassword: null as string | null,
+}
 
-// Test component to consume auth context
+const mockLogin = jest.fn()
+
+jest.mock('@/src/services/clients', () => ({
+  AUTH_TOKEN_KEY: 'wayd.token',
+  AUTH_REFRESH_TOKEN_KEY: 'wayd.refreshToken',
+  AUTH_TOKEN_EXPIRY_KEY: 'wayd.tokenExpiry',
+  AUTH_MUST_CHANGE_PASSWORD_KEY: 'wayd.mustChangePassword',
+  getAuthStorage: () => ({
+    getItem: (key: string) => {
+      if (key === 'wayd.mustChangePassword') return mockStorage.mustChangePassword
+      if (key === 'wayd.token') return mockStorage.token
+      return null
+    },
+    setItem: (key: string, value: string) => {
+      if (key === 'wayd.mustChangePassword') mockStorage.mustChangePassword = value
+    },
+    removeItem: (key: string) => {
+      if (key === 'wayd.mustChangePassword') mockStorage.mustChangePassword = null
+    },
+  }),
+  getAuthToken: () => mockStorage.token,
+  getAuthRefreshToken: () => mockStorage.refreshToken,
+  isAuthActive: () => mockStorage.token !== null,
+  storeAuth: (tokenResponse: any) => {
+    mockStorage.token = tokenResponse.token
+    mockStorage.refreshToken = tokenResponse.refreshToken
+    mockStorage.tokenExpiry = new Date(tokenResponse.tokenExpiresAt).toISOString()
+    mockStorage.mustChangePassword = tokenResponse.mustChangePassword ? 'true' : null
+  },
+  clearAuth: () => {
+    mockStorage.token = null
+    mockStorage.refreshToken = null
+    mockStorage.tokenExpiry = null
+    mockStorage.mustChangePassword = null
+  },
+  getAuthClient: () => ({
+    login: mockLogin,
+  }),
+}))
+
+// Imports after mocks.
+import { AuthProvider } from './auth-context'
+import useAuth from './use-auth'
+import { clearAuth, storeAuth } from '@/src/services/clients'
+
+// --- Test helpers ---
+
+function makeWaydJwt(claims: Record<string, unknown>): string {
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }))
+  const payload = btoa(JSON.stringify(claims))
+  return `${header}.${payload}.signature`
+}
+
 const TestConsumer = () => {
   const auth = useAuth()
   return (
     <div>
-      <span data-testid="user-name">{auth.user?.name || 'No user'}</span>
-      <span data-testid="user-authenticated">
-        {auth.user?.isAuthenticated ? 'true' : 'false'}
-      </span>
-      <span data-testid="is-loading">{auth.isLoading ? 'true' : 'false'}</span>
-      <button onClick={auth.login} data-testid="login-btn">
-        Login
-      </button>
-      <button onClick={auth.logout} data-testid="logout-btn">
-        Logout
-      </button>
+      <div data-testid="name">{auth.user?.name ?? ''}</div>
+      <div data-testid="username">{auth.user?.username ?? ''}</div>
+      <div data-testid="authenticated">
+        {auth.user?.isAuthenticated ? 'yes' : 'no'}
+      </div>
+      <div data-testid="auth-method">{auth.authMethod ?? 'null'}</div>
+      <div data-testid="employee-id">{auth.user?.employeeId ?? ''}</div>
+      <div data-testid="permissions">
+        {auth.user?.claims
+          .filter((c) => c.type === 'Permission')
+          .map((c) => c.value)
+          .join(',') ?? ''}
+      </div>
+      <div data-testid="has-projects-view">
+        {auth.hasPermissionClaim('Permissions.Projects.View') ? 'yes' : 'no'}
+      </div>
+      <div data-testid="must-change-password">
+        {auth.mustChangePassword ? 'yes' : 'no'}
+      </div>
     </div>
   )
 }
 
-// Test component that exposes auth context via ref for testing
-interface AuthContextHandle {
-  getContext: () => AuthContextType
-}
+beforeEach(() => {
+  jest.clearAllMocks()
+  clearAuth()
+})
 
-const TestConsumerWithRef = forwardRef<AuthContextHandle>(
-  function TestConsumerWithRef(_props, ref) {
+afterEach(() => {
+  clearAuth()
+})
+
+// --- Tests ---
+
+describe('AuthProvider hydration from stored Wayd JWT', () => {
+  it('hydrates user, permissions, and authMethod from a Wayd-provider JWT', async () => {
+    storeAuth({
+      token: makeWaydJwt({
+        given_name: 'Alice',
+        family_name: 'Example',
+        email: 'alice@example.com',
+        loginProvider: 'Wayd',
+        EmployeeId: 'emp-123',
+        permission: ['Permissions.Projects.View', 'Permissions.Teams.Manage'],
+      }),
+      refreshToken: 'r1',
+      tokenExpiresAt: new Date(Date.now() + 3600_000),
+      mustChangePassword: false,
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('authenticated')).toHaveTextContent('yes')
+    })
+    expect(screen.getByTestId('name')).toHaveTextContent('Alice Example')
+    expect(screen.getByTestId('username')).toHaveTextContent('alice@example.com')
+    expect(screen.getByTestId('auth-method')).toHaveTextContent('local')
+    expect(screen.getByTestId('employee-id')).toHaveTextContent('emp-123')
+    expect(screen.getByTestId('permissions')).toHaveTextContent(
+      'Permissions.Projects.View,Permissions.Teams.Manage',
+    )
+    expect(screen.getByTestId('has-projects-view')).toHaveTextContent('yes')
+  })
+
+  it('hydrates an Entra-issued JWT with authMethod = msal', async () => {
+    storeAuth({
+      token: makeWaydJwt({
+        given_name: 'Bob',
+        family_name: 'Cloud',
+        email: 'bob@acme.com',
+        loginProvider: 'MicrosoftEntraId',
+        permission: [],
+      }),
+      refreshToken: 'r2',
+      tokenExpiresAt: new Date(Date.now() + 3600_000),
+      mustChangePassword: false,
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    )
+
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('yes')
+    expect(screen.getByTestId('auth-method')).toHaveTextContent('msal')
+  })
+
+  it('supports permission claim as a single string (not just array)', () => {
+    storeAuth({
+      token: makeWaydJwt({
+        given_name: 'Solo',
+        loginProvider: 'Wayd',
+        permission: 'Permissions.Projects.View',
+      }),
+      refreshToken: 'r',
+      tokenExpiresAt: new Date(Date.now() + 3600_000),
+      mustChangePassword: false,
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    )
+
+    expect(screen.getByTestId('has-projects-view')).toHaveTextContent('yes')
+  })
+
+  it('clears storage when the stored JWT is malformed', () => {
+    mockStorage.token = 'not-a-valid-jwt'
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    )
+
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('no')
+    // Malformed tokens are purged so the user falls through to login.
+    expect(mockStorage.token).toBeNull()
+  })
+
+  it('shows change-password gate when mustChangePassword is set on a local session', () => {
+    storeAuth({
+      token: makeWaydJwt({
+        given_name: 'Dana',
+        loginProvider: 'Wayd',
+        permission: [],
+      }),
+      refreshToken: 'r',
+      tokenExpiresAt: new Date(Date.now() + 3600_000),
+      mustChangePassword: true,
+    })
+
+    render(
+      <AuthProvider>
+        <TestConsumer />
+      </AuthProvider>,
+    )
+
+    expect(screen.getByTestId('change-password-form')).toBeInTheDocument()
+  })
+})
+
+describe('AuthProvider local login', () => {
+  const TestLoginConsumer = () => {
     const auth = useAuth()
-
-    useImperativeHandle(ref, () => ({
-      getContext: () => auth,
-    }))
-
     return (
       <div>
-        <span data-testid="user-name">{auth.user?.name || 'No user'}</span>
-        <span data-testid="user-authenticated">
-          {auth.user?.isAuthenticated ? 'true' : 'false'}
-        </span>
-        <span data-testid="is-loading">
-          {auth.isLoading ? 'true' : 'false'}
-        </span>
+        <div data-testid="authenticated">
+          {auth.user?.isAuthenticated ? 'yes' : 'no'}
+        </div>
+        <button
+          data-testid="do-login"
+          onClick={() => auth.localLogin('alice', 'password')}
+        >
+          login
+        </button>
       </div>
     )
-  },
-)
-
-describe('AuthContext', () => {
-  const mockAccount = {
-    username: 'test@example.com',
-    name: 'Test User',
-    homeAccountId: 'account-home-id-123',
-    idTokenClaims: {
-      sub: '12345',
-      email: 'test@example.com',
-    },
   }
 
-  beforeEach(() => {
-    jest.clearAllMocks()
-    _resetRedirectFlag()
-
-    // Default mock implementations
-    mockUsePathname.mockReturnValue('/') // Default to home route
-    mockUseMsal.mockReturnValue({
-      instance: mockInstance,
-      accounts: [],
-      inProgress: 'none',
-    })
-    mockUseIsAuthenticated.mockReturnValue(false)
-    mockUseGetUserPermissionsQuery.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-      error: undefined,
-    })
-    mockInstance.getActiveAccount.mockReturnValue(null)
-    mockInstance.getAllAccounts.mockReturnValue([])
-  })
-
-  describe('useAuth hook', () => {
-    it('throws error when used outside AuthProvider', () => {
-      const consoleError = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-
-      expect(() => {
-        render(<TestConsumer />)
-      }).toThrow('useAuth must be used within an AuthProvider')
-
-      consoleError.mockRestore()
+  it('stores the token response and hydrates the user on success', async () => {
+    mockLogin.mockResolvedValue({
+      token: makeWaydJwt({
+        given_name: 'Alice',
+        loginProvider: 'Wayd',
+        permission: [],
+      }),
+      refreshToken: 'r',
+      tokenExpiresAt: new Date(Date.now() + 3600_000),
+      mustChangePassword: false,
     })
 
-    it('returns auth context when used within AuthProvider', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
+    render(
+      <AuthProvider>
+        <TestLoginConsumer />
+      </AuthProvider>,
+    )
 
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('no')
 
-      await waitFor(() => {
-        expect(screen.getByTestId('is-loading').textContent).toBe('false')
-      })
-
-      expect(screen.getByTestId('user-name')).toBeInTheDocument()
-    })
-  })
-
-  describe('AuthProvider', () => {
-    it('shows loading state when authenticated user is loading permissions', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: true,
-        error: undefined,
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      expect(screen.getByTestId('loading-account')).toBeInTheDocument()
+    await act(async () => {
+      screen.getByTestId('do-login').click()
     })
 
-    it('does not show loading state for unauthenticated users', () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(false)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Should render children directly without loading screen
-      expect(screen.queryByTestId('loading-account')).not.toBeInTheDocument()
-      expect(screen.getByTestId('user-authenticated').textContent).toBe('false')
-    })
-
-    it('sets active account when accounts exist but no active account', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(null)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(mockAccount)
-      })
-    })
-
-    it('does not set active account when one already exists', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('is-loading').textContent).toBe('false')
-      })
-
-      // setActiveAccount should not be called since one already exists
-      expect(mockInstance.setActiveAccount).not.toHaveBeenCalled()
-    })
-
-    it('updates user when MSAL transitions from startup to ready with accounts', async () => {
-      // Simulate MSAL startup state (like after a login redirect)
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'startup',
-      })
-      mockUseIsAuthenticated.mockReturnValue(false)
-      mockInstance.getActiveAccount.mockReturnValue(null)
-
-      const { rerender } = render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // During startup, should show loading or initial state
-      expect(screen.getByTestId('user-authenticated').textContent).toBe('false')
-
-      // Now simulate MSAL finishing initialization with an authenticated user
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount
-        .mockReturnValueOnce(null) // First call returns null (before setActiveAccount)
-        .mockReturnValue(mockAccount) // Subsequent calls return the account
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      rerender(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Should set the active account and build user profile
-      await waitFor(() => {
-        expect(screen.getByTestId('user-name').textContent).toBe('Test User')
-        expect(screen.getByTestId('user-authenticated').textContent).toBe(
-          'true',
-        )
-      })
-    })
-
-    it('clears activeAccount state when MSAL is not ready', async () => {
-      // Start with authenticated user
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const { rerender } = render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('user-authenticated').textContent).toBe(
-          'true',
-        )
-      })
-
-      // Simulate MSAL going back to not ready (e.g., during a redirect)
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'handleRedirect',
-      })
-
-      rerender(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Should show loading state during redirect handling
-      expect(screen.getByTestId('loading-account')).toBeInTheDocument()
-    })
-
-    it('builds user profile with permissions when authenticated', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read', 'Permission.Write'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('user-name').textContent).toBe('Test User')
-        expect(screen.getByTestId('user-authenticated').textContent).toBe(
-          'true',
-        )
-      })
-    })
-
-    it('skips permissions query when not ready', () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'startup',
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      expect(mockUseGetUserPermissionsQuery).toHaveBeenCalledWith(undefined, {
-        skip: true,
-        pollingInterval: 5 * 60 * 1000,
-      })
-    })
-
-    it('skips permissions query when not authenticated', () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(false)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      expect(mockUseGetUserPermissionsQuery).toHaveBeenCalledWith(undefined, {
-        skip: true,
-        pollingInterval: 5 * 60 * 1000,
-      })
-    })
-
-    it('fetches permissions when authenticated and ready', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(mockUseGetUserPermissionsQuery).toHaveBeenCalledWith(undefined, {
-          skip: false,
-          pollingInterval: 5 * 60 * 1000,
-        })
-      })
-    })
-  })
-
-  describe('hasClaim and hasPermissionClaim', () => {
-    it('hasClaim returns true when claim exists', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const ref = React.createRef<AuthContextHandle>()
-
-      render(
-        <AuthProvider>
-          <TestConsumerWithRef ref={ref} />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(ref.current?.getContext().user?.isAuthenticated).toBe(true)
-      })
-
-      const authContext = ref.current!.getContext()
-      expect(authContext.hasClaim('email', 'test@example.com')).toBe(true)
-      expect(authContext.hasClaim('email', 'other@example.com')).toBe(false)
-    })
-
-    it('hasPermissionClaim returns true when permission exists', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read', 'Permission.Write'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const ref = React.createRef<AuthContextHandle>()
-
-      render(
-        <AuthProvider>
-          <TestConsumerWithRef ref={ref} />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(ref.current?.getContext().user?.isAuthenticated).toBe(true)
-      })
-
-      const authContext = ref.current!.getContext()
-      expect(authContext.hasPermissionClaim('Permission.Read')).toBe(true)
-      expect(authContext.hasPermissionClaim('Permission.Delete')).toBe(false)
-    })
-  })
-
-  describe('login and logout', () => {
-    it('calls loginRedirect when login is invoked', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('is-loading').textContent).toBe('false')
-      })
-
-      await act(async () => {
-        screen.getByTestId('login-btn').click()
-      })
-
-      expect(mockInstance.loginRedirect).toHaveBeenCalled()
-    })
-
-    it('logout function can be called without error', async () => {
-      // Note: Testing window.location.href assignment is difficult in jsdom
-      // The actual navigation to /logout is verified via integration tests
-      // This test verifies the logout function is accessible and callable
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: [], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const ref = React.createRef<AuthContextHandle>()
-
-      render(
-        <AuthProvider>
-          <TestConsumerWithRef ref={ref} />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(ref.current?.getContext().user?.isAuthenticated).toBe(true)
-      })
-
-      // Verify logout function exists and can be called
-      const authContext = ref.current!.getContext()
-      expect(typeof authContext.logout).toBe('function')
-
-      // The actual window.location.href assignment will throw "Not implemented" in jsdom
-      // but the function itself should be defined and callable
-    })
-  })
-
-  describe('acquireToken', () => {
-    it('acquires token silently when possible', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockInstance.acquireTokenSilent.mockResolvedValue({
-        accessToken: 'test-token',
-      })
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: [], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const ref = React.createRef<AuthContextHandle>()
-
-      render(
-        <AuthProvider>
-          <TestConsumerWithRef ref={ref} />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(ref.current?.getContext().user?.isAuthenticated).toBe(true)
-      })
-
-      const token = await ref.current!.getContext().acquireToken()
-      expect(token).toBe('test-token')
-      expect(mockInstance.acquireTokenSilent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          account: mockAccount,
-        }),
-      )
-    })
-
-    it('falls back to popup when silent acquisition fails with interaction required', async () => {
-      // Use the mocked InteractionRequiredAuthError from our jest.mock
-      const { InteractionRequiredAuthError } =
-        await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-
-      const interactionError = new InteractionRequiredAuthError(
-        'interaction_required',
-      )
-      mockInstance.acquireTokenSilent.mockRejectedValue(interactionError)
-      mockInstance.acquireTokenPopup.mockResolvedValue({
-        accessToken: 'popup-token',
-      })
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: [], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const ref = React.createRef<AuthContextHandle>()
-
-      render(
-        <AuthProvider>
-          <TestConsumerWithRef ref={ref} />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(ref.current?.getContext().user?.isAuthenticated).toBe(true)
-      })
-
-      const token = await ref.current!.getContext().acquireToken()
-      expect(token).toBe('popup-token')
-      expect(mockInstance.acquireTokenPopup).toHaveBeenCalled()
-    })
-
-    it('throws error when no accounts are found', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([]) // No accounts
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: [], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      const ref = React.createRef<AuthContextHandle>()
-
-      render(
-        <AuthProvider>
-          <TestConsumerWithRef ref={ref} />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(ref.current?.getContext().user?.isAuthenticated).toBe(true)
-      })
-
-      await expect(ref.current!.getContext().acquireToken()).rejects.toThrow(
-        'No authenticated accounts found',
-      )
-    })
-  })
-
-  describe('cross-tab authentication (localStorage)', () => {
-    it('uses cached accounts from localStorage on mount', async () => {
-      // Simulate scenario where accounts are already in cache (cross-tab)
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount], // Accounts loaded from localStorage
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Should immediately show authenticated user without redirect
-      await waitFor(() => {
-        expect(screen.getByTestId('user-name').textContent).toBe('Test User')
-        expect(screen.getByTestId('user-authenticated').textContent).toBe(
-          'true',
-        )
-      })
-
-      // Should not have triggered login redirect
-      expect(mockInstance.loginRedirect).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('error handling', () => {
-    it('shows unauthorized page when permissions return 403', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: { status: 403, error: 'Forbidden' },
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(screen.getByTestId('unauthorized-page')).toBeInTheDocument()
-      })
-    })
-
-    it('shows service unavailable page when permissions API fails', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: { status: 500, error: 'Server error' },
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(() => {
-        expect(
-          screen.getByTestId('service-unavailable-page'),
-        ).toBeInTheDocument()
-      })
-    })
-
-    it('triggers loginRedirect when permissions return 401', async () => {
-      const consoleLogSpy = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockInstance.loginRedirect.mockResolvedValue()
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: { status: 401, error: 'Unauthorized' },
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(
-        () => {
-          expect(mockInstance.loginRedirect).toHaveBeenCalled()
-        },
-        { timeout: 3000 },
-      )
-
-      consoleLogSpy.mockRestore()
-    })
-
-    it('handles loginRedirect failure gracefully on 401', async () => {
-      const consoleErrorSpy = jest
-        .spyOn(console, 'error')
-        .mockImplementation(() => {})
-      const consoleLogSpy = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-
-      const redirectError = new Error('Redirect failed')
-      mockInstance.loginRedirect.mockRejectedValue(redirectError)
-
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: { status: 401, error: 'Unauthorized' },
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await waitFor(
-        () => {
-          expect(mockInstance.loginRedirect).toHaveBeenCalled()
-        },
-        { timeout: 3000 },
-      )
-
-      // Wait for error handling
-      await waitFor(
-        () => {
-          expect(consoleErrorSpy).toHaveBeenCalledWith(
-            '[Auth] Re-authentication redirect failed',
-            redirectError,
-          )
-        },
-        { timeout: 3000 },
-      )
-
-      consoleErrorSpy.mockRestore()
-      consoleLogSpy.mockRestore()
-    })
-
-    it('prevents concurrent redirects when global flag is set', async () => {
-      const consoleLogSpy = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-
-      // Make loginRedirect hang so the flag stays set
-      mockInstance.loginRedirect.mockImplementation(
-        () => new Promise(() => {}),
-      )
-
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: { status: 401, error: 'Unauthorized' },
-        refetch: jest.fn(),
-      })
-
-      const { rerender } = render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Should trigger loginRedirect once
-      await waitFor(
-        () => {
-          expect(mockInstance.loginRedirect).toHaveBeenCalledTimes(1)
-        },
-        { timeout: 3000 },
-      )
-
-      // Force re-renders to simulate additional 401 errors triggering refreshUser
-      rerender(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      rerender(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      await new Promise((resolve) => setTimeout(resolve, 200))
-
-      // Still only called once - the isRedirectInProgress flag prevented duplicates
-      expect(mockInstance.loginRedirect).toHaveBeenCalledTimes(1)
-
-      consoleLogSpy.mockRestore()
-    })
-
-    it('skips redirect when MSAL interaction already in progress', async () => {
-      const consoleLogSpy = jest
-        .spyOn(console, 'log')
-        .mockImplementation(() => {})
-
-      // Start with 401 error AND MSAL interaction in progress
-      // This simulates the scenario where loginRedirect was already called
-      // (either by us or another part of the app) and we get another 401
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'login', // MSAL is already handling a login redirect
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: { status: 401, error: 'Unauthorized' },
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // When inProgress !== 'none', the component shows loading screen
-      // and doesn't try to call loginRedirect (effect returns early)
-      await waitFor(() => {
-        expect(screen.getByTestId('loading-account')).toBeInTheDocument()
-      })
-
-      // Should not call loginRedirect when MSAL interaction in progress
-      expect(mockInstance.loginRedirect).not.toHaveBeenCalled()
-
-      // The console.log for skipping redirect only happens inside refreshUser,
-      // which doesn't run when inProgress !== 'none', so we won't see that log.
-      // The protection here is at a higher level - the whole effect doesn't run.
-      consoleLogSpy.mockRestore()
-    })
-  })
-
-  describe('MSAL event callbacks', () => {
-    let eventCallback: (event: any) => void
-
-    beforeEach(() => {
-      // Capture the event callback registered by the component
-      mockInstance.addEventCallback.mockImplementation((cb) => {
-        eventCallback = cb
-        return 'callback-id'
-      })
-    })
-
-    it('updates active account on LOGIN_SUCCESS event', async () => {
-      const { EventType } = await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(false)
-      mockInstance.getActiveAccount.mockReturnValue(null)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Simulate LOGIN_SUCCESS event
-      await act(async () => {
-        eventCallback({
-          eventType: EventType.LOGIN_SUCCESS,
-          payload: { account: mockAccount },
-        })
-      })
-
-      expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(mockAccount)
-    })
-
-    it('updates active account on ACQUIRE_TOKEN_SUCCESS when account changes', async () => {
-      const { EventType } = await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      const newAccount = {
-        ...mockAccount,
-        username: 'updated@example.com',
-        homeAccountId: 'different-home-id',
-      }
-
-      // Simulate ACQUIRE_TOKEN_SUCCESS event with a different account
-      await act(async () => {
-        eventCallback({
-          eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
-          payload: { account: newAccount },
-        })
-      })
-
-      expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(newAccount)
-    })
-
-    it('skips update on ACQUIRE_TOKEN_SUCCESS when account is the same', async () => {
-      const { EventType } = await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Clear any calls from component mount
-      mockInstance.setActiveAccount.mockClear()
-
-      // Simulate ACQUIRE_TOKEN_SUCCESS with the same account (same homeAccountId)
-      await act(async () => {
-        eventCallback({
-          eventType: EventType.ACQUIRE_TOKEN_SUCCESS,
-          payload: { account: mockAccount },
-        })
-      })
-
-      // Should NOT call setActiveAccount since the account hasn't changed
-      expect(mockInstance.setActiveAccount).not.toHaveBeenCalled()
-    })
-
-    it('clears active account on LOGOUT_SUCCESS event', async () => {
-      const { EventType } = await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Simulate LOGOUT_SUCCESS event
-      await act(async () => {
-        eventCallback({
-          eventType: EventType.LOGOUT_SUCCESS,
-          payload: null,
-        })
-      })
-
-      // Active account state should be cleared (component's internal state)
-      // We can't directly test the state, but we can verify the callback was called
-      expect(mockInstance.addEventCallback).toHaveBeenCalled()
-    })
-
-    it('updates active account on ACTIVE_ACCOUNT_CHANGED event', async () => {
-      const { EventType } = await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      const newAccount = { ...mockAccount, username: 'changed@example.com' }
-      mockInstance.getActiveAccount.mockReturnValue(newAccount)
-
-      // Simulate ACTIVE_ACCOUNT_CHANGED event
-      await act(async () => {
-        eventCallback({
-          eventType: EventType.ACTIVE_ACCOUNT_CHANGED,
-          payload: null,
-        })
-      })
-
-      expect(mockInstance.getActiveAccount).toHaveBeenCalled()
-    })
-
-    it('handles event with null payload gracefully', async () => {
-      const { EventType } = await import('@azure/msal-browser')
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(false)
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Simulate LOGIN_SUCCESS with null payload
-      await act(async () => {
-        eventCallback({
-          eventType: EventType.LOGIN_SUCCESS,
-          payload: null,
-        })
-      })
-
-      // Should not crash - just not call setActiveAccount
-      expect(mockInstance.setActiveAccount).not.toHaveBeenCalled()
-    })
-
-    it('removes event callback on unmount', () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-
-      const { unmount } = render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      unmount()
-
-      expect(mockInstance.removeEventCallback).toHaveBeenCalledWith(
-        'callback-id',
-      )
-    })
-  })
-
-  describe('cross-tab storage synchronization', () => {
-    let storageEventHandlers: Array<(event: StorageEvent) => void> = []
-    let originalAddEventListener: typeof window.addEventListener
-
-    beforeEach(() => {
-      storageEventHandlers = []
-
-      // Save original
-      originalAddEventListener = window.addEventListener
-
-      // Capture the storage event handler
-      window.addEventListener = jest.fn((event, handler) => {
-        if (event === 'storage' && typeof handler === 'function') {
-          storageEventHandlers.push(handler as (event: StorageEvent) => void)
-        }
-      })
-    })
-
-    afterEach(() => {
-      window.addEventListener = originalAddEventListener
-      jest.restoreAllMocks()
-    })
-
-    it('clears active account when accounts are cleared in another tab', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Wait for component to mount and register storage event listener
-      await waitFor(() => {
-        expect(storageEventHandlers.length).toBeGreaterThan(0)
-      })
-
-      // Clear setActiveAccount calls from mount
-      mockInstance.setActiveAccount.mockClear()
-
-      // Simulate another tab clearing MSAL storage (logout)
-      mockInstance.getAllAccounts.mockReturnValue([])
-
-      await act(async () => {
-        storageEventHandlers[0](
-          new StorageEvent('storage', {
-            key: 'msal.account.keys',
-            newValue: null,
-            oldValue: '["account-1"]',
-          }),
-        )
-      })
-
-      // Should clear active account instead of reloading the page
-      expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(null)
-    })
-
-    it('sets active account when account added in another tab', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(false)
-      mockInstance.getActiveAccount.mockReturnValue(null)
-      mockInstance.getAllAccounts.mockReturnValue([])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: undefined,
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Wait for component to mount and register storage event listener
-      await waitFor(() => {
-        expect(storageEventHandlers.length).toBeGreaterThan(0)
-      })
-
-      // Simulate another tab logging in
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockInstance.getActiveAccount.mockReturnValue(null)
-
-      await act(async () => {
-        storageEventHandlers[0](
-          new StorageEvent('storage', {
-            key: 'msal.account.keys',
-            newValue: '["account-1"]',
-            oldValue: null,
-          }),
-        )
-      })
-
-      expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(mockAccount)
-    })
-
-    it('ignores non-MSAL storage events', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Wait for component to mount and register storage event listener
-      await waitFor(() => {
-        expect(storageEventHandlers.length).toBeGreaterThan(0)
-      })
-
-      const getAllAccountsCallsBefore =
-        mockInstance.getAllAccounts.mock.calls.length
-
-      // Simulate storage event for non-MSAL key
-      await act(async () => {
-        storageEventHandlers[0](
-          new StorageEvent('storage', {
-            key: 'theme-preference',
-            newValue: 'dark',
-            oldValue: 'light',
-          }),
-        )
-      })
-
-      // Should not check accounts or set active account (early return in filter logic)
-      expect(mockInstance.getAllAccounts.mock.calls.length).toBe(
-        getAllAccountsCallsBefore,
-      )
-      expect(mockInstance.setActiveAccount).not.toHaveBeenCalled()
-    })
-
-    it('clears active account on localStorage.clear() event (null key)', async () => {
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [mockAccount],
-        inProgress: 'none',
-      })
-      mockUseIsAuthenticated.mockReturnValue(true)
-      mockInstance.getActiveAccount.mockReturnValue(mockAccount)
-      mockInstance.getAllAccounts.mockReturnValue([mockAccount])
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: { permissions: ['Permission.Read'], employeeId: null },
-        isLoading: false,
-        error: undefined,
-        refetch: jest.fn(),
-      })
-
-      render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Wait for component to mount and register storage event listener
-      await waitFor(() => {
-        expect(storageEventHandlers.length).toBeGreaterThan(0)
-      })
-
-      // Clear setActiveAccount calls from mount
-      mockInstance.setActiveAccount.mockClear()
-
-      // After event, accounts should be empty to trigger account clear
-      mockInstance.getAllAccounts.mockReturnValue([])
-
-      // Simulate localStorage.clear() in another tab (null key)
-      await act(async () => {
-        storageEventHandlers[0](
-          new StorageEvent('storage', {
-            key: null, // null key indicates clear()
-            newValue: null,
-            oldValue: null,
-          }),
-        )
-      })
-
-      // Should clear active account instead of reloading the page
-      expect(mockInstance.setActiveAccount).toHaveBeenCalledWith(null)
-    })
-
-    it('removes storage event listener on unmount', async () => {
-      let removeEventListenerHandler: (event: StorageEvent) => void
-      const originalRemoveEventListener = window.removeEventListener
-
-      window.removeEventListener = jest.fn((event, handler) => {
-        if (event === 'storage' && typeof handler === 'function') {
-          removeEventListenerHandler = handler as (event: StorageEvent) => void
-        }
-      })
-
-      mockUseMsal.mockReturnValue({
-        instance: mockInstance,
-        accounts: [],
-        inProgress: 'none',
-      })
-      mockUseGetUserPermissionsQuery.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        error: undefined,
-        refetch: jest.fn(),
-      })
-
-      const { unmount } = render(
-        <AuthProvider>
-          <TestConsumer />
-        </AuthProvider>,
-      )
-
-      // Wait for component to mount
-      await waitFor(() => {
-        expect(storageEventHandlers.length).toBeGreaterThan(0)
-      })
-
-      unmount()
-
-      expect(window.removeEventListener).toHaveBeenCalledWith(
-        'storage',
-        expect.any(Function),
-      )
-
-      window.removeEventListener = originalRemoveEventListener
+    expect(screen.getByTestId('authenticated')).toHaveTextContent('yes')
+    expect(mockLogin).toHaveBeenCalledWith({
+      userName: 'alice',
+      password: 'password',
     })
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.tsx
@@ -1,583 +1,318 @@
 'use client'
 
-import React, {
-  createContext,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
-import { usePathname } from 'next/navigation'
-import { useMsal, useIsAuthenticated } from '@azure/msal-react'
-import {
-  AccountInfo,
-  EventType,
-  InteractionRequiredAuthError,
-  SilentRequest,
-} from '@azure/msal-browser'
-import { LoadingAccount } from '@/src/components/common'
+import React, { createContext, useCallback, useMemo, useState } from 'react'
+import { useMsal } from '@azure/msal-react'
 import { AuthContextType, AuthMethod, Claim, User } from './types'
-import { tokenRequest } from '@/auth-config'
-import { useGetUserPermissionsQuery } from '@/src/store/features/user-management/profile-api'
-import UnauthorizedPage from '@/src/app/unauthorized/page'
-import ServiceUnavailablePage from '@/src/app/service-unavailable/page'
 import ChangePasswordForm from '@/src/app/account/profile/change-password-form'
 import useTheme from '@/src/components/contexts/theme/use-theme'
 import styles from './auth-provider.module.css'
 import {
+  AUTH_MUST_CHANGE_PASSWORD_KEY,
+  clearAuth,
   getAuthClient,
   getAuthStorage,
-  isLocalAuthActive,
-  clearLocalAuth,
-  getLocalAuthToken,
-  LOCAL_AUTH_TOKEN_KEY,
-  LOCAL_AUTH_REFRESH_TOKEN_KEY,
-  LOCAL_AUTH_TOKEN_EXPIRY_KEY,
-  LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY,
+  getAuthToken,
+  isAuthActive,
+  storeAuth,
 } from '@/src/services/clients'
 
 export const AuthContext = createContext<AuthContextType | null>(null)
 
-// Global flag to prevent concurrent redirect attempts across multiple 401 errors.
-// This prevents MSAL interaction_in_progress errors when multiple API calls
-// fail simultaneously (e.g., when a token expires).
-let isRedirectInProgress = false
+// --- JWT decoding ---
 
-/** @internal Reset redirect flag between tests */
-export const _resetRedirectFlag = () => {
-  isRedirectInProgress = false
+type DecodedClaims = {
+  name: string
+  username: string
+  employeeId: string | null
+  loginProvider: string | null
+  permissions: string[]
+  genericClaims: Claim[]
 }
 
-export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
-  const { instance, accounts, inProgress } = useMsal()
-  const isAuthenticated = useIsAuthenticated()
-  const pathname = usePathname()
-  const { token } = useTheme()
+const PERMISSION_CLAIM = 'permission'
+const EMPLOYEE_ID_CLAIM = 'EmployeeId'
+const LOGIN_PROVIDER_CLAIMS = [
+  'loginProvider',
+  'http://schemas.microsoft.com/identity/claims/loginprovider',
+]
+const GIVEN_NAME_CLAIMS = [
+  'given_name',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name',
+  'name',
+]
+const SURNAME_CLAIMS = [
+  'family_name',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname',
+]
+const USERNAME_CLAIMS = [
+  'email',
+  'preferred_username',
+  'http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress',
+]
 
-  // Bypass loading/error gates on logout route so logout always executes promptly
-  const isLogoutRoute = pathname === '/logout'
+function firstDefined(
+  payload: Record<string, unknown>,
+  keys: readonly string[],
+): string | null {
+  for (const key of keys) {
+    const value = payload[key]
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return null
+}
 
-  // Note: We no longer use useMsalAuthentication for auto-login
-  // Users will see the LoginPage and click "Sign in with Microsoft" manually
+function decodeWaydJwt(token: string): DecodedClaims | null {
+  try {
+    const payloadPart = token.split('.')[1]
+    if (!payloadPart) return null
+    const payload = JSON.parse(atob(payloadPart)) as Record<string, unknown>
 
-  const [isLoading, setIsLoading] = useState(true)
-  const [isUnauthorized, setIsUnauthorized] = useState(false)
-  const [isServiceUnavailable, setIsServiceUnavailable] = useState(false)
-  const [authStatus, setAuthStatus] = useState('Initializing authentication...')
-  const [activeAccount, setActiveAccountState] = useState<AccountInfo | null>(
-    null,
-  )
+    const rawPermissions = payload[PERMISSION_CLAIM]
+    const permissions = Array.isArray(rawPermissions)
+      ? rawPermissions.filter((p): p is string => typeof p === 'string')
+      : typeof rawPermissions === 'string'
+        ? [rawPermissions]
+        : []
 
-  const [authMethod, setAuthMethod] = useState<AuthMethod>(
-    typeof window !== 'undefined' && isLocalAuthActive() ? 'local' : null,
-  )
+    const given = firstDefined(payload, GIVEN_NAME_CLAIMS) ?? ''
+    const surname = firstDefined(payload, SURNAME_CLAIMS) ?? ''
+    const name = [given, surname].filter(Boolean).join(' ')
+    const username = firstDefined(payload, USERNAME_CLAIMS) ?? ''
+    const employeeId =
+      typeof payload[EMPLOYEE_ID_CLAIM] === 'string'
+        ? (payload[EMPLOYEE_ID_CLAIM] as string)
+        : null
+    const loginProvider = firstDefined(payload, LOGIN_PROVIDER_CLAIMS)
 
-  const [mustChangePassword, setMustChangePassword] = useState(
-    typeof window !== 'undefined' &&
-      getAuthStorage().getItem(LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY) === 'true',
-  )
-
-  const [user, setUser] = useState<User>({
-    name: '',
-    username: '',
-    isAuthenticated: false,
-    employeeId: null,
-    claims: [],
-  })
-
-  // Track when MSAL has finished any in-progress operations
-  const isReady = inProgress === 'none'
-
-  /**
-   * -------------------------------------------------------------
-   * Ensure active account is set when we have accounts
-   * Uses useState to ensure React properly tracks the active account
-   * -------------------------------------------------------------
-   */
-  useEffect(() => {
-    if (!isReady) {
-      setActiveAccountState(null)
-      return
-    }
-
-    let account = instance.getActiveAccount()
-    if (!account && accounts.length > 0) {
-      instance.setActiveAccount(accounts[0])
-      account = accounts[0]
-    }
-    setActiveAccountState(account)
-  }, [accounts, instance, isReady])
-
-  /**
-   * -------------------------------------------------------------
-   * Cross-tab account synchronization.
-   * MSAL event callbacks handle same-tab events (login, logout,
-   * token refresh). The storage event listener detects changes
-   * from other tabs via localStorage.
-   * -------------------------------------------------------------
-   */
-  useEffect(() => {
-    // Same-tab: react to MSAL lifecycle events
-    const callbackId = instance.addEventCallback((event) => {
-      switch (event.eventType) {
-        case EventType.LOGIN_SUCCESS:
-        case EventType.ACQUIRE_TOKEN_SUCCESS: {
-          const payload = event.payload as { account?: AccountInfo } | null
-          if (payload?.account) {
-            // ACQUIRE_TOKEN_SUCCESS fires on every silent token acquisition,
-            // so only update if the account has actually changed to avoid
-            // unnecessary re-renders.
-            const currentActiveAccount = instance.getActiveAccount()
-            const isDifferentAccount =
-              !currentActiveAccount ||
-              currentActiveAccount.homeAccountId !==
-                payload.account.homeAccountId
-
-            if (isDifferentAccount) {
-              instance.setActiveAccount(payload.account)
-              setActiveAccountState(payload.account)
-            }
-          }
-          break
-        }
-        case EventType.LOGOUT_SUCCESS: {
-          setActiveAccountState(null)
-          break
-        }
-        case EventType.ACTIVE_ACCOUNT_CHANGED: {
-          setActiveAccountState(instance.getActiveAccount())
-          break
-        }
-      }
-    })
-
-    // Cross-tab: detect account changes via localStorage storage events.
-    // MSAL stores auth state in localStorage with keys prefixed by 'msal.'.
-    // A null key means localStorage.clear() was called.
-    const handleStorageChange = (event: StorageEvent) => {
-      if (!event.key?.startsWith('msal.') && event.key !== null) return
-
-      const currentAccounts = instance.getAllAccounts()
-      if (currentAccounts.length === 0) {
-        // Accounts were cleared (e.g., logout in another tab).
-        // Clear active account so React naturally transitions to the
-        // unauthenticated view without a disruptive full-page reload.
-        instance.setActiveAccount(null)
-        setActiveAccountState(null)
-      } else if (!instance.getActiveAccount()) {
-        // Accounts exist but no active account (e.g., login in another tab)
-        instance.setActiveAccount(currentAccounts[0])
-        setActiveAccountState(currentAccounts[0])
+    const genericClaims: Claim[] = []
+    for (const [key, value] of Object.entries(payload)) {
+      if (typeof value === 'string') {
+        genericClaims.push({ type: key, value })
       }
     }
 
-    window.addEventListener('storage', handleStorageChange, { passive: true })
-
-    return () => {
-      if (callbackId) {
-        instance.removeEventCallback(callbackId)
-      }
-      window.removeEventListener('storage', handleStorageChange)
+    return {
+      name,
+      username,
+      employeeId,
+      loginProvider,
+      permissions,
+      genericClaims,
     }
-  }, [instance])
+  } catch {
+    return null
+  }
+}
 
-  /**
-   * -------------------------------------------------------------
-   * Permissions (RTK Query)
-   * -------------------------------------------------------------
-   */
-  const {
-    data: permissionsData,
-    isLoading: permissionsLoading,
-    error: permissionsError,
-    refetch: refetchPermissions,
-  } = useGetUserPermissionsQuery(undefined, {
-    skip: authMethod === 'local'
-      ? false // Local auth: always fetch (token is in localStorage)
-      : !isReady || !isAuthenticated || !activeAccount,
-    pollingInterval: 5 * 60 * 1000, // Re-fetch permissions every 5 minutes
-  })
+function authMethodFromLoginProvider(
+  loginProvider: string | null,
+): AuthMethod {
+  if (loginProvider === 'MicrosoftEntraId') return 'msal'
+  if (loginProvider === 'Wayd') return 'local'
+  return null
+}
 
-  /**
-   * -------------------------------------------------------------
-   * Retry handler for service unavailable
-   * -------------------------------------------------------------
-   */
-  const handleRetry = () => {
-    setIsServiceUnavailable(false)
-    setIsLoading(true)
-    refetchPermissions()
+// --- Session derivation ---
+
+const UNAUTHENTICATED_USER: User = {
+  name: '',
+  username: '',
+  isAuthenticated: false,
+  employeeId: null,
+  claims: [],
+}
+
+type SessionSnapshot = {
+  user: User
+  permissionsSet: Set<string>
+  authMethod: AuthMethod
+  mustChangePassword: boolean
+}
+
+const EMPTY_SESSION: SessionSnapshot = {
+  user: UNAUTHENTICATED_USER,
+  permissionsSet: new Set(),
+  authMethod: null,
+  mustChangePassword: false,
+}
+
+/**
+ * Pure function: reads whatever is in storage and returns the session snapshot.
+ * Used for the initial render (lazy useState initializer) and for cross-tab
+ * storage events. No side effects except clearing a malformed token.
+ */
+function deriveSessionFromStorage(): SessionSnapshot {
+  if (typeof window === 'undefined') return EMPTY_SESSION
+
+  const storedToken = getAuthToken()
+  if (!storedToken) return EMPTY_SESSION
+
+  const decoded = decodeWaydJwt(storedToken)
+  if (!decoded) {
+    // Malformed token — purge it so the app falls through to /login cleanly.
+    clearAuth()
+    return EMPTY_SESSION
   }
 
-  /**
-   * -------------------------------------------------------------
-   * Token helper
-   * -------------------------------------------------------------
-   */
-  const acquireToken = useCallback(async (requestOverrides?: Partial<SilentRequest>): Promise<string> => {
-    // For local auth, return the stored token
-    if (authMethod === 'local') {
-      const token = getLocalAuthToken()
-      if (token) return token
-      throw new Error('No local auth token found')
+  const claims: Claim[] = [...decoded.genericClaims]
+  if (decoded.employeeId) {
+    claims.push({ type: EMPLOYEE_ID_CLAIM, value: decoded.employeeId })
+  }
+  for (const permission of decoded.permissions) {
+    claims.push({ type: 'Permission', value: permission })
+  }
+
+  return {
+    user: {
+      name: decoded.name,
+      username: decoded.username,
+      isAuthenticated: true,
+      employeeId: decoded.employeeId,
+      claims,
+    },
+    permissionsSet: new Set(decoded.permissions),
+    authMethod: authMethodFromLoginProvider(decoded.loginProvider),
+    mustChangePassword:
+      getAuthStorage().getItem(AUTH_MUST_CHANGE_PASSWORD_KEY) === 'true',
+  }
+}
+
+/**
+ * AuthProvider — reads the current session from the stored Wayd JWT and
+ * exposes it to the app. That's all it does.
+ *
+ * No exchange logic, no MSAL watching, no auto-redirects. Getting a JWT
+ * into storage is the login page's job; removing it is the logout action's
+ * job. AuthProvider just decodes whatever is there.
+ *
+ * The login page / MSAL redirect handler is responsible for:
+ *   - Initiating Entra or local login.
+ *   - Running /api/auth/exchange on the MSAL redirect response.
+ *   - Storing the Wayd JWT.
+ *   - Navigating to the protected app.
+ *
+ * This separation means AuthProvider doesn't need to distinguish "just logged
+ * in, exchange pending" from "just logged out, MSAL cache still present" —
+ * a distinction it can't actually make, and the source of the logout race
+ * we hit during PR 3.2 testing.
+ */
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const { token } = useTheme()
+  const { instance } = useMsal()
+
+  const [session, setSession] = useState<SessionSnapshot>(
+    deriveSessionFromStorage,
+  )
+
+  const refresh = useCallback(() => {
+    setSession(deriveSessionFromStorage())
+  }, [])
+
+  // Cross-tab sync. If another tab logs in, logs out, or refreshes the token,
+  // our stored session might be stale — rehydrate.
+  React.useEffect(() => {
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key !== null && !event.key?.startsWith('wayd.local.')) return
+      refresh()
     }
+    window.addEventListener('storage', handleStorageChange, { passive: true })
+    return () => window.removeEventListener('storage', handleStorageChange)
+  }, [refresh])
 
-    const request = { ...tokenRequest, ...requestOverrides }
+  // --- Actions ---
 
-    try {
-      // MSAL v5 requires account parameter for silent token acquisition
-      const accounts = instance.getAllAccounts()
-      if (accounts.length === 0) {
-        throw new Error('No authenticated accounts found')
-      }
+  const acquireToken = useCallback(async (): Promise<string> => {
+    const t = getAuthToken()
+    if (t) return t
+    throw new Error('No auth token found')
+  }, [])
 
-      const response = await instance.acquireTokenSilent({
-        ...request,
-        account: request.account || accounts[0],
-      })
-      return response.accessToken
-    } catch (error) {
-      if (error instanceof InteractionRequiredAuthError) {
-        const response = await instance.acquireTokenPopup(request)
-        return response.accessToken
-      }
-      throw error
-    }
-  }, [authMethod, instance])
-
-  /**
-   * -------------------------------------------------------------
-   * Build user
-   * -------------------------------------------------------------
-   */
   const refreshUser = useCallback(async () => {
-    // Handle local auth users
-    if (authMethod === 'local') {
-      if (permissionsLoading) return
+    refresh()
+  }, [refresh])
 
-      try {
-        setAuthStatus('Loading user profile...')
-        const claims: Claim[] = []
-
-        if (permissionsData) {
-          if (permissionsData.employeeId) {
-            claims.push({ type: 'EmployeeId', value: permissionsData.employeeId })
-          }
-          claims.push(
-            ...permissionsData.permissions.map((p) => ({
-              type: 'Permission',
-              value: p,
-            })),
-          )
-
-          // Decode JWT to get user info
-          const token = getLocalAuthToken()
-          let name = ''
-          let username = ''
-          if (token) {
-            try {
-              const payload = JSON.parse(atob(token.split('.')[1]))
-              name = [
-                payload['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name'],
-                payload['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/surname'],
-              ].filter(Boolean).join(' ')
-              username = payload['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress'] ?? ''
-            } catch {
-              // Token decode failed, use empty values
-            }
-          }
-
-          setUser({
-            name,
-            username,
-            isAuthenticated: true,
-            employeeId: permissionsData.employeeId ?? null,
-            claims,
-          })
-        } else if (permissionsError) {
-          const errorStatus = (permissionsError as any)?.status
-          if (errorStatus === 401) {
-            // Local token expired and refresh failed
-            clearLocalAuth()
-            setAuthMethod(null)
-            setIsLoading(false)
-            return
-          }
-          if (errorStatus === 403) {
-            setIsUnauthorized(true)
-            setIsLoading(false)
-            return
-          }
-          setIsServiceUnavailable(true)
-          setIsLoading(false)
-          return
-        }
-      } catch (error) {
-        console.error('[Auth] Error building local user profile', error)
-      } finally {
-        setIsLoading(false)
-      }
-      return
-    }
-
-    // Handle MSAL auth users
-    if (!activeAccount) {
-      setUser({
-        name: '',
-        username: '',
-        isAuthenticated: false,
-        employeeId: null,
-        claims: [],
-      })
-      setIsLoading(false)
-      return
-    }
-
-    if (permissionsLoading) return
-
-    try {
-      setAuthStatus('Loading user profile...')
-
-      const idTokenClaims = activeAccount.idTokenClaims ?? {}
-      const claims: Claim[] = []
-
-      for (const [key, value] of Object.entries(idTokenClaims)) {
-        if (typeof value === 'string') {
-          claims.push({ type: key, value })
-        }
-      }
-
-      if (permissionsData) {
-        if (permissionsData.employeeId) {
-          claims.push({
-            type: 'EmployeeId',
-            value: permissionsData.employeeId,
-          })
-        }
-        claims.push(
-          ...permissionsData.permissions.map((p) => ({
-            type: 'Permission',
-            value: p,
-          })),
-        )
-      } else if (permissionsError) {
-        const errorStatus = (permissionsError as any)?.status
-        if (errorStatus === 403) {
-          setIsUnauthorized(true)
-          setIsLoading(false)
-          return
-        }
-        if (errorStatus === 401) {
-          if (isRedirectInProgress || inProgress !== 'none') {
-            console.log(
-              '[Auth] Redirect already in progress, skipping duplicate redirect',
-            )
-            setIsLoading(false)
-            return
-          }
-
-          setAuthStatus('Session expired, redirecting to login...')
-          isRedirectInProgress = true
-
-          try {
-            await instance.loginRedirect()
-          } catch (loginError) {
-            console.error(
-              '[Auth] Re-authentication redirect failed',
-              loginError,
-            )
-            isRedirectInProgress = false
-            setIsLoading(false)
-          }
-          return
-        }
-        setIsServiceUnavailable(true)
-        setIsLoading(false)
-        return
-      }
-
-      setUser({
-        name: activeAccount.name ?? '',
-        username: activeAccount.username,
-        isAuthenticated: true,
-        employeeId: permissionsData?.employeeId ?? null,
-        claims,
-      })
-    } catch (error) {
-      console.error('[Auth] Error building user profile', error)
-      setUser({
-        name: '',
-        username: '',
-        isAuthenticated: false,
-        employeeId: null,
-        claims: [],
-      })
-    } finally {
-      setIsLoading(false)
-    }
-  }, [
-    authMethod,
-    activeAccount,
-    permissionsLoading,
-    permissionsData,
-    permissionsError,
-    inProgress,
-    instance,
-  ])
-
-  /**
-   * -------------------------------------------------------------
-   * React to auth readiness
-   * -------------------------------------------------------------
-   */
-  useEffect(() => {
-    // Handle local auth separately
-    if (authMethod === 'local') {
-      if (permissionsLoading) {
-        setAuthStatus('Loading user permissions...')
-        return
-      }
-      refreshUser()
-      return
-    }
-
-    if (!isReady) {
-      setIsLoading(true)
-      setAuthStatus('Authenticating...')
-      return
-    }
-
-    // For unauthenticated users, don't show loading - they'll see login page
-    if (!isAuthenticated) {
-      setIsLoading(false)
-      return
-    }
-
-    // Wait for activeAccount to be set (happens in separate useEffect)
-    if (!activeAccount) {
-      setAuthStatus('Loading account...')
-      return
-    }
-
-    if (permissionsLoading) {
-      setAuthStatus('Loading user permissions...')
-      return
-    }
-
-    // Only proceed when permissions have loaded or errored
-    refreshUser()
-  }, [authMethod, isReady, isAuthenticated, activeAccount, permissionsLoading, refreshUser])
-
-  /**
-   * -------------------------------------------------------------
-   * Auth actions
-   * -------------------------------------------------------------
-   */
+  // login() is intentionally a no-op stub here. The login page owns the
+  // actual MSAL loginRedirect call — AuthProvider doesn't need to know
+  // about MSAL at all. Kept in the context to satisfy the interface while
+  // consumers (e.g., 401 recovery paths) are migrated to route-based navigation.
   const login = useCallback(async () => {
-    await instance.loginRedirect()
-  }, [instance])
+    // eslint-disable-next-line react-compiler/react-compiler
+    window.location.href = '/login'
+  }, [])
 
-  const localLogin = useCallback(async (username: string, password: string) => {
-    setIsLoading(true)
-    setAuthStatus('Signing in...')
-    try {
-      const authClient = getAuthClient()
-      const tokenResponse = await authClient.login({ userName: username, password })
-      const storage = getAuthStorage()
-      storage.setItem(LOCAL_AUTH_TOKEN_KEY, tokenResponse.token)
-      storage.setItem(LOCAL_AUTH_REFRESH_TOKEN_KEY, tokenResponse.refreshToken)
-      storage.setItem(LOCAL_AUTH_TOKEN_EXPIRY_KEY, new Date(tokenResponse.tokenExpiresAt).toISOString())
-      if (tokenResponse.mustChangePassword) {
-        storage.setItem(LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY, 'true')
-        setMustChangePassword(true)
-      }
-      setAuthMethod('local')
-      refetchPermissions()
-    } catch (error) {
-      setIsLoading(false)
-      throw error
-    }
-  }, [refetchPermissions])
+  const localLogin = useCallback(
+    async (username: string, password: string) => {
+      const tokenResponse = await getAuthClient().login({
+        userName: username,
+        password,
+      })
+      storeAuth(tokenResponse)
+      refresh()
+    },
+    [refresh],
+  )
 
   const logout = useCallback(async () => {
-    if (authMethod === 'local') {
-      // Clear tokens and redirect immediately without updating React state.
-      // Updating state before redirect causes a re-render that briefly shows
-      // the app behind the forced change password gate.
-      clearLocalAuth()
-      window.location.href = '/login'
-      return
+    // Drop the Wayd session AND MSAL's local cache. Without clearing MSAL,
+    // the login page's exchange-on-mount effect sees an authenticated MSAL
+    // account, silently acquires a new access token, and exchanges it for a
+    // fresh Wayd JWT — putting the user right back in the app.
+    //
+    // This only clears MSAL's cache in the browser; the user's Entra SSO
+    // cookie on login.microsoftonline.com stays intact. Their next "Sign in
+    // with Microsoft" click silently re-auths without a password prompt —
+    // the standard "sign out of this app, stay signed in to Microsoft"
+    // behavior used by most B2B SaaS.
+    clearAuth()
+    instance.setActiveAccount(null)
+    try {
+      await instance.clearCache()
+    } catch (e) {
+      console.warn('[Auth] MSAL clearCache failed; continuing logout.', e)
     }
-    // Navigate to logout page which handles the Microsoft logout redirect
-    window.location.href = '/logout'
-  }, [authMethod])
+    window.location.href = '/login'
+  }, [instance])
 
-  /**
-   * -------------------------------------------------------------
-   * Context value
-   * -------------------------------------------------------------
-   */
+  // --- Context value ---
+
   const authContext: AuthContextType = useMemo(
-    () => {
-      const permissionsSet = new Set(permissionsData?.permissions ?? [])
-      return {
-        user,
-        isLoading,
-        authMethod,
-        mustChangePassword,
-        acquireToken,
-        refreshUser,
-        hasClaim: (type: string, value: string) =>
-          user.claims.some((c) => c.type === type && c.value === value),
-        hasPermissionClaim: (value: string) => permissionsSet.has(value),
-        login,
-        localLogin,
-        logout,
-      }
-    },
-    [
-      user,
-      isLoading,
-      authMethod,
-      mustChangePassword,
+    () => ({
+      user: session.user,
+      isLoading: false,
+      authMethod: session.authMethod,
+      mustChangePassword: session.mustChangePassword,
       acquireToken,
       refreshUser,
-      permissionsData,
+      hasClaim: (type: string, value: string) =>
+        session.user.claims.some((c) => c.type === type && c.value === value),
+      hasPermissionClaim: (value: string) =>
+        session.permissionsSet.has(value),
       login,
       localLogin,
       logout,
-    ],
+    }),
+    [session, acquireToken, refreshUser, login, localLogin, logout],
   )
 
-  // Bypass all loading/error gates on logout route so logout executes promptly
-  // This ensures users can always sign out, even if permissions call is slow/failed
-  if (!isLogoutRoute) {
-    // Show loading state for authenticated users (MSAL or local)
-    if (isLoading && (isAuthenticated || authMethod === 'local')) {
-      return <LoadingAccount message={authStatus} />
-    }
+  // --- Forced password change gate ---
 
-    if (isUnauthorized) {
-      return <UnauthorizedPage />
-    }
-
-    if (isServiceUnavailable) {
-      return <ServiceUnavailablePage onRetry={handleRetry} onLogout={logout} />
-    }
-  }
-
-  // Force password change for users who must change their password
-  if (mustChangePassword && authMethod === 'local' && user.isAuthenticated) {
+  if (
+    session.mustChangePassword &&
+    session.authMethod === 'local' &&
+    session.user.isAuthenticated
+  ) {
     return (
       <AuthContext.Provider value={authContext}>
         <div
           className={styles.changePasswordBackground}
-          style={{ '--auth-bg-color': token.colorBgContainer } as React.CSSProperties}
+          style={
+            { '--auth-bg-color': token.colorBgContainer } as React.CSSProperties
+          }
         >
           <ChangePasswordForm
             required
             onFormComplete={() => {
-              // Password changed successfully — logout happens in the form
+              // Form triggers logout on completion.
             }}
             onFormCancel={() => logout()}
           />
@@ -592,3 +327,11 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
 }
 
 export default AuthProvider
+
+/** @internal exported for tests */
+export const _internal = {
+  decodeWaydJwt,
+  deriveSessionFromStorage,
+  authMethodFromLoginProvider,
+  isAuthActive,
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/contexts/auth/auth-context.tsx
@@ -61,11 +61,28 @@ function firstDefined(
   return null
 }
 
+// RFC 7515 §2: JWT segments are base64url-encoded (URL-safe alphabet, padding
+// stripped). atob only speaks standard base64, so any segment containing `-`
+// or `_`, or one whose length isn't a multiple of 4, fails to decode. Convert
+// to standard base64 before handing it to atob.
+function base64UrlDecode(input: string): string {
+  const normalized = input.replace(/-/g, '+').replace(/_/g, '/')
+  const padded = normalized.padEnd(
+    normalized.length + ((4 - (normalized.length % 4)) % 4),
+    '=',
+  )
+  return atob(padded)
+}
+
 function decodeWaydJwt(token: string): DecodedClaims | null {
   try {
     const payloadPart = token.split('.')[1]
     if (!payloadPart) return null
-    const payload = JSON.parse(atob(payloadPart)) as Record<string, unknown>
+    const payload = JSON.parse(base64UrlDecode(payloadPart)) as Record<
+      string,
+      unknown
+    >
+
 
     const rawPermissions = payload[PERMISSION_CLAIM]
     const permissions = Array.isArray(rawPermissions)

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
@@ -37,21 +37,20 @@ import {
   PersonalAccessTokensClient,
   SearchClient,
 } from './wayd-api'
-import { tokenRequest } from '@/auth-config'
-import { InteractionRequiredAuthError } from '@azure/msal-browser'
-import { msalInstance, getMsalReady } from '../components/contexts/auth/msal-instance'
 
 const apiUrl = process.env.NEXT_PUBLIC_API_BASE_URL
 
-// Local auth storage keys
-export const LOCAL_AUTH_TOKEN_KEY = 'moda.local.token'
-export const LOCAL_AUTH_REFRESH_TOKEN_KEY = 'moda.local.refreshToken'
-export const LOCAL_AUTH_TOKEN_EXPIRY_KEY = 'moda.local.tokenExpiry'
-export const LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY = 'moda.local.mustChangePassword'
-const LOCAL_AUTH_REMEMBER_KEY = 'moda.local.rememberMe'
+// Storage keys for the Wayd JWT session. The same keys are used for every
+// login provider — local JWT and Entra-exchanged sessions are indistinguishable
+// at the storage layer.
+export const AUTH_TOKEN_KEY = 'wayd.local.token'
+export const AUTH_REFRESH_TOKEN_KEY = 'wayd.local.refreshToken'
+export const AUTH_TOKEN_EXPIRY_KEY = 'wayd.local.tokenExpiry'
+export const AUTH_MUST_CHANGE_PASSWORD_KEY = 'wayd.local.mustChangePassword'
+const AUTH_REMEMBER_KEY = 'wayd.local.rememberMe'
 
 /**
- * Returns the storage backend for local auth tokens.
+ * Returns the storage backend for the auth session.
  * The routing flag in localStorage determines whether tokens live in
  * localStorage (remember me) or sessionStorage (ephemeral session).
  */
@@ -59,48 +58,75 @@ export function getAuthStorage(): Storage {
   if (typeof window === 'undefined') {
     throw new Error('getAuthStorage() cannot be called during SSR')
   }
-  return localStorage.getItem(LOCAL_AUTH_REMEMBER_KEY) === 'false'
+  return localStorage.getItem(AUTH_REMEMBER_KEY) === 'false'
     ? sessionStorage
     : localStorage
 }
 
 /** Sets the remember-me routing flag (always in localStorage). */
 export function setRememberMe(remember: boolean): void {
-  localStorage.setItem(LOCAL_AUTH_REMEMBER_KEY, remember ? 'true' : 'false')
+  localStorage.setItem(AUTH_REMEMBER_KEY, remember ? 'true' : 'false')
 }
 
-export function getLocalAuthToken(): string | null {
+export function getAuthToken(): string | null {
   if (typeof window === 'undefined') return null
-  return getAuthStorage().getItem(LOCAL_AUTH_TOKEN_KEY)
+  return getAuthStorage().getItem(AUTH_TOKEN_KEY)
 }
 
-export function isLocalAuthActive(): boolean {
+export function getAuthRefreshToken(): string | null {
+  if (typeof window === 'undefined') return null
+  return getAuthStorage().getItem(AUTH_REFRESH_TOKEN_KEY)
+}
+
+export function isAuthActive(): boolean {
   if (typeof window === 'undefined') return false
-  // Check both storages since we don't know which was used until we read the flag
+  // Check both storages since we don't know which was used until we read the flag.
   return !!(
-    localStorage.getItem(LOCAL_AUTH_TOKEN_KEY) ||
-    sessionStorage.getItem(LOCAL_AUTH_TOKEN_KEY)
+    localStorage.getItem(AUTH_TOKEN_KEY) ||
+    sessionStorage.getItem(AUTH_TOKEN_KEY)
   )
 }
 
-export function clearLocalAuth(): void {
-  // Clear from both storages to ensure clean state
+export function clearAuth(): void {
+  // Clear from both storages to ensure clean state.
   for (const storage of [localStorage, sessionStorage]) {
-    storage.removeItem(LOCAL_AUTH_TOKEN_KEY)
-    storage.removeItem(LOCAL_AUTH_REFRESH_TOKEN_KEY)
-    storage.removeItem(LOCAL_AUTH_TOKEN_EXPIRY_KEY)
-    storage.removeItem(LOCAL_AUTH_MUST_CHANGE_PASSWORD_KEY)
+    storage.removeItem(AUTH_TOKEN_KEY)
+    storage.removeItem(AUTH_REFRESH_TOKEN_KEY)
+    storage.removeItem(AUTH_TOKEN_EXPIRY_KEY)
+    storage.removeItem(AUTH_MUST_CHANGE_PASSWORD_KEY)
   }
-  localStorage.removeItem(LOCAL_AUTH_REMEMBER_KEY)
+  localStorage.removeItem(AUTH_REMEMBER_KEY)
 }
 
-// Unauthenticated axios client for login/refresh (no token interceptors)
+/** Persists a token response from /api/auth/login, /exchange, or /refresh-token. */
+export function storeAuth(tokenResponse: {
+  token: string
+  refreshToken: string
+  tokenExpiresAt: Date | string
+  mustChangePassword: boolean
+}): void {
+  const storage = getAuthStorage()
+  storage.setItem(AUTH_TOKEN_KEY, tokenResponse.token)
+  storage.setItem(AUTH_REFRESH_TOKEN_KEY, tokenResponse.refreshToken)
+  storage.setItem(
+    AUTH_TOKEN_EXPIRY_KEY,
+    new Date(tokenResponse.tokenExpiresAt).toISOString(),
+  )
+  if (tokenResponse.mustChangePassword) {
+    storage.setItem(AUTH_MUST_CHANGE_PASSWORD_KEY, 'true')
+  } else {
+    storage.removeItem(AUTH_MUST_CHANGE_PASSWORD_KEY)
+  }
+}
+
+// Unauthenticated axios client for login/refresh/exchange (no token interceptors).
 const unauthAxiosClient = axios.create({
   baseURL: apiUrl,
   timeout: 30000,
 })
 
-// Auth client uses unauthenticated axios (login endpoints are [AllowAnonymous])
+// Auth client uses unauthenticated axios — login, refresh, exchange, and
+// getProviders are all [AllowAnonymous] on the backend.
 export const getAuthClient = () => new AuthClient('', unauthAxiosClient)
 
 const axiosClient = axios.create({
@@ -108,7 +134,10 @@ const axiosClient = axios.create({
   timeout: 30000, // 30 second timeout
 })
 
-// Response interceptor with automatic 401 token refresh and retry.
+// Response interceptor: automatic Wayd refresh-token retry on 401.
+// One path for every provider because every provider ends up with the same
+// Wayd JWT shape in storage after login/exchange. No MSAL involvement — the
+// Wayd refresh token is the sole mechanism for extending the session.
 axiosClient.interceptors.response.use(
   (response) => response,
   async (error) => {
@@ -121,46 +150,21 @@ axiosClient.interceptors.response.use(
     ) {
       ;(originalRequest as any)._retry = true
 
-      // Try local JWT refresh first
-      const storage = getAuthStorage()
-      const localRefreshToken = storage.getItem(LOCAL_AUTH_REFRESH_TOKEN_KEY)
-      const localToken = getLocalAuthToken()
-      if (localToken && localRefreshToken) {
+      const refreshToken = getAuthRefreshToken()
+      const currentToken = getAuthToken()
+      if (currentToken && refreshToken) {
         try {
-          const authClient = getAuthClient()
-          const tokenResponse = await authClient.refreshToken({
-            token: localToken,
-            refreshToken: localRefreshToken,
+          const tokenResponse = await getAuthClient().refreshToken({
+            token: currentToken,
+            refreshToken,
           })
-          storage.setItem(LOCAL_AUTH_TOKEN_KEY, tokenResponse.token)
-          storage.setItem(LOCAL_AUTH_REFRESH_TOKEN_KEY, tokenResponse.refreshToken)
-          storage.setItem(LOCAL_AUTH_TOKEN_EXPIRY_KEY, new Date(tokenResponse.tokenExpiresAt).toISOString())
+          storeAuth(tokenResponse)
           originalRequest.headers = originalRequest.headers || {}
           originalRequest.headers.Authorization = `Bearer ${tokenResponse.token}`
           return axiosClient(originalRequest)
         } catch (refreshError) {
-          console.error('Local token refresh on 401 failed:', refreshError)
-          clearLocalAuth()
-        }
-      }
-
-      // Fall back to MSAL refresh
-      if (msalInstance) {
-        try {
-          await getMsalReady()
-          const accounts = msalInstance.getAllAccounts()
-          if (accounts.length > 0) {
-            const response = await msalInstance.acquireTokenSilent({
-              ...tokenRequest,
-              account: accounts[0],
-              forceRefresh: true,
-            })
-            originalRequest.headers = originalRequest.headers || {}
-            originalRequest.headers.Authorization = `Bearer ${response.accessToken}`
-            return axiosClient(originalRequest)
-          }
-        } catch (refreshError) {
-          console.error('MSAL token refresh on 401 failed:', refreshError)
+          console.error('Token refresh on 401 failed:', refreshError)
+          clearAuth()
         }
       }
     }
@@ -170,45 +174,10 @@ axiosClient.interceptors.response.use(
   },
 )
 
-// Request interceptor: attach auth token (local JWT or MSAL) to outgoing requests.
+// Request interceptor: attach the Wayd JWT to outgoing requests.
 axiosClient.interceptors.request.use(
-  async (config) => {
-    // Check for local JWT first
-    const localToken = getLocalAuthToken()
-    if (localToken) {
-      config.headers.Authorization = `Bearer ${localToken}`
-      return config
-    }
-
-    // Fall back to MSAL token acquisition.
-    // Wait for MSAL to finish initializing and processing any pending redirect
-    // before attempting silent token acquisition, otherwise acquireTokenSilent
-    // throws block_iframe_reload during the startup window.
-    let token: string | null = null
-    try {
-      await getMsalReady()
-      const accounts = msalInstance?.getAllAccounts() ?? []
-
-      if (accounts.length > 0) {
-        const response = await msalInstance.acquireTokenSilent({
-          ...tokenRequest,
-          account: accounts[0],
-        })
-        token = response.accessToken
-      }
-    } catch (error: any) {
-      if (error instanceof InteractionRequiredAuthError) {
-        try {
-          const response = await msalInstance.acquireTokenPopup(tokenRequest)
-          token = response.accessToken
-        } catch (popupError) {
-          console.error('Token popup failed:', popupError)
-        }
-      } else {
-        console.error('Token acquisition error:', error)
-      }
-    }
-
+  (config) => {
+    const token = getAuthToken()
     if (token) {
       config.headers.Authorization = `Bearer ${token}`
     }
@@ -293,66 +262,26 @@ export const getPersonalAccessTokensClient = () =>
   new PersonalAccessTokensClient('', axiosClient)
 
 /**
- * Performs an authenticated fetch request with automatic token acquisition.
- * Use this for custom API calls that need authentication but can't use the generated clients.
- *
- * @param url - The URL to fetch (relative to API base URL or absolute)
- * @param options - Standard fetch RequestInit options
- * @returns Promise<Response>
- *
- * @example
- * const response = await authenticatedFetch('/api/ppm/projects/123/tasks/456', {
- *   method: 'PATCH',
- *   headers: { 'Content-Type': 'application/json-patch+json' },
- *   body: JSON.stringify(patchOperations)
- * })
+ * Performs an authenticated fetch request.
+ * Use this for custom API calls that need authentication but can't use the
+ * generated clients (e.g., JSON Patch endpoints that NSwag doesn't generate).
  */
 export async function authenticatedFetch(
   url: string,
   options: RequestInit = {},
 ): Promise<Response> {
-  // Acquire auth token — check local JWT first, then fall back to MSAL
-  let token: string | null = getLocalAuthToken()
+  const token = getAuthToken()
 
-  if (!token) {
-    try {
-      const accounts = msalInstance?.getAllAccounts() ?? []
-      if (accounts.length > 0) {
-        const response = await msalInstance.acquireTokenSilent({
-          ...tokenRequest,
-          account: accounts[0],
-        })
-        token = response.accessToken
-      }
-    } catch (error: any) {
-      if (error instanceof InteractionRequiredAuthError) {
-        try {
-          const response = await msalInstance.acquireTokenPopup(tokenRequest)
-          token = response.accessToken
-        } catch (popupError) {
-          console.error('Token popup failed:', popupError)
-        }
-      } else {
-        console.error('Token acquisition error:', error)
-      }
-    }
-  }
-
-  // Merge headers
   const headers = new Headers(options.headers)
   if (token) {
     headers.set('Authorization', `Bearer ${token}`)
   }
-
-  // Add Accept header if not present
   if (!headers.has('Accept')) {
     headers.set('Accept', 'application/json')
   }
 
-  // Prepend base URL if the URL is relative
   const fullUrl = url.startsWith('http') ? url : `${apiUrl}${url}`
 
-  // Make the fetch call
   return fetch(fullUrl, {
     ...options,
     headers,

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/user-management/profile-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/user-management/profile-api.ts
@@ -1,8 +1,11 @@
 import { getProfileClient } from '@/src/services/clients'
 import { apiSlice } from '../apiSlice'
-import { ChangePasswordRequest, UserDetailsDto, UserPermissionsResponse, UserPreferencesDto } from '@/src/services/wayd-api'
+import { ChangePasswordRequest, UserDetailsDto, UserPreferencesDto } from '@/src/services/wayd-api'
 import { QueryTags } from '../query-tags'
 
+// Note: permissions are no longer fetched via a separate endpoint — they're
+// embedded as claims in the Wayd JWT and decoded by AuthProvider. The old
+// getUserPermissions query was removed as part of PR 3.2.
 export const profileApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
     getProfile: builder.query<UserDetailsDto, void>({
@@ -15,30 +18,6 @@ export const profileApi = apiSlice.injectEndpoints({
           return { error }
         }
       },
-    }),
-    getUserPermissions: builder.query<UserPermissionsResponse, void>({
-      queryFn: async () => {
-        try {
-          const data = await getProfileClient().getPermissions()
-          return { data }
-        } catch (error: any) {
-          console.error('Error fetching permissions:', error)
-          // Extract status code from axios error or API exception
-          const status = error?.status || error?.response?.status || 500
-          return {
-            error: {
-              status,
-              error:
-                error instanceof Error
-                  ? error.message
-                  : 'Failed to load permissions',
-            },
-          }
-        }
-      },
-      providesTags: () => [{ type: QueryTags.UserPermission, id: 'USER' }],
-      // Cache current user permissions for 1 minute since they don't change often
-      keepUnusedDataFor: 60,
     }),
     getUserPreferences: builder.query<UserPreferencesDto, void>({
       queryFn: async () => {
@@ -80,7 +59,6 @@ export const profileApi = apiSlice.injectEndpoints({
 
 export const {
   useGetProfileQuery,
-  useGetUserPermissionsQuery,
   useGetUserPreferencesQuery,
   useUpdateUserPreferencesMutation,
   useChangePasswordMutation,

--- a/docs/contributing/configuration.mdx
+++ b/docs/contributing/configuration.mdx
@@ -88,14 +88,63 @@ Configure in `Wayd.Web/src/Wayd.Web.Api/Configurations/security.json` or User Se
     "SecuritySettings": {
         "LocalJwt": {
             "Secret": "<strong-random-secret-at-least-32-chars>",
-            "Issuer": "Wayd",
-            "Audience": "WaydApi",
+            "Issuer": "https://wayd.dev",
+            "Audience": "https://api.wayd.dev",
             "TokenExpirationInMinutes": 60,
             "RefreshTokenExpirationInDays": 7
         }
     }
 }
 ```
+
+Only `Secret` needs to be set per deploy — the rest have sensible defaults and in particular `Issuer` / `Audience` are JWT claim identifiers, not environment-specific config. Don't override them per environment.
+
+### Auth flow (high level)
+
+Every login path produces a **Wayd JWT + Wayd refresh token** stored in `localStorage`/`sessionStorage`. The API only ever validates Wayd JWTs — MSAL tokens are exchanged for a Wayd JWT at login and never presented to the API directly.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant F as Frontend
+    participant M as MSAL
+    participant E as Microsoft Entra
+    participant W as Wayd API
+    participant A as Any API endpoint
+
+    Note over U,A: Local (username/password) login
+    U->>F: Submit credentials
+    F->>W: POST /api/auth/login
+    W-->>F: { token, refreshToken }
+    F->>F: storeWaydAuth(...)
+
+    Note over U,A: Entra (SSO) login
+    U->>F: Click "Sign in with Microsoft"
+    F->>M: loginRedirect
+    M->>E: OIDC auth flow
+    E-->>M: ID token + access token
+    F->>M: acquireTokenSilent(apiScope)
+    M-->>F: Entra access token
+    F->>W: POST /api/auth/exchange<br/>{ provider, subjectToken }
+    W->>W: Validate signature via JWKS<br/>Check tenant allowlist
+    W->>W: Resolve UserIdentity<br/>Load permissions
+    W-->>F: { token (Wayd JWT), refreshToken }
+    F->>F: storeWaydAuth(...)
+
+    Note over U,A: Subsequent API calls (both providers)
+    F->>A: Request + Authorization: Bearer wayd-jwt
+    A-->>F: Response
+
+    Note over U,A: Token refresh
+    F->>W: POST /api/auth/refresh-token<br/>{ token, refreshToken }
+    W-->>F: New { token, refreshToken }
+```
+
+Permissions travel as `permission` claims inside the Wayd JWT — no separate `/permissions` round-trip. An admin permission change takes effect on the user's next refresh (within the access-token TTL).
+
+The login page consults `GET /api/auth/providers` to decide which provider buttons to show; a deployment with `SecuritySettings:Providers:Entra:Enabled = false` hides the Microsoft button entirely.
+
+See [Identity Model Refactor](./specs/identity-model-refactor.mdx) for the full design rationale.
 
 ## Environment Variables
 

--- a/docs/contributing/specs/identity-model-refactor.mdx
+++ b/docs/contributing/specs/identity-model-refactor.mdx
@@ -226,17 +226,20 @@ Delivers the Entra exchange endpoint, the Wayd JWT changes (permission claims, u
 
 #### PR 3.2 — Auth-context cutover (replace MSAL-direct-to-API)
 
-- auth-context calls `/api/auth/exchange` after MSAL login instead of passing the Entra token straight to the API.
-- Frontend stores the Wayd JWT + refresh token (same storage shape as local login today). All API calls use the Wayd JWT.
-- Permissions decoded from Wayd JWT claims; `useGetUserPermissionsQuery` and the separate `/permissions` round-trip are removed.
-- "Loading Permissions" screen goes away.
-- Logout routing: dispatches to the right IdP end-session endpoint based on the user's active `UserIdentity.Provider`.
+- `auth-context` calls `POST /api/auth/exchange` after an MSAL login succeeds, passing the access token MSAL acquires with the API scope. The returned Wayd JWT + refresh token are stored in localStorage/sessionStorage — the same shape local login has used since PR 1. No provider-specific branches for storage, token attachment, or refresh.
+- `axios` interceptors collapsed to a single path: the request interceptor reads `getWaydAuthToken()` and attaches it; the response interceptor retries on 401 using the Wayd refresh token. MSAL logic removed from `clients.ts` entirely.
+- `authenticatedFetch` simplified accordingly — now a thin wrapper that attaches the Wayd JWT.
+- Permissions decoded directly from the Wayd JWT's `permission` claims on mount via a lazy `useState` initializer. `useGetUserPermissionsQuery` endpoint removed from `profile-api.ts`, the separate `/permissions` round-trip is gone, and **the "Loading Permissions" 10-second delay disappears**.
+- Storage helpers renamed `LOCAL_AUTH_*` → `WAYD_AUTH_*` (keys preserved as `moda.local.*` for session continuity). `isLocalAuthActive` → `isWaydAuthActive`, etc.
+- `authMethod` is derived from the `loginProvider` claim inside the Wayd JWT, not from which storage key is set. Enables provider-aware logout (Entra users redirect to `/logout` for MSAL cleanup; local users clear storage and go to `/login`).
+- **Legacy-session migration:** on first load after the PR 3.2 deploy, a user with an active MSAL session but no Wayd JWT triggers an automatic exchange, producing a Wayd JWT in place. Users don't notice the cutover.
+- `auth-context` shrinks meaningfully — the dual MSAL/local paths, the RTK Query permissions hook, the 401-triggers-loginRedirect flow, and the MSAL event callbacks that mirrored login/logout state all go away. Tests rewritten from scratch to cover the new state machine (~200 lines replacing ~1,500 lines of tests for behavior that no longer exists).
 
-#### PR 3.3 (deferred; post-Auth0) — Multi-provider frontend
+#### PR 3.3 (deferred; post-Auth0) — Multi-provider frontend + legacy cleanup
 
 - Home-realm discovery (email domain → which provider SDK to initialize).
-- Auth0 registered as a second provider in the config registry.
-- Remove the legacy `AzureAd` middleware-based API validation once no code path uses it.
+- Auth0 registered as a second provider in the config registry and in the capabilities endpoint.
+- Remove the legacy `AzureAd` middleware-based API validation on the backend once no code path uses it (after PR 3.2 has baked).
 
 **Refresh strategy (confirmed):** Wayd-owned refresh token, uniform across providers. The frontend stores `{ wayd JWT, wayd refresh token }`; on access-token expiry it calls `/api/auth/refresh` with the refresh token and gets a new Wayd JWT. No re-exchange with the external IdP on every refresh. Matches RFC 8693's framing (exchanged token lives in the issuing authority's lifecycle) and what most SaaS products do (Slack, Linear, GitHub, Atlassian Cloud).
 

--- a/docs/contributing/specs/identity-model-refactor.mdx
+++ b/docs/contributing/specs/identity-model-refactor.mdx
@@ -12,9 +12,22 @@ This spec coordinates a multi-PR effort to generalize Wayd's identity model so i
 1. Multiple OIDC providers side-by-side (Microsoft Entra ID today, Auth0 soon).
 2. Multi-tenant Entra logins where different orgs' tenants are onboarded independently.
 3. History-preserving tenant migrations (e.g., an org moves their users from one Entra tenant to another).
-4. A future token-exchange flow that mints a Wayd JWT carrying permission claims, eliminating the "Loading Permissions" wait on first load after inactivity.
+4. A token-exchange flow that mints a Wayd JWT carrying permission claims, eliminating the "Loading Permissions" wait on first load after inactivity.
 
 The work is sequenced across several PRs so each is independently shippable and reversible.
+
+**Status** (as of PR 3.2 merge):
+
+| PR | Status |
+|---|---|
+| PR 1 — `UserIdentity` table + cutover | ✅ Shipped |
+| PR 2 — Drop `ObjectId` from `ApplicationUser` | ✅ Shipped |
+| PR 3.1 — Backend exchange endpoint + login-page provider gating | ✅ Shipped |
+| PR 3.2 — Auth-context cutover | ✅ Shipped (this PR) |
+| PR 3.3 — Auth0 + legacy `AzureAd` middleware cleanup | Not started |
+| PR 4 — Admin-initiated tenant migration | Not started |
+
+The shipped sections below are retained as design context — they document *why* the current architecture looks the way it does, not what to go build.
 
 ## Background
 
@@ -88,7 +101,7 @@ Every provider — Entra, Auth0, Wayd local — uses the same query. Provider-sp
 
 Four PRs, landing in order. Each is independently shippable and reversible.
 
-### PR 1 — Introduce `UserIdentity` table + cutover (invisible)
+### PR 1 — Introduce `UserIdentity` table + cutover (invisible) ✅ Shipped
 
 **Goal:** replace the flat `ObjectId` column with a proper identity table. No behavior changes, no new features. If done right, no user notices.
 
@@ -137,9 +150,9 @@ WHERE LoginProvider = 'MicrosoftEntraId' AND ObjectId IS NULL;
 
 **Merge criteria:** logs show the null-`tid` upgrade path populating tenants on normal logins for at least a few days, across both providers. Zero duplicate-user creations. Zero login failures attributable to the new lookup.
 
-### PR 2 — Drop `ObjectId` from `ApplicationUser`
+### PR 2 — Drop `ObjectId` from `ApplicationUser` ✅ Shipped
 
-Removes the now-unused `ObjectId` column and rewires the remaining callers that still referenced it. Safe to ship in the same release as PR 1, or in a follow-up release after a soak period — the code paths are independent.
+Removed the now-unused `ObjectId` column and rewired the remaining callers that still referenced it.
 
 **Scope:**
 
@@ -151,9 +164,9 @@ Removes the now-unused `ObjectId` column and rewires the remaining callers that 
 
 **Rollback:** revert the code. The migration's `Down` re-creates the column and re-populates it from `UserIdentity.ProviderSubject` for active Entra identities, so the old `ObjectId`-based lookups would work unchanged if PR 1 were also reverted.
 
-### PR 3 — Token exchange + Wayd JWT with permission claims (multi-PR effort on its own)
+### PR 3 — Token exchange + Wayd JWT with permission claims (multi-PR effort)
 
-This is the architectural shift that also fixes the 10-second "Loading Permissions" screen. It will likely span several PRs internally.
+The architectural shift that also fixed the 10-second "Loading Permissions" screen. Split into three sub-PRs (3.1 and 3.2 shipped; 3.3 deferred).
 
 **Premise:** treat external IdP tokens (Entra, Auth0) as *identity assertions*, not API credentials. The API only ever validates Wayd JWTs.
 
@@ -198,9 +211,9 @@ One config row per onboarded external tenant. Multi-tenant Entra = N rows, one p
 
 **Sub-PRs:**
 
-#### PR 3.1 — Backend exchange endpoint + login-page provider gating
+#### PR 3.1 — Backend exchange endpoint + login-page provider gating ✅ Shipped
 
-Delivers the Entra exchange endpoint, the Wayd JWT changes (permission claims, uniform shape across providers), and a small frontend piece: the login page asks which providers are enabled and hides buttons for disabled ones. The exchange endpoint itself still runs dark for actual authentication — auth-context keeps using MSAL-direct-to-API until PR 3.2.
+Delivered the Entra exchange endpoint, the Wayd JWT changes (permission claims, uniform shape across providers), and a small frontend piece: the login page asks which providers are enabled and hides buttons for disabled ones. The exchange endpoint ran dark for actual authentication until PR 3.2 cut the frontend over.
 
 **Backend:**
 
@@ -224,18 +237,23 @@ Delivers the Entra exchange endpoint, the Wayd JWT changes (permission claims, u
 - New `useGetAuthProvidersQuery` RTK Query hook wrapping `getAuthClient().getProviders()`.
 - Login page hides the Microsoft tab + button when `entra: false`; hides the tab bar entirely when only one provider is enabled. No flash of a broken Microsoft button on local-only deployments. Default active tab is derived (`tabOverride ?? (entraEnabled ? 'microsoft' : 'local')`) rather than stored, avoiding `setState` in `useEffect`.
 
-#### PR 3.2 — Auth-context cutover (replace MSAL-direct-to-API)
+#### PR 3.2 — Auth-context cutover (replace MSAL-direct-to-API) ✅ Shipped
 
-- `auth-context` calls `POST /api/auth/exchange` after an MSAL login succeeds, passing the access token MSAL acquires with the API scope. The returned Wayd JWT + refresh token are stored in localStorage/sessionStorage — the same shape local login has used since PR 1. No provider-specific branches for storage, token attachment, or refresh.
-- `axios` interceptors collapsed to a single path: the request interceptor reads `getWaydAuthToken()` and attaches it; the response interceptor retries on 401 using the Wayd refresh token. MSAL logic removed from `clients.ts` entirely.
+- **The login page owns the exchange**, not `auth-context`. When MSAL returns an authenticated session with no Wayd JWT in storage, the login page silently acquires the access token, `POST`s it to `/api/auth/exchange`, stores the returned Wayd JWT + refresh token, and reloads the app. This is the standard OIDC callback-route pattern — we just fold it into `/login` rather than splitting into `/auth/callback`.
+- **`auth-context` becomes a pure session reader.** It decodes whatever Wayd JWT is in storage into a `User` + permissions set and exposes them. No MSAL watching, no exchange logic, no auto-redirects. No provider-specific branches for storage, token attachment, or refresh — everything reads the single Wayd JWT.
+- `axios` interceptors collapsed to a single path: the request interceptor reads `getAuthToken()` and attaches it; the response interceptor retries on 401 using the Wayd refresh token. MSAL logic removed from `clients.ts` entirely.
 - `authenticatedFetch` simplified accordingly — now a thin wrapper that attaches the Wayd JWT.
 - Permissions decoded directly from the Wayd JWT's `permission` claims on mount via a lazy `useState` initializer. `useGetUserPermissionsQuery` endpoint removed from `profile-api.ts`, the separate `/permissions` round-trip is gone, and **the "Loading Permissions" 10-second delay disappears**.
-- Storage helpers renamed `LOCAL_AUTH_*` → `WAYD_AUTH_*` (keys preserved as `moda.local.*` for session continuity). `isLocalAuthActive` → `isWaydAuthActive`, etc.
-- `authMethod` is derived from the `loginProvider` claim inside the Wayd JWT, not from which storage key is set. Enables provider-aware logout (Entra users redirect to `/logout` for MSAL cleanup; local users clear storage and go to `/login`).
-- **Legacy-session migration:** on first load after the PR 3.2 deploy, a user with an active MSAL session but no Wayd JWT triggers an automatic exchange, producing a Wayd JWT in place. Users don't notice the cutover.
-- `auth-context` shrinks meaningfully — the dual MSAL/local paths, the RTK Query permissions hook, the 401-triggers-loginRedirect flow, and the MSAL event callbacks that mirrored login/logout state all go away. Tests rewritten from scratch to cover the new state machine (~200 lines replacing ~1,500 lines of tests for behavior that no longer exists).
+- **Storage keys renamed `moda.local.*` → `wayd.local.*`; helper constants renamed `WAYD_AUTH_*` → `AUTH_*`** (the `WAYD_` prefix is redundant in a Wayd file). Accessor functions are `getAuthToken`, `getAuthRefreshToken`, `isAuthActive`, `storeAuth`, `clearAuth`. All currently-issued sessions invalidate on deploy — users re-log-in once. Acceptable pre-production; we'd want a dual-read window for prod traffic.
+- `authMethod` is derived from the `loginProvider` claim inside the Wayd JWT, not from which storage key is set.
+- **Provider-aware logout clears the MSAL cache too.** `logout` calls `clearAuth()` + `instance.setActiveAccount(null)` + `instance.clearCache()` before navigating to `/login`. Without the MSAL clear, the login page's exchange-on-mount effect sees a live MSAL session and silently re-auths — the "logged out and right back in" race PR 3.2's earlier revisions hit. This only wipes MSAL's *local* cache; the user's Entra SSO cookie on `login.microsoftonline.com` stays intact (standard "sign out of this app, stay signed in to Microsoft" behavior).
+- **Root-layout gate flattened.** Replaced the nested `AuthenticatedTemplate` / `UnauthenticatedTemplate` / `MsalInitializingView` branches with a single `useSyncExternalStore` check on `isAuthActive()`. MSAL state is deliberately **not** part of the gate decision — conflating "has Entra cookie" with "logged into Wayd" was the source of the logout race.
+- **Hydration fix.** `layout.tsx` uses a `mounted` state so server and first client render emit the same `SsrFallback`, then swap to the MsalProvider tree after the mount effect fires. Previously the server emitted `<SsrFallback/>` (MSAL null during SSR) and the client emitted the full app (MSAL available), causing a visible hydration error.
+- `auth-context` shrinks meaningfully — the dual MSAL/local paths, the RTK Query permissions hook, the 401-triggers-loginRedirect flow, and the MSAL event callbacks that mirrored login/logout state all go away. Tests rewritten from scratch to cover the new state machine (~450 lines replacing ~1,700 lines of tests for behavior that no longer exists).
+- **Bonus fixes discovered while writing Entra validator tests:** `JwtSecurityTokenHandler.MapInboundClaims = false` added to `EntraIdTokenValidator` (default mapping was rewriting `tid` to a schema URL, so `principal.FindFirstValue("tid")` silently returned null for org tokens — the `iss`-fallback was masking it); malformed non-JWT input's `ArgumentException` now caught alongside `SecurityTokenException` so it returns 401 instead of 500.
+- **JWT `iss` / `aud` renamed to URI form:** `Wayd` → `https://wayd.dev`, `WaydApi` → `https://api.wayd.dev`. Matches mainstream OIDC convention (Entra, Auth0, Okta all use URIs), globally unique so they can't collide once we federate, and naturally expresses "which resource is this token for." Redundant `jwt_issuer` / `jwt_audience` Terraform variables removed in the same change — they were JWT claim identifiers, not per-environment config, with no legitimate operator override story.
 
-#### PR 3.3 (deferred; post-Auth0) — Multi-provider frontend + legacy cleanup
+#### PR 3.3 (not started; blocked on Auth0 onboarding) — Multi-provider frontend + legacy cleanup
 
 - Home-realm discovery (email domain → which provider SDK to initialize).
 - Auth0 registered as a second provider in the config registry and in the capabilities endpoint.
@@ -243,9 +261,9 @@ Delivers the Entra exchange endpoint, the Wayd JWT changes (permission claims, u
 
 **Refresh strategy (confirmed):** Wayd-owned refresh token, uniform across providers. The frontend stores `{ wayd JWT, wayd refresh token }`; on access-token expiry it calls `/api/auth/refresh` with the refresh token and gets a new Wayd JWT. No re-exchange with the external IdP on every refresh. Matches RFC 8693's framing (exchanged token lives in the issuing authority's lifecycle) and what most SaaS products do (Slack, Linear, GitHub, Atlassian Cloud).
 
-### PR 4 — Admin-initiated tenant migration
+### PR 4 — Admin-initiated tenant migration (not started)
 
-Land this just before the org's migration window. Builds on PR 3's exchange endpoint — the rebind lives naturally in the exchange handler.
+Land this just before the org's migration window. Builds on PR 3's shipped exchange endpoint — the rebind lives naturally in the exchange handler.
 
 **Scope:**
 
@@ -303,20 +321,20 @@ Every rebind preserves the old `UserIdentity` row (inactive, with `UnlinkedAt` +
 ### What this does *not* address
 
 - **Account linking** (one Wayd user authenticating via multiple providers simultaneously — e.g., both Entra and Auth0). The schema supports it — multiple active rows per user — but no flow creates that state today. Defer until there's a concrete need.
-- **Auth0 onboarding itself.** PR 1 makes Auth0 a config/provider-registry problem rather than a schema problem; the actual Auth0 integration is downstream of PR 3.
+- **Auth0 onboarding itself.** PR 1 made Auth0 a config/provider-registry problem rather than a schema problem; the actual Auth0 integration is PR 3.3 (not yet started).
 - **Personal Microsoft accounts.** Out of scope for all four PRs. The email-trust assumptions in migration (PR 4) rely on org-controlled tenants.
 
-## Impact on the "Loading Permissions" delay
+## "Loading Permissions" delay — fixed by PR 3 ✅
 
-The 10-second "Loading Permissions" screen users see on first load after ~24 hours of inactivity is caused by a sequential waterfall in the frontend:
+The 10-second "Loading Permissions" screen users used to see on first load after ~24 hours of inactivity was caused by a sequential waterfall in the frontend:
 
-1. MSAL forces a silent token refresh (3–8s when the access token has expired).
-2. RTK Query's permissions fetch (60-second cache, long-gone after 24h) waits for the token refresh.
-3. User profile assembly waits for permissions.
+1. MSAL forced a silent token refresh (3–8s when the access token had expired).
+2. RTK Query's permissions fetch (60-second cache, long-gone after 24h) waited for the token refresh.
+3. User profile assembly waited for permissions.
 
-The perf problem is fixed by **PR 3**, not PR 1 or PR 2. Embedding permissions as Wayd JWT claims eliminates step 2 entirely; silent refresh returns a token that already carries everything auth-context needs.
+PR 3 eliminated this entirely. Embedding permissions as Wayd JWT claims removed step 2; silent refresh now returns a token that already carries everything `auth-context` needs. As of PR 3.2, there is no separate permissions fetch — the screen is gone.
 
-This is called out here because it's often the spark for discussing this work, and it's useful to know which PR actually delivers the fix.
+Preserved here because the delay was often the spark for discussing this work, and "that's what PR 3 actually delivered" is worth recording.
 
 ## References
 

--- a/docs/getting-started/logging-in.mdx
+++ b/docs/getting-started/logging-in.mdx
@@ -7,7 +7,7 @@ audience: [user]
 
 # Logging In
 
-Wayd supports two interactive authentication methods. Your administrator will tell you which one to use.
+Wayd supports two interactive authentication methods. Your administrator will tell you which one to use. Deployments that have Microsoft Entra ID disabled show only the **Email & Password** form — you won't see the Microsoft option on those.
 
 ## Microsoft Entra ID (Azure AD)
 

--- a/docs/reference/api.mdx
+++ b/docs/reference/api.mdx
@@ -16,39 +16,66 @@ The Wayd API is a RESTful ASP.NET Core Web API.
 
 ## Authentication
 
-All API requests require authentication via Bearer token. Wayd supports three authentication methods:
+All API requests require a **Wayd JWT** in the `Authorization: Bearer` header, regardless of which login provider the user authenticated with. The JWT carries the user's identity and permission claims and is minted by one of two login flows:
 
-### Azure AD (Microsoft Entra ID)
+### Username / password
 
-Include the access token from MSAL in the Authorization header:
+Authenticate with the local login endpoint:
+
 ```
-Authorization: Bearer {access_token}
-```
-
-### Local JWT (Username/Password)
-
-Authenticate via the login endpoint to receive a JWT token:
-```
-POST /api/account/login
+POST /api/auth/login
 {
   "userName": "your-username",
   "password": "your-password"
 }
 ```
 
-The response includes an `accessToken` and `refreshToken`. Include the access token in subsequent requests:
-```
-Authorization: Bearer {accessToken}
-```
+The response is the same shape for every login flow:
 
-When the access token expires, use the refresh endpoint to get a new one:
 ```
-POST /api/account/refresh
 {
-  "accessToken": "your-expired-token",
-  "refreshToken": "your-refresh-token"
+  "token": "<wayd-jwt>",
+  "refreshToken": "<wayd-refresh-token>",
+  "tokenExpiresAt": "2026-04-21T19:00:00Z",
+  "mustChangePassword": false
 }
 ```
+
+Include the Wayd JWT in subsequent requests:
+
+```
+Authorization: Bearer {token}
+```
+
+### Microsoft Entra ID (token exchange)
+
+For users authenticating via Microsoft Entra ID, the frontend obtains an access token from MSAL for the API scope and exchanges it for a Wayd JWT:
+
+```
+POST /api/auth/exchange
+{
+  "provider": "MicrosoftEntraId",
+  "subjectToken": "<entra-access-token-from-MSAL>"
+}
+```
+
+The response shape is identical to `/login`. The MSAL token is only used during the exchange — all subsequent API calls use the Wayd JWT.
+
+Deployments can disable Entra exchange (e.g., local-only customers); the endpoint returns HTTP 503 when disabled. Use `GET /api/auth/providers` (anonymous) to discover which providers are enabled.
+
+### Refreshing tokens
+
+When the Wayd JWT expires, exchange the refresh token for a new JWT:
+
+```
+POST /api/auth/refresh-token
+{
+  "token": "<expired-wayd-jwt>",
+  "refreshToken": "<wayd-refresh-token>"
+}
+```
+
+Same response shape. Refresh works uniformly for both login providers — the refresh flow doesn't need to know how the user originally authenticated.
 
 ### Personal Access Tokens (PATs)
 
@@ -77,7 +104,8 @@ PATs inherit the permissions of the user who created them. See [Your Profile](..
 | Planning | `/api/planning/` | Planning intervals, iterations |
 | Portfolio Management | `/api/portfolio-management/` | Projects, portfolios |
 | Settings | `/api/settings/` | Configuration, feature flags |
-| Account | `/api/account/` | Authentication, profile |
+| Auth | `/api/auth/` | Login, refresh, exchange, providers |
+| User Management | `/api/user-management/` | Profile, roles, permissions, PATs |
 
 ## OpenAPI Specification
 


### PR DESCRIPTION
# Frontend auth cutover: Wayd JWT as the sole session

## Summary

This is PR 3.2 of the identity-model refactor. It moves the frontend off MSAL-direct-to-API and onto the `/api/auth/exchange` flow introduced in PR 3.1, so **every authenticated request now carries a Wayd JWT** regardless of which login provider (local or Entra) produced the session.

Along the way, fixed a latent hydration bug in the Next.js root layout, a latent `tid`-claim bug in the Entra token validator, dropped some redundant Terraform knobs, and normalized JWT `iss` / `aud` to URI form (`https://wayd.dev` / `https://api.wayd.dev`) to match mainstream OIDC convention.

Net: **1291 insertions, 2439 deletions** — the rewrite is a large simplification.

## Why

Before this PR the frontend had two parallel session mechanisms:

- **Local login** → Wayd JWT in `moda.local.*` storage keys → sent to API as `Bearer`
- **Entra login** → MSAL-managed access tokens → acquired silently before each API call → sent to API as `Bearer`

The API had to accept both. `AuthProvider` had to reconcile both. The login page had to detect both. Permissions came from a separate `/api/profile/permissions` query that ran on every login with a ~10-second "Loading permissions" gate.

The split was the source of:

- A logout race where clicking Sign Out silently re-authed via a live MSAL session
- An "exchange-pending vs just-logged-out" distinction `AuthProvider` couldn't actually make
- The 10-second permissions-load delay
- Enough state that cross-tab sync had to watch two storage spaces
- An auth gate that conflated "has Entra cookie" with "logged into Wayd"

After PR 3.1 introduced `/api/auth/exchange` (RFC 8693-style token exchange that mints a Wayd JWT with permissions embedded as claims), the split was no longer necessary. This PR collapses it.

## What changed

### Session model (the core change)

- **Wayd JWT is the session.** Both login providers produce one; the app reads it and nothing else for auth state.
- **Permissions come from JWT claims**, not a separate API call. `useGetUserPermissionsQuery` is gone. The "Loading permissions" screen is gone.
- **Unified storage** under `wayd.local.*` keys (`token`, `refreshToken`, `tokenExpiry`, `mustChangePassword`). Renamed from `moda.local.*` — all currently-issued sessions invalidate on deploy and users re-log-in once.
- **Storage-key constants renamed** from `WAYD_AUTH_*` to `AUTH_*` (dropped the redundant prefix since they live in a Wayd file).
- **Provider-aware logout** clears both the Wayd JWT AND MSAL's local account cache. Without the MSAL clear, the login page's exchange-on-mount effect silently re-authed from the Entra SSO cookie and put the user right back in the app.

### `AuthProvider` rewrite

Previously ~780 lines of exchange-watching, MSAL-reconciliation, race-prevention logic. Now ~330 lines that do one thing: read the Wayd JWT from storage and decode it into a `User` + permissions set. No MSAL watching, no exchange logic, no auto-redirects.

The login page owns the exchange flow — it's the standard OIDC callback-route pattern (we just fold it into `/login` rather than splitting into `/auth/callback`).

### Root layout gate

Flattened from multiple nested `AuthenticatedTemplate` / `UnauthenticatedTemplate` / `MsalInitializingView` branches into a single `useSyncExternalStore` check on `isAuthActive()`. MSAL state is deliberately **not** part of the gate decision — conflating "has Entra cookie" with "logged into Wayd" was the root cause of the re-login race.

### Hydration mismatch fix

`layout.tsx` now uses a `mounted` state that matches SSR output on first client render, then swaps to the MsalProvider tree after the mount effect fires. Previously the server rendered one tree (MSAL unavailable → `SsrFallback`) and the client rendered a different tree (MSAL available → full app), producing a hydration error visible in browser DevTools.

### Entra token validator fixes

Two latent bugs found while writing unit tests for `EntraIdTokenValidator`:

1. **`MapInboundClaims` was left at its default (`true`)**, so the validator's `principal.FindFirstValue("tid")` was silently returning `null` for every organizational Entra token. The code only worked because a fallback path (`ExtractTenantFromIssuer(iss)`) caught the same tenant a different way. A user from a non-primary tenant would have been rejected.
2. **Malformed non-JWT input threw `ArgumentException`**, which bypassed the `SecurityTokenException` catch and bubbled as a 500 instead of a 401.

Both fixed. See the new test file for coverage.

### JWT `iss` / `aud` convention

Renamed both claims from short-name form to URI form:

- `iss`: `Wayd` → `https://wayd.dev`
- `aud`: `WaydApi` → `https://api.wayd.dev`

The URI form matches what every mainstream OIDC IdP (Entra, Auth0, Okta, Cognito, Keycloak) produces, is globally unique (can't collide with anyone else's tokens once we federate), and naturally expresses "which resource is this token for" if a second API surface is ever added.

Applied across `LocalJwtSettings.cs`, `security.json`, `variables.tf`, `TokenServiceTests.cs`, and contributor docs. Historical notes in `migrating-from-moda.mdx` intentionally left as written — they record what the earlier rename PR did.

### Dropped redundant Terraform variables

Removed `jwt_issuer` and `jwt_audience` from `variables.tf` along with their env-var blocks in `container-apps.tf`. These are JWT claim identifiers — not environment-specific — and `security.json` baked into the image is the single source of truth. Operator-configurability here existed without a real operator story.

### New tests

- **24 new `EntraIdTokenValidator` tests** covering: empty-token rejection, empty-allowlist defense-in-depth, OIDC discovery failure, happy path, tenant-not-in-allowlist rejection, `tid`-missing fallback to `iss` parsing, case-insensitive allowlist, wrong audience, expired token, wrong signing key, malformed JWT, and 8 `ExtractTenantFromIssuer` edge cases (v1/v2 shapes, `common`/`organizations` pseudo-tenants, MSA tenant, malformed URLs).
- **`auth-context` test suite rewritten** (~1700 lines removed, ~450 added) to reflect the new session model — covers JWT hydration, permission claims, must-change-password gating, local login, and the MSAL mock needed for logout's `clearCache` call.

## Test plan

- [x] `dotnet test Wayd.Infrastructure.Tests` — 105/105 passing (was 81; +24 new)
- [x] `npm run lint` — 0 errors (1 pre-existing warning in an unrelated file)
- [x] `npm test` — 1768/1768 passing across 101 suites
- [x] `terraform -chdir=.iac/wayd validate` — config valid
- [x] Playwright manual flow:
  - [x] Fresh load → `/login` renders cleanly (no hydration error, no auto-redirect to Microsoft)
  - [x] Sign in with Microsoft → exchange succeeds → land in app with permissions visible
  - [x] Sign out → `wayd.local.*` and MSAL account cache both cleared → lands on `/login` → does NOT auto-re-exchange
  - [x] Local login → Wayd JWT stored → land in app
  - [x] Forced password change gate still renders for `mustChangePassword: true`

## Breaking changes

- **All current sessions invalidate on deploy.** Storage key rename (`moda.local.*` → `wayd.local.*`) plus `aud` claim change (`WaydApi` → `https://api.wayd.dev`) means every user re-logs in once. Acceptable pre-production; would need a dual-read window if we had prod traffic.
- **Terraform env vars removed.** Any operator relying on overriding `jwt_issuer` / `jwt_audience` per environment would break. No known consumers.

## Follow-ups (not in this PR)

- Remove the old `AzureAd` JWT bearer middleware in the API once confident no stale frontend builds are still issuing MSAL-direct-to-API requests.
- Consider splitting `auth.wayd.dev` as a separate `iss` if we ever stand up a dedicated auth service.
