### PR TITLE
Add MCP tools for objective and project health checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -360,3 +360,4 @@ nul
 
 # Playwright MCP screenshots
 .playwright-mcp/
+*.lscache

--- a/Wayd.Web/src/Wayd.Mcp/.changeset/objective-and-project-health-check-tools.md
+++ b/Wayd.Web/src/Wayd.Mcp/.changeset/objective-and-project-health-check-tools.md
@@ -1,0 +1,14 @@
+---
+"@wayd/mcp": minor
+---
+
+Add MCP tools for inspecting and creating health checks on planning interval objectives and PPM projects.
+
+**New tools:**
+
+- `PlanningIntervals_GetObjectiveHealthChecks` — get the full health check history for a PI objective (newest first)
+- `PlanningIntervals_GetObjectiveHealthCheck` — get a specific PI objective health check by ID
+- `PlanningIntervals_CreateObjectiveHealthCheck` — log a new health check on a PI objective (`statusId` 1=Healthy, 2=AtRisk, 3=Unhealthy); auto-expires the previously active check
+- `Projects_GetProjectHealthChecks` — get the full health check history for a project (newest first)
+- `Projects_GetProjectHealthCheck` — get a specific project health check by ID
+- `Projects_CreateProjectHealthCheck` — log a new health check on a project (`status` "Healthy" / "AtRisk" / "Unhealthy"); auto-expires the previously active check

--- a/Wayd.Web/src/Wayd.Mcp/README.md
+++ b/Wayd.Web/src/Wayd.Mcp/README.md
@@ -162,14 +162,14 @@ Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, `/
 | **Portfolios** | List, get details, get programs, get projects |
 | **Programs** | List, get details, get projects |
 | **Project Lifecycles** | List (with state filter), get details |
-| **Projects** | List (with role filter), get details, get team, get phases, get phase details, get plan tree, get plan summary |
+| **Projects** | List (with role filter), get details, get team, get phases, get phase details, get plan tree, get plan summary, list health checks, get health check, create health check |
 | **Tasks** | List, get details, get critical path, get types/statuses/priorities, create, update, delete, add/remove dependencies |
 
 ### Planning
 
 | Category | Operations |
 | --- | --- |
-| **Planning Intervals** | List, get details, calendar, predictability, teams, iterations, objectives, risks |
+| **Planning Intervals** | List, get details, calendar, predictability, teams, iterations, objectives, risks, objective health check history, get/create objective health check |
 | **Roadmaps** | List, get details, get items and activities |
 
 ### Organization

--- a/Wayd.Web/src/Wayd.Mcp/package.json
+++ b/Wayd.Web/src/Wayd.Mcp/package.json
@@ -14,6 +14,7 @@
   ],
   "scripts": {
     "start": "node build/index.js",
+    "inspect": "npm run build && npx -y @modelcontextprotocol/inspector node build/index.js",
     "build": "npm run generate && tsc && shx chmod 755 build/index.js",
     "generate": "tsx scripts/generate-zod-schemas.ts",
     "lint": "eslint src",

--- a/Wayd.Web/src/Wayd.Mcp/src/tools/index.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/tools/index.ts
@@ -3,8 +3,10 @@ import { definitions as portfolios } from './portfolios.js';
 import { definitions as programs } from './programs.js';
 import { definitions as projectLifecycles } from './project-lifecycles.js';
 import { definitions as projects } from './projects.js';
+import { definitions as projectHealthChecks } from './project-health-checks.js';
 import { definitions as roadmaps } from './roadmaps.js';
 import { definitions as planningIntervals } from './planning-intervals.js';
+import { definitions as objectiveHealthChecks } from './objective-health-checks.js';
 import { definitions as tasks } from './tasks.js';
 import { definitions as teams } from './teams.js';
 import { definitions as users } from './users.js';
@@ -14,8 +16,10 @@ export const toolDefinitionMap: Map<string, McpToolDefinition> = new Map([
   ...programs,
   ...projectLifecycles,
   ...projects,
+  ...projectHealthChecks,
   ...roadmaps,
   ...planningIntervals,
+  ...objectiveHealthChecks,
   ...tasks,
   ...teams,
   ...users,

--- a/Wayd.Web/src/Wayd.Mcp/src/tools/objective-health-checks.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/tools/objective-health-checks.ts
@@ -1,0 +1,38 @@
+import type { McpToolDefinition } from '../types.js';
+
+export const definitions: [string, McpToolDefinition][] = [
+
+  ['PlanningIntervals_GetObjectiveHealthChecks', {
+    name: 'PlanningIntervals_GetObjectiveHealthChecks',
+    description: `Get the full health check history for a planning interval objective, ordered newest first.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid","description":"Planning interval ID."},"objectiveId":{"type":"string","format":"uuid","description":"Planning interval objective ID."}},"required":["id","objectiveId"]},
+    method: 'get',
+    pathTemplate: '/api/planning/planning-intervals/{id}/objectives/{objectiveId}/health-checks',
+    executionParameters: [{"name":"id","in":"path"},{"name":"objectiveId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['PlanningIntervals_GetObjectiveHealthCheck', {
+    name: 'PlanningIntervals_GetObjectiveHealthCheck',
+    description: `Get a single planning interval objective health check by ID.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid","description":"Planning interval ID."},"objectiveId":{"type":"string","format":"uuid","description":"Planning interval objective ID."},"healthCheckId":{"type":"string","format":"uuid"}},"required":["id","objectiveId","healthCheckId"]},
+    method: 'get',
+    pathTemplate: '/api/planning/planning-intervals/{id}/objectives/{objectiveId}/health-checks/{healthCheckId}',
+    executionParameters: [{"name":"id","in":"path"},{"name":"objectiveId","in":"path"},{"name":"healthCheckId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['PlanningIntervals_CreateObjectiveHealthCheck', {
+    name: 'PlanningIntervals_CreateObjectiveHealthCheck',
+    description: `Log a new health check on a planning interval objective. Creating a new check automatically expires the previously active check (only one non-expired check can exist at a time). Note: the API requires planningIntervalObjectiveId in the body in addition to the objectiveId path parameter — they must match.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid","description":"Planning interval ID."},"objectiveId":{"type":"string","format":"uuid","description":"Planning interval objective ID. Must match requestBody.planningIntervalObjectiveId."},"requestBody":{"type":"object","properties":{"planningIntervalObjectiveId":{"type":"string","format":"uuid","description":"Must match the objectiveId path parameter."},"statusId":{"type":"number","format":"int32","description":"Health status: 1=Healthy, 2=AtRisk, 3=Unhealthy."},"expiration":{"type":"string","format":"date-time","description":"ISO 8601 UTC datetime when this health check expires. Must be in the future."},"note":{"type":["string","null"],"maxLength":1024}},"required":["planningIntervalObjectiveId","statusId","expiration"]}},"required":["id","objectiveId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/planning-intervals/{id}/objectives/{objectiveId}/health-checks',
+    executionParameters: [{"name":"id","in":"path"},{"name":"objectiveId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+];

--- a/Wayd.Web/src/Wayd.Mcp/src/tools/project-health-checks.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/tools/project-health-checks.ts
@@ -1,0 +1,38 @@
+import type { McpToolDefinition } from '../types.js';
+
+export const definitions: [string, McpToolDefinition][] = [
+
+  ['Projects_GetProjectHealthChecks', {
+    name: 'Projects_GetProjectHealthChecks',
+    description: `Get the full health check history for a project, ordered newest first.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid","description":"Project ID."}},"required":["id"]},
+    method: 'get',
+    pathTemplate: '/api/ppm/projects/{id}/health-checks',
+    executionParameters: [{"name":"id","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['Projects_GetProjectHealthCheck', {
+    name: 'Projects_GetProjectHealthCheck',
+    description: `Get a single project health check by ID.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid","description":"Project ID."},"healthCheckId":{"type":"string","format":"uuid"}},"required":["id","healthCheckId"]},
+    method: 'get',
+    pathTemplate: '/api/ppm/projects/{id}/health-checks/{healthCheckId}',
+    executionParameters: [{"name":"id","in":"path"},{"name":"healthCheckId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['Projects_CreateProjectHealthCheck', {
+    name: 'Projects_CreateProjectHealthCheck',
+    description: `Log a new health check on a project. Creating a new check automatically expires the previously active check (only one non-expired check can exist at a time). Caller must be the project, parent portfolio, or parent program owner or manager.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid","description":"Project ID."},"requestBody":{"type":"object","properties":{"status":{"type":"string","enum":["Healthy","AtRisk","Unhealthy"],"description":"Health status."},"expiration":{"type":"string","format":"date-time","description":"ISO 8601 UTC datetime when this health check expires. Must be in the future."},"note":{"type":["string","null"],"maxLength":1024}},"required":["status","expiration"]}},"required":["id","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/ppm/projects/{id}/health-checks',
+    executionParameters: [{"name":"id","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+];

--- a/docs/getting-started/mcp-server.mdx
+++ b/docs/getting-started/mcp-server.mdx
@@ -17,8 +17,8 @@ The MCP server exposes 50+ tools across Wayd's core modules:
 
 | Module | Capabilities |
 |--------|-------------|
-| **[PPM](../user-guide/ppm/index.mdx)** | List/view portfolios, programs, projects, phases, tasks. Create and update tasks. View project plan tree and summary metrics. Get critical path. Manage task dependencies. |
-| **[Planning](../user-guide/planning/index.mdx)** | List/view planning intervals, iterations, objectives, risks. Get PI predictability and health reports. View calendars. |
+| **[PPM](../user-guide/ppm/index.mdx)** | List/view portfolios, programs, projects, phases, tasks. Create and update tasks. View project plan tree and summary metrics. Get critical path. Manage task dependencies. Review and log project health checks. |
+| **[Planning](../user-guide/planning/index.mdx)** | List/view planning intervals, iterations, objectives, risks. Get PI predictability and health reports. Review and log objective health checks. View calendars. |
 | **[Roadmaps](../user-guide/planning/roadmaps.mdx)** | List/view roadmaps and their items (activities, milestones, timeboxes). |
 | **[Organizations](../user-guide/organizations/index.mdx)** | List/view teams and users. |
 
@@ -157,6 +157,9 @@ npx skills add destacey/wayd
 | `Projects_GetProjectPhases` | Get all project phases |
 | `Projects_GetProjectPlanTree` | Get full plan as a hierarchical tree (WBS) |
 | `Projects_GetProjectPlanSummary` | Get plan metrics (overdue, due this week, totals) |
+| `Projects_GetProjectHealthChecks` | Get the health check history for a project |
+| `Projects_GetProjectHealthCheck` | Get a specific project health check by ID |
+| `Projects_CreateProjectHealthCheck` | Log a new health check (Healthy / AtRisk / Unhealthy) on a project |
 | `ProjectLifecycles_GetProjectLifecycles` | List lifecycles with state filter |
 
 ### Tasks
@@ -186,7 +189,8 @@ npx skills add destacey/wayd
 | `PlanningIntervals_GetRisks` | Get risks |
 | `PlanningIntervals_GetObjectivesHealthReport` | Get health report for all objectives in a PI |
 | `PlanningIntervals_GetObjectiveHealthChecks` | Get the health check history for a PI objective |
-| `PlanningIntervals_GetHealthStatuses` | List the available health check status values |
+| `PlanningIntervals_GetObjectiveHealthCheck` | Get a specific PI objective health check by ID |
+| `PlanningIntervals_CreateObjectiveHealthCheck` | Log a new health check (1=Healthy, 2=AtRisk, 3=Unhealthy) on a PI objective |
 | `Roadmaps_GetRoadmaps` | List all roadmaps |
 | `Roadmaps_GetRoadmap` | Get roadmap details |
 | `Roadmaps_GetItems` | Get all roadmap items |

--- a/skills/wayd-pi/SKILL.md
+++ b/skills/wayd-pi/SKILL.md
@@ -11,6 +11,7 @@ description: Guides agents working with Wayd Planning Intervals — iterations, 
 - Getting sprint mappings, iteration metrics, or iteration backlogs
 - Listing or analyzing team objectives and their linked work items
 - Generating PI health reports or predictability summaries
+- Reviewing or logging health checks on individual PI objectives (Healthy / AtRisk / Unhealthy)
 - Reviewing PI risks
 
 ---
@@ -88,12 +89,24 @@ Planning Interval (PI)
 - Work items linked to an objective: `PlanningIntervals_GetObjectiveWorkItems`
 - Daily work item metrics for an objective: `PlanningIntervals_GetObjectiveWorkItemMetrics`
 
-### Health report
+### Health report and per-objective health checks
 
-The health report is a dedicated endpoint — do not attempt to derive it from objectives manually.
+The PI-wide health report is a dedicated endpoint — do not attempt to derive it from objectives manually.
 
-- All teams: `PlanningIntervals_GetObjectivesHealthReport` with `idOrKey`
-- Scoped to one team: add `teamId` filter
+| Goal | Tool | Notes |
+|---|---|---|
+| Bulk RAG snapshot (latest check per objective, all teams) | `PlanningIntervals_GetObjectivesHealthReport` | Takes `idOrKey`. Add `teamId` to scope to one team. |
+| Full health check history for one objective | `PlanningIntervals_GetObjectiveHealthChecks` | Takes PI `id` and `objectiveId` (both UUIDs). Newest first. |
+| One specific health check | `PlanningIntervals_GetObjectiveHealthCheck` | Takes PI `id`, `objectiveId`, and `healthCheckId`. |
+| Log a new health check on an objective | `PlanningIntervals_CreateObjectiveHealthCheck` | Takes PI `id` and `objectiveId`; body: `{ planningIntervalObjectiveId, statusId, expiration, note? }`. |
+
+Notes for logging a check:
+
+- `statusId` is a **number**: `1=Healthy, 2=AtRisk, 3=Unhealthy` (asymmetric with the project version, which takes a string `status`).
+- `expiration` is an ISO 8601 UTC datetime and **must be in the future**.
+- `note` is optional, max 1024 characters.
+- The body redundantly requires `planningIntervalObjectiveId` in addition to the path `objectiveId` — they must match.
+- Logging a new check automatically expires the previously active check; only one non-expired check can exist at a time.
 
 ### Predictability
 

--- a/skills/wayd-ppm/SKILL.md
+++ b/skills/wayd-ppm/SKILL.md
@@ -13,8 +13,9 @@ description: Guides agents working with Wayd Portfolio, Program, Project, and Ta
 - Viewing a project's plan tree, phases, team, or plan summary metrics
 - Listing, creating, updating, or deleting tasks within a project
 - Managing task hierarchies, dependencies, or the critical path
+- Reviewing or logging project health checks (Healthy / AtRisk / Unhealthy)
 
-> **Note:** Portfolios, programs, projects, lifecycles, and phases are **read-only** via MCP — only GET and LIST operations are exposed. Task management (create, update, delete) is fully supported.
+> **Note:** Portfolios, programs, lifecycles, and phases are **read-only** via MCP — only GET and LIST operations are exposed. Tasks support full CRUD (create, update, delete). Project **health checks** are read+create (no update or delete from MCP); the rest of the project surface remains read-only.
 
 ---
 
@@ -156,3 +157,22 @@ Required fields: `name`, `typeId`, `statusId`, `priorityId`
 
 - **Add** (finish-to-start): `Tasks_AddTaskDependency` with `{ predecessorId, successorId }` — both UUIDs. Also pass the predecessor task's `id` as the path parameter.
 - **Remove**: `Tasks_RemoveTaskDependency` with path params `id` (predecessor UUID) and `successorId`.
+
+### Project health checks
+
+A health check records a point-in-time RAG assessment of a project (Healthy / AtRisk / Unhealthy) with a reporter, a note, and an expiration. Only one non-expired check is active at a time — logging a new check automatically expires the previous one.
+
+| Goal | Tool | Notes |
+|---|---|---|
+| Full health check history for a project | `Projects_GetProjectHealthChecks` | Takes project `id` (UUID). Newest first. |
+| One specific health check | `Projects_GetProjectHealthCheck` | Takes project `id` and `healthCheckId` (both UUIDs). |
+| Log a new health check | `Projects_CreateProjectHealthCheck` | Takes project `id`; body: `{ status, expiration, note? }`. |
+
+Notes for logging a check:
+
+- `status` is a **string enum**: `"Healthy"`, `"AtRisk"`, or `"Unhealthy"` (asymmetric with the PI objective version, which takes a numeric `statusId`).
+- `expiration` is an ISO 8601 UTC datetime and **must be in the future**.
+- `note` is optional, max 1024 characters.
+- Authorization (server-enforced): the caller must be an Owner or Manager of the project, the parent portfolio, or the parent program. Sponsors are intentionally excluded.
+
+The current active check (if any) is also embedded in `Projects_GetProject` and `Projects_GetProjects` — prefer those when you only need the latest status, and use the dedicated tools when you need history or want to log a new check.


### PR DESCRIPTION
Wayd MCP previously only exposed the bulk RAG report (PlanningIntervals_GetObjectivesHealthReport). Agents could see aggregate status but could not read per-entity history or log a new check. Adds read + create coverage for both PI objectives and PPM projects, wiring up existing REST endpoints.

New tools:
- PlanningIntervals_GetObjectiveHealthChecks
- PlanningIntervals_GetObjectiveHealthCheck
- PlanningIntervals_CreateObjectiveHealthCheck
- Projects_GetProjectHealthChecks
- Projects_GetProjectHealthCheck
- Projects_CreateProjectHealthCheck

Also updates the MCP README, docs site mcp-server.mdx, and wayd-ppm/wayd-pi skill files; queues a minor changeset; and adds an 'inspect' npm script for local smoke testing via the MCP Inspector.