### PR TITLE
Bug/fix global sprint grid

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Middleware/ExceptionMiddleware.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Middleware/ExceptionMiddleware.cs
@@ -79,7 +79,7 @@ public sealed class ExceptionMiddleware(IProblemDetailsService problemDetailsSer
             ConflictException => StatusCodes.Status409Conflict,
             ValidationException => StatusCodes.Status422UnprocessableEntity,
             ServiceUnavailableException => StatusCodes.Status503ServiceUnavailable,
-            _ => StatusCodes.Status418ImATeapot
+            _ => StatusCodes.Status500InternalServerError
         };
     }
     public static LogEventLevel GetLogLevelFromException(Exception exception)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Iterations/Queries/GetSprintsQuery.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Iterations/Queries/GetSprintsQuery.cs
@@ -13,7 +13,7 @@ internal sealed class GetSprintsQueryHandler(IPlanningDbContext planningDbContex
     public async Task<List<SprintListDto>> Handle(GetSprintsQuery request, CancellationToken cancellationToken)
     {
         var query = _planningDbContext.Iterations
-            .Where(i => i.Type == IterationType.Sprint)
+            .Where(i => i.Type == IterationType.Sprint && i.TeamId != null)
             .AsQueryable();
 
         if (request.TeamId.HasValue)

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Sut/Iterations/Queries/GetSprintsQueryHandlerTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Sut/Iterations/Queries/GetSprintsQueryHandlerTests.cs
@@ -1,0 +1,80 @@
+using Wayd.Planning.Application.Iterations.Queries;
+using Wayd.Planning.Application.Tests.Infrastructure;
+using Wayd.Planning.Domain.Tests.Data;
+
+namespace Wayd.Planning.Application.Tests.Sut.Iterations.Queries;
+
+public class GetSprintsQueryHandlerTests : IDisposable
+{
+    private readonly FakePlanningDbContext _dbContext;
+    private readonly GetSprintsQueryHandler _handler;
+    private readonly IterationFaker _iterationFaker;
+
+    public GetSprintsQueryHandlerTests()
+    {
+        _dbContext = new FakePlanningDbContext();
+        _handler = new GetSprintsQueryHandler(_dbContext);
+        _iterationFaker = new IterationFaker();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOnlySprints_WhenMixedIterationTypesExist()
+    {
+        // Arrange
+        var sprint = _iterationFaker.AsSprint().Generate();
+        var nonSprint = _iterationFaker.AsIteration().Generate();
+        _dbContext.AddIterations([sprint, nonSprint]);
+
+        // Act
+        var result = await _handler.Handle(new GetSprintsQuery(), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().ContainSingle(s => s.Id == sprint.Id);
+        result.Should().NotContain(s => s.Id == nonSprint.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesSprints_WhenTeamIdIsNull()
+    {
+        // Arrange
+        var sprintWithTeam = _iterationFaker.AsSprint().Generate(); // TeamId is random Guid by default
+        var sprintWithoutTeam = _iterationFaker.AsSprint().WithTeamId(null).Generate();
+        _dbContext.AddIterations([sprintWithTeam, sprintWithoutTeam]);
+
+        // Act
+        var result = await _handler.Handle(new GetSprintsQuery(), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().ContainSingle(s => s.Id == sprintWithTeam.Id);
+        result.Should().NotContain(s => s.Id == sprintWithoutTeam.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsOnlyTeamSprints_WhenTeamIdFilterProvided()
+    {
+        // Arrange
+        var teamId = Guid.NewGuid();
+        var teamSprint = _iterationFaker.AsSprint().WithTeamId(teamId).Generate();
+        var otherSprint = _iterationFaker.AsSprint().WithTeamId(Guid.NewGuid()).Generate();
+        _dbContext.AddIterations([teamSprint, otherSprint]);
+
+        // Act
+        var result = await _handler.Handle(new GetSprintsQuery(teamId), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().ContainSingle(s => s.Id == teamSprint.Id);
+        result.Should().NotContain(s => s.Id == otherSprint.Id);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEmpty_WhenNoSprintsExist()
+    {
+        // Act
+        var result = await _handler.Handle(new GetSprintsQuery(), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/_components/employee-teams-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/_components/employee-teams-grid.tsx
@@ -17,8 +17,9 @@ interface Props {
 
 const TeamLinkCellRenderer = ({ data }: ICellRendererParams<TeamMemberDto>) => {
   if (!data) return null
+  const segment = data.team.type === 'Team of Teams' ? 'team-of-teams' : 'teams'
   return (
-    <Link href={`/organizations/teams/${data.team.key}`}>{data.team.name}</Link>
+    <Link href={`/organizations/${segment}/${data.team.key}`}>{data.team.name}</Link>
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -15,6 +15,7 @@ import RisksGrid, {
 import { useDocumentTitle } from '@/src/hooks/use-document-title'
 import { EditTeamForm, TeamMembershipsGrid } from '../../_components'
 import TeamMembersGrid from '../../teams/_components/team-members-grid'
+import AddTeamMemberForm from '../../teams/_components/add-team-member-form'
 import useAuth from '@/src/components/contexts/auth'
 import {
   useGetTeamOfTeamsMembershipsQuery,
@@ -189,9 +190,6 @@ const TeamOfTeamsDetailsPage = (props: {
           <TeamMembersGrid
             teamId={team?.id ?? ''}
             teamType="TeamOfTeams"
-            teamIsActive={team?.isActive ?? false}
-            openAddForm={openAddMemberForm}
-            onAddFormClose={() => setOpenAddMemberForm(false)}
           />
         )
       default:
@@ -280,6 +278,14 @@ const TeamOfTeamsDetailsPage = (props: {
           team={team!}
           onFormComplete={() => onDeactivateTeamFormClosed(true)}
           onFormCancel={() => onDeactivateTeamFormClosed(false)}
+        />
+      )}
+      {openAddMemberForm && team?.isActive && (
+        <AddTeamMemberForm
+          teamId={team.id!}
+          teamType="TeamOfTeams"
+          onFormComplete={() => setOpenAddMemberForm(false)}
+          onFormCancel={() => setOpenAddMemberForm(false)}
         />
       )}
     </>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -90,6 +90,7 @@ const TeamOfTeamsDetailsPage = (props: {
 
   const {
     item,
+    isLoading: teamIsLoading,
     isInEditMode,
     notFound: teamNotFound,
     error,
@@ -238,7 +239,7 @@ const TeamOfTeamsDetailsPage = (props: {
     }
   }
 
-  if (teamNotFound) {
+  if (!teamIsLoading && teamNotFound) {
     return notFound()
   }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -26,6 +26,7 @@ import { notFound, usePathname } from 'next/navigation'
 import {
   retrieveTeam,
   setEditMode,
+  resetTeamDetail,
   selectTeamContext,
 } from '../../../../store/features/organizations/team-slice'
 import { useAppDispatch, useAppSelector } from '@/src/hooks'
@@ -90,7 +91,6 @@ const TeamOfTeamsDetailsPage = (props: {
 
   const {
     item,
-    isLoading: teamIsLoading,
     isInEditMode,
     notFound: teamNotFound,
     error,
@@ -199,6 +199,7 @@ const TeamOfTeamsDetailsPage = (props: {
   }
 
   useEffect(() => {
+    dispatch(resetTeamDetail())
     dispatch(retrieveTeam({ key: teamKey, type: 'Team of Teams' }))
   }, [teamKey, dispatch])
 
@@ -239,7 +240,7 @@ const TeamOfTeamsDetailsPage = (props: {
     }
   }
 
-  if (!teamIsLoading && teamNotFound) {
+  if (teamNotFound) {
     return notFound()
   }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -47,6 +47,7 @@ import {
   TeamMembershipsGrid,
 } from '../../_components'
 import TeamMembersGrid from '../_components/team-members-grid'
+import AddTeamMemberForm from '../_components/add-team-member-form'
 
 const CycleTimeReport = dynamic(
   () =>
@@ -352,9 +353,6 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
           <TeamMembersGrid
             teamId={team!.id!}
             teamType="Team"
-            teamIsActive={team!.isActive ?? false}
-            openAddForm={openAddMemberForm}
-            onAddFormClose={() => setOpenAddMemberForm(false)}
           />
         )
       case TeamTabs.CycleTimeReport:
@@ -505,6 +503,14 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
           operatingModelId={team.operatingModel.id}
           onFormComplete={() => onUpdateOperatingModelFormClosed(true)}
           onFormCancel={() => onUpdateOperatingModelFormClosed(false)}
+        />
+      )}
+      {openAddMemberForm && team?.isActive && (
+        <AddTeamMemberForm
+          teamId={team.id!}
+          teamType="Team"
+          onFormComplete={() => setOpenAddMemberForm(false)}
+          onFormCancel={() => setOpenAddMemberForm(false)}
         />
       )}
     </>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -25,6 +25,7 @@ import { notFound, usePathname } from 'next/navigation'
 import {
   retrieveTeam,
   setEditMode,
+  resetTeamDetail,
   selectEditTeamContext,
 } from '../../../../store/features/organizations/team-slice'
 import { useAppDispatch, useAppSelector } from '@/src/hooks'
@@ -146,7 +147,6 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
   const {
     item,
     error,
-    isLoading: teamIsLoading,
     isInEditMode,
     notFound: teamNotFound,
   } = useAppSelector(selectEditTeamContext)
@@ -364,6 +364,7 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
   }
 
   useEffect(() => {
+    dispatch(resetTeamDetail())
     dispatch(retrieveTeam({ key: teamKey, type: 'Team' }))
   }, [teamKey, dispatch])
 
@@ -455,7 +456,7 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
     }
   }
 
-  if (!teamIsLoading && teamNotFound) {
+  if (teamNotFound) {
     return notFound()
   }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -146,6 +146,7 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
   const {
     item,
     error,
+    isLoading: teamIsLoading,
     isInEditMode,
     notFound: teamNotFound,
   } = useAppSelector(selectEditTeamContext)
@@ -454,7 +455,7 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
     }
   }
 
-  if (teamNotFound) {
+  if (!teamIsLoading && teamNotFound) {
     return notFound()
   }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-members-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-members-grid.tsx
@@ -14,16 +14,12 @@ import {
   useGetTeamOfTeamsMembersQuery,
 } from '@/src/store/features/organization/team-members-api'
 import { useGetTeamMemberRolesQuery } from '@/src/store/features/organization/team-member-roles-api'
-import AddTeamMemberForm from './add-team-member-form'
 import EditTeamMemberForm from './edit-team-member-form'
 import RemoveTeamMemberForm from './remove-team-member-form'
 
 interface TeamMembersGridProps {
   teamId: string
   teamType: 'Team' | 'TeamOfTeams'
-  teamIsActive: boolean
-  openAddForm?: boolean
-  onAddFormClose?: () => void
 }
 
 const NameCellRenderer = ({ data }: ICellRendererParams<TeamMemberDto>) => {
@@ -38,9 +34,6 @@ const NameCellRenderer = ({ data }: ICellRendererParams<TeamMemberDto>) => {
 const TeamMembersGrid = ({
   teamId,
   teamType,
-  teamIsActive,
-  openAddForm,
-  onAddFormClose,
 }: TeamMembersGridProps) => {
   const [editingMember, setEditingMember] = useState<TeamMemberDto | null>(null)
   const [removingMember, setRemovingMember] = useState<TeamMemberDto | null>(
@@ -161,17 +154,6 @@ const TeamMembersGrid = ({
           refetch()
         }}
       />
-      {openAddForm && teamIsActive && (
-        <AddTeamMemberForm
-          teamId={teamId}
-          teamType={teamType}
-          onFormComplete={() => {
-            onAddFormClose?.()
-            refetch()
-          }}
-          onFormCancel={() => onAddFormClose?.()}
-        />
-      )}
       {editingMember && (
         <EditTeamMemberForm
           teamId={teamId}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/edit-project-task-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/edit-project-task-form.tsx
@@ -164,7 +164,7 @@ const EditProjectTaskForm = ({
       priority: taskData.priority?.id,
       assigneeIds: taskData.assignees.map((a: any) => a.id),
       progress: taskData.progress,
-      parentId: taskData.parent?.id,
+      parentId: taskData.parent?.id ?? taskData.projectPhaseId,
       plannedRange,
       plannedDate: taskData.plannedDate
         ? dayjs(taskData.plannedDate)

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-plan-table.columns.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-plan-table.columns.tsx
@@ -227,7 +227,7 @@ export const getProjectPlanTableColumns = ({
     {
       accessorKey: 'key',
       header: 'Key',
-      size: 120,
+      size: 140,
       enableColumnFilter: true,
       filterFn: 'includesString',
       sortingFn: 'alphanumeric',

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/crud-slice.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/crud-slice.ts
@@ -203,6 +203,15 @@ const createCrudSlice = <
           state.detail.validationErrors = []
         }
       },
+      resetDetail(state) {
+        ;(state.detail.item as TDetail | null) = null
+        state.detail.isLoading = false
+        state.detail.notFound = false
+        state.detail.isSaving = false
+        state.detail.isInEditMode = false
+        state.detail.validationErrors = []
+        state.detail.error = null
+      },
       ...options.reducers,
     },
     extraReducers: (builder) => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/organizations/team-slice.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/organizations/team-slice.ts
@@ -115,6 +115,7 @@ const teamSlice = createCrudSlice({
 export const {
   setIncludeInactive,
   setEditMode,
+  resetDetail: resetTeamDetail,
   getData: retrieveTeams,
   getDetail: retrieveTeam,
   refreshDetail: refreshActiveTeam,


### PR DESCRIPTION
- Filter sprints to require non-null TeamId in query

Other
- Change default error status to 500 in ExceptionMiddleware
- Improve parentId fallback and widen Key column in table
- Refactor: move AddTeamMemberForm to parent pages
- Update team links and improve notFound handling in pages