### PR TITLE
Sync and surface Azure DevOps Work Item Tags

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Application/Interfaces/ExternalWork/IExternalWorkItem.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Interfaces/ExternalWork/IExternalWorkItem.cs
@@ -20,4 +20,5 @@ public interface IExternalWorkItem
     string? ExternalTeamIdentifier { get; }
     int? IterationId { get; }
     double? StoryPoints { get; }
+    IReadOnlyCollection<string> Tags { get; }
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260521130503_AddWorkItemTags.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260521130503_AddWorkItemTags.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260521130503_AddWorkItemTags")]
+    partial class AddWorkItemTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260521130503_AddWorkItemTags.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260521130503_AddWorkItemTags.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddWorkItemTags : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "Tags",
+            schema: "Work",
+            table: "WorkItems",
+            type: "nvarchar(max)",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Tags",
+            schema: "Work",
+            table: "WorkItems");
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -175,6 +175,11 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
         builder.Property(w => w.ActivatedTimestamp);
         builder.Property(w => w.DoneTimestamp);
 
+        builder.OwnsMany(w => w.Tags, t =>
+        {
+            t.ToJson();
+            t.UsePropertyAccessMode(PropertyAccessMode.Field);
+        });
 
         // Relationships
         builder.HasOne(w => w.Type)

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/WorkConfiguration.cs
@@ -180,6 +180,9 @@ public class WorkItemConfig : IEntityTypeConfiguration<WorkItem>
             t.ToJson();
             t.UsePropertyAccessMode(PropertyAccessMode.Field);
         });
+        builder.Navigation(w => w.Tags)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+        builder.Navigation(w => w.Tags).Metadata.SetField("_tags");
 
         // Relationships
         builder.HasOne(w => w.Type)

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/Contracts/AzdoWorkItem.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/Contracts/AzdoWorkItem.cs
@@ -23,4 +23,5 @@ public sealed record AzdoWorkItem : IExternalWorkItem
     public string? ExternalTeamIdentifier { get; set; }
     public int? IterationId { get; set; }
     public double? StoryPoints { get; set; }
+    public IReadOnlyCollection<string> Tags { get; set; } = [];
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemFieldsResponse.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemFieldsResponse.cs
@@ -48,4 +48,7 @@ internal class WorkItemFieldsResponse
 
     [JsonPropertyName("Microsoft.VSTS.Common.ClosedDate")]
     public DateTime? ClosedDate { get; set; }
+
+    [JsonPropertyName("System.Tags")]
+    public string? Tags { get; set; }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
@@ -56,6 +56,9 @@ internal static class WorkItemResponseExtensions
             ExternalTeamIdentifier = iteration.Identifier.ToString(),
             IterationId = workItem.Fields.IterationId,
             StoryPoints = storyPoints,
+            Tags = string.IsNullOrWhiteSpace(workItem.Fields.Tags)
+                ? []
+                : [.. workItem.Fields.Tags.Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)],
         };
     }
 

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/WorkItemService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/WorkItemService.cs
@@ -45,7 +45,8 @@ internal sealed class WorkItemService(string organizationUrl, string token, stri
                 "Microsoft.VSTS.Common.StackRank",
                 "Microsoft.VSTS.Scheduling.StoryPoints",
                 "Microsoft.VSTS.Common.ActivatedDate",
-                "Microsoft.VSTS.Common.ClosedDate"
+                "Microsoft.VSTS.Common.ClosedDate",
+                "System.Tags"
             ];
 
             var workitems = await _workItemClient.GetWorkItems(projectName, workItemIds, fields, cancellationToken).ConfigureAwait(false);

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Commands/SyncExternalWorkItemsCommandHandler.cs
@@ -5,6 +5,7 @@ using Wayd.Common.Domain.Enums.Work;
 using Wayd.Work.Application.Persistence;
 using Wayd.Work.Application.WorkItems.Dtos;
 using Wayd.Work.Domain.Interfaces;
+using Wayd.Work.Domain.Models;
 
 namespace Wayd.Work.Application.WorkItems.Commands;
 
@@ -225,7 +226,8 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
                                 iterationId,
                                 externalWorkItem.ActivatedTimestamp,
                                 externalWorkItem.DoneTimestamp,
-                                externalWorkItem.ExternalTeamIdentifier
+                                externalWorkItem.ExternalTeamIdentifier,
+                                [.. externalWorkItem.Tags.Select(t => new WorkItemTag(t))]
                             );
                             newWorkItems.Add(workItem);
 
@@ -251,7 +253,8 @@ internal sealed class SyncExternalWorkItemsCommandHandler(IWorkDbContext workDbC
                                 iterationId,
                                 externalWorkItem.ActivatedTimestamp,
                                 externalWorkItem.DoneTimestamp,
-                                CreateExtendedPropsIfNeeded(workItem.Id, externalWorkItem.ExternalTeamIdentifier)
+                                CreateExtendedPropsIfNeeded(workItem.Id, externalWorkItem.ExternalTeamIdentifier),
+                                [.. externalWorkItem.Tags.Select(t => new WorkItemTag(t))]
                             );
 
                             syncLog.ItemUpdated();

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/SprintBacklogItemDto.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/SprintBacklogItemDto.cs
@@ -36,6 +36,7 @@ public sealed record SprintBacklogItemDto : IMapFrom<WorkItem>
     // This is used to set the rank of the work items in the backlog
     public double StackRank { get; set; }
     public double? StoryPoints { get; set; }
+    public List<string> Tags { get; set; } = [];
 
     public double? CycleTime => Activated.HasValue && Done.HasValue && !Activated.Value.Equals(Done.Value) && StatusCategory?.Id == DoneStatusCategoryId
         ? (Done.Value - Activated.Value).ToTimeSpan().TotalDays
@@ -57,6 +58,7 @@ public sealed record SprintBacklogItemDto : IMapFrom<WorkItem>
                 : src.ParentProject != null
                     ? src.ParentProject
                     : null)
-            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
+            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}")
+            .Map(dest => dest.Tags, src => src.Tags.Select(t => t.Value).ToList());
     }
 }

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/WorkItemBacklogItemDto.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/WorkItemBacklogItemDto.cs
@@ -30,6 +30,7 @@ public sealed record WorkItemBacklogItemDto : IMapFrom<WorkItem>
     // This is used to set the rank of the work items in the backlog
     public double StackRank { get; set; }
     public double? StoryPoints { get; set; }
+    public List<string> Tags { get; set; } = [];
 
     public void ConfigureMapping(TypeAdapterConfig config)
     {
@@ -45,6 +46,7 @@ public sealed record WorkItemBacklogItemDto : IMapFrom<WorkItem>
                 : src.ParentProject != null
                     ? src.ParentProject
                     : null)
-            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
+            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}")
+            .Map(dest => dest.Tags, src => src.Tags.Select(t => t.Value).ToList());
     }
 }

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/WorkItemDetailsDto.cs
@@ -33,6 +33,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
     public WorkProjectNavigationDto? Project { get; set; }
     public string? ExternalViewWorkItemUrl { get; set; }
     public double? StoryPoints { get; set; }
+    public List<string> Tags { get; set; } = [];
 
     public void ConfigureMapping(TypeAdapterConfig config)
     {
@@ -50,6 +51,7 @@ public sealed record WorkItemDetailsDto : IMapFrom<WorkItem>
                 : src.ParentProject != null
                     ? src.ParentProject
                     : null)
-            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}");
+            .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}")
+            .Map(dest => dest.Tags, src => src.Tags.Select(t => t.Value).ToList());
     }
 }

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Dtos/WorkItemListDto.cs
@@ -33,6 +33,7 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
     public Instant Created { get; set; }
     public Instant? Activated { get; set; }
     public Instant? Done { get; set; }
+    public List<string> Tags { get; set; } = [];
 
     public double? CycleTime => Activated.HasValue && Done.HasValue && !Activated.Value.Equals(Done.Value) && StatusCategory?.Id == DoneStatusCategoryId
         ? (Done.Value - Activated.Value).ToTimeSpan().TotalDays
@@ -53,7 +54,8 @@ public sealed record WorkItemListDto : IMapFrom<WorkItem>
                     : null)
             .Map(dest => dest.ExternalViewWorkItemUrl, src => src.Workspace.ExternalViewWorkItemUrlTemplate == null ? null : $"{src.Workspace.ExternalViewWorkItemUrlTemplate}{src.ExternalId}")
             .Map(dest => dest.Activated, src => src.ActivatedTimestamp)
-            .Map(dest => dest.Done, src => src.DoneTimestamp);
+            .Map(dest => dest.Done, src => src.DoneTimestamp)
+            .Map(dest => dest.Tags, src => src.Tags.Select(t => t.Value).ToList());
     }
 }
 

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Domain/Models/WorkItem.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Domain/Models/WorkItem.cs
@@ -15,12 +15,13 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
     private readonly List<WorkItemDependency> _outboundDependencyHistory = []; // source links
     private readonly List<WorkItemDependency> _inboundDependencyHistory = []; // target links
     private readonly List<WorkItemReference> _referenceLinks = [];
+    private readonly List<WorkItemTag> _tags = [];
 
     //private readonly List<WorkItemRevision> _history = [];
 
     private WorkItem() { }
 
-    private WorkItem(WorkItemKey key, string title, Guid workspaceId, int? externalId, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, string? externalTeamIdentifier)
+    private WorkItem(WorkItemKey key, string title, Guid workspaceId, int? externalId, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, string? externalTeamIdentifier, List<WorkItemTag>? tags)
     {
         Key = key;
         Title = title;
@@ -39,6 +40,7 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
         StackRank = stackRank;
         StoryPoints = storyPoints;
         IterationId = iterationId;
+        if (tags != null) _tags.AddRange(tags.Distinct());
 
         ActivatedTimestamp = activatedTimestamp;
         DoneTimestamp = doneTimestamp;
@@ -146,6 +148,8 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
 
     public Instant? DoneTimestamp { get; private set; }
 
+    public IReadOnlyCollection<WorkItemTag> Tags => _tags.AsReadOnly();
+
     public WorkItemExtended? ExtendedProps { get; private set; }
 
     public IReadOnlyCollection<WorkItemDependency> OutboundDependencies => _outboundDependencyHistory.AsReadOnly();
@@ -180,7 +184,7 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
     /// <param name="doneTimestamp"></param>
     /// <param name="extendedProps"></param>
     /// <exception cref="InvalidOperationException"></exception>
-    public void Update(string title, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, WorkItemExtended? extendedProps)
+    public void Update(string title, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, WorkItemExtended? extendedProps, List<WorkItemTag>? tags = null)
     {
         if (extendedProps != null && Id != extendedProps.Id)
         {
@@ -202,6 +206,8 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
         StackRank = stackRank;
         StoryPoints = storyPoints;
         IterationId = iterationId;
+        _tags.Clear();
+        if (tags != null) _tags.AddRange(tags.Distinct());
 
         var result = UpdateParent(parentInfo, workType);
         if (result.IsFailure)
@@ -363,7 +369,7 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
         return Result.Success();
     }
 
-    public static WorkItem CreateExternal(Workspace workspace, int externalId, string title, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, string? externalTeamIdentifier)
+    public static WorkItem CreateExternal(Workspace workspace, int externalId, string title, WorkType workType, int statusId, WorkStatusCategory statusCategory, IWorkItemParentInfo? parentInfo, Guid? teamId, Instant created, Guid? createdById, Instant lastModified, Guid? lastModifiedById, Guid? assignedToId, int? priority, double stackRank, double? storyPoints, Guid? iterationId, Instant? activatedTimestamp, Instant? doneTimestamp, string? externalTeamIdentifier, List<WorkItemTag>? tags = null)
     {
         Guard.Against.Null(workspace, nameof(workspace));
         Guard.Against.Null(workType, nameof(workType));
@@ -374,7 +380,7 @@ public sealed class WorkItem : BaseAuditableEntity, IHasWorkspace, IHasOptionalW
         }
 
         var key = new WorkItemKey(workspace.Key, externalId);
-        return new WorkItem(key, title, workspace.Id, externalId, workType, statusId, statusCategory, parentInfo, teamId, created, createdById, lastModified, lastModifiedById, assignedToId, priority, stackRank, storyPoints, iterationId, activatedTimestamp, doneTimestamp, externalTeamIdentifier);
+        return new WorkItem(key, title, workspace.Id, externalId, workType, statusId, statusCategory, parentInfo, teamId, created, createdById, lastModified, lastModifiedById, assignedToId, priority, stackRank, storyPoints, iterationId, activatedTimestamp, doneTimestamp, externalTeamIdentifier, tags);
 
         //var result = workspace.AddWorkItem(workItem);  // this is handled in the handler for performance reasons
     }

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Domain/Models/WorkItemTag.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Domain/Models/WorkItemTag.cs
@@ -1,13 +1,15 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 
 namespace Wayd.Work.Domain.Models;
 
 public record WorkItemTag
 {
+    private WorkItemTag() { Value = null!; }
+
     public WorkItemTag(string value)
     {
         Value = Guard.Against.NullOrWhiteSpace(value, nameof(value)).Trim();
     }
 
-    public string Value { get; }
+    public string Value { get; private set; }
 }

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Domain/Models/WorkItemTag.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Domain/Models/WorkItemTag.cs
@@ -1,0 +1,13 @@
+using Ardalis.GuardClauses;
+
+namespace Wayd.Work.Domain.Models;
+
+public record WorkItemTag
+{
+    public WorkItemTag(string value)
+    {
+        Value = Guard.Against.NullOrWhiteSpace(value, nameof(value)).Trim();
+    }
+
+    public string Value { get; }
+}

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Data/ExternalWorkItemFaker.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Data/ExternalWorkItemFaker.cs
@@ -143,4 +143,10 @@ public static class ExternalWorkItemFakerExtensions
         faker.RuleFor(x => x.StoryPoints, storyPoints);
         return faker;
     }
+
+    public static ExternalWorkItemFaker WithTags(this ExternalWorkItemFaker faker, params string[] tags)
+    {
+        faker.RuleFor(x => x.Tags, tags);
+        return faker;
+    }
 }

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Models/ExternalTestWorkItem.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Models/ExternalTestWorkItem.cs
@@ -23,4 +23,5 @@ public class ExternalTestWorkItem : IExternalWorkItem
     public Guid? TeamId { get; set; }
     public int? IterationId { get; set; }
     public double? StoryPoints { get; set; }
+    public IReadOnlyCollection<string> Tags { get; set; } = [];
 }

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Sut/WorkItems/Commands/SyncExternalWorkItemsCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Sut/WorkItems/Commands/SyncExternalWorkItemsCommandHandlerTests.cs
@@ -246,6 +246,83 @@ public class SyncExternalWorkItemsCommandHandlerTests : IDisposable
         exception.Message.Should().Be("Database error");
     }
 
+    [Fact]
+    public async Task Handle_WithTags_CreatesWorkItemSuccessfully()
+    {
+        // Arrange
+        var workspaceId = Guid.NewGuid();
+        var workProcessId = Guid.NewGuid();
+
+        var workProcess = CreateWorkProcessWithSchemes("User Story", "New");
+
+        var workspace = _workspaceFaker
+            .AsExternal()
+            .WithId(workspaceId)
+            .WithWorkProcessId(workProcessId)
+            .Generate();
+
+        var externalWorkItem = _externalWorkItemFaker
+            .WithWorkType("User Story")
+            .WithWorkStatus("New")
+            .WithTags("Backend", "Q2", "Performance")
+            .Generate();
+
+        var updatedWorkProcess = _workProcessFaker
+            .WithId(workProcessId)
+            .WithSchemes([.. workProcess.Schemes])
+            .Generate();
+
+        _fakeWorkDbContext.AddWorkspace(workspace);
+        _fakeWorkDbContext.AddWorkProcess(updatedWorkProcess);
+
+        var command = CreateCommand(workspaceId, [externalWorkItem]);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _fakeWorkDbContext.SaveChangesCallCount.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    public async Task Handle_WithNoTags_CreatesWorkItemSuccessfully()
+    {
+        // Arrange
+        var workspaceId = Guid.NewGuid();
+        var workProcessId = Guid.NewGuid();
+
+        var workProcess = CreateWorkProcessWithSchemes("User Story", "New");
+
+        var workspace = _workspaceFaker
+            .AsExternal()
+            .WithId(workspaceId)
+            .WithWorkProcessId(workProcessId)
+            .Generate();
+
+        var externalWorkItem = _externalWorkItemFaker
+            .WithWorkType("User Story")
+            .WithWorkStatus("New")
+            .Generate();
+
+        var updatedWorkProcess = _workProcessFaker
+            .WithId(workProcessId)
+            .WithSchemes([.. workProcess.Schemes])
+            .Generate();
+
+        _fakeWorkDbContext.AddWorkspace(workspace);
+        _fakeWorkDbContext.AddWorkProcess(updatedWorkProcess);
+
+        var command = CreateCommand(workspaceId, [externalWorkItem]);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        _fakeWorkDbContext.SaveChangesCallCount.Should().BeGreaterThan(0);
+    }
+
     #region Helper Methods
 
     private SyncExternalWorkItemsCommand CreateCommand(

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Domain.Tests/Data/WorkItemFaker.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Domain.Tests/Data/WorkItemFaker.cs
@@ -74,6 +74,7 @@ public class WorkItemFaker : PrivateConstructorFaker<WorkItem>
 
         RuleFor(x => x.ActivatedTimestamp, activatedTimestamp);
         RuleFor(x => x.DoneTimestamp, doneTimestamp);
+        RuleFor("_tags", f => new List<WorkItemTag>());
     }
 }
 
@@ -157,6 +158,18 @@ public static class WorkItemFakerExtensions
         faker.RuleFor(x => x.ActivatedTimestamp, activated);
         faker.RuleFor(x => x.DoneTimestamp, done);
 
+        return faker;
+    }
+
+    public static WorkItemFaker WithExternalId(this WorkItemFaker faker, int externalId)
+    {
+        faker.RuleFor(x => x.ExternalId, externalId);
+        return faker;
+    }
+
+    public static WorkItemFaker WithTags(this WorkItemFaker faker, params string[] tags)
+    {
+        faker.RuleFor("_tags", f => tags.Select(t => new WorkItemTag(t)).ToList());
         return faker;
     }
 }

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Domain.Tests/Sut/Models/WorkItemTagsTests.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Domain.Tests/Sut/Models/WorkItemTagsTests.cs
@@ -1,0 +1,308 @@
+using FluentAssertions;
+using NodaTime;
+using Wayd.Common.Domain.Enums.Work;
+using Wayd.Work.Domain.Models;
+using Wayd.Work.Domain.Tests.Data;
+using Xunit;
+
+namespace Wayd.Work.Domain.Tests.Sut.Models;
+
+public class WorkItemTagsTests
+{
+    private readonly WorkspaceFaker _workspaceFaker = new();
+    private readonly WorkTypeFaker _workTypeFaker = new();
+    private readonly WorkItemFaker _workItemFaker = new();
+
+    private static readonly Instant _now = Instant.FromUtc(2024, 1, 15, 12, 0, 0);
+
+    #region WorkItemTag
+
+    [Fact]
+    public void WorkItemTag_TrimsWhitespace()
+    {
+        var tag = new WorkItemTag("  Backend  ");
+
+        tag.Value.Should().Be("Backend");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void WorkItemTag_ThrowsOnNullOrWhiteSpace(string? value)
+    {
+        var act = () => new WorkItemTag(value!);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    #endregion
+
+    #region CreateExternal
+
+    [Fact]
+    public void CreateExternal_WithTags_PopulatesTagsCollection()
+    {
+        // Arrange
+        var workspace = _workspaceFaker.AsExternal().Generate();
+        var workType = _workTypeFaker.AsStory().Generate();
+        var tags = new List<WorkItemTag> { new("Backend"), new("Q2"), new("Performance") };
+
+        // Act
+        var workItem = WorkItem.CreateExternal(
+            workspace: workspace,
+            externalId: 1,
+            title: "Title",
+            workType: workType,
+            statusId: 1,
+            statusCategory: WorkStatusCategory.Proposed,
+            parentInfo: null,
+            teamId: null,
+            created: _now,
+            createdById: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            externalTeamIdentifier: null,
+            tags: tags);
+
+        // Assert
+        workItem.Tags.Should().HaveCount(3);
+        workItem.Tags.Select(t => t.Value).Should().BeEquivalentTo("Backend", "Q2", "Performance");
+    }
+
+    [Fact]
+    public void CreateExternal_WithNullTags_HasEmptyTagsCollection()
+    {
+        // Arrange
+        var workspace = _workspaceFaker.AsExternal().Generate();
+        var workType = _workTypeFaker.AsStory().Generate();
+
+        // Act
+        var workItem = WorkItem.CreateExternal(
+            workspace: workspace,
+            externalId: 1,
+            title: "Title",
+            workType: workType,
+            statusId: 1,
+            statusCategory: WorkStatusCategory.Proposed,
+            parentInfo: null,
+            teamId: null,
+            created: _now,
+            createdById: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            externalTeamIdentifier: null,
+            tags: null);
+
+        // Assert
+        workItem.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void CreateExternal_WithEmptyTags_HasEmptyTagsCollection()
+    {
+        // Arrange
+        var workspace = _workspaceFaker.AsExternal().Generate();
+        var workType = _workTypeFaker.AsStory().Generate();
+
+        // Act
+        var workItem = WorkItem.CreateExternal(
+            workspace: workspace,
+            externalId: 1,
+            title: "Title",
+            workType: workType,
+            statusId: 1,
+            statusCategory: WorkStatusCategory.Proposed,
+            parentInfo: null,
+            teamId: null,
+            created: _now,
+            createdById: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            externalTeamIdentifier: null,
+            tags: []);
+
+        // Assert
+        workItem.Tags.Should().BeEmpty();
+    }
+
+    #endregion
+
+    #region Update
+
+    [Fact]
+    public void Update_WithTags_ReplacesTags()
+    {
+        // Arrange
+        var workItem = _workItemFaker.WithTags("OldTag").Generate();
+        var newTags = new List<WorkItemTag> { new("NewTag1"), new("NewTag2") };
+
+        // Act
+        workItem.Update(
+            title: workItem.Title,
+            workType: workItem.Type,
+            statusId: workItem.Status.Id,
+            statusCategory: workItem.StatusCategory,
+            parentInfo: null,
+            teamId: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            extendedProps: null,
+            tags: newTags);
+
+        // Assert
+        workItem.Tags.Should().HaveCount(2);
+        workItem.Tags.Select(t => t.Value).Should().BeEquivalentTo("NewTag1", "NewTag2");
+    }
+
+    [Fact]
+    public void Update_WithEmptyTags_ClearsTags()
+    {
+        // Arrange
+        var workItem = _workItemFaker.WithTags("Tag1", "Tag2").Generate();
+
+        // Act
+        workItem.Update(
+            title: workItem.Title,
+            workType: workItem.Type,
+            statusId: workItem.Status.Id,
+            statusCategory: workItem.StatusCategory,
+            parentInfo: null,
+            teamId: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            extendedProps: null,
+            tags: []);
+
+        // Assert
+        workItem.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Update_WithNullTags_ClearsTags()
+    {
+        // Arrange
+        var workItem = _workItemFaker.WithTags("Tag1", "Tag2").Generate();
+
+        // Act
+        workItem.Update(
+            title: workItem.Title,
+            workType: workItem.Type,
+            statusId: workItem.Status.Id,
+            statusCategory: workItem.StatusCategory,
+            parentInfo: null,
+            teamId: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            extendedProps: null,
+            tags: null);
+
+        // Assert
+        workItem.Tags.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Update_DeduplicatesTags()
+    {
+        // Arrange
+        var workItem = _workItemFaker.Generate();
+        var duplicateTags = new List<WorkItemTag> { new("Backend"), new("Backend"), new("Q2") };
+
+        // Act
+        workItem.Update(
+            title: workItem.Title,
+            workType: workItem.Type,
+            statusId: workItem.Status.Id,
+            statusCategory: workItem.StatusCategory,
+            parentInfo: null,
+            teamId: null,
+            lastModified: _now,
+            lastModifiedById: null,
+            assignedToId: null,
+            priority: null,
+            stackRank: 0,
+            storyPoints: null,
+            iterationId: null,
+            activatedTimestamp: null,
+            doneTimestamp: null,
+            extendedProps: null,
+            tags: duplicateTags);
+
+        // Assert
+        workItem.Tags.Should().HaveCount(2);
+        workItem.Tags.Select(t => t.Value).Should().BeEquivalentTo("Backend", "Q2");
+    }
+
+    [Fact]
+    public void Tags_AreExposedAsReadOnly()
+    {
+        var workItem = _workItemFaker.WithTags("Tag1").Generate();
+
+        workItem.Tags.Should().BeAssignableTo<IReadOnlyCollection<WorkItemTag>>();
+    }
+
+    #endregion
+
+    #region Faker
+
+    [Fact]
+    public void WorkItemFaker_WithTags_GeneratesWorkItemWithExpectedTags()
+    {
+        var workItem = _workItemFaker.WithTags("Alpha", "Beta").Generate();
+
+        workItem.Tags.Should().HaveCount(2);
+        workItem.Tags.Select(t => t.Value).Should().BeEquivalentTo("Alpha", "Beta");
+    }
+
+    [Fact]
+    public void WorkItemFaker_DefaultGenerate_HasEmptyTags()
+    {
+        var workItem = _workItemFaker.Generate();
+
+        workItem.Tags.Should().BeEmpty();
+    }
+
+    #endregion
+}

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -29063,7 +29063,8 @@
           "id",
           "created",
           "rank",
-          "stackRank"
+          "stackRank",
+          "tags"
         ],
         "properties": {
           "id": {
@@ -29160,6 +29161,12 @@
             "type": "number",
             "format": "double",
             "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "cycleTime": {
             "type": "number",
@@ -33397,7 +33404,8 @@
           "id",
           "created",
           "rank",
-          "stackRank"
+          "stackRank",
+          "tags"
         ],
         "properties": {
           "id": {
@@ -33489,6 +33497,12 @@
             "type": "number",
             "format": "double",
             "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -25795,7 +25795,8 @@
           "statusCategory",
           "id",
           "stackRank",
-          "created"
+          "created",
+          "tags"
         ],
         "properties": {
           "id": {
@@ -25888,6 +25889,12 @@
             "type": "string",
             "format": "date-time",
             "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "cycleTime": {
             "type": "number",
@@ -31965,7 +31972,8 @@
           "statusCategory",
           "id",
           "created",
-          "lastModified"
+          "lastModified",
+          "tags"
         ],
         "properties": {
           "id": {
@@ -32084,6 +32092,12 @@
             "type": "number",
             "format": "double",
             "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       },

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/manage-planning-interval-objective-work-items-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/manage-planning-interval-objective-work-items-form.tsx
@@ -15,13 +15,14 @@ import { SearchOutlined } from '@ant-design/icons'
 import { Flex, Input, Modal, Typography } from 'antd'
 import { ChangeEvent, useState } from 'react'
 import { ColDef } from 'ag-grid-community'
+import { CustomCellRendererProps } from 'ag-grid-react'
 import {
   AgGridTransfer,
   asDeletableColDefs,
   asDraggableColDefs,
 } from '@/src/components/common/grid/ag-grid-transfer'
 import { useMessage } from '@/src/components/contexts/messaging'
-import { workItemKeyComparator } from '@/src/components/common/work'
+import { workItemKeyComparator, WorkItemTagsCell } from '@/src/components/common/work'
 import { isApiError, type ApiError } from '@/src/utils'
 
 const { Text } = Typography
@@ -74,6 +75,15 @@ const workItemColDefs: ColDef<WorkItemListDto>[] = [
     headerName: 'Project',
     width: 200,
   },
+  {
+    field: 'tags',
+    headerName: 'Tags',
+    width: 200,
+    valueGetter: (params) => params.data?.tags?.join(', ') ?? '',
+    cellRenderer: (params: CustomCellRendererProps<WorkItemListDto>) => (
+      <WorkItemTagsCell tags={params.data?.tags} />
+    ),
+  },
 ]
 
 const leftColDefs = [...asDraggableColDefs(workItemColDefs)]
@@ -83,7 +93,8 @@ const defaultSort = (a: WorkItemListDto, b: WorkItemListDto) => {
 }
 
 const defaultColDef: ColDef = {
-  filter: false,
+  filter: true,
+  floatingFilter: true,
 }
 
 const ManagePlanningIntervalObjectiveWorkItemsForm = ({

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-work-items-tree-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-work-items-tree-grid.tsx
@@ -9,6 +9,7 @@ import {
   ExportOutlined,
 } from '@ant-design/icons'
 import { Button, Flex } from 'antd'
+import { WorkItemTagsCell } from '@/src/components/common/work'
 import treeGridStyles from '@/src/components/common/tree-grid/tree-grid.module.css'
 import { TreeGrid } from '@/src/components/common/tree-grid'
 import type { TreeGridColumnMeta } from '@/src/components/common/tree-grid'
@@ -222,6 +223,17 @@ const getColumns = (
     filterFn: 'includesString',
     sortingFn: 'text',
     cell: ({ row }) => <AssignedToCell item={row.original} />,
+  },
+  {
+    id: 'tags',
+    accessorFn: (row) => row.tags?.join(', ') ?? '',
+    header: 'Tags',
+    size: 200,
+    enableGlobalFilter: true,
+    enableColumnFilter: true,
+    filterFn: 'includesString',
+    sortingFn: 'text',
+    cell: ({ row }) => <WorkItemTagsCell tags={row.original.tags} />,
   },
   ...(!hideProjectColumn
     ? [

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/work-item-details.tsx
@@ -2,7 +2,7 @@
 
 import { WorkItemDetailsDto } from '@/src/services/wayd-api'
 import { SprintLink } from '@/src/components/common/planning'
-import { Descriptions } from 'antd'
+import { Descriptions, Space, Tag } from 'antd'
 import dayjs from 'dayjs'
 import Link from 'next/link'
 import WorkItemSteps from './work-item-steps'
@@ -98,6 +98,15 @@ const WorkItemDetails = ({ workItem }: WorkItemDetailsProps) => {
         <Item label="Updated">
           {dayjs(workItem.lastModified).format('MMM D, YYYY @ h:mm A')}
         </Item>
+        {workItem.tags && workItem.tags.length > 0 && (
+          <Item label="Tags">
+            <Space wrap size={[4, 4]}>
+              {workItem.tags.map((tag) => (
+                <Tag key={tag}>{tag}</Tag>
+              ))}
+            </Space>
+          </Item>
+        )}
       </Descriptions>
       <br />
       <WorkItemSteps workItem={workItem} />

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprint-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprint-backlog-grid.tsx
@@ -4,6 +4,8 @@ import { WaydGrid } from '@/src/components/common'
 import { SprintBacklogItemDto } from '@/src/services/wayd-api'
 import { ColDef } from 'ag-grid-community'
 import { useMemo } from 'react'
+import { CustomCellRendererProps } from 'ag-grid-react'
+import { WorkItemTagsCell } from '@/src/components/common/work'
 import {
   workItemKeyComparator,
   workStatusCategoryComparator,
@@ -93,6 +95,15 @@ const SprintBacklogGrid = (props: SprintBacklogGridProps) => {
       headerName: 'Project',
       width: 300,
       cellRenderer: ProjectLinkCellRenderer,
+    },
+    {
+      field: 'tags',
+      headerName: 'Tags',
+      width: 200,
+      valueGetter: (params) => params.data?.tags?.join(', ') ?? '',
+      cellRenderer: (params: CustomCellRendererProps<SprintBacklogItemDto>) => (
+        <WorkItemTagsCell tags={params.data?.tags} />
+      ),
     },
   ], [hideTeamColumn, hideSprintColumn])
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/index.ts
@@ -11,3 +11,4 @@ export {
   workItemKeyComparator,
   workStatusCategoryComparator,
 } from './work-item-utils'
+export { default as WorkItemTagsCell } from './work-item-tags-cell'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-tags-cell.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-tags-cell.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { Space, Tag, Tooltip } from 'antd'
+
+interface WorkItemTagsCellProps {
+  tags: string[] | undefined
+  maxVisible?: number
+}
+
+const WorkItemTagsCell = ({ tags, maxVisible }: WorkItemTagsCellProps) => {
+  if (!tags || tags.length === 0) return null
+
+  const visible = maxVisible !== undefined ? tags.slice(0, maxVisible) : tags
+  const hidden = maxVisible !== undefined ? tags.slice(maxVisible) : []
+
+  return (
+    <Space
+      wrap={false}
+      size={[2, 0]}
+      style={{ overflow: 'hidden', flexWrap: 'nowrap' }}
+    >
+      {visible.map((t) => (
+        <Tag key={t} style={{ margin: 0 }}>
+          {t}
+        </Tag>
+      ))}
+      {hidden.length > 0 && (
+        <Tooltip title={hidden.join(', ')}>
+          <Tag style={{ margin: 0 }}>+{hidden.length}</Tag>
+        </Tooltip>
+      )}
+    </Space>
+  )
+}
+
+export default WorkItemTagsCell
+

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
@@ -1,10 +1,7 @@
 'use client'
 
 import { WaydGrid } from '@/src/components/common'
-import {
-  SprintBacklogItemDto,
-  WorkItemBacklogItemDto,
-} from '@/src/services/wayd-api'
+import { WorkItemBacklogItemDto } from '@/src/services/wayd-api'
 import { ColDef } from 'ag-grid-community'
 import { useMemo } from 'react'
 import {
@@ -95,7 +92,7 @@ const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
         width: 200,
         valueGetter: (params) => params.data?.tags?.join(', ') ?? '',
         cellRenderer: (
-          params: CustomCellRendererProps<SprintBacklogItemDto>,
+          params: CustomCellRendererProps<WorkItemBacklogItemDto>,
         ) => <WorkItemTagsCell tags={params.data?.tags} />,
       },
     ],

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { WaydGrid } from '@/src/components/common'
-import { WorkItemBacklogItemDto } from '@/src/services/wayd-api'
+import {
+  SprintBacklogItemDto,
+  WorkItemBacklogItemDto,
+} from '@/src/services/wayd-api'
 import { ColDef } from 'ag-grid-community'
 import { useMemo } from 'react'
 import {
@@ -17,6 +20,8 @@ import {
   workItemKeyComparator,
   workStatusCategoryComparator,
 } from './work-item-utils'
+import { CustomCellRendererProps } from 'ag-grid-react'
+import WorkItemTagsCell from './work-item-tags-cell'
 
 export interface WorkItemsBacklogGridProps {
   workItems: WorkItemBacklogItemDto[]
@@ -28,62 +33,74 @@ export interface WorkItemsBacklogGridProps {
 const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<WorkItemBacklogItemDto>[]>(() => [
-    { field: 'rank', width: 125 },
-    {
-      field: 'key',
-      comparator: workItemKeyComparator,
-      cellRenderer: WorkItemLinkCellRenderer,
-    },
-    { field: 'title', width: 400 },
-    { field: 'type', width: 125 },
-    {
-      field: 'storyPoints',
-      headerName: 'SPs',
-      headerTooltip: 'Story Points',
-      width: 80,
-    },
-    { field: 'status', width: 125, cellRenderer: WorkStatusTagCellRenderer },
-    {
-      field: 'statusCategory.name',
-      headerName: 'Status Category',
-      width: 140,
-      comparator: workStatusCategoryComparator,
-    },
-    {
-      field: 'team.name',
-      headerName: 'Team',
-      cellRenderer: NestedTeamNameLinkCellRenderer,
-      hide: props.hideTeamColumn,
-    },
-    {
-      field: 'sprint.name',
-      headerName: 'Sprint',
-      cellRenderer: NestedWorkSprintLinkCellRenderer,
-    },
-    {
-      field: 'parent.key',
-      headerName: 'Parent Key',
-      comparator: workItemKeyComparator,
-      cellRenderer: ParentWorkItemLinkCellRenderer,
-    },
-    {
-      field: 'parent.title',
-      headerName: 'Parent',
-      width: 400,
-    },
-    {
-      field: 'assignedTo.name',
-      headerName: 'Assigned To',
-      cellRenderer: AssignedToLinkCellRenderer,
-    },
-    {
-      field: 'project.name',
-      headerName: 'Project',
-      width: 300,
-      cellRenderer: ProjectLinkCellRenderer,
-    },
-  ], [props.hideTeamColumn])
+  const columnDefs = useMemo<ColDef<WorkItemBacklogItemDto>[]>(
+    () => [
+      { field: 'rank', width: 125 },
+      {
+        field: 'key',
+        comparator: workItemKeyComparator,
+        cellRenderer: WorkItemLinkCellRenderer,
+      },
+      { field: 'title', width: 400 },
+      { field: 'type', width: 125 },
+      {
+        field: 'storyPoints',
+        headerName: 'SPs',
+        headerTooltip: 'Story Points',
+        width: 80,
+      },
+      { field: 'status', width: 125, cellRenderer: WorkStatusTagCellRenderer },
+      {
+        field: 'statusCategory.name',
+        headerName: 'Status Category',
+        width: 140,
+        comparator: workStatusCategoryComparator,
+      },
+      {
+        field: 'team.name',
+        headerName: 'Team',
+        cellRenderer: NestedTeamNameLinkCellRenderer,
+        hide: props.hideTeamColumn,
+      },
+      {
+        field: 'sprint.name',
+        headerName: 'Sprint',
+        cellRenderer: NestedWorkSprintLinkCellRenderer,
+      },
+      {
+        field: 'parent.key',
+        headerName: 'Parent Key',
+        comparator: workItemKeyComparator,
+        cellRenderer: ParentWorkItemLinkCellRenderer,
+      },
+      {
+        field: 'parent.title',
+        headerName: 'Parent',
+        width: 400,
+      },
+      {
+        field: 'assignedTo.name',
+        headerName: 'Assigned To',
+        cellRenderer: AssignedToLinkCellRenderer,
+      },
+      {
+        field: 'project.name',
+        headerName: 'Project',
+        width: 300,
+        cellRenderer: ProjectLinkCellRenderer,
+      },
+      {
+        field: 'tags',
+        headerName: 'Tags',
+        width: 200,
+        valueGetter: (params) => params.data?.tags?.join(', ') ?? '',
+        cellRenderer: (
+          params: CustomCellRendererProps<SprintBacklogItemDto>,
+        ) => <WorkItemTagsCell tags={params.data?.tags} />,
+      },
+    ],
+    [props.hideTeamColumn],
+  )
 
   const refresh = async () => {
     refetch()

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -27917,6 +27917,7 @@ export interface SprintBacklogItemDto {
     externalViewWorkItemUrl?: string | undefined;
     stackRank: number;
     storyPoints?: number | undefined;
+    tags: string[];
     cycleTime?: number | undefined;
 }
 
@@ -28950,6 +28951,7 @@ export interface WorkItemBacklogItemDto {
     externalViewWorkItemUrl?: string | undefined;
     stackRank: number;
     storyPoints?: number | undefined;
+    tags: string[];
 }
 
 export enum WorkStatusCategory {

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -27112,6 +27112,7 @@ export interface WorkItemListDto {
     created: Date;
     activated?: Date | undefined;
     done?: Date | undefined;
+    tags: string[];
     cycleTime?: number | undefined;
 }
 
@@ -28601,6 +28602,7 @@ export interface WorkItemDetailsDto {
     project?: WorkProjectNavigationDto | undefined;
     externalViewWorkItemUrl?: string | undefined;
     storyPoints?: number | undefined;
+    tags: string[];
 }
 
 export interface WorkItemProjectInfoDto {


### PR DESCRIPTION
Closes #593

## Summary

- **ADO sync**: Fetches `System.Tags` from Azure DevOps (semicolon-delimited string), parses it into a `List<WorkItemTag>`, and persists it on `WorkItem` via `OwnsMany(...).ToJson()`
- **Domain model**: New `WorkItemTag` record with validation (null/whitespace guard, auto-trim, deduplication via record equality)
- **API**: Tags exposed as `List<string>` on `WorkItemDetailsDto`, `WorkItemListDto`, `SprintBacklogItemDto`, and `WorkItemBacklogItemDto`
- **Migration**: Adds `Tags nvarchar(max)` JSON column to `Work.WorkItems`
- **Frontend**: New shared `WorkItemTagsCell` component renders tags as Ant Design chips with optional `maxVisible` truncation and tooltip overflow; used consistently across:
  - Work item detail page
  - PI objective work item transfer list (with floating column filters)
  - Sprint backlog grid
  - Project work items tree grid
  - Team backlog grid

## Test plan

- [ ] Trigger an ADO workspace sync and confirm `Tags` column in `Work.WorkItems` is populated
- [ ] Verify tags appear on the work item detail page; confirm no tags row shown when empty
- [ ] Open the PI objective work item linking modal — Tags column renders chips and filters correctly
- [ ] Verify tags appear in the sprint backlog and project work items grids
- [ ] Confirm duplicate tags from ADO are deduplicated; whitespace-padded tags are trimmed
- [ ] Run `dotnet test Wayd.slnx` — all tests pass