### PR TITLE
Feature/initial setup process

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Application/Identity/Bootstrap/IBootstrapTokenService.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/Bootstrap/IBootstrapTokenService.cs
@@ -11,8 +11,14 @@ public interface IBootstrapTokenService
     bool IsActive { get; }
 
     /// <summary>
-    /// Validates the supplied token and, if valid, consumes it (preventing reuse).
+    /// Validates the supplied token without consuming it.
     /// Returns false if no token is active or the token does not match.
     /// </summary>
-    bool TryConsume(string token);
+    bool Validate(string token);
+
+    /// <summary>
+    /// Invalidates the active token, preventing any further use.
+    /// Should be called after setup completes successfully.
+    /// </summary>
+    void Consume();
 }

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/Bootstrap/IBootstrapTokenService.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/Bootstrap/IBootstrapTokenService.cs
@@ -1,0 +1,18 @@
+namespace Wayd.Common.Application.Identity.Bootstrap;
+
+/// <summary>
+/// Manages the one-time bootstrap token used to create the first admin user.
+/// The token is generated in-memory on startup when no users exist, logged to
+/// the console, and consumed exactly once via POST /api/auth/setup.
+/// </summary>
+public interface IBootstrapTokenService
+{
+    /// <summary>Returns true if a bootstrap token is currently active.</summary>
+    bool IsActive { get; }
+
+    /// <summary>
+    /// Validates the supplied token and, if valid, consumes it (preventing reuse).
+    /// Returns false if no token is active or the token does not match.
+    /// </summary>
+    bool TryConsume(string token);
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/Users/CreateUserCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/Users/CreateUserCommand.cs
@@ -9,6 +9,7 @@ public sealed record CreateUserCommand
     public Guid? EmployeeId { get; set; }
     public string LoginProvider { get; set; } = null!;
     public string? Password { get; set; }
+    public bool MustChangePassword { get; set; } = true;
 }
 
 public sealed class CreateUserCommandValidator : CustomValidator<CreateUserCommand>

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapService.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -20,8 +21,7 @@ internal static class BootstrapService
         using var scope = services.CreateScope();
         var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
 
