### PR TITLE
Feature/improve auth error handling

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Local/TokenService.cs
@@ -202,6 +202,11 @@ internal class TokenService(
             new(ClaimTypes.Email, user.Email ?? string.Empty),
             new(ClaimTypes.Name, user.FirstName ?? string.Empty),
             new(ClaimTypes.Surname, user.LastName ?? string.Empty),
+            // Frontend reads this to drive provider-specific UX (e.g. showing the
+            // "Change Password" button only for local users) and to gate the
+            // forced-password-change flow. Without it, authMethod is null for
+            // every session and those branches silently disable themselves.
+            new("loginProvider", user.LoginProvider),
         };
 
         if (user.EmployeeId.HasValue)

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
@@ -504,6 +504,27 @@ public class TokenServiceTests
         jwt.Claims.Where(c => c.Type == "permission").Should().BeEmpty();
     }
 
+    [Fact]
+    public async Task GetTokenAsync_ShouldEmbedLoginProviderClaim()
+    {
+        // The frontend reads loginProvider to drive provider-specific UX
+        // (Change Password button, forced-password-change gate). A missing
+        // claim silently disables those features.
+        var user = CreateLocalUser();
+        SeedActiveWaydIdentity(user.Id);
+
+        _mockUserManager.Setup(x => x.FindByNameAsync("testuser")).ReturnsAsync(user);
+        _mockSignInManager.Setup(x => x.CheckPasswordSignInAsync(user, "Password123!", true))
+            .ReturnsAsync(SignInResult.Success);
+        _mockUserManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+
+        var result = await _sut.GetTokenAsync(new LoginCommand("testuser", "Password123!"), TestContext.Current.CancellationToken);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(result.Token);
+        jwt.Claims.First(c => c.Type == "loginProvider").Value.Should().Be(LoginProviders.Wayd);
+    }
+
     #endregion
 
     #region ExchangeTokenAsync
@@ -595,6 +616,33 @@ public class TokenServiceTests
         var handler = new JwtSecurityTokenHandler();
         var jwt = handler.ReadJwtToken(result.Token);
         jwt.Claims.Where(c => c.Type == "permission").Select(c => c.Value).Should().Contain("Permissions.Projects.View");
+    }
+
+    [Fact]
+    public async Task ExchangeTokenAsync_ShouldEmbedLoginProviderClaim()
+    {
+        // Same provider-aware UX hooks as the local-login path — verifying
+        // the claim is also set on Entra-exchanged tokens.
+        var user = CreateEntraUser();
+        var principal = CreateEntraPrincipal();
+
+        _mockEntraIdTokenValidator
+            .Setup(v => v.Validate(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(principal);
+        _mockUserService
+            .Setup(s => s.GetOrCreateFromPrincipalAsync(principal))
+            .ReturnsAsync((user.Id, (string?)null));
+        _mockUserManager.Setup(x => x.FindByIdAsync(user.Id)).ReturnsAsync(user);
+        _mockUserManager.Setup(x => x.UpdateAsync(user)).ReturnsAsync(IdentityResult.Success);
+        SeedActiveEntraIdentity(user.Id);
+
+        var result = await _sut.ExchangeTokenAsync(
+            new ExchangeTokenCommand(LoginProviders.MicrosoftEntraId, "token"),
+            TestContext.Current.CancellationToken);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(result.Token);
+        jwt.Claims.First(c => c.Type == "loginProvider").Value.Should().Be(LoginProviders.MicrosoftEntraId);
     }
 
     [Fact]

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
@@ -485,7 +485,7 @@ function LocalLoginTab() {
 }
 
 export default function LoginPage() {
-  useDocumentTitle('Moda Login')
+  useDocumentTitle('Wayd Login')
   const isMsalAuthenticated = useIsAuthenticated()
   const { instance, accounts, inProgress } = useMsal()
   const router = useRouter()
@@ -564,7 +564,10 @@ export default function LoginPage() {
           instance.setActiveAccount(null)
           await instance.clearCache()
         } catch (cacheError) {
-          console.warn('[Login] MSAL clearCache failed; continuing.', cacheError)
+          console.warn(
+            '[Login] MSAL clearCache failed; continuing.',
+            cacheError,
+          )
         }
 
         const message =

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
@@ -559,20 +559,25 @@ export default function LoginPage() {
         window.location.href = '/'
       } catch (error) {
         console.error('[Login] Entra token exchange failed:', error)
-        if (error instanceof InteractionRequiredAuthError) {
-          // A silent acquisition failed because interaction is required.
-          // Signal to the user to click the Microsoft button again; that
-          // triggers a full loginRedirect.
-          setExchangeError(
-            'Sign-in needs to be completed interactively. Please click Sign in with Microsoft again.',
-          )
-        } else {
-          setExchangeError(
-            error instanceof Error
-              ? error.message
-              : 'Sign-in failed. Please try again.',
-          )
+
+        // Silent acquisition failed — typical after a long idle when MSAL's
+        // cached account is stale (timed_out) or the Entra session needs
+        // re-consent (InteractionRequiredAuthError). Clear MSAL's cache so the
+        // next button click triggers a fresh loginRedirect rather than another
+        // doomed silent acquire. Without this, the user clicks the button and
+        // immediately lands back on this same failure branch.
+        try {
+          instance.setActiveAccount(null)
+          await instance.clearCache()
+        } catch (cacheError) {
+          console.warn('[Login] MSAL clearCache failed; continuing.', cacheError)
         }
+
+        const message =
+          error instanceof InteractionRequiredAuthError
+            ? 'Sign-in needs to be completed interactively. Please click Sign in with Microsoft.'
+            : 'Sign-in session expired. Please click Sign in with Microsoft to continue.'
+        setExchangeError(message)
         setExchangeState('failed')
       }
     }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/login/page.tsx
@@ -543,6 +543,12 @@ export default function LoginPage() {
     setExchangeError(null)
 
     const run = async () => {
+      // Step 1: silent MSAL token acquisition. Failures here mean MSAL's
+      // cached state is unusable — typical after a long idle (timed_out) or
+      // when Entra needs re-consent (InteractionRequiredAuthError). We clear
+      // MSAL's cache so the next button click runs a fresh loginRedirect
+      // rather than another doomed silent acquire.
+      let accessToken: string
       try {
         const account = instance.getActiveAccount() ?? accounts[0]
         instance.setActiveAccount(account)
@@ -550,22 +556,10 @@ export default function LoginPage() {
           ...tokenRequest,
           account,
         })
-        const tokenResponse = await getAuthClient().exchange({
-          provider: 'MicrosoftEntraId',
-          subjectToken: msalResponse.accessToken,
-        })
-        storeAuth(tokenResponse)
-        // Full reload so the layout gate re-reads storage and mounts the app.
-        window.location.href = '/'
+        accessToken = msalResponse.accessToken
       } catch (error) {
-        console.error('[Login] Entra token exchange failed:', error)
+        console.error('[Login] MSAL silent token acquisition failed:', error)
 
-        // Silent acquisition failed — typical after a long idle when MSAL's
-        // cached account is stale (timed_out) or the Entra session needs
-        // re-consent (InteractionRequiredAuthError). Clear MSAL's cache so the
-        // next button click triggers a fresh loginRedirect rather than another
-        // doomed silent acquire. Without this, the user clicks the button and
-        // immediately lands back on this same failure branch.
         try {
           instance.setActiveAccount(null)
           await instance.clearCache()
@@ -578,6 +572,28 @@ export default function LoginPage() {
             ? 'Sign-in needs to be completed interactively. Please click Sign in with Microsoft.'
             : 'Sign-in session expired. Please click Sign in with Microsoft to continue.'
         setExchangeError(message)
+        setExchangeState('failed')
+        return
+      }
+
+      // Step 2: trade the MSAL access token for a Wayd JWT. Failures here are
+      // backend/network issues — the user's Entra session is fine, so we
+      // deliberately leave MSAL's cache intact. Forcing them to redo Entra
+      // auth for a transient API failure would be a regression; on retry the
+      // existing MSAL account can still produce a token silently.
+      try {
+        const tokenResponse = await getAuthClient().exchange({
+          provider: 'MicrosoftEntraId',
+          subjectToken: accessToken,
+        })
+        storeAuth(tokenResponse)
+        // Full reload so the layout gate re-reads storage and mounts the app.
+        window.location.href = '/'
+      } catch (error) {
+        console.error('[Login] Wayd token exchange failed:', error)
+        setExchangeError(
+          'Unable to complete sign-in. Please try again in a moment.',
+        )
         setExchangeState('failed')
       }
     }

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
@@ -192,10 +192,17 @@ axiosClient.interceptors.response.use(
           originalRequest.headers.Authorization = `Bearer ${tokenResponse.token}`
           return axiosClient(originalRequest)
         } catch (refreshError) {
-          // Server rejected the refresh — the session is invalid. Wipe it so
-          // the app falls through to /login on the next protected route.
+          // Server rejected the refresh — the session is invalid. Wipe storage
+          // and force a hard navigation to /login. Without the redirect, the
+          // app keeps rendering with no token: every subsequent request 401s,
+          // pages load missing data, and the user only escapes by manually
+          // refreshing. AuthGate reads isAuthActive() once and won't re-check
+          // on its own, so the navigation is the trigger that resets it.
           console.error('Token refresh on 401 failed:', refreshError)
           clearAuth()
+          if (typeof window !== 'undefined') {
+            window.location.href = '/login'
+          }
         }
       }
       // No tokens to refresh with: the caller was already unauthenticated.

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
@@ -198,11 +198,23 @@ axiosClient.interceptors.response.use(
           // pages load missing data, and the user only escapes by manually
           // refreshing. AuthGate reads isAuthActive() once and won't re-check
           // on its own, so the navigation is the trigger that resets it.
+          //
+          // Stash the current path under the same key AuthGate uses (see
+          // app/layout.tsx) so post-login lands the user back on the page that
+          // 401'd, not on /. Hard-navigation skips AuthGate's own preservation
+          // path, so we have to write the key ourselves here.
           console.error('Token refresh on 401 failed:', refreshError)
           clearAuth()
           if (typeof window !== 'undefined') {
+            const { pathname } = window.location
+            if (pathname && pathname !== '/' && pathname !== '/login' && pathname !== '/logout') {
+              sessionStorage.setItem('wayd.returnUrl', pathname)
+            }
             window.location.href = '/login'
           }
+          // Reject early so the generic "API Error" log + downstream error
+          // handlers don't run for a 401 we've already handled.
+          return Promise.reject(refreshError)
         }
       }
       // No tokens to refresh with: the caller was already unauthenticated.


### PR DESCRIPTION
- Improve auth error handling and session recovery

LoginPage now clears MSAL cache and unsets active account on silent token failures, ensuring a fresh login redirect. axiosClient now clears auth storage and redirects to /login on refresh failures, preventing repeated 401s and broken app state. Error messages are more specific for better user guidance.