### PR TITLE
Wayd MCP rename

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -59,7 +59,7 @@ jobs:
               uses: changesets/action@v1.5.1
               with:
                   cwd: Wayd.Web/src/Wayd.Mcp
-                  title: "chore: release @modanpm/moda-mcp"
+                  title: "chore: release @wayd/mcp"
                   commit: "chore: version mcp package"
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -44,5 +44,5 @@ jobs:
                   VERSION=$(node -p "require('./Wayd.Web/src/Wayd.Mcp/package.json').version")
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git tag "mcp-v${VERSION}"
-                  git push origin "mcp-v${VERSION}"
+                  git tag "wayd-mcp-v${VERSION}"
+                  git push origin "wayd-mcp-v${VERSION}"

--- a/Wayd.Web/src/Wayd.Mcp/.changeset/README.md
+++ b/Wayd.Web/src/Wayd.Mcp/.changeset/README.md
@@ -1,6 +1,6 @@
 # Changesets
 
-This directory manages versioning and changelog generation for the `@modanpm/moda-mcp` npm package.
+This directory manages versioning and changelog generation for the `@wayd/mcp` npm package.
 
 ## What is a changeset?
 

--- a/Wayd.Web/src/Wayd.Mcp/.env.example
+++ b/Wayd.Web/src/Wayd.Mcp/.env.example
@@ -1,5 +1,5 @@
-# Moda API base URL
-MODA_API_BASE_URL=https://your-moda-instance.com
+# Wayd API base URL
+WAYD_API_BASE_URL=https://your-wayd-instance.com
 
-# Moda API key (Personal Access Token)
-MODA_API_KEY=your_api_key_here
+# Wayd API key (Personal Access Token)
+WAYD_API_KEY=your_api_key_here

--- a/Wayd.Web/src/Wayd.Mcp/CHANGELOG.md
+++ b/Wayd.Web/src/Wayd.Mcp/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @modanpm/moda-mcp
+# @wayd/mcp
 
 ## 0.1.0
 

--- a/Wayd.Web/src/Wayd.Mcp/README.md
+++ b/Wayd.Web/src/Wayd.Mcp/README.md
@@ -1,4 +1,4 @@
-# @modanpm/moda-mcp
+# @wayd/mcp
 
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server for the [Wayd](https://wayd.dev) work management API. Exposes Wayd's project portfolio management, planning, and work item data to AI assistants.
 
@@ -14,8 +14,8 @@ The server requires two values: the base URL of your Wayd instance and an API ke
 
 | | Environment variable | CLI argument |
 |---|---|---|
-| Base URL | `MODA_API_BASE_URL` | `--base-url` |
-| API key | `MODA_API_KEY` | `--api-key` |
+| Base URL | `WAYD_API_BASE_URL` | `--base-url` |
+| API key | `WAYD_API_KEY` | `--api-key` |
 
 ## Installation
 
@@ -26,12 +26,12 @@ CLI arguments are not supported in Claude Desktop — use environment variables.
 ```json
 {
   "mcpServers": {
-    "moda": {
+    "wayd": {
       "command": "npx",
-      "args": ["-y", "@modanpm/moda-mcp"],
+      "args": ["-y", "@wayd/mcp"],
       "env": {
-        "MODA_API_BASE_URL": "https://your-moda-instance.com",
-        "MODA_API_KEY": "your-personal-access-token"
+        "WAYD_API_BASE_URL": "https://your-wayd-instance.com",
+        "WAYD_API_KEY": "your-personal-access-token"
       }
     }
   }
@@ -46,25 +46,25 @@ CLI args enable the `inputs` pattern, which prompts for values at connection tim
 {
   "inputs": [
     {
-      "id": "modaBaseUrl",
+      "id": "waydBaseUrl",
       "description": "Wayd base URL",
       "type": "promptString"
     },
     {
-      "id": "modaApiKey",
+      "id": "waydApiKey",
       "description": "Wayd API key (Personal Access Token)",
       "type": "promptString",
       "password": true
     }
   ],
   "servers": {
-    "moda": {
+    "wayd": {
       "type": "stdio",
       "command": "npx",
       "args": [
-        "-y", "@modanpm/moda-mcp",
-        "--base-url", "${input:modaBaseUrl}",
-        "--api-key",  "${input:modaApiKey}"
+        "-y", "@wayd/mcp",
+        "--base-url", "${input:waydBaseUrl}",
+        "--api-key",  "${input:waydApiKey}"
       ]
     }
   }
@@ -76,13 +76,13 @@ Or with environment variables directly:
 ```json
 {
   "servers": {
-    "moda": {
+    "wayd": {
       "type": "stdio",
       "command": "npx",
-      "args": ["-y", "@modanpm/moda-mcp"],
+      "args": ["-y", "@wayd/mcp"],
       "env": {
-        "MODA_API_BASE_URL": "https://your-moda-instance.com",
-        "MODA_API_KEY": "your-personal-access-token"
+        "WAYD_API_BASE_URL": "https://your-wayd-instance.com",
+        "WAYD_API_KEY": "your-personal-access-token"
       }
     }
   }
@@ -96,14 +96,14 @@ Claude Code doesn't support the `inputs` prompt pattern, so the recommended way 
 Add to `~/.zshrc` / `~/.bashrc` (or equivalent):
 
 ```bash
-export MODA_API_BASE_URL="https://your-moda-instance.com"
-export MODA_API_KEY="your-personal-access-token"
+export WAYD_API_BASE_URL="https://your-wayd-instance.com"
+export WAYD_API_KEY="your-personal-access-token"
 ```
 
 Then register the server via the CLI (values are read from your environment at connection time):
 
 ```bash
-claude mcp add moda -- npx -y @modanpm/moda-mcp
+claude mcp add wayd -- npx -y @wayd/mcp
 ```
 
 Or add it to a project-level `.mcp.json` that reads from the same environment variables:
@@ -111,23 +111,23 @@ Or add it to a project-level `.mcp.json` that reads from the same environment va
 ```json
 {
   "mcpServers": {
-    "moda": {
+    "wayd": {
       "command": "npx",
-      "args": ["-y", "@modanpm/moda-mcp"]
+      "args": ["-y", "@wayd/mcp"]
     }
   }
 }
 ```
 
-Because the server reads `MODA_API_BASE_URL` and `MODA_API_KEY` from the environment automatically, no credentials appear in any config file.
+Because the server reads `WAYD_API_BASE_URL` and `WAYD_API_KEY` from the environment automatically, no credentials appear in any config file.
 
 ### Global install
 
 ```bash
-npm install -g @modanpm/moda-mcp
+npm install -g @wayd/mcp
 ```
 
-Then use `moda-mcp` as the command instead of `npx -y @modanpm/moda-mcp` in any of the configs above.
+Then use `wayd-mcp` as the command instead of `npx -y @wayd/mcp` in any of the configs above.
 
 ## Agent Skills (Claude Code)
 
@@ -137,19 +137,19 @@ Three self-contained skills are available:
 
 | Skill | Trigger |
 | --- | --- |
-| `moda-ppm` | Portfolios, programs, projects — lookup, create, update, lifecycle |
-| `moda-pi` | Planning intervals, iterations, objectives, health reports, risks |
-| `moda-roadmaps` | Roadmap exploration — activities, timeboxes, milestones |
+| `wayd-ppm` | Portfolios, programs, projects — lookup, create, update, lifecycle |
+| `wayd-pi` | Planning intervals, iterations, objectives, health reports, risks |
+| `wayd-roadmaps` | Roadmap exploration — activities, timeboxes, milestones |
 
 ### Installing the skills
 
 From your project root:
 
 ```bash
-npx skills add destacey/moda
+npx skills add destacey/wayd
 ```
 
-Once installed, activate a skill in Claude Code with `/moda-ppm`, `/moda-pi`, or `/moda-roadmaps`.
+Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, or `/wayd-roadmaps`.
 
 ## Available Tools
 

--- a/Wayd.Web/src/Wayd.Mcp/README.md
+++ b/Wayd.Web/src/Wayd.Mcp/README.md
@@ -133,13 +133,15 @@ Then use `wayd-mcp` as the command instead of `npx -y @wayd/mcp` in any of the c
 
 Skills are prompt files that guide Claude on how to efficiently use the Wayd MCP tools — which tools to call in sequence, how to resolve IDs, and what the entity relationships look like. Without them, agents tend to make redundant calls or miss non-obvious patterns (e.g. project lifecycle transitions use separate action endpoints, not a status field).
 
-Three self-contained skills are available:
+Five self-contained skills are available:
 
 | Skill | Trigger |
 | --- | --- |
 | `wayd-ppm` | Portfolios, programs, projects — lookup, create, update, lifecycle |
 | `wayd-pi` | Planning intervals, iterations, objectives, health reports, risks |
 | `wayd-roadmaps` | Roadmap exploration — activities, timeboxes, milestones |
+| `wayd-teams` | Team lookup — resolve a team name to an ID |
+| `wayd-users` | User lookup — resolve a user name to a UUID for assignees and project roles |
 
 ### Installing the skills
 
@@ -149,7 +151,7 @@ From your project root:
 npx skills add destacey/wayd
 ```
 
-Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, or `/wayd-roadmaps`.
+Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, `/wayd-roadmaps`, `/wayd-teams`, or `/wayd-users`.
 
 ## Available Tools
 

--- a/Wayd.Web/src/Wayd.Mcp/README.md
+++ b/Wayd.Web/src/Wayd.Mcp/README.md
@@ -137,19 +137,19 @@ Three self-contained skills are available:
 
 | Skill | Trigger |
 | --- | --- |
-| `wayd-ppm` | Portfolios, programs, projects — lookup, create, update, lifecycle |
-| `wayd-pi` | Planning intervals, iterations, objectives, health reports, risks |
-| `wayd-roadmaps` | Roadmap exploration — activities, timeboxes, milestones |
+| `moda-ppm` | Portfolios, programs, projects — lookup, create, update, lifecycle |
+| `moda-pi` | Planning intervals, iterations, objectives, health reports, risks |
+| `moda-roadmaps` | Roadmap exploration — activities, timeboxes, milestones |
 
 ### Installing the skills
 
 From your project root:
 
 ```bash
-npx skills add destacey/wayd
+npx skills add destacey/Wayd
 ```
 
-Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, or `/wayd-roadmaps`.
+Once installed, activate a skill in Claude Code with `/moda-ppm`, `/moda-pi`, or `/moda-roadmaps`.
 
 ## Available Tools
 

--- a/Wayd.Web/src/Wayd.Mcp/package-lock.json
+++ b/Wayd.Web/src/Wayd.Mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@modanpm/moda-mcp",
-  "version": "0.0.2",
+  "name": "@wayd/mcp",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@modanpm/moda-mcp",
-      "version": "0.0.2",
+      "name": "@wayd/mcp",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
@@ -15,7 +15,7 @@
         "zod": "^3.24.3"
       },
       "bin": {
-        "moda-mcp": "build/index.js"
+        "wayd-mcp": "build/index.js"
       },
       "devDependencies": {
         "@changesets/cli": "^2.27.0",

--- a/Wayd.Web/src/Wayd.Mcp/package.json
+++ b/Wayd.Web/src/Wayd.Mcp/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "@modanpm/moda-mcp",
+  "name": "@wayd/mcp",
   "version": "0.1.0",
-  "description": "MCP server for the Moda work management API",
+  "description": "MCP server for the Wayd work management API",
   "type": "module",
   "main": "build/index.js",
   "bin": {
-    "moda-mcp": "build/index.js"
+    "wayd-mcp": "build/index.js"
   },
   "files": [
     "build",
@@ -25,7 +25,7 @@
   },
   "keywords": [
     "mcp",
-    "moda",
+    "wayd",
     "model-context-protocol",
     "work-management",
     "project-management"
@@ -38,7 +38,7 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/destacey/Wayd.git",
-    "directory": "Moda.Web/src/Moda.Mcp"
+    "directory": "Wayd.Web/src/Wayd.Mcp"
   },
   "publishConfig": {
     "access": "public"

--- a/Wayd.Web/src/Wayd.Mcp/src/config.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/config.ts
@@ -15,7 +15,7 @@ const { values: cliArgs } = parseArgs({
   strict: false, // ignore unknown args passed by MCP clients
 });
 
-export const SERVER_NAME    = 'moda-mcp';
+export const SERVER_NAME    = 'wayd-mcp';
 export const SERVER_VERSION = packageVersion;
-export const API_BASE_URL   = (cliArgs['base-url'] as string | undefined) || process.env.MODA_API_BASE_URL || '';
-export const MODA_API_KEY   = (cliArgs['api-key']  as string | undefined) || process.env.MODA_API_KEY  || '';
+export const API_BASE_URL   = (cliArgs['base-url'] as string | undefined) || process.env.WAYD_API_BASE_URL || '';
+export const WAYD_API_KEY   = (cliArgs['api-key']  as string | undefined) || process.env.WAYD_API_KEY  || '';

--- a/Wayd.Web/src/Wayd.Mcp/src/executor.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/executor.ts
@@ -2,7 +2,7 @@ import { z, ZodError } from 'zod';
 import axios, { type AxiosRequestConfig, type AxiosError } from 'axios';
 import { zodSchemas } from './generated/zod-schemas.js';
 import type { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
-import { API_BASE_URL, MODA_API_KEY } from './config.js';
+import { API_BASE_URL, WAYD_API_KEY } from './config.js';
 import type { McpToolDefinition, JsonObject } from './types.js';
 
 export const securitySchemes = {
@@ -79,7 +79,7 @@ export async function executeApiTool(
         const scheme = allSecuritySchemes[schemeName];
         if (scheme?.type !== 'apiKey') continue;
 
-        const apiKey = MODA_API_KEY;
+        const apiKey = WAYD_API_KEY;
         if (!apiKey) continue;
 
         if (scheme.in === 'header') {

--- a/Wayd.Web/src/Wayd.Mcp/src/index.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/index.ts
@@ -39,7 +39,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request: CallToolRequest)
 
 async function main() {
   if (!API_BASE_URL) {
-    console.error('Error: MODA_API_BASE_URL environment variable or --base-url argument is required.');
+    console.error('Error: WAYD_API_BASE_URL environment variable or --base-url argument is required.');
     process.exit(1);
   }
 

--- a/Wayd.Web/src/Wayd.Web.Api/Wayd.Web.Api.csproj
+++ b/Wayd.Web/src/Wayd.Web.Api/Wayd.Web.Api.csproj
@@ -92,7 +92,7 @@
         Condition=" '$(Configuration)' == 'Debug' ">
         <Exec ConsoleToMSBuild="true" ContinueOnError="true" WorkingDirectory="$(ProjectDir)"
             EnvironmentVariables="ASPNETCORE_ENVIRONMENT=Development"
-            Command="npx openapi-mcp-generator -i wwwroot\api\v1\specification.json -o $(RepoRoot)/Wayd.MCP -t stdio -n moda-mcp">
+            Command="npx openapi-mcp-generator -i wwwroot\api\v1\specification.json -o $(RepoRoot)/Wayd.MCP -t stdio -n wayd-mcp">
             <Output TaskParameter="ExitCode" PropertyName="OpenAPIMCPGeneratorExitCode" />
             <Output TaskParameter="ConsoleOutput" PropertyName="OpenAPIMCPGeneratorOutput" />
         </Exec>

--- a/docs/contributing/migrating-from-moda.mdx
+++ b/docs/contributing/migrating-from-moda.mdx
@@ -212,7 +212,6 @@ These are deferred because they live outside the repo or depend on data compatib
 - `LoginProviders.Moda = "Moda"` constant and matching frontend `loginProvider === 'Moda'` checks — user rows in the database have `LoginProvider = "Moda"`; renaming requires a coordinated data migration
 - `awaldow/moda-api` / `awaldow/moda-client` Docker Hub images — third-party publisher
 - `docs/_legacy/*.drawio.svg` — embedded text inside legacy architecture diagrams (art assets)
-- `skills/moda-pi`, `skills/moda-ppm`, `skills/moda-roadmaps`, `skills/moda-teams`, `skills/moda-users` — separately published skill names
 
 ## Troubleshooting
 

--- a/docs/contributing/migrating-from-moda.mdx
+++ b/docs/contributing/migrating-from-moda.mdx
@@ -210,7 +210,6 @@ The Moda → Wayd transition shipped across three PRs:
 These are deferred because they live outside the repo or depend on data compatibility:
 
 - `LoginProviders.Moda = "Moda"` constant and matching frontend `loginProvider === 'Moda'` checks — user rows in the database have `LoginProvider = "Moda"`; renaming requires a coordinated data migration
-- `@modanpm/moda-mcp` npm package — published artifact on the npm registry
 - `awaldow/moda-api` / `awaldow/moda-client` Docker Hub images — third-party publisher
 - `docs/_legacy/*.drawio.svg` — embedded text inside legacy architecture diagrams (art assets)
 - `skills/moda-pi`, `skills/moda-ppm`, `skills/moda-roadmaps`, `skills/moda-teams`, `skills/moda-users` — separately published skill names

--- a/docs/getting-started/mcp-server.mdx
+++ b/docs/getting-started/mcp-server.mdx
@@ -124,11 +124,13 @@ CLI arguments take precedence over environment variables.
 
 ## Agent Skills
 
-For Claude Code users, three pre-built skills provide guided workflows:
+For Claude Code users, five pre-built skills provide guided workflows:
 
 - **`/wayd-ppm`** — Portfolio, program, and project operations
 - **`/wayd-pi`** — Planning intervals, iterations, objectives, and risks
 - **`/wayd-roadmaps`** — Roadmap exploration with activities and milestones
+- **`/wayd-teams`** — Team lookup and resolving team names to IDs
+- **`/wayd-users`** — User lookup and resolving names to UUIDs for assignees and project roles
 
 Install the skills:
 

--- a/docs/getting-started/mcp-server.mdx
+++ b/docs/getting-started/mcp-server.mdx
@@ -9,7 +9,7 @@ audience: [user, developer, agent]
 
 Wayd provides an [MCP (Model Context Protocol)](https://modelcontextprotocol.io) server that lets AI assistants like Claude interact directly with your Wayd instance. The MCP server exposes Wayd's API as structured tools that AI agents can call to read and manage your delivery data.
 
-**Package:** [`@modanpm/wayd-mcp`](https://www.npmjs.com/package/@modanpm/wayd-mcp)
+**Package:** [`@wayd/mcp`](https://www.npmjs.com/package/@wayd/mcp)
 
 ## What Can It Do?
 
@@ -42,10 +42,10 @@ Add the following to your Claude Desktop configuration file:
   "mcpServers": {
     "wayd": {
       "command": "npx",
-      "args": ["-y", "@modanpm/wayd-mcp"],
+      "args": ["-y", "@wayd/mcp"],
       "env": {
-        "MODA_API_BASE_URL": "https://your-wayd-instance.com",
-        "MODA_API_KEY": "your-personal-access-token"
+        "WAYD_API_BASE_URL": "https://your-wayd-instance.com",
+        "WAYD_API_KEY": "your-personal-access-token"
       }
     }
   }
@@ -61,10 +61,10 @@ Add a `.mcp.json` file to your project root:
   "mcpServers": {
     "wayd": {
       "command": "npx",
-      "args": ["-y", "@modanpm/wayd-mcp"],
+      "args": ["-y", "@wayd/mcp"],
       "env": {
-        "MODA_API_BASE_URL": "https://your-wayd-instance.com",
-        "MODA_API_KEY": "your-personal-access-token"
+        "WAYD_API_BASE_URL": "https://your-wayd-instance.com",
+        "WAYD_API_KEY": "your-personal-access-token"
       }
     }
   }
@@ -74,8 +74,8 @@ Add a `.mcp.json` file to your project root:
 Or set environment variables in your shell and omit the `env` block:
 
 ```bash
-export MODA_API_BASE_URL="https://your-wayd-instance.com"
-export MODA_API_KEY="your-personal-access-token"
+export WAYD_API_BASE_URL="https://your-wayd-instance.com"
+export WAYD_API_KEY="your-personal-access-token"
 ```
 
 ### VS Code / Cursor
@@ -86,12 +86,12 @@ Add to your `.vscode/mcp.json` or workspace settings:
 {
   "inputs": [
     {
-      "id": "modaBaseUrl",
+      "id": "waydBaseUrl",
       "description": "Wayd API base URL",
       "type": "promptString"
     },
     {
-      "id": "modaApiKey",
+      "id": "waydApiKey",
       "description": "Wayd API key (Personal Access Token)",
       "type": "promptString",
       "password": true
@@ -102,9 +102,9 @@ Add to your `.vscode/mcp.json` or workspace settings:
       "type": "stdio",
       "command": "npx",
       "args": [
-        "-y", "@modanpm/wayd-mcp",
-        "--base-url", "${input:modaBaseUrl}",
-        "--api-key", "${input:modaApiKey}"
+        "-y", "@wayd/mcp",
+        "--base-url", "${input:waydBaseUrl}",
+        "--api-key", "${input:waydApiKey}"
       ]
     }
   }
@@ -117,8 +117,8 @@ The MCP server accepts configuration via environment variables or CLI arguments:
 
 | Environment Variable | CLI Argument | Description |
 |---------------------|-------------|-------------|
-| `MODA_API_BASE_URL` | `--base-url` | The base URL of your Wayd API instance |
-| `MODA_API_KEY` | `--api-key` | Your [Personal Access Token](./your-profile.mdx#personal-access-tokens) |
+| `WAYD_API_BASE_URL` | `--base-url` | The base URL of your Wayd API instance |
+| `WAYD_API_KEY` | `--api-key` | Your [Personal Access Token](./your-profile.mdx#personal-access-tokens) |
 
 CLI arguments take precedence over environment variables.
 

--- a/skills/wayd-pi/SKILL.md
+++ b/skills/wayd-pi/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: moda-pi
-description: Guides agents working with Moda Planning Intervals — iterations, sprint metrics, team objectives, health reports, predictability, and risks.
+name: wayd-pi
+description: Guides agents working with Wayd Planning Intervals — iterations, sprint metrics, team objectives, health reports, predictability, and risks.
 ---
 
-# Moda Planning Intervals (PI)
+# Wayd Planning Intervals (PI)
 
 ## When to use
 

--- a/skills/wayd-ppm/SKILL.md
+++ b/skills/wayd-ppm/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: moda-ppm
-description: Guides agents working with Moda Portfolio, Program, Project, and Task management via the Moda MCP server. Use when looking up portfolios, programs, or projects, exploring project lifecycles and phases, viewing the project plan or team, or creating, updating, or managing tasks within a project.
+name: wayd-ppm
+description: Guides agents working with Wayd Portfolio, Program, Project, and Task management via the Wayd MCP server. Use when looking up portfolios, programs, or projects, exploring project lifecycles and phases, viewing the project plan or team, or creating, updating, or managing tasks within a project.
 ---
 
-# Moda PPM (Portfolio / Program / Project / Task Management)
+# Wayd PPM (Portfolio / Program / Project / Task Management)
 
 ## When to use
 

--- a/skills/wayd-roadmaps/SKILL.md
+++ b/skills/wayd-roadmaps/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: moda-roadmaps
-description: Guides agents working with Moda Roadmaps — exploring activities, timeboxes, milestones, and roadmap item details.
+name: wayd-roadmaps
+description: Guides agents working with Wayd Roadmaps — exploring activities, timeboxes, milestones, and roadmap item details.
 ---
 
-# Moda Roadmaps
+# Wayd Roadmaps
 
 ## When to use
 

--- a/skills/wayd-teams/SKILL.md
+++ b/skills/wayd-teams/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: moda-teams
-description: Guides agents working with Moda Teams via the Moda MCP server. Use when looking up teams or resolving a team name to an ID.
+name: wayd-teams
+description: Guides agents working with Wayd Teams via the Wayd MCP server. Use when looking up teams or resolving a team name to an ID.
 ---
 
-# Moda Teams
+# Wayd Teams
 
 ## When to use
 
@@ -17,8 +17,8 @@ description: Guides agents working with Moda Teams via the Moda MCP server. Use 
 
 ### Team
 
-- Represents an organizational team in Moda
-- Team `id` is an **integer** (not a UUID) — this is different from most other Moda entities
+- Represents an organizational team in Wayd
+- Team `id` is an **integer** (not a UUID) — this is different from most other Wayd entities
 - Teams can be active or inactive; `Teams_GetTeams` returns active teams by default
 - Pass `includeInactive: true` to include inactive teams
 

--- a/skills/wayd-users/SKILL.md
+++ b/skills/wayd-users/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: moda-users
-description: Guides agents working with Moda Users via the Moda MCP server. Use when looking up users or resolving a user name to a UUID for assignees or project team roles.
+name: wayd-users
+description: Guides agents working with Wayd Users via the Wayd MCP server. Use when looking up users or resolving a user name to a UUID for assignees or project team roles.
 ---
 
-# Moda Users
+# Wayd Users
 
 ## When to use
 
@@ -17,7 +17,7 @@ description: Guides agents working with Moda Users via the Moda MCP server. Use 
 
 ### User
 
-- Represents a Moda user account
+- Represents a Wayd user account
 - User `id` is a **UUID** (string)
 - Users can be active or inactive; `Users_GetUsers` returns all users
 


### PR DESCRIPTION
Renaming things from moda -> wayd on the MCP side, including docs and package. On the CLI, it will show as wayd-mcp but the package will be wayd/mcp, @destacey let me know if we want wayd/wayd-mcp to distinguish from others but right now I don't know how important that is.