-        var userCount = userManager.Users.Count();
-        if (userCount > 0)
+        if (await userManager.Users.AnyAsync(cancellationToken))
             return;
 
         var token = tokenService.Generate();

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapService.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Wayd.Infrastructure.Auth.Bootstrap;
+
+internal static class BootstrapService
+{
+    /// <summary>
+    /// Called once after database initialization. If no users exist, generates
+    /// a one-time setup token and logs it prominently so the operator can hit
+    /// POST /api/auth/setup to create the first admin account.
+    /// </summary>
+    internal static async Task RunAsync(
+        IServiceProvider services,
+        BootstrapTokenService tokenService,
+        ILogger logger,
+        CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var userManager = scope.ServiceProvider.GetRequiredService<UserManager<ApplicationUser>>();
+
+        var userCount = userManager.Users.Count();
+        if (userCount > 0)
+            return;
+
+        var token = tokenService.Generate();
+
+        logger.LogWarning(
+            """
+
+            ============================================================
+             WAYD FIRST-RUN SETUP
+            ============================================================
+             No users exist. Use the token below to create the first
+             admin account.
+
+             UI:    <your-app-url>/setup
+             API:   POST /api/auth/setup
+
+             Token: {Token}
+
+             This token is valid for the lifetime of this process only.
+             Restart the application to generate a new token.
+            ============================================================
+            """,
+            token);
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapTokenService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapTokenService.cs
@@ -5,8 +5,9 @@ namespace Wayd.Infrastructure.Auth.Bootstrap;
 
 /// <summary>
 /// Singleton. Holds a one-time bootstrap token in memory, generated only when
-/// the database has no users. The token is consumed on first successful use and
-/// is never persisted or logged in full — only printed to stdout on startup.
+/// the database has no users. The token is consumed on first successful use.
+/// It is printed in full to the application log on startup — operators should
+/// be aware it may be captured by any configured log sinks (Seq, App Insights, etc.).
 /// </summary>
 internal sealed class BootstrapTokenService : IBootstrapTokenService
 {
@@ -16,7 +17,8 @@ internal sealed class BootstrapTokenService : IBootstrapTokenService
 
     /// <summary>
     /// Generates and stores the bootstrap token. Must be called once from the
-    /// startup path when user count is confirmed to be zero.
+    /// startup path when user count is confirmed to be zero. The returned value
+    /// is printed to the application log and may be captured by configured log sinks.
     /// </summary>
     internal string Generate()
     {
@@ -26,19 +28,16 @@ internal sealed class BootstrapTokenService : IBootstrapTokenService
         return _token;
     }
 
-    public bool TryConsume(string token)
+    public bool Validate(string token)
     {
         if (_token is null)
             return false;
 
         // Constant-time comparison to prevent timing attacks.
-        var match = CryptographicOperations.FixedTimeEquals(
+        return CryptographicOperations.FixedTimeEquals(
             System.Text.Encoding.UTF8.GetBytes(token),
             System.Text.Encoding.UTF8.GetBytes(_token));
-
-        if (match)
-            _token = null;
-
-        return match;
     }
+
+    public void Consume() => _token = null;
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapTokenService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Bootstrap/BootstrapTokenService.cs
@@ -1,0 +1,44 @@
+using System.Security.Cryptography;
+using Wayd.Common.Application.Identity.Bootstrap;
+
+namespace Wayd.Infrastructure.Auth.Bootstrap;
+
+/// <summary>
+/// Singleton. Holds a one-time bootstrap token in memory, generated only when
+/// the database has no users. The token is consumed on first successful use and
+/// is never persisted or logged in full — only printed to stdout on startup.
+/// </summary>
+internal sealed class BootstrapTokenService : IBootstrapTokenService
+{
+    private string? _token;
+
+    public bool IsActive => _token is not null;
+
+    /// <summary>
+    /// Generates and stores the bootstrap token. Must be called once from the
+    /// startup path when user count is confirmed to be zero.
+    /// </summary>
+    internal string Generate()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        _token = Convert.ToBase64String(bytes);
+        return _token;
+    }
+
+    public bool TryConsume(string token)
+    {
+        if (_token is null)
+            return false;
+
+        // Constant-time comparison to prevent timing attacks.
+        var match = CryptographicOperations.FixedTimeEquals(
+            System.Text.Encoding.UTF8.GetBytes(token),
+            System.Text.Encoding.UTF8.GetBytes(_token));
+
+        if (match)
+            _token = null;
+
+        return match;
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/ConfigureServices.cs
@@ -2,7 +2,9 @@
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Wayd.Common.Application.Identity.Bootstrap;
 using Wayd.Infrastructure.Auth.AzureAd;
+using Wayd.Infrastructure.Auth.Bootstrap;
 using Wayd.Infrastructure.Auth.Local;
 using Wayd.Infrastructure.Auth.Oidc;
 using Wayd.Infrastructure.Auth.Permissions;
@@ -14,6 +16,9 @@ internal static class ConfigureServices
 {
     internal static IServiceCollection AddAuth(this IServiceCollection services, IConfiguration config, IHostEnvironment environment)
     {
+        services.AddSingleton<BootstrapTokenService>();
+        services.AddSingleton<IBootstrapTokenService>(sp => sp.GetRequiredService<BootstrapTokenService>());
+
         return services
             .AddCurrentUser()
             .AddPermissions()

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Wayd.Infrastructure.FeatureManagement;
 using Wayd.Infrastructure.Logging;
 using Wayd.Infrastructure.OpenTelemetry;
@@ -126,6 +127,17 @@ public static class ConfigureServices
 
         await scope.ServiceProvider.GetRequiredService<IDatabaseInitializer>()
             .InitializeDatabase(cancellationToken);
+    }
+
+    /// <summary>
+    /// Must be called after <see cref="InitializeDatabases"/>.
+    /// Generates and logs a one-time setup token when no users exist.
+    /// </summary>
+    public static async Task RunBootstrapCheck(this IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        var tokenService = services.GetRequiredService<Wayd.Infrastructure.Auth.Bootstrap.BootstrapTokenService>();
+        var logger = services.GetRequiredService<ILogger<Wayd.Infrastructure.Auth.Bootstrap.BootstrapTokenService>>();
+        await Wayd.Infrastructure.Auth.Bootstrap.BootstrapService.RunAsync(services, tokenService, logger, cancellationToken);
     }
 
     public static IApplicationBuilder UseInfrastructure(this IApplicationBuilder builder, IConfiguration config) =>

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -478,7 +478,7 @@ internal partial class UserService
             EmployeeId = command.EmployeeId,
             PhoneNumber = command.PhoneNumber,
             LoginProvider = command.LoginProvider,
-            MustChangePassword = command.LoginProvider == LoginProviders.Wayd,
+            MustChangePassword = command.LoginProvider == LoginProviders.Wayd && command.MustChangePassword,
         };
 
         // User creation, role assignment, and the Wayd identity row must land

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/AuthController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/AuthController.cs
@@ -73,7 +73,7 @@ public class AuthController(
         if (!_bootstrapTokenService.IsActive)
             return Conflict(ProblemDetailsExtensions.ForConflict("Setup has already been completed.", HttpContext));
 
-        if (!_bootstrapTokenService.TryConsume(request.Token))
+        if (!_bootstrapTokenService.Validate(request.Token))
             return BadRequest(ProblemDetailsExtensions.ForBadRequest("Invalid setup token.", HttpContext));
 
         // Double-check that no users exist — prevents a race where two concurrent
@@ -100,6 +100,11 @@ public class AuthController(
         await _userService.AssignRolesAsync(
             new AssignUserRolesCommand(userId, [ApplicationRoles.Admin]),
             cancellationToken);
+
+        // Consume the token only after successful user creation so a failed
+        // attempt (e.g. validation error, duplicate email) doesn't force the
+        // operator to restart the application to get a new token.
+        _bootstrapTokenService.Consume();
 
         var token = await _tokenService.GetTokenAsync(
             new LoginCommand(request.Email, request.Password),

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/AuthController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/AuthController.cs
@@ -1,5 +1,9 @@
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authorization;
+using Wayd.Common.Application.Identity;
+using Wayd.Common.Application.Identity.Bootstrap;
 using Wayd.Common.Application.Identity.Tokens;
+using Wayd.Web.Api.Extensions;
+using Wayd.Web.Api.Models.UserManagement.Users;
 
 namespace Wayd.Web.Api.Controllers.UserManagement;
 
@@ -7,9 +11,14 @@ namespace Wayd.Web.Api.Controllers.UserManagement;
 [ApiVersionNeutral]
 [ApiController]
 [AllowAnonymous]
-public class AuthController(ITokenService tokenService) : ControllerBase
+public class AuthController(
+    ITokenService tokenService,
+    IBootstrapTokenService bootstrapTokenService,
+    IUserService userService) : ControllerBase
 {
     private readonly ITokenService _tokenService = tokenService;
+    private readonly IBootstrapTokenService _bootstrapTokenService = bootstrapTokenService;
+    private readonly IUserService _userService = userService;
 
     [HttpPost("login")]
     [OpenApiOperation("Authenticate with username and password.", "")]
@@ -52,5 +61,50 @@ public class AuthController(ITokenService tokenService) : ControllerBase
         // future secrets are deliberately not exposed here.
         var response = await _tokenService.GetAuthProviders(cancellationToken);
         return Ok(response);
+    }
+
+    [HttpPost("setup")]
+    [OpenApiOperation("Create the first admin user using the one-time bootstrap token.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<ActionResult<TokenResponse>> Setup(SetupRequest request, CancellationToken cancellationToken)
+    {
+        if (!_bootstrapTokenService.IsActive)
+            return Conflict(ProblemDetailsExtensions.ForConflict("Setup has already been completed.", HttpContext));
+
+        if (!_bootstrapTokenService.TryConsume(request.Token))
+            return BadRequest(ProblemDetailsExtensions.ForBadRequest("Invalid setup token.", HttpContext));
+
+        // Double-check that no users exist — prevents a race where two concurrent
+        // setup requests both pass the token check before one consumes it.
+        var userCount = await _userService.GetCountAsync(cancellationToken);
+        if (userCount > 0)
+            return Conflict(ProblemDetailsExtensions.ForConflict("Setup has already been completed.", HttpContext));
+
+        var createResult = await _userService.CreateAsync(new CreateUserCommand
+        {
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            Email = request.Email,
+            LoginProvider = LoginProviders.Wayd,
+            Password = request.Password,
+            MustChangePassword = false,
+        }, cancellationToken);
+
+        if (createResult.IsFailure)
+            return BadRequest(createResult.ToBadRequestObject(HttpContext));
+
+        var userId = createResult.Value;
+
+        await _userService.AssignRolesAsync(
+            new AssignUserRolesCommand(userId, [ApplicationRoles.Admin]),
+            cancellationToken);
+
+        var token = await _tokenService.GetTokenAsync(
+            new LoginCommand(request.Email, request.Password),
+            cancellationToken);
+
+        return Ok(token);
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Models/UserManagement/Users/SetupRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/UserManagement/Users/SetupRequest.cs
@@ -1,0 +1,10 @@
+namespace Wayd.Web.Api.Models.UserManagement.Users;
+
+public sealed record SetupRequest
+{
+    public string Token { get; set; } = null!;
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public string Email { get; set; } = null!;
+    public string Password { get; set; } = null!;
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Program.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Program.cs
@@ -6,6 +6,7 @@ using Wayd.Common.Application;
 using Wayd.Common.Application.Interfaces;
 using Wayd.Goals.Application;
 using Wayd.Infrastructure;
+using Wayd.Infrastructure.Auth;
 using Wayd.Infrastructure.Common;
 using Wayd.Links;
 using Wayd.Organization.Application;
@@ -74,6 +75,7 @@ try
     var app = builder.Build();
 
     await app.Services.InitializeDatabases();
+    await app.Services.RunBootstrapCheck();
 
     app.UseInfrastructure(builder.Configuration);
     app.MapDefaultEndpoints();

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -260,6 +260,59 @@
         }
       }
     },
+    "/api/auth/setup": {
+      "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Create the first admin user using the one-time bootstrap token.",
+        "operationId": "Auth_Setup",
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetupRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/user-management/oidc-providers": {
       "get": {
         "tags": [
@@ -22117,6 +22170,34 @@
             "items": {
               "type": "string"
             }
+          }
+        }
+      },
+      "SetupRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "token",
+          "firstName",
+          "lastName",
+          "email",
+          "password"
+        ],
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
           }
         }
       },

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/change-password-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/change-password-form.tsx
@@ -108,6 +108,9 @@ const ChangePasswordForm = ({
           rules={[
             { required: true, message: 'Please enter a new password.' },
             { min: 8, message: 'Password must be at least 8 characters.' },
+            { pattern: /[A-Z]/, message: 'Password must contain at least one uppercase letter.' },
+            { pattern: /[a-z]/, message: 'Password must contain at least one lowercase letter.' },
+            { pattern: /[0-9]/, message: 'Password must contain at least one digit.' },
             ({ getFieldValue }) => ({
               validator(_, value) {
                 if (!value || getFieldValue('currentPassword') !== value) {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/layout.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/layout.tsx
@@ -21,6 +21,7 @@ import { AuthProvider } from '../components/contexts/auth'
 import { MessageProvider } from '../components/contexts/messaging'
 import LoginPage from './login/page'
 import LogoutPage from './logout/page'
+import SetupPage from './setup/page'
 import { usePathname, useRouter } from 'next/navigation'
 import { isAuthActive } from '../services/clients'
 import ReleaseCleanup from '../components/release-cleanup'
@@ -122,13 +123,18 @@ const AuthGate = ({ children }: PropsWithChildren) => {
     pathname &&
     pathname !== '/' &&
     pathname !== '/login' &&
-    pathname !== '/logout'
+    pathname !== '/logout' &&
+    pathname !== '/setup'
   ) {
     sessionStorage.setItem(RETURN_URL_KEY, pathname)
   }
 
   if (pathname === '/logout') {
     return <LogoutPage />
+  }
+
+  if (pathname === '/setup') {
+    return <SetupPage />
   }
 
   return <LoginPage />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/setup/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/setup/page.tsx
@@ -1,0 +1,495 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { getAuthClient, setRememberMe, storeAuth } from '@/src/services/clients'
+import { useDocumentTitle } from '@/src/hooks'
+import { notFound } from 'next/navigation'
+
+function LoadingSpinner() {
+  return (
+    <svg
+      style={{ animation: 'spin 1s linear infinite' }}
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+    >
+      <style>{`@keyframes spin { from { transform: rotate(0deg); } to { transform: rotate(360deg); } }`}</style>
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        strokeWidth="3"
+        strokeLinecap="round"
+        strokeDasharray="31.4 31.4"
+      />
+    </svg>
+  )
+}
+
+export default function SetupPage() {
+  useDocumentTitle('Wayd Setup')
+
+  const [status, setStatus] = useState<'checking' | 'ready' | 'done' | 'unavailable'>('checking')
+  const [token, setToken] = useState('')
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [passwordFieldError, setPasswordFieldError] = useState('')
+  const [confirmFieldError, setConfirmFieldError] = useState('')
+  const [error, setError] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const checkStarted = useRef(false)
+
+  useEffect(() => {
+    if (checkStarted.current) return
+    checkStarted.current = true
+
+    // Check if bootstrap is available by attempting a GET-like probe.
+    // The setup endpoint returns 409 if already complete, 400 for bad token.
+    // We POST with an empty token — a 400 means the endpoint is live (token
+    // is active, just rejected), a 409 means already complete.
+    const probe = async () => {
+      try {
+        await getAuthClient().setup({ token: '', firstName: '', lastName: '', email: '', password: '' })
+        // Should not reach here on empty token, but if it does setup worked.
+        setStatus('done')
+      } catch (err: any) {
+        const status = err?.response?.status ?? err?.status
+        if (status === 400) {
+          // 400 = bad token, but the endpoint is active — bootstrap is available.
+          setStatus('ready')
+        } else if (status === 409) {
+          // Already complete.
+          setStatus('unavailable')
+        } else {
+          // Any other error (network, 500) — treat as unavailable.
+          setStatus('unavailable')
+        }
+      }
+    }
+    probe()
+  }, [])
+
+  const validatePassword = (pw: string): string => {
+    if (pw.length < 8) return 'Password must be at least 8 characters.'
+    if (!/[A-Z]/.test(pw)) return 'Password must contain at least one uppercase letter.'
+    if (!/[a-z]/.test(pw)) return 'Password must contain at least one lowercase letter.'
+    if (!/[0-9]/.test(pw)) return 'Password must contain at least one digit.'
+    return ''
+  }
+
+  const handlePasswordBlur = () => {
+    setPasswordFieldError(validatePassword(password))
+  }
+
+  const handleConfirmBlur = () => {
+    if (confirmPassword && password !== confirmPassword) {
+      setConfirmFieldError('Passwords do not match.')
+    } else {
+      setConfirmFieldError('')
+    }
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+
+    const pwErr = validatePassword(password)
+    if (pwErr) {
+      setPasswordFieldError(pwErr)
+      return
+    }
+    if (password !== confirmPassword) {
+      setConfirmFieldError('Passwords do not match.')
+      return
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const tokenResponse = await getAuthClient().setup({
+        token,
+        firstName,
+        lastName,
+        email,
+        password,
+      })
+      setRememberMe(true)
+      storeAuth(tokenResponse)
+      window.location.href = '/'
+    } catch (err: any) {
+      const message =
+        err?.response?.data?.detail ||
+        err?.detail ||
+        err?.message ||
+        'Setup failed. Check your token and try again.'
+      setError(message)
+      setIsSubmitting(false)
+    }
+  }
+
+  if (status === 'unavailable') {
+    notFound()
+  }
+
+  const isLoading = status === 'checking'
+
+  return (
+    <div style={styles.pageBackground}>
+      <div style={{...styles.bgCircle, top: -120, left: -100, width: 340, height: 340, background: 'rgba(255,255,255,0.06)'}} />
+      <div style={{...styles.bgCircle, bottom: -80, right: -60, width: 260, height: 260, background: 'rgba(255,255,255,0.05)'}} />
+
+      <div style={styles.card}>
+        {/* Left panel */}
+        <div style={styles.leftPanel}>
+          <div style={styles.leftPanelText}>
+            <h2 style={styles.leftPanelTitle}>First-time setup</h2>
+            <p style={styles.leftPanelDescription}>
+              Create the first administrator account to get started. You&apos;ll
+              use this account to configure identity providers and invite your
+              team.
+            </p>
+          </div>
+          <ol style={styles.steps}>
+            <li style={styles.step}><span style={styles.stepNum}>1</span> Create admin account</li>
+            <li style={styles.step}><span style={styles.stepNum}>2</span> Configure identity provider</li>
+            <li style={styles.step}><span style={styles.stepNum}>3</span> Invite your team</li>
+          </ol>
+        </div>
+
+        {/* Right panel */}
+        <div style={styles.rightPanel}>
+          <div style={styles.rightPanelContent}>
+            <div style={styles.logo}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src="/wayd-icon.png" alt="wayd" style={styles.logoIcon} />
+              <div style={styles.logoDivider} />
+              <span style={styles.logoText}>wayd</span>
+            </div>
+
+            <h1 style={styles.title}>Welcome</h1>
+            <p style={styles.subtitle}>
+              Enter the setup token from your server logs to create the first admin account.
+            </p>
+
+            {isLoading ? (
+              <div style={styles.loadingRow}>
+                <LoadingSpinner />
+                <span style={styles.loadingText}>Checking setup status…</span>
+              </div>
+            ) : (
+              <form onSubmit={handleSubmit} style={styles.form} noValidate>
+                <input
+                  type="text"
+                  placeholder="Setup token (from server logs)"
+                  value={token}
+                  onChange={(e) => setToken(e.target.value)}
+                  style={styles.input}
+                  required
+                  disabled={isSubmitting}
+                  autoComplete="off"
+                />
+
+                <div style={styles.nameRow}>
+                  <input
+                    type="text"
+                    placeholder="First name"
+                    value={firstName}
+                    onChange={(e) => setFirstName(e.target.value)}
+                    style={styles.input}
+                    required
+                    disabled={isSubmitting}
+                    autoComplete="given-name"
+                  />
+                  <input
+                    type="text"
+                    placeholder="Last name"
+                    value={lastName}
+                    onChange={(e) => setLastName(e.target.value)}
+                    style={styles.input}
+                    required
+                    disabled={isSubmitting}
+                    autoComplete="family-name"
+                  />
+                </div>
+
+                <input
+                  type="email"
+                  placeholder="Email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  style={styles.input}
+                  required
+                  disabled={isSubmitting}
+                  autoComplete="email"
+                />
+                <input
+                  type="password"
+                  placeholder="Password"
+                  value={password}
+                  onChange={(e) => { setPassword(e.target.value); setPasswordFieldError('') }}
+                  onBlur={handlePasswordBlur}
+                  style={{...styles.input, ...(passwordFieldError ? styles.inputError : {})}}
+                  disabled={isSubmitting}
+                  autoComplete="new-password"
+                />
+                {passwordFieldError && <div style={styles.fieldError} role="alert">{passwordFieldError}</div>}
+                <input
+                  type="password"
+                  placeholder="Confirm password"
+                  value={confirmPassword}
+                  onChange={(e) => { setConfirmPassword(e.target.value); setConfirmFieldError('') }}
+                  onBlur={handleConfirmBlur}
+                  style={{...styles.input, ...(confirmFieldError ? styles.inputError : {})}}
+                  disabled={isSubmitting}
+                  autoComplete="new-password"
+                />
+                {confirmFieldError && <div style={styles.fieldError} role="alert">{confirmFieldError}</div>}
+
+                {error && <div style={styles.errorMessage} role="alert">{error}</div>}
+
+                <button
+                  type="submit"
+                  disabled={isSubmitting || !token || !firstName || !lastName || !email || !password || !confirmPassword}
+                  style={{
+                    ...styles.submitButton,
+                    ...(isSubmitting ? styles.submitButtonDisabled : {}),
+                  }}
+                >
+                  {isSubmitting ? (
+                    <span style={styles.buttonInner}>
+                      <LoadingSpinner />
+                      Creating account…
+                    </span>
+                  ) : (
+                    'Create admin account'
+                  )}
+                </button>
+              </form>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  pageBackground: {
+    position: 'fixed',
+    top: 0, left: 0, right: 0, bottom: 0,
+    width: '100%',
+    height: '100dvh',
+    overflowX: 'hidden',
+    overflowY: 'auto',
+    fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
+    background: 'linear-gradient(135deg, #42a5f5 0%, #2196f3 40%, #1976d2 100%)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '40px 20px',
+  },
+  bgCircle: {
+    position: 'absolute',
+    borderRadius: '50%',
+    pointerEvents: 'none',
+  },
+  card: {
+    display: 'flex',
+    width: 'min(66vw, 1100px)',
+    minWidth: 680,
+    minHeight: 'min(82vh, 600px)',
+    borderRadius: 8,
+    overflow: 'hidden',
+    boxShadow: '0 25px 60px rgba(13, 71, 161, 0.35)',
+  },
+  leftPanel: {
+    flex: '1 1 45%',
+    minWidth: 0,
+    background: 'linear-gradient(160deg, #0d47a1 0%, #1565c0 100%)',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '48px 32px',
+  },
+  leftPanelText: {
+    textAlign: 'center',
+    marginBottom: 40,
+  },
+  leftPanelTitle: {
+    color: '#fff',
+    fontSize: 22,
+    fontWeight: 700,
+    letterSpacing: -0.3,
+    marginBottom: 12,
+  },
+  leftPanelDescription: {
+    color: 'rgba(187, 222, 251, 0.75)',
+    fontSize: 13,
+    maxWidth: 260,
+    margin: '0 auto',
+    lineHeight: 1.6,
+  },
+  steps: {
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    width: '100%',
+    maxWidth: 220,
+  },
+  step: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    color: 'rgba(187, 222, 251, 0.85)',
+    fontSize: 14,
+    fontWeight: 500,
+  },
+  stepNum: {
+    width: 28,
+    height: 28,
+    borderRadius: '50%',
+    background: 'rgba(255,255,255,0.15)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    fontSize: 12,
+    fontWeight: 700,
+    color: '#fff',
+    flexShrink: 0,
+  },
+  rightPanel: {
+    flex: '1 1 55%',
+    minWidth: 0,
+    background: '#fff',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: '40px 48px',
+  },
+  rightPanelContent: {
+    width: '100%',
+    maxWidth: 380,
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  },
+  logo: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 16,
+    marginBottom: 32,
+  },
+  logoIcon: {
+    width: 48,
+    height: 48,
+    objectFit: 'contain',
+  },
+  logoDivider: {
+    width: 1,
+    height: 40,
+    background: '#90caf9',
+  },
+  logoText: {
+    fontSize: 32,
+    fontWeight: 600,
+    color: '#1976d2',
+    letterSpacing: -0.5,
+  },
+  title: {
+    fontSize: 26,
+    fontWeight: 700,
+    color: '#0d47a1',
+    letterSpacing: -0.5,
+    marginBottom: 8,
+    textAlign: 'center',
+  },
+  subtitle: {
+    fontSize: 13.5,
+    color: '#6b7280',
+    textAlign: 'center',
+    lineHeight: 1.5,
+    maxWidth: 300,
+    marginBottom: 32,
+  },
+  loadingRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 12,
+    color: '#6b7280',
+  },
+  loadingText: {
+    fontSize: 14,
+  },
+  form: {
+    width: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  nameRow: {
+    display: 'flex',
+    gap: 12,
+  },
+  input: {
+    width: '100%',
+    padding: '12px 16px',
+    border: '1.5px solid #bbdefb',
+    borderRadius: 4,
+    fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
+    fontSize: 14,
+    color: '#0d47a1',
+    background: '#fff',
+    outline: 'none',
+    boxSizing: 'border-box',
+    transition: 'border-color 0.2s, box-shadow 0.2s',
+  },
+  submitButton: {
+    width: '100%',
+    padding: '14px 24px',
+    border: 'none',
+    borderRadius: 4,
+    background: '#1976d2',
+    color: '#fff',
+    fontFamily: "'Segoe UI', system-ui, -apple-system, sans-serif",
+    fontSize: 15,
+    fontWeight: 600,
+    cursor: 'pointer',
+    transition: 'background 0.2s, transform 0.15s',
+    marginTop: 4,
+  },
+  submitButtonDisabled: {
+    opacity: 0.7,
+    cursor: 'not-allowed',
+  },
+  buttonInner: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 10,
+  },
+  inputError: {
+    borderColor: '#d32f2f',
+  },
+  fieldError: {
+    color: '#d32f2f',
+    fontSize: 12,
+    marginTop: -4,
+  },
+  errorMessage: {
+    color: '#d32f2f',
+    fontSize: 13,
+    padding: '8px 12px',
+    background: '#fce4ec',
+    borderRadius: 4,
+    textAlign: 'center',
+  },
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -774,6 +774,75 @@ export class AuthClient {
         }
         return Promise.resolve<AuthProvidersResponse>(null as any);
     }
+
+    /**
+     * Create the first admin user using the one-time bootstrap token.
+     */
+    setup(request: SetupRequest, cancelToken?: CancelToken): Promise<TokenResponse> {
+        let url_ = this.baseUrl + "/api/auth/setup";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processSetup(_response);
+        });
+    }
+
+    protected processSetup(response: AxiosResponse): Promise<TokenResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<TokenResponse>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 409) {
+            const _responseText = response.data;
+            let result409: any = null;
+            let resultData409  = _responseText;
+            result409 = resultData409;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result409);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<TokenResponse>(null as any);
+    }
 }
 
 export class OidcProvidersClient {
@@ -26118,6 +26187,14 @@ export interface OidcProviderInfo {
     authority: string;
     clientId: string;
     scopes: string[];
+}
+
+export interface SetupRequest {
+    token: string;
+    firstName: string;
+    lastName: string;
+    email: string;
+    password: string;
 }
 
 export interface OidcProviderListItemDto {

--- a/docs/contributing/configuration.mdx
+++ b/docs/contributing/configuration.mdx
@@ -22,6 +22,10 @@ Wayd supports two authentication paths:
 - **Local (username + password)** — always available, configured per-deployment via JWT signing settings.
 - **Identity providers (OIDC)** — Microsoft Entra ID and any standards-compliant OIDC provider (Google, Okta, Auth0, Keycloak, …). Providers are stored in the database and managed by admins through the Settings UI; no app restart is needed to add, edit, enable, or disable one.
 
+:::tip First deployment?
+If this is a fresh deployment with no users yet, see [First-Run Setup](./first-run-setup.mdx) to create the initial administrator account before configuring identity providers.
+:::
+
 ### Identity providers (DB-managed)
 
 Each row in the `Identity.OidcProviders` table is one configured provider — its discovery `Authority`, public `ClientId`, expected token `Audience`, scopes, and (for Entra) the allowed-tenant list. The token-exchange endpoint resolves provider metadata from this table on every request, with a short cache TTL and explicit invalidation on admin writes.

--- a/docs/contributing/first-run-setup.mdx
+++ b/docs/contributing/first-run-setup.mdx
@@ -1,0 +1,80 @@
+---
+title: First-Run Setup
+description: How to create the first administrator account on a fresh Wayd deployment.
+sidebar_position: 4
+audience: [developer, operator]
+---
+
+# First-Run Setup
+
+When Wayd starts with an empty database it generates a one-time **bootstrap token** and prints it to the application log. This token lets you create the first administrator account without any pre-existing credentials — solving the chicken-and-egg problem of needing an admin to configure identity providers.
+
+Once an admin account exists the token is invalidated and the setup page returns 404.
+
+## Step 1 — Start the application
+
+Run Wayd using any of the [standard options](./installation.mdx#run-the-application). On first boot you will see a message like this in the logs:
+
+```
+============================================================
+ WAYD FIRST-RUN SETUP
+============================================================
+ No users exist. Use the token below to create the first
+ admin account.
+
+ UI:    <your-app-url>/setup
+ API:   POST /api/auth/setup
+
+ Token: <bootstrap-token>
+
+ This token is valid for the lifetime of this process only.
+ Restart the application to generate a new token.
+============================================================
+```
+
+Copy the token value — you will need it in the next step.
+
+## Step 2 — Complete setup
+
+Navigate to `<your-app-url>/setup` in a browser. The page will not load (404) if setup has already been completed.
+
+Fill in the form:
+
+| Field | Notes |
+| --- | --- |
+| **Setup token** | Paste the token from the server log |
+| **First name / Last name** | Your name |
+| **Email** | Used as your login username |
+| **Password** | Must be at least 8 characters, with at least one uppercase letter, one lowercase letter, and one digit |
+| **Confirm password** | Must match exactly |
+
+Click **Create admin account**. On success you are logged in immediately as an administrator with no forced password change.
+
+## Step 3 — Configure authentication
+
+With your admin account you can now:
+
+- **Add an identity provider** — Settings → Identity Providers. Lets your team log in via Microsoft Entra ID or another OIDC provider. See [Configuration → Identity providers](./configuration.mdx#identity-providers-db-managed).
+- **Invite users** — Settings → Users → Create user.
+
+:::tip Token expired?
+The bootstrap token lives only in memory. If you restart the application before completing setup, a new token is generated and printed again.
+:::
+
+:::note API alternative
+If you prefer to complete setup without a browser, POST directly to the API:
+
+```bash
+curl -X POST <api-url>/api/auth/setup \
+  -H "Content-Type: application/json" \
+  -d '{
+    "token": "<bootstrap-token>",
+    "firstName": "Admin",
+    "lastName": "User",
+    "email": "admin@example.com",
+    "password": "YourPassword1"
+  }'
+```
+
+A successful response returns a Wayd JWT + refresh token identical to a normal login response.
+:::

--- a/docs/contributing/installation.mdx
+++ b/docs/contributing/installation.mdx
@@ -74,3 +74,9 @@ Access points:
 - API: `https://localhost:5001`
 - Client: `http://localhost:5002`
 - Seq (logs): `http://localhost:8081`
+
+## First-Run Setup
+
+On first boot with an empty database, Wayd prints a one-time bootstrap token to the log. Navigate to `/setup` in your browser and use the token to create the first administrator account.
+
+See [First-Run Setup](./first-run-setup.mdx) for the full walkthrough.


### PR DESCRIPTION
## Summary

Solves the chicken-and-egg problem of needing an admin account to configure identity providers on a fresh deployment, when there's no way to log in yet.

On startup with an empty database, a one-time cryptographically random token is generated in-memory and printed prominently to the application log. The token can be used at `POST /api/auth/setup` or via the new `/setup` UI page to create the first administrator account. Once any user exists, the token is never generated again and the `/setup` page returns 404.

## Changes

### Backend
- `IBootstrapTokenService` / `BootstrapTokenService` — singleton in-memory token, consumed exactly once, constant-time comparison to prevent timing attacks
- `BootstrapService` — checks user count post-migrations, generates and logs the token with both UI and API paths
- `POST /api/auth/setup` — anonymous endpoint; validates token, double-checks zero users, creates user, assigns Admin role, returns JWT so the admin is immediately logged in
- `CreateUserCommand.MustChangePassword` — defaults `true`; setup passes `false` so the bootstrap admin isn't forced to change their password on first login
- Password policy rules (uppercase, lowercase, digit) added to the change-password form to match backend `CreateUserCommandValidator`

### Frontend
- `/setup` page — matches login page visual style, probes the API on load and calls `notFound()` if bootstrap isn't active, inline blur validation for password policy and confirm-password mismatch
- `AuthGate` — `/setup` bypasses the auth gate (same pattern as `/login` and `/logout`)

### Docs
- New `contributing/first-run-setup.mdx` — full operator walkthrough including token location, form fields, and a `curl` alternative for headless environments
- `installation.mdx` — "First-Run Setup" section added after "Run the Application"
- `configuration.mdx` — callout tip directing fresh deployments to the setup guide before configuring identity providers
