### PR TITLE
Feature/update work sync flow

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -48,6 +48,7 @@
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.5.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.6.0" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.6.0" />
     <PackageVersion Include="Microsoft.Graph" Version="6.0.3" />

--- a/Wayd.ArchitectureTests/Sut/CrossProjectDependencyTests.cs
+++ b/Wayd.ArchitectureTests/Sut/CrossProjectDependencyTests.cs
@@ -173,20 +173,25 @@ public class CrossProjectDependencyTests
     }
 
     [Fact]
-    public void ApplicationLayer_ShouldNotDependOnIntegrations()
+    public void ApplicationLayer_ShouldNotDependOnConcreteIntegrations()
     {
-        // Arrange
+        // Arrange: Application layer is allowed to depend on Wayd.Integrations.Abstractions
+        // (it defines the contracts concrete integrations implement, e.g. IWorkItemSource) but
+        // must NOT depend on any concrete integration package such as Wayd.Integrations.AzureDevOps.
         var applicationAssemblies = Types.InAssemblies(AssemblyHelper.GetApplicationAssemblies());
 
         // Act
         var result = applicationAssemblies
             .ShouldNot()
-            .HaveDependencyOn("Wayd.Integrations")
+            .HaveDependencyOnAny(
+                "Wayd.Integrations.AzureDevOps",
+                "Wayd.Integrations.AzureOpenAI",
+                "Wayd.Integrations.MicrosoftGraph")
             .GetResult();
 
         // Assert
         result.IsSuccessful.Should().BeTrue(
-            "Application layer should not depend on Integrations projects. Violating types: {0}",
+            "Application layer should not depend on concrete Integration projects. Violating types: {0}",
             string.Join(", ", result.FailingTypes ?? []));
     }
 

--- a/Wayd.Common/src/Wayd.Common.Application/BackgroundJobs/BackgroundJobType.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/BackgroundJobs/BackgroundJobType.cs
@@ -9,11 +9,11 @@ public enum BackgroundJobType
     [Display(Name = "Employee Sync", Description = "Synchronize employees from external directory service.", Order = 1, GroupName = "Integration Jobs")]
     EmployeeSync = 0,
 
-    [Display(Name = "Azure DevOps Full Sync", Description = "Synchronize active connectors for Azure DevOps and return all work items.", Order = 2, GroupName = "Integration Jobs")]
-    AzdoBoardsFullSync = 1,
+    [Display(Name = "Work Full Sync", Description = "Run a full sync across all active work-management connections (Azure DevOps and any future Jira/GitHub connectors).", Order = 2, GroupName = "Integration Jobs")]
+    WorkFullSync = 1,
 
-    [Display(Name = "Azure DevOps Differential Sync", Description = "Synchronize active connectors for Azure DevOps and return work items that have changed since the last sync.", Order = 3, GroupName = "Integration Jobs")]
-    AzdoBoardsDiffSync = 2,
+    [Display(Name = "Work Differential Sync", Description = "Run a differential sync across all active work-management connections (only items changed since the last sync).", Order = 3, GroupName = "Integration Jobs")]
+    WorkDiffSync = 2,
 
 
     // Data Replication Jobs

--- a/Wayd.Common/src/Wayd.Common.Application/Logging/AppEventId.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Logging/AppEventId.cs
@@ -22,6 +22,10 @@ public enum AppEventId
     AppIntegration_AzureDevOpsBoardsSyncManager_DeletedWorkItemsRetrieved = 10109,
     AppIntegration_AzureDevOpsBoardsSyncManager_SyncSummary = 10110,
 
+    // WorkSyncRunner (generic orchestrator across all WorkSync-category connectors)
+    AppIntegration_WorkSyncRunner_RunStarted = 10200,
+    AppIntegration_WorkSyncRunner_RunSummary = 10201,
+
     // Integration Projects
     // Integrations.AzureDevOps (100000-100999)
     Integrations_AzureDevOps_ProjectService_DuplicateIterationTeamMapping = 100100,

--- a/Wayd.Common/src/Wayd.Common.Domain/Enums/AppIntegrations/ConnectorCategory.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Enums/AppIntegrations/ConnectorCategory.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Wayd.Common.Domain.Enums.AppIntegrations;
+
+/// <summary>
+/// Classifies what shape of integration a <see cref="Connector"/> represents. The category
+/// determines which background jobs and orchestrators a connection participates in — e.g. only
+/// <see cref="WorkSync"/> connectors are handled by the work sync runner.
+/// </summary>
+public enum ConnectorCategory
+{
+    [Display(Name = "Unknown", Description = "The connector has not been categorized.")]
+    Unknown = 0,
+
+    [Display(Name = "Work Sync", Description = "Pulls work items, processes, workspaces, and teams from a delivery system (Azure DevOps, Jira, GitHub).")]
+    WorkSync = 1,
+
+    [Display(Name = "People Sync", Description = "Pulls employees and org structure from an HR system or directory service (Workday, Entra).")]
+    PeopleSync = 2,
+
+    [Display(Name = "AI Provider", Description = "Outbound LLM client used by Wayd features (Azure OpenAI, OpenAI, Anthropic). No data is synced.")]
+    AiProvider = 3
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Enums/AppIntegrations/ConnectorExtensions.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Enums/AppIntegrations/ConnectorExtensions.cs
@@ -1,0 +1,16 @@
+namespace Wayd.Common.Domain.Enums.AppIntegrations;
+
+public static class ConnectorExtensions
+{
+    /// <summary>
+    /// Returns the orchestration category for a connector — drives which background runner
+    /// processes it. Add new connectors here when they're introduced.
+    /// </summary>
+    public static ConnectorCategory GetCategory(this Connector connector) => connector switch
+    {
+        Connector.AzureDevOps => ConnectorCategory.WorkSync,
+        Connector.AzureOpenAI => ConnectorCategory.AiProvider,
+        Connector.OpenAI => ConnectorCategory.AiProvider,
+        _ => ConnectorCategory.Unknown
+    };
+}

--- a/Wayd.Common/tests/Wayd.Tests.Shared/Infrastructure/MockDbSetFactory.cs
+++ b/Wayd.Common/tests/Wayd.Tests.Shared/Infrastructure/MockDbSetFactory.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Moq;
 
 namespace Wayd.Tests.Shared.Infrastructure;
@@ -18,23 +19,31 @@ public static class MockDbSetFactory
     /// <returns>A mocked DbSet that supports async queries</returns>
     public static DbSet<T> CreateMockDbSet<T>(List<T> data) where T : class
     {
-        var queryable = data.AsQueryable();
         var mockSet = new Mock<DbSet<T>>();
 
-        // Setup async enumeration support
+        // Re-evaluate the queryable each call so newly Added items are visible.
         mockSet.As<IAsyncEnumerable<T>>()
             .Setup(m => m.GetAsyncEnumerator(It.IsAny<CancellationToken>()))
-            .Returns(new TestAsyncEnumerator<T>(data.GetEnumerator()));
+            .Returns(() => new TestAsyncEnumerator<T>(data.GetEnumerator()));
 
-        // Setup async query provider
         mockSet.As<IQueryable<T>>()
             .Setup(m => m.Provider)
-            .Returns(new TestAsyncQueryProvider<T>(queryable.Provider));
+            .Returns(() => new TestAsyncQueryProvider<T>(data.AsQueryable().Provider));
+        mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(() => data.AsQueryable().Expression);
+        mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(() => data.AsQueryable().ElementType);
+        mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(() => data.GetEnumerator());
 
-        // Setup standard IQueryable members
-        mockSet.As<IQueryable<T>>().Setup(m => m.Expression).Returns(queryable.Expression);
-        mockSet.As<IQueryable<T>>().Setup(m => m.ElementType).Returns(queryable.ElementType);
-        mockSet.As<IQueryable<T>>().Setup(m => m.GetEnumerator()).Returns(queryable.GetEnumerator());
+        // Intercept mutating methods so handlers that call dbSet.Add(...) / AddAsync(...) / Remove(...)
+        // actually persist into the underlying list, which is what tests then inspect.
+        mockSet.Setup(m => m.Add(It.IsAny<T>())).Callback<T>(data.Add).Returns((EntityEntry<T>)null!);
+        mockSet.Setup(m => m.AddAsync(It.IsAny<T>(), It.IsAny<CancellationToken>()))
+            .Callback<T, CancellationToken>((entity, _) => data.Add(entity))
+            .Returns((T entity, CancellationToken _) => ValueTask.FromResult<EntityEntry<T>>(null!));
+        mockSet.Setup(m => m.AddRange(It.IsAny<IEnumerable<T>>())).Callback<IEnumerable<T>>(items => data.AddRange(items));
+        mockSet.Setup(m => m.AddRange(It.IsAny<T[]>())).Callback<T[]>(items => data.AddRange(items));
+        mockSet.Setup(m => m.Remove(It.IsAny<T>())).Callback<T>(e => data.Remove(e)).Returns((EntityEntry<T>)null!);
+        mockSet.Setup(m => m.RemoveRange(It.IsAny<IEnumerable<T>>()))
+            .Callback<IEnumerable<T>>(items => { foreach (var i in items.ToList()) data.Remove(i); });
 
         return mockSet.Object;
     }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260524034350_Add-SyncRuns.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260524034350_Add-SyncRuns.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260524034350_Add-SyncRuns")]
+    partial class AddSyncRuns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260524034350_Add-SyncRuns.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260524034350_Add-SyncRuns.cs
@@ -1,0 +1,65 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddSyncRuns : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.CreateTable(
+            name: "SyncRuns",
+            schema: "AppIntegrations",
+            columns: table => new
+            {
+                Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                ConnectionId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                ConnectorType = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                StartedAt = table.Column<DateTime>(type: "datetime2", nullable: false),
+                FinishedAt = table.Column<DateTime>(type: "datetime2", nullable: true),
+                Status = table.Column<string>(type: "varchar(16)", maxLength: 16, nullable: false),
+                TriggerSource = table.Column<string>(type: "varchar(16)", maxLength: 16, nullable: false),
+                SyncType = table.Column<string>(type: "varchar(16)", maxLength: 16, nullable: false),
+                WorkspacesPlanned = table.Column<int>(type: "int", nullable: false),
+                WorkspacesSucceeded = table.Column<int>(type: "int", nullable: false),
+                WorkspacesFailed = table.Column<int>(type: "int", nullable: false),
+                WorkItemsProcessed = table.Column<int>(type: "int", nullable: false),
+                ErrorsCount = table.Column<int>(type: "int", nullable: false),
+                ErrorMessage = table.Column<string>(type: "nvarchar(2000)", maxLength: 2000, nullable: true),
+                DetailsJson = table.Column<string>(type: "nvarchar(max)", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_SyncRuns", x => x.Id);
+            });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SyncRuns_ConnectionId",
+            schema: "AppIntegrations",
+            table: "SyncRuns",
+            column: "ConnectionId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SyncRuns_ConnectionId_StartedAt",
+            schema: "AppIntegrations",
+            table: "SyncRuns",
+            columns: new[] { "ConnectionId", "StartedAt" });
+
+        migrationBuilder.CreateIndex(
+            name: "IX_SyncRuns_Status_StartedAt",
+            schema: "AppIntegrations",
+            table: "SyncRuns",
+            columns: new[] { "Status", "StartedAt" });
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "SyncRuns",
+            schema: "AppIntegrations");
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
@@ -75,9 +75,10 @@ public static class ConfigureServices
         services.AddTransient<IAzureDevOpsService, AzureDevOpsService>();
         services.AddScoped<IExternalEmployeeDirectoryService, MicrosoftGraphService>();
 
-        // Generic sync orchestration: one keyed IWorkItemSource per connector.
+        // Generic sync orchestration: one IWorkItemSource and one descriptor builder per connector.
         // (IWorkItemSourceFactory is auto-registered via the IScopedService marker scan.)
         services.AddKeyedTransient<IWorkItemSource, AzureDevOpsWorkItemSource>(Connector.AzureDevOps);
+        services.AddScoped<ISyncableConnectionDescriptorBuilder, AzureDevOpsConnectionDescriptorBuilder>();
 
         // SIGNALR
         var signalRBuilder = services.AddSignalR();

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
@@ -17,6 +17,9 @@ using Wayd.Infrastructure.FeatureManagement;
 using Wayd.Infrastructure.Logging;
 using Wayd.Infrastructure.OpenTelemetry;
 using Wayd.Infrastructure.SignalR;
+using Wayd.AppIntegration.Application.Connections.Managers;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Wayd.Integrations.Abstractions;
 using Wayd.Integrations.AzureDevOps;
 using Wayd.Integrations.MicrosoftGraph;
 using Wayd.Planning.Application.PokerSessions.Interfaces;
@@ -71,6 +74,10 @@ public static class ConfigureServices
         // INTEGRATIONS
         services.AddTransient<IAzureDevOpsService, AzureDevOpsService>();
         services.AddScoped<IExternalEmployeeDirectoryService, MicrosoftGraphService>();
+
+        // Generic sync orchestration: one keyed IWorkItemSource per connector.
+        // (IWorkItemSourceFactory is auto-registered via the IScopedService marker scan.)
+        services.AddKeyedTransient<IWorkItemSource, AzureDevOpsWorkItemSource>(Connector.AzureDevOps);
 
         // SIGNALR
         var signalRBuilder = services.AddSignalR();

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/AppIntegrationConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/AppIntegrationConfiguration.cs
@@ -1,7 +1,9 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Wayd.AppIntegration.Domain.Models;
 using Wayd.AppIntegration.Domain.Models.AzureOpenAI;
 using Wayd.AppIntegration.Domain.Models.OpenAI;
+using Wayd.Common.Application.Enums;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 using Wayd.Infrastructure.Persistence.Converters;
 using Wayd.Infrastructure.Persistence.Extensions;
@@ -96,5 +98,53 @@ public class OpenAIConnectionConfig : IEntityTypeConfiguration<OpenAIConnection>
         builder.Property(c => c.Configuration)
             .HasEncryptedJsonConversion()
             .HasColumnName("Configuration");
+    }
+}
+
+public class SyncRunConfig : IEntityTypeConfiguration<SyncRun>
+{
+    public void Configure(EntityTypeBuilder<SyncRun> builder)
+    {
+        builder.ToTable("SyncRuns", SchemaNames.AppIntegration);
+
+        builder.HasKey(r => r.Id);
+        builder.Property(r => r.Id).ValueGeneratedNever();
+
+        builder.Property(r => r.ConnectionId).IsRequired();
+
+        builder.Property(r => r.ConnectorType).IsRequired()
+            .HasConversion<EnumConverter<Connector>>()
+            .HasColumnType("varchar")
+            .HasMaxLength(32);
+
+        builder.Property(r => r.Status).IsRequired()
+            .HasConversion<EnumConverter<SyncRunStatus>>()
+            .HasColumnType("varchar")
+            .HasMaxLength(16);
+
+        builder.Property(r => r.TriggerSource).IsRequired()
+            .HasConversion<EnumConverter<SyncTriggerSource>>()
+            .HasColumnType("varchar")
+            .HasMaxLength(16);
+
+        builder.Property(r => r.SyncType).IsRequired()
+            .HasConversion<EnumConverter<SyncType>>()
+            .HasColumnType("varchar")
+            .HasMaxLength(16);
+
+        builder.Property(r => r.StartedAt).IsRequired();
+        builder.Property(r => r.FinishedAt);
+        builder.Property(r => r.WorkspacesPlanned);
+        builder.Property(r => r.WorkspacesSucceeded);
+        builder.Property(r => r.WorkspacesFailed);
+        builder.Property(r => r.WorkItemsProcessed);
+        builder.Property(r => r.ErrorsCount);
+        builder.Property(r => r.ErrorMessage).HasMaxLength(2000);
+        builder.Property(r => r.DetailsJson);
+
+        // No FK to Connections — history must survive connection deletion.
+        builder.HasIndex(r => r.ConnectionId);
+        builder.HasIndex(r => new { r.ConnectionId, r.StartedAt });
+        builder.HasIndex(r => new { r.Status, r.StartedAt });
     }
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Context/WaydDbContext.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Context/WaydDbContext.cs
@@ -56,6 +56,7 @@ public class WaydDbContext : BaseDbContext, IAppIntegrationDbContext, IFeatureMa
     public DbSet<Connection> Connections => Set<Connection>();
     public DbSet<AzureDevOpsBoardsConnection> AzureDevOpsBoardsConnections => Set<AzureDevOpsBoardsConnection>();
     public DbSet<AzureOpenAIConnection> AzureOpenAIConnections => Set<AzureOpenAIConnection>();
+    public DbSet<SyncRun> SyncRuns => Set<SyncRun>();
 
     #endregion IAppIntegration
 

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Wayd.Infrastructure.csproj
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Wayd.Infrastructure.csproj
@@ -84,6 +84,7 @@
         <ProjectReference Include="..\..\..\Wayd.Common\src\Wayd.Common.Domain\Wayd.Common.Domain.csproj" />
         <ProjectReference Include="..\..\..\Wayd.Services\Wayd.Goals\src\Wayd.Goals.Application\Wayd.Goals.Application.csproj" />
         <ProjectReference Include="..\..\..\Wayd.Services\Wayd.Goals\src\Wayd.Goals.Domain\Wayd.Goals.Domain.csproj" />
+        <ProjectReference Include="..\..\..\Wayd.Integrations\src\Wayd.Integrations.Abstractions\Wayd.Integrations.Abstractions.csproj" />
         <ProjectReference Include="..\..\..\Wayd.Integrations\src\Wayd.Integrations.AzureDevOps\Wayd.Integrations.AzureDevOps.csproj" />
         <ProjectReference Include="..\..\..\Wayd.Integrations\src\Wayd.Integrations.MicrosoftGraph\Wayd.Integrations.MicrosoftGraph.csproj" />
         <ProjectReference Include="..\..\..\Wayd.Services\Wayd.Links\src\Wayd.Links\Wayd.Links.csproj" />

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/GlobalUsings.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/GlobalUsings.cs
@@ -1,0 +1,4 @@
+global using CSharpFunctionalExtensions;
+global using NodaTime;
+global using Wayd.Common.Application.Enums;
+global using Wayd.Common.Domain.Enums.AppIntegrations;

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/ISyncableConnectionDescriptorBuilder.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/ISyncableConnectionDescriptorBuilder.cs
@@ -1,0 +1,17 @@
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// Builds a <see cref="SyncableConnectionDescriptor"/> for a connection — i.e. loads the typed
+/// EF entity for a connector and boxes its configuration into the connector-neutral descriptor
+/// the runner hands to <see cref="IWorkItemSourceFactory"/>.
+///
+/// Implementations are registered keyed by <see cref="Connector"/>. The runner resolves the
+/// right builder for each connection's connector value, so adding a new connector means adding
+/// one builder rather than editing the runner.
+/// </summary>
+public interface ISyncableConnectionDescriptorBuilder
+{
+    Connector Connector { get; }
+
+    Task<Result<SyncableConnectionDescriptor>> Build(Guid connectionId, CancellationToken cancellationToken);
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/IWorkItemSource.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/IWorkItemSource.cs
@@ -1,0 +1,59 @@
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// Connector-neutral contract for pulling work items from an external system. One implementation
+/// per connector, registered as a keyed transient by <see cref="Connector"/> value. The runner
+/// (<c>IWorkSyncRunner</c>) consumes this interface and is unaware of any connector-specific concepts
+/// such as Azure DevOps work processes or Jira projects.
+/// </summary>
+public interface IWorkItemSource
+{
+    /// <summary>The connector this source serves.</summary>
+    Connector Connector { get; }
+
+    /// <summary>
+    /// Bind this source instance to a specific connection. Called once by the factory before any
+    /// sync method is invoked. Sources should cast the descriptor's boxed configuration here and
+    /// fail fast if the shape is wrong.
+    /// </summary>
+    Result Bind(SyncableConnectionDescriptor descriptor);
+
+    /// <summary>Cheap reachability/auth check.</summary>
+    Task<Result> TestConnection(CancellationToken cancellationToken);
+
+    /// <summary>Returns the external system identifier (e.g. AzDO instance id).</summary>
+    Task<Result<string>> GetSystemId(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Refresh the connection's inventory of processes / workspaces / teams from the external
+    /// system. Called once per connection at the start of every sync run.
+    /// </summary>
+    Task<Result> RefreshOrganizationConfiguration(Guid syncId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns the flat list of workspaces to sync for this connection. For connectors with
+    /// intermediate hierarchy the source walks it internally; the runner only sees workspaces.
+    /// </summary>
+    Task<Result<IReadOnlyList<WorkspaceSyncTarget>>> GetSyncPlan(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Prepare a workspace for item sync — refresh whatever schema/metadata the connector requires
+    /// before <see cref="SyncIterations"/> and <see cref="SyncWorkItems"/> will produce correct
+    /// results. For AzDO this is work-process (types/statuses/workflow) + workspace metadata.
+    /// Failure is blocking for the workspace (the runner skips iterations/items).
+    /// </summary>
+    Task<Result> PrepareWorkspaceForItemSync(WorkspaceSyncTarget target, Guid syncId, CancellationToken cancellationToken);
+
+    /// <summary>Sync iteration / sprint structure for a workspace.</summary>
+    Task<Result> SyncIterations(WorkspaceSyncTarget target, string systemId, Guid syncId, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Sync work items and their relationship changes for a workspace. The source decides the
+    /// "since" cutoff internally based on <paramref name="syncType"/> and returns aggregate counters.
+    /// </summary>
+    Task<Result<WorkspaceItemsSyncResult>> SyncWorkItems(
+        WorkspaceSyncTarget target,
+        SyncType syncType,
+        Guid syncId,
+        CancellationToken cancellationToken);
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/IWorkItemSourceFactory.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/IWorkItemSourceFactory.cs
@@ -1,0 +1,13 @@
+﻿using Wayd.Common.Application.Interfaces;
+
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// Resolves an <see cref="IWorkItemSource"/> for a given connection. Returns a failure result
+/// when no source is registered for the descriptor's connector — the runner treats this as
+/// "skip this connection" rather than a fatal error.
+/// </summary>
+public interface IWorkItemSourceFactory : IScopedService
+{
+    Result<IWorkItemSource> Create(SyncableConnectionDescriptor descriptor);
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/SyncableConnectionDescriptor.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/SyncableConnectionDescriptor.cs
@@ -1,0 +1,13 @@
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// Connector-neutral snapshot of a syncable connection handed to an <see cref="IWorkItemSource"/>
+/// via <see cref="IWorkItemSourceFactory.Create"/>. Carries the boxed connector-specific
+/// configuration and team configuration — each source casts to the type it knows.
+/// </summary>
+public sealed record SyncableConnectionDescriptor(
+    Guid ConnectionId,
+    Connector Connector,
+    string? SystemId,
+    object Configuration,
+    object? TeamConfiguration);

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/Wayd.Integrations.Abstractions.csproj
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/Wayd.Integrations.Abstractions.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <ItemGroup>
+        <PackageReference Include="CSharpFunctionalExtensions" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+        <PackageReference Include="NodaTime" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\..\Wayd.Common\src\Wayd.Common.Application\Wayd.Common.Application.csproj" />
+        <ProjectReference Include="..\..\..\Wayd.Common\src\Wayd.Common.Domain\Wayd.Common.Domain.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <InternalsVisibleTo Include="Wayd.Integrations.AzureDevOps" />
+        <InternalsVisibleTo Include="Wayd.AppIntegration.Application" />
+    </ItemGroup>
+
+</Project>

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkItemSourceFactory.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkItemSourceFactory.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Wayd.Integrations.Abstractions;
+
+internal sealed class WorkItemSourceFactory(IServiceProvider serviceProvider) : IWorkItemSourceFactory
+{
+    private readonly IServiceProvider _serviceProvider = serviceProvider;
+
+    public Result<IWorkItemSource> Create(SyncableConnectionDescriptor descriptor)
+    {
+        var source = _serviceProvider.GetKeyedService<IWorkItemSource>(descriptor.Connector);
+        if (source is null)
+            return Result.Failure<IWorkItemSource>($"No IWorkItemSource is registered for connector '{descriptor.Connector}'.");
+
+        var bind = source.Bind(descriptor);
+        return bind.IsFailure
+            ? Result.Failure<IWorkItemSource>(bind.Error)
+            : Result.Success(source);
+    }
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkItemSyncFilters.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkItemSyncFilters.cs
@@ -1,0 +1,29 @@
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// Opaque, connector-specific filter payload travelling inside a <see cref="WorkspaceSyncTarget"/>.
+/// The runner never inspects the contents — it just hands the filters back to the source on each
+/// per-workspace sync call. Each source defines its own well-known keys (e.g. <c>"azdo.teamSettings"</c>).
+/// </summary>
+public sealed class WorkItemSyncFilters
+{
+    public static readonly WorkItemSyncFilters Empty = new();
+
+    private readonly Dictionary<string, string> _payload;
+
+    public WorkItemSyncFilters(IReadOnlyDictionary<string, string>? payload = null)
+    {
+        _payload = payload is null
+            ? new Dictionary<string, string>()
+            : payload.ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+    }
+
+    public bool TryGet(string key, out string? value)
+    {
+        var found = _payload.TryGetValue(key, out var v);
+        value = found ? v : null;
+        return found;
+    }
+
+    public IReadOnlyDictionary<string, string> AsDictionary => _payload;
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkspaceItemsSyncResult.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkspaceItemsSyncResult.cs
@@ -1,0 +1,21 @@
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// Counters returned from <see cref="IWorkItemSource.SyncWorkItems"/>. Sub-step failures inside
+/// the source are surfaced via <see cref="HadPartialFailure"/> and <see cref="PartialFailureMessage"/>
+/// rather than as a top-level <see cref="Result"/> failure — this preserves the "attempt each step
+/// independently" semantics of the AzDO sync.
+/// </summary>
+public sealed record WorkspaceItemsSyncResult(
+    int WorkItemsProcessed,
+    int ParentLinkChangesProcessed,
+    int DependencyLinkChangesProcessed,
+    int DeletedWorkItemsProcessed,
+    bool HadPartialFailure = false,
+    string? PartialFailureMessage = null)
+{
+    public static readonly WorkspaceItemsSyncResult Zero = new(0, 0, 0, 0);
+
+    public int TotalProcessed =>
+        WorkItemsProcessed + ParentLinkChangesProcessed + DependencyLinkChangesProcessed + DeletedWorkItemsProcessed;
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkspaceSyncTarget.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkspaceSyncTarget.cs
@@ -1,0 +1,14 @@
+namespace Wayd.Integrations.Abstractions;
+
+/// <summary>
+/// A single workspace the runner should sync. The source computes the list of targets in
+/// <see cref="IWorkItemSource.GetSyncPlan"/> — for connectors with intermediate hierarchy
+/// (e.g. AzDO's WorkProcess → Workspace), the hierarchy is walked internally and the result
+/// is a flat list. Filters carry any connector-specific per-workspace context.
+/// </summary>
+public sealed record WorkspaceSyncTarget(
+    Guid ExternalWorkspaceId,
+    Guid InternalWorkspaceId,
+    string WorkspaceName,
+    string WorkspaceKey,
+    WorkItemSyncFilters Filters);

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsConnectionDescriptorBuilder.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsConnectionDescriptorBuilder.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Domain.Interfaces;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Wayd.Integrations.Abstractions;
+
+namespace Wayd.AppIntegration.Application.Connections.Managers;
+
+/// <summary>
+/// Builds a <see cref="SyncableConnectionDescriptor"/> for an
+/// <c>AzureDevOpsBoardsConnection</c> by loading the EF entity and boxing its configuration
+/// and team configuration. Registered keyed by <see cref="Connector.AzureDevOps"/>.
+/// </summary>
+public sealed class AzureDevOpsConnectionDescriptorBuilder(IAppIntegrationDbContext db) : ISyncableConnectionDescriptorBuilder
+{
+    private readonly IAppIntegrationDbContext _db = db;
+
+    public Connector Connector => Connector.AzureDevOps;
+
+    public async Task<Result<SyncableConnectionDescriptor>> Build(Guid connectionId, CancellationToken cancellationToken)
+    {
+        var entity = await _db.AzureDevOpsBoardsConnections.AsNoTracking()
+            .FirstOrDefaultAsync(c => c.Id == connectionId, cancellationToken);
+        if (entity is null)
+            return Result.Failure<SyncableConnectionDescriptor>($"Azure DevOps connection {connectionId} not found.");
+
+        return Result.Success(new SyncableConnectionDescriptor(
+            ConnectionId: entity.Id,
+            Connector: Connector.AzureDevOps,
+            SystemId: ((ISyncableConnection)entity).SystemId,
+            Configuration: entity.Configuration,
+            TeamConfiguration: entity.TeamConfiguration));
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs
@@ -1,0 +1,491 @@
+﻿using System.Text.Json;
+using Ardalis.GuardClauses;
+using MediatR;
+using NodaTime;
+using Wayd.AppIntegration.Application.Connections.Dtos.AzureDevOps;
+using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
+using Wayd.AppIntegration.Application.Interfaces;
+using Wayd.AppIntegration.Application.Logging;
+using Wayd.Common.Application.Enums;
+using Wayd.Common.Application.Requests.Planning.Iterations;
+using Wayd.Common.Application.Requests.WorkManagement.Commands;
+using Wayd.Common.Application.Requests.WorkManagement.Dtos;
+using Wayd.Common.Application.Requests.WorkManagement.Queries;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Wayd.Integrations.Abstractions;
+
+namespace Wayd.AppIntegration.Application.Connections.Managers;
+
+/// <summary>
+/// Adapter that exposes the existing Azure DevOps integration as an <see cref="IWorkItemSource"/>.
+/// The runner sees only the connector-neutral surface; AzDO's per-process iteration, team-settings,
+/// and "since" lookup all live inside this class.
+/// </summary>
+public sealed class AzureDevOpsWorkItemSource(
+    ILogger<AzureDevOpsWorkItemSource> logger,
+    IAzureDevOpsService azureDevOpsService,
+    ISender sender,
+    IAzureDevOpsInitManager initManager) : IWorkItemSource
+{
+    public const string TeamSettingsFilterKey = "azdo.teamSettings";
+
+    private static readonly DateTime _minSyncDate = new(1900, 01, 01);
+
+    private readonly ILogger<AzureDevOpsWorkItemSource> _logger = logger;
+    private readonly IAzureDevOpsService _azureDevOpsService = azureDevOpsService;
+    private readonly ISender _sender = sender;
+    private readonly IAzureDevOpsInitManager _initManager = initManager;
+
+    private SyncableConnectionDescriptor? _descriptor;
+    private AzureDevOpsBoardsConnectionConfiguration? _cfg;
+    private AzureDevOpsBoardsTeamConfiguration? _teamCfg;
+
+    // Captured during GetSyncPlan() so subsequent per-workspace calls can look up work-process
+    // integration state without re-querying. Cleared on Bind().
+    private List<AzureDevOpsWorkProcessDto>? _planWorkProcesses;
+    private readonly HashSet<Guid> _workProcessesSynced = [];
+
+    public Connector Connector => Connector.AzureDevOps;
+
+    public Result Bind(SyncableConnectionDescriptor descriptor)
+    {
+        if (descriptor.Connector != Connector.AzureDevOps)
+            return Result.Failure($"AzureDevOpsWorkItemSource cannot bind to connector '{descriptor.Connector}'.");
+
+        if (descriptor.Configuration is not AzureDevOpsBoardsConnectionConfiguration cfg)
+            return Result.Failure("Connection configuration is not an AzureDevOpsBoardsConnectionConfiguration.");
+
+        _descriptor = descriptor;
+        _cfg = cfg;
+        _teamCfg = descriptor.TeamConfiguration as AzureDevOpsBoardsTeamConfiguration;
+        _planWorkProcesses = null;
+        _workProcessesSynced.Clear();
+        return Result.Success();
+    }
+
+    public Task<Result> TestConnection(CancellationToken cancellationToken)
+    {
+        var ctx = RequireBound();
+        return _azureDevOpsService.TestConnection(ctx.OrganizationUrl, ctx.PersonalAccessToken);
+    }
+
+    public Task<Result<string>> GetSystemId(CancellationToken cancellationToken)
+    {
+        var ctx = RequireBound();
+        return _azureDevOpsService.GetSystemId(ctx.OrganizationUrl, ctx.PersonalAccessToken, cancellationToken);
+    }
+
+    public Task<Result> RefreshOrganizationConfiguration(Guid syncId, CancellationToken cancellationToken)
+    {
+        var connectionId = RequireDescriptor().ConnectionId;
+        return _initManager.SyncOrganizationConfiguration(connectionId, cancellationToken, syncId);
+    }
+
+    public async Task<Result<IReadOnlyList<WorkspaceSyncTarget>>> GetSyncPlan(CancellationToken cancellationToken)
+    {
+        var connectionId = RequireDescriptor().ConnectionId;
+
+        // Load fresh state so workspace/process integration flags reflect the most recent
+        // RefreshOrganizationConfiguration() result.
+        var connection = await _sender.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
+        if (connection is null)
+            return Result.Failure<IReadOnlyList<WorkspaceSyncTarget>>($"Unable to load Azure DevOps connection {connectionId}.");
+
+        // Capture the freshly-loaded work-process list (DTO shape) so subsequent per-workspace
+        // calls can look up integration state without re-querying.
+        _planWorkProcesses = connection.Configuration.WorkProcesses;
+
+        var activeWorkProcessIds = connection.Configuration.WorkProcesses
+            .Where(wp => wp.IntegrationState is not null && wp.IntegrationState.IsActive)
+            .Select(wp => wp.ExternalId)
+            .ToHashSet();
+
+        if (activeWorkProcessIds.Count == 0)
+            return Result.Success<IReadOnlyList<WorkspaceSyncTarget>>([]);
+
+        var workspaceTeamsLookup = connection.TeamConfiguration?.WorkspaceTeams is not null
+            ? connection.TeamConfiguration.WorkspaceTeams.GroupBy(t => t.WorkspaceId).ToDictionary(g => g.Key, g => g.ToArray())
+            : [];
+
+        var targets = new List<WorkspaceSyncTarget>();
+        foreach (var workspace in connection.Configuration.Workspaces)
+        {
+            if (workspace.IntegrationState is null || !workspace.IntegrationState.IsActive)
+                continue;
+            if (!activeWorkProcessIds.Contains(workspace.WorkProcessId))
+                continue;
+
+            var workspaceTeams = workspaceTeamsLookup.TryGetValue(workspace.ExternalId, out var wt) ? wt : [];
+            BuildTeamSettingsAndMappings(workspaceTeams, out var teamSettings, out var teamMappings);
+
+            var filterPayload = new Dictionary<string, string>
+            {
+                [TeamSettingsFilterKey] = SerializeGuidNullableGuidMap(teamSettings),
+                [TeamMappingsFilterKey] = SerializeGuidNullableGuidMap(teamMappings),
+                [WorkProcessExternalIdFilterKey] = workspace.WorkProcessId.ToString(),
+            };
+
+            targets.Add(new WorkspaceSyncTarget(
+                ExternalWorkspaceId: workspace.ExternalId,
+                InternalWorkspaceId: workspace.IntegrationState.InternalId,
+                WorkspaceName: workspace.Name,
+                WorkspaceKey: workspace.ExternalId.ToString(),
+                Filters: new WorkItemSyncFilters(filterPayload)));
+        }
+
+        return Result.Success<IReadOnlyList<WorkspaceSyncTarget>>(targets);
+    }
+
+    public async Task<Result> PrepareWorkspaceForItemSync(WorkspaceSyncTarget target, Guid syncId, CancellationToken cancellationToken)
+    {
+        var ctx = RequireBound();
+
+        // Look up the work-process internal id from the fresh configuration.
+        if (!TryGetWorkProcessForTarget(target, out var workProcessExternalId, out var workProcessInternalId, out var error))
+            return Result.Failure(error!);
+
+        // Sync the work process once per source instance (per connection per sync run).
+        if (_workProcessesSynced.Add(workProcessExternalId))
+        {
+            var processResult = await SyncWorkProcess(ctx, syncId, workProcessExternalId, workProcessInternalId, cancellationToken);
+            if (processResult.IsFailure)
+                return processResult;
+        }
+
+        // Workspace metadata refresh.
+        var workspaceResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetWorkspace",
+            () => _azureDevOpsService.GetWorkspace(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.ExternalWorkspaceId, cancellationToken), syncId);
+        if (workspaceResult.IsFailure)
+            return workspaceResult.ConvertFailure();
+
+        var updateResult = await _sender.Send(new UpdateExternalWorkspaceCommand(workspaceResult.Value), cancellationToken);
+        return updateResult;
+    }
+
+    public async Task<Result> SyncIterations(WorkspaceSyncTarget target, string systemId, Guid syncId, CancellationToken cancellationToken)
+    {
+        var ctx = RequireBound();
+        var (teamSettings, teamMappings) = DeserializeTeamMaps(target);
+
+        var iterationsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetIterations",
+            () => _azureDevOpsService.GetIterations(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, teamSettings, cancellationToken), syncId);
+        if (iterationsResult.IsFailure)
+            return iterationsResult.ConvertFailure();
+
+        return await _sender.Send(new SyncAzureDevOpsIterationsCommand(systemId, iterationsResult.Value, teamMappings), cancellationToken);
+    }
+
+    public async Task<Result<WorkspaceItemsSyncResult>> SyncWorkItems(WorkspaceSyncTarget target, SyncType syncType, Guid syncId, CancellationToken cancellationToken)
+    {
+        var ctx = RequireBound();
+        var (teamSettings, teamMappings) = DeserializeTeamMaps(target);
+
+        var lastChangedDate = syncType switch
+        {
+            SyncType.Full => _minSyncDate,
+            SyncType.Differential => await GetWorkspaceMostRecentChangeDate(target.InternalWorkspaceId, cancellationToken),
+            _ => _minSyncDate
+        };
+
+        var workTypesResult = await _sender.Send(new GetWorkspaceWorkTypesQuery(target.InternalWorkspaceId), cancellationToken);
+        if (workTypesResult.IsFailure)
+            return workTypesResult.ConvertFailure<WorkspaceItemsSyncResult>();
+
+        var workTypeNames = workTypesResult.Value.Select(t => t.Name).ToArray();
+
+        int workItems = 0, parents = 0, deps = 0, deleted = 0;
+        var hadPartialFailure = false;
+        var failureMessages = new List<string>();
+
+        // Work items
+        var workItemsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetWorkItems",
+            () => _azureDevOpsService.GetWorkItems(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, workTypeNames, teamSettings, cancellationToken), syncId);
+        if (workItemsResult.IsFailure)
+        {
+            _logger.LogError("Failed to retrieve work items for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, workItemsResult.Error);
+            hadPartialFailure = true;
+            failureMessages.Add($"work-items: {workItemsResult.Error}");
+        }
+        else if (workItemsResult.Value.Count > 0)
+        {
+            var iterationMappings = await _sender.Send(new GetIterationMappingsQuery(Connector.AzureDevOps, ctx.SystemId), cancellationToken);
+            var syncResult = await _sender.Send(new SyncExternalWorkItemsCommand(target.InternalWorkspaceId, workItemsResult.Value, teamMappings, iterationMappings), cancellationToken);
+            if (syncResult.IsFailure)
+            {
+                hadPartialFailure = true;
+                failureMessages.Add($"work-items-sync: {syncResult.Error}");
+            }
+            else
+            {
+                workItems = workItemsResult.Value.Count;
+            }
+        }
+
+        // Parent link changes (Differential only)
+        if (syncType == SyncType.Differential)
+        {
+            var parentsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetParentLinkChanges",
+                () => _azureDevOpsService.GetParentLinkChanges(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
+            if (parentsResult.IsFailure)
+            {
+                _logger.LogError("Failed to retrieve parent link changes for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, parentsResult.Error);
+                hadPartialFailure = true;
+                failureMessages.Add($"parents: {parentsResult.Error}");
+            }
+            else if (parentsResult.Value.Count > 0)
+            {
+                var syncResult = await _sender.Send(new SyncExternalWorkItemParentChangesCommand(target.InternalWorkspaceId, parentsResult.Value), cancellationToken);
+                if (syncResult.IsFailure)
+                {
+                    hadPartialFailure = true;
+                    failureMessages.Add($"parents-sync: {syncResult.Error}");
+                }
+                else
+                {
+                    parents = parentsResult.Value.Count;
+                }
+            }
+        }
+
+        // Dependency link changes
+        var depsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetDependencyLinkChanges",
+            () => _azureDevOpsService.GetDependencyLinkChanges(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
+        if (depsResult.IsFailure)
+        {
+            _logger.LogError("Failed to retrieve dependency link changes for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, depsResult.Error);
+            hadPartialFailure = true;
+            failureMessages.Add($"deps: {depsResult.Error}");
+        }
+        else if (depsResult.Value.Count > 0)
+        {
+            var syncResult = await _sender.Send(new SyncExternalWorkItemDependencyChangesCommand(target.InternalWorkspaceId, depsResult.Value), cancellationToken);
+            if (syncResult.IsFailure)
+            {
+                hadPartialFailure = true;
+                failureMessages.Add($"deps-sync: {syncResult.Error}");
+            }
+            else
+            {
+                deps = depsResult.Value.Count;
+            }
+        }
+
+        // Deleted work items
+        var deletedResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetDeletedWorkItemIds",
+            () => _azureDevOpsService.GetDeletedWorkItemIds(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, cancellationToken), syncId);
+        if (deletedResult.IsFailure)
+        {
+            _logger.LogError("Failed to retrieve deleted work item ids for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, deletedResult.Error);
+            hadPartialFailure = true;
+            failureMessages.Add($"deleted: {deletedResult.Error}");
+        }
+        else if (deletedResult.Value.Length > 0)
+        {
+            var syncResult = await _sender.Send(new DeleteExternalWorkItemsCommand(target.InternalWorkspaceId, deletedResult.Value), cancellationToken);
+            if (syncResult.IsFailure)
+            {
+                hadPartialFailure = true;
+                failureMessages.Add($"deleted-sync: {syncResult.Error}");
+            }
+            else
+            {
+                deleted = deletedResult.Value.Length;
+            }
+        }
+
+        return Result.Success(new WorkspaceItemsSyncResult(
+            WorkItemsProcessed: workItems,
+            ParentLinkChangesProcessed: parents,
+            DependencyLinkChangesProcessed: deps,
+            DeletedWorkItemsProcessed: deleted,
+            HadPartialFailure: hadPartialFailure,
+            PartialFailureMessage: hadPartialFailure ? string.Join("; ", failureMessages) : null));
+    }
+
+    // ----- helpers -----
+
+    private const string TeamMappingsFilterKey = "azdo.teamMappings";
+    private const string WorkProcessExternalIdFilterKey = "azdo.workProcessExternalId";
+
+    private SyncContext RequireBound()
+    {
+        if (_descriptor is null || _cfg is null)
+            throw new InvalidOperationException("AzureDevOpsWorkItemSource has not been bound. Call Bind(descriptor) before invoking sync methods.");
+        return new SyncContext(_cfg.OrganizationUrl, _cfg.PersonalAccessToken, _descriptor.SystemId ?? string.Empty);
+    }
+
+    private SyncableConnectionDescriptor RequireDescriptor()
+    {
+        if (_descriptor is null)
+            throw new InvalidOperationException("AzureDevOpsWorkItemSource has not been bound.");
+        return _descriptor;
+    }
+
+    private async Task<Result> SyncWorkProcess(SyncContext ctx, Guid syncId, Guid workProcessExternalId, Guid workProcessInternalId, CancellationToken cancellationToken)
+    {
+        Guard.Against.Default(workProcessExternalId, nameof(workProcessExternalId));
+        Guard.Against.Default(workProcessInternalId, nameof(workProcessInternalId));
+
+        var processResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetWorkProcess",
+            () => _azureDevOpsService.GetWorkProcess(ctx.OrganizationUrl, ctx.PersonalAccessToken, workProcessExternalId, cancellationToken), syncId);
+        if (processResult.IsFailure)
+            return processResult.ConvertFailure();
+
+        var workTypes = processResult.Value.WorkTypes.OfType<Wayd.Common.Application.Interfaces.ExternalWork.IExternalWorkType>().ToList();
+        if (workTypes.Count != 0)
+        {
+            var levels = await _sender.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
+            if (levels is null)
+                return Result.Failure("Unable to get work type levels.");
+
+            int defaultLevelId = -1;
+            foreach (var l in levels)
+            {
+                if (l.Tier.Id == (int)Wayd.Common.Domain.Enums.Work.WorkTypeTier.Other)
+                {
+                    defaultLevelId = l.Id;
+                    break;
+                }
+            }
+
+            if (defaultLevelId == -1)
+                return Result.Failure("Unable to get work type levels.");
+
+            var syncWorkTypesResult = await _sender.Send(new SyncExternalWorkTypesCommand(workTypes, defaultLevelId), cancellationToken);
+            if (syncWorkTypesResult.IsFailure)
+                return syncWorkTypesResult;
+        }
+
+        if (processResult.Value.WorkStatuses.Count != 0)
+        {
+            var syncWorkStatusesResult = await _sender.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);
+            if (syncWorkStatusesResult.IsFailure)
+                return syncWorkStatusesResult;
+        }
+
+        var workProcessSchemes = await _sender.Send(new GetWorkProcessSchemesQuery(workProcessInternalId), cancellationToken);
+        var workProcessSchemesByWorkTypeName = workProcessSchemes.ToDictionary(s => s.WorkType.Name);
+
+        var workflowMappings = new List<CreateWorkProcessSchemeDto>(processResult.Value.WorkTypes.Count);
+        foreach (var workType in processResult.Value.WorkTypes)
+        {
+            workProcessSchemesByWorkTypeName.TryGetValue(workType.Name, out var scheme);
+            if (scheme is null || scheme.Workflow is null)
+            {
+                var createWorkflowResult = await _sender.Send(new CreateExternalWorkflowCommand(
+                    $"{processResult.Value.Name} - {workType.Name}",
+                    "Auto-generated workflow for Azure DevOps work process.",
+                    workType), cancellationToken);
+                if (createWorkflowResult.IsFailure)
+                    return createWorkflowResult.ConvertFailure();
+
+                workflowMappings.Add(CreateWorkProcessSchemeDto.Create(workType.Name, workType.IsActive, createWorkflowResult.Value));
+            }
+            else
+            {
+                var syncWorkflowResult = await _sender.Send(new UpdateExternalWorkflowCommand(scheme.Workflow.Id, scheme.Workflow.Name, scheme.Workflow.Description, workType), cancellationToken);
+                if (syncWorkflowResult.IsFailure)
+                    return syncWorkflowResult;
+
+                workflowMappings.Add(CreateWorkProcessSchemeDto.Create(workType.Name, workType.IsActive, scheme.Workflow.Id));
+            }
+        }
+
+        var updateWorkProcessResult = await _sender.Send(new UpdateExternalWorkProcessCommand(processResult.Value, processResult.Value.WorkTypes, workflowMappings), cancellationToken);
+        return updateWorkProcessResult.IsSuccess ? Result.Success() : updateWorkProcessResult;
+    }
+
+    private bool TryGetWorkProcessForTarget(WorkspaceSyncTarget target, out Guid workProcessExternalId, out Guid workProcessInternalId, out string? error)
+    {
+        workProcessExternalId = default;
+        workProcessInternalId = default;
+        error = null;
+
+        if (_planWorkProcesses is null)
+        {
+            error = "GetSyncPlan() must be invoked before PrepareWorkspaceForItemSync.";
+            return false;
+        }
+
+        if (!target.Filters.TryGet(WorkProcessExternalIdFilterKey, out var raw) || !Guid.TryParse(raw, out var wpId))
+        {
+            error = $"WorkspaceSyncTarget for {target.WorkspaceName} is missing AzDO work-process metadata.";
+            return false;
+        }
+
+        var workProcess = _planWorkProcesses.FirstOrDefault(wp => wp.ExternalId == wpId);
+        if (workProcess?.IntegrationState is null)
+        {
+            error = $"Work process {wpId} is not integrated for this connection.";
+            return false;
+        }
+
+        workProcessExternalId = workProcess.ExternalId;
+        workProcessInternalId = workProcess.IntegrationState.InternalId;
+        return true;
+    }
+
+    private async Task<DateTime> GetWorkspaceMostRecentChangeDate(Guid workspaceId, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new GetWorkspaceMostRecentChangeDateQuery(workspaceId), cancellationToken);
+        return result.IsSuccess && result.Value != null
+            ? ((Instant)result.Value).ToDateTimeUtc()
+            : _minSyncDate;
+    }
+
+    private static (Dictionary<Guid, Guid?> teamSettings, Dictionary<Guid, Guid?> teamMappings) DeserializeTeamMaps(WorkspaceSyncTarget target)
+    {
+        target.Filters.TryGet(TeamSettingsFilterKey, out var settingsJson);
+        target.Filters.TryGet(TeamMappingsFilterKey, out var mappingsJson);
+        return (
+            DeserializeGuidNullableGuidMap(settingsJson),
+            DeserializeGuidNullableGuidMap(mappingsJson));
+    }
+
+    private static string SerializeGuidNullableGuidMap(Dictionary<Guid, Guid?> map)
+    {
+        if (map.Count == 0)
+            return "{}";
+        var stringified = map.ToDictionary(kvp => kvp.Key.ToString(), kvp => kvp.Value?.ToString());
+        return JsonSerializer.Serialize(stringified);
+    }
+
+    private static Dictionary<Guid, Guid?> DeserializeGuidNullableGuidMap(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json) || json == "{}")
+            return [];
+        var stringified = JsonSerializer.Deserialize<Dictionary<string, string?>>(json);
+        if (stringified is null)
+            return [];
+        var result = new Dictionary<Guid, Guid?>(stringified.Count);
+        foreach (var kvp in stringified)
+        {
+            if (!Guid.TryParse(kvp.Key, out var key)) continue;
+            Guid? value = Guid.TryParse(kvp.Value, out var v) ? v : null;
+            result[key] = value;
+        }
+        return result;
+    }
+
+    private static void BuildTeamSettingsAndMappings(AzureDevOpsWorkspaceTeamDto[] workspaceTeams, out Dictionary<Guid, Guid?> teamSettings, out Dictionary<Guid, Guid?> teamMappings)
+    {
+        if (workspaceTeams is null || workspaceTeams.Length == 0)
+        {
+            teamSettings = [];
+            teamMappings = [];
+            return;
+        }
+
+        teamSettings = new(workspaceTeams.Length);
+        teamMappings = new(workspaceTeams.Length);
+        foreach (var team in workspaceTeams)
+        {
+            if (team.InternalTeamId is null)
+                continue;
+            teamSettings[team.TeamId] = team.BoardId;
+            teamMappings[team.TeamId] = team.InternalTeamId;
+        }
+    }
+
+    private sealed record SyncContext(string OrganizationUrl, string PersonalAccessToken, string SystemId);
+}

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs
@@ -1,9 +1,7 @@
 ﻿using System.Text.Json;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 using Wayd.AppIntegration.Application.Connections.Queries;
 using Wayd.AppIntegration.Application.Interfaces;
-using Wayd.AppIntegration.Domain.Interfaces;
 using Wayd.Common.Application.Enums;
 using Wayd.Common.Application.Logging;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
@@ -17,21 +15,33 @@ namespace Wayd.AppIntegration.Application.Connections.Managers;
 /// appropriate <see cref="IWorkItemSource"/> for each via the factory, and walks the source's
 /// flat sync plan. Persists a <see cref="SyncRun"/> row per connection per run.
 /// </summary>
-public sealed class WorkSyncRunner(
-    ILogger<WorkSyncRunner> logger,
-    ISender sender,
-    IWorkItemSourceFactory sourceFactory,
-    IAppIntegrationDbContext db,
-    IDateTimeProvider clock) : IWorkSyncRunner
+public sealed class WorkSyncRunner : IWorkSyncRunner
 {
-    private readonly ILogger<WorkSyncRunner> _logger = logger;
-    private readonly ISender _sender = sender;
-    private readonly IWorkItemSourceFactory _sourceFactory = sourceFactory;
-    private readonly IAppIntegrationDbContext _db = db;
-    private readonly IDateTimeProvider _clock = clock;
+    private readonly ILogger<WorkSyncRunner> _logger;
+    private readonly ISender _sender;
+    private readonly IWorkItemSourceFactory _sourceFactory;
+    private readonly IAppIntegrationDbContext _db;
+    private readonly IDateTimeProvider _clock;
+    private readonly IReadOnlyDictionary<Connector, ISyncableConnectionDescriptorBuilder> _descriptorBuilders;
+
+    public WorkSyncRunner(
+        ILogger<WorkSyncRunner> logger,
+        ISender sender,
+        IWorkItemSourceFactory sourceFactory,
+        IAppIntegrationDbContext db,
+        IDateTimeProvider clock,
+        IEnumerable<ISyncableConnectionDescriptorBuilder> descriptorBuilders)
+    {
+        _logger = logger;
+        _sender = sender;
+        _sourceFactory = sourceFactory;
+        _db = db;
+        _clock = clock;
+        _descriptorBuilders = descriptorBuilders.ToDictionary(b => b.Connector);
+    }
 
     private static readonly Action<ILogger, Exception?> _runStarted = LoggerMessage.Define(LogLevel.Information,
-        AppEventId.AppIntegration_AzureDevOpsBoardsSyncManager_SyncStarted.ToEventId(),
+        AppEventId.AppIntegration_WorkSyncRunner_RunStarted.ToEventId(),
         "WorkSyncRunner starting");
 
     private static readonly Action<ILogger, Exception?> _cancellationRequested = LoggerMessage.Define(LogLevel.Information,
@@ -39,7 +49,7 @@ public sealed class WorkSyncRunner(
         "Cancellation requested. Stopping sync.");
 
     private static readonly Action<ILogger, int, int, Exception?> _runSummary = LoggerMessage.Define<int, int>(LogLevel.Information,
-        AppEventId.AppIntegration_AzureDevOpsBoardsSyncManager_SyncSummary.ToEventId(),
+        AppEventId.AppIntegration_WorkSyncRunner_RunSummary.ToEventId(),
         "WorkSyncRunner finished: {SucceededRuns}/{TotalRuns} connection runs succeeded.");
 
     public async Task<Result> Run(SyncType syncType, SyncTriggerSource trigger, CancellationToken cancellationToken)
@@ -155,9 +165,18 @@ public sealed class WorkSyncRunner(
                     workspaceDetails.Add(detail);
 
                     if (detail.Succeeded)
+                    {
                         run.RecordWorkspaceSuccess(detail.WorkItemsProcessed);
+                        // A workspace that succeeded overall but had a sub-step failure inside the
+                        // source still counts as a degraded run — bump ErrorsCount so dashboards
+                        // can flag it without parsing DetailsJson.
+                        if (detail.HadPartialFailure)
+                            run.RecordError();
+                    }
                     else
+                    {
                         run.RecordWorkspaceFailure();
+                    }
                 }
             }
 
@@ -213,26 +232,13 @@ public sealed class WorkSyncRunner(
         return WorkspaceSyncDetail.FromSuccess(target, itemsResult.Value);
     }
 
-    private async Task<Result<SyncableConnectionDescriptor>> BuildDescriptor(Guid connectionId, Connector connector, CancellationToken cancellationToken)
+    private Task<Result<SyncableConnectionDescriptor>> BuildDescriptor(Guid connectionId, Connector connector, CancellationToken cancellationToken)
     {
-        switch (connector)
-        {
-            case Connector.AzureDevOps:
-                {
-                    var entity = await _db.AzureDevOpsBoardsConnections.AsNoTracking()
-                        .FirstOrDefaultAsync(c => c.Id == connectionId, cancellationToken);
-                    if (entity is null)
-                        return Result.Failure<SyncableConnectionDescriptor>($"Azure DevOps connection {connectionId} not found.");
-                    return Result.Success(new SyncableConnectionDescriptor(
-                        ConnectionId: entity.Id,
-                        Connector: Connector.AzureDevOps,
-                        SystemId: ((ISyncableConnection)entity).SystemId,
-                        Configuration: entity.Configuration,
-                        TeamConfiguration: entity.TeamConfiguration));
-                }
-            default:
-                return Result.Failure<SyncableConnectionDescriptor>($"Connector '{connector}' is not supported by the sync runner.");
-        }
+        if (!_descriptorBuilders.TryGetValue(connector, out var builder))
+            return Task.FromResult(Result.Failure<SyncableConnectionDescriptor>(
+                $"No ISyncableConnectionDescriptorBuilder registered for connector '{connector}'."));
+
+        return builder.Build(connectionId, cancellationToken);
     }
 
     private async Task SaveRun(SyncRun run, List<WorkspaceSyncDetail> details, CancellationToken cancellationToken)

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs
@@ -1,0 +1,281 @@
+﻿using System.Text.Json;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Connections.Queries;
+using Wayd.AppIntegration.Application.Interfaces;
+using Wayd.AppIntegration.Domain.Interfaces;
+using Wayd.Common.Application.Enums;
+using Wayd.Common.Application.Logging;
+using Wayd.Common.Application.Requests.WorkManagement.Commands;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Wayd.Integrations.Abstractions;
+
+namespace Wayd.AppIntegration.Application.Connections.Managers;
+
+/// <summary>
+/// Generic per-run sync orchestrator. Loops over all active syncable connections, resolves the
+/// appropriate <see cref="IWorkItemSource"/> for each via the factory, and walks the source's
+/// flat sync plan. Persists a <see cref="SyncRun"/> row per connection per run.
+/// </summary>
+public sealed class WorkSyncRunner(
+    ILogger<WorkSyncRunner> logger,
+    ISender sender,
+    IWorkItemSourceFactory sourceFactory,
+    IAppIntegrationDbContext db,
+    IDateTimeProvider clock) : IWorkSyncRunner
+{
+    private readonly ILogger<WorkSyncRunner> _logger = logger;
+    private readonly ISender _sender = sender;
+    private readonly IWorkItemSourceFactory _sourceFactory = sourceFactory;
+    private readonly IAppIntegrationDbContext _db = db;
+    private readonly IDateTimeProvider _clock = clock;
+
+    private static readonly Action<ILogger, Exception?> _runStarted = LoggerMessage.Define(LogLevel.Information,
+        AppEventId.AppIntegration_AzureDevOpsBoardsSyncManager_SyncStarted.ToEventId(),
+        "WorkSyncRunner starting");
+
+    private static readonly Action<ILogger, Exception?> _cancellationRequested = LoggerMessage.Define(LogLevel.Information,
+        AppEventId.AppIntegration_CancellationRequested.ToEventId(),
+        "Cancellation requested. Stopping sync.");
+
+    private static readonly Action<ILogger, int, int, Exception?> _runSummary = LoggerMessage.Define<int, int>(LogLevel.Information,
+        AppEventId.AppIntegration_AzureDevOpsBoardsSyncManager_SyncSummary.ToEventId(),
+        "WorkSyncRunner finished: {SucceededRuns}/{TotalRuns} connection runs succeeded.");
+
+    public async Task<Result> Run(SyncType syncType, SyncTriggerSource trigger, CancellationToken cancellationToken)
+    {
+        _runStarted(_logger, null);
+
+        var syncId = Guid.CreateVersion7();
+        using (_logger.BeginScope(new Dictionary<string, object> { ["SyncId"] = syncId }))
+        {
+            try
+            {
+                var connections = await _sender.Send(
+                    new GetConnectionsQuery(IncludeInactive: false, Category: ConnectorCategory.WorkSync),
+                    cancellationToken);
+                var active = connections
+                    .Where(c => c.CanSync == true)
+                    .ToList();
+
+                if (active.Count == 0)
+                {
+                    _logger.LogInformation("No active syncable connections found.");
+                    return Result.Failure("No active syncable connections found.");
+                }
+
+                int successCount = 0;
+                foreach (var connection in active)
+                {
+                    using (_logger.BeginScope(new Dictionary<string, object> { ["ConnectionId"] = connection.Id }))
+                    {
+                        cancellationToken.ThrowIfCancellationRequested();
+                        var connectorEnum = (Connector)connection.Connector.Id;
+                        var connectionResult = await RunConnection(connection.Id, connectorEnum, syncType, trigger, syncId, cancellationToken);
+                        if (connectionResult.IsSuccess)
+                            successCount++;
+                    }
+                }
+
+                _runSummary(_logger, successCount, active.Count, null);
+                return Result.Success();
+            }
+            catch (OperationCanceledException)
+            {
+                _cancellationRequested(_logger, null);
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "WorkSyncRunner failed unexpectedly.");
+                throw;
+            }
+        }
+    }
+
+    private async Task<Result> RunConnection(Guid connectionId, Connector connector, SyncType syncType, SyncTriggerSource trigger, Guid syncId, CancellationToken cancellationToken)
+    {
+        // Load the typed entity + build a connector-neutral descriptor.
+        var descriptorResult = await BuildDescriptor(connectionId, connector, cancellationToken);
+        if (descriptorResult.IsFailure)
+        {
+            _logger.LogWarning("Skipping connection {ConnectionId}: {Error}", connectionId, descriptorResult.Error);
+            return Result.Failure(descriptorResult.Error);
+        }
+
+        var sourceResult = _sourceFactory.Create(descriptorResult.Value);
+        if (sourceResult.IsFailure)
+        {
+            _logger.LogWarning("Skipping connection {ConnectionId}: {Error}", connectionId, sourceResult.Error);
+            return Result.Failure(sourceResult.Error);
+        }
+
+        var source = sourceResult.Value;
+
+        var run = SyncRun.Start(connectionId, connector, syncType, trigger, _clock.Now);
+        _db.SyncRuns.Add(run);
+        await _db.SaveChangesAsync(cancellationToken);
+
+        var workspaceDetails = new List<WorkspaceSyncDetail>();
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var refreshResult = await source.RefreshOrganizationConfiguration(syncId, cancellationToken);
+            if (refreshResult.IsFailure)
+            {
+                run.MarkFailed(_clock.Now, $"RefreshOrganizationConfiguration failed: {refreshResult.Error}");
+                await SaveRun(run, workspaceDetails, cancellationToken);
+                return Result.Failure(refreshResult.Error);
+            }
+
+            var planResult = await source.GetSyncPlan(cancellationToken);
+            if (planResult.IsFailure)
+            {
+                run.MarkFailed(_clock.Now, $"GetSyncPlan failed: {planResult.Error}");
+                await SaveRun(run, workspaceDetails, cancellationToken);
+                return Result.Failure(planResult.Error);
+            }
+
+            run.SetWorkspacesPlanned(planResult.Value.Count);
+
+            if (descriptorResult.Value.SystemId is null)
+            {
+                run.MarkFailed(_clock.Now, "Connection has no SystemId.");
+                await SaveRun(run, workspaceDetails, cancellationToken);
+                return Result.Failure("Connection has no SystemId.");
+            }
+
+            foreach (var target in planResult.Value)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                using (_logger.BeginScope(new Dictionary<string, object> { ["WorkspaceId"] = target.InternalWorkspaceId }))
+                {
+                    var detail = await RunWorkspace(source, target, descriptorResult.Value.SystemId!, syncType, syncId, cancellationToken);
+                    workspaceDetails.Add(detail);
+
+                    if (detail.Succeeded)
+                        run.RecordWorkspaceSuccess(detail.WorkItemsProcessed);
+                    else
+                        run.RecordWorkspaceFailure();
+                }
+            }
+
+            var dependenciesResult = await _sender.Send(new ProcessDependenciesCommand(descriptorResult.Value.SystemId!), cancellationToken);
+            if (dependenciesResult.IsFailure)
+            {
+                _logger.LogError("ProcessDependencies failed for connection {ConnectionId}: {Error}", connectionId, dependenciesResult.Error);
+                run.RecordError();
+            }
+
+            run.MarkSucceeded(_clock.Now);
+            await SaveRun(run, workspaceDetails, cancellationToken);
+            return Result.Success();
+        }
+        catch (OperationCanceledException)
+        {
+            run.MarkCancelled(_clock.Now);
+            await SaveRun(run, workspaceDetails, CancellationToken.None);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Unhandled exception while syncing connection {ConnectionId}.", connectionId);
+            run.MarkFailed(_clock.Now, ex.Message);
+            await SaveRun(run, workspaceDetails, CancellationToken.None);
+            return Result.Failure(ex.Message);
+        }
+    }
+
+    private async Task<WorkspaceSyncDetail> RunWorkspace(IWorkItemSource source, WorkspaceSyncTarget target, string systemId, SyncType syncType, Guid syncId, CancellationToken cancellationToken)
+    {
+        var prepResult = await source.PrepareWorkspaceForItemSync(target, syncId, cancellationToken);
+        if (prepResult.IsFailure)
+        {
+            _logger.LogError("PrepareWorkspaceForItemSync failed for workspace {WorkspaceId}: {Error}", target.InternalWorkspaceId, prepResult.Error);
+            return WorkspaceSyncDetail.FromFailure(target, prepResult.Error);
+        }
+
+        var iterationsResult = await source.SyncIterations(target, systemId, syncId, cancellationToken);
+        if (iterationsResult.IsFailure)
+        {
+            _logger.LogError("SyncIterations failed for workspace {WorkspaceId}: {Error}", target.InternalWorkspaceId, iterationsResult.Error);
+            return WorkspaceSyncDetail.FromFailure(target, iterationsResult.Error);
+        }
+
+        var itemsResult = await source.SyncWorkItems(target, syncType, syncId, cancellationToken);
+        if (itemsResult.IsFailure)
+        {
+            _logger.LogError("SyncWorkItems failed for workspace {WorkspaceId}: {Error}", target.InternalWorkspaceId, itemsResult.Error);
+            return WorkspaceSyncDetail.FromFailure(target, itemsResult.Error);
+        }
+
+        return WorkspaceSyncDetail.FromSuccess(target, itemsResult.Value);
+    }
+
+    private async Task<Result<SyncableConnectionDescriptor>> BuildDescriptor(Guid connectionId, Connector connector, CancellationToken cancellationToken)
+    {
+        switch (connector)
+        {
+            case Connector.AzureDevOps:
+                {
+                    var entity = await _db.AzureDevOpsBoardsConnections.AsNoTracking()
+                        .FirstOrDefaultAsync(c => c.Id == connectionId, cancellationToken);
+                    if (entity is null)
+                        return Result.Failure<SyncableConnectionDescriptor>($"Azure DevOps connection {connectionId} not found.");
+                    return Result.Success(new SyncableConnectionDescriptor(
+                        ConnectionId: entity.Id,
+                        Connector: Connector.AzureDevOps,
+                        SystemId: ((ISyncableConnection)entity).SystemId,
+                        Configuration: entity.Configuration,
+                        TeamConfiguration: entity.TeamConfiguration));
+                }
+            default:
+                return Result.Failure<SyncableConnectionDescriptor>($"Connector '{connector}' is not supported by the sync runner.");
+        }
+    }
+
+    private async Task SaveRun(SyncRun run, List<WorkspaceSyncDetail> details, CancellationToken cancellationToken)
+    {
+        if (details.Count > 0)
+        {
+            try
+            {
+                run.SetDetails(JsonSerializer.Serialize(details));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to serialize per-workspace details for SyncRun {SyncRunId}.", run.Id);
+            }
+        }
+
+        try
+        {
+            await _db.SaveChangesAsync(cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to persist SyncRun {SyncRunId} updates.", run.Id);
+        }
+    }
+
+    private sealed record WorkspaceSyncDetail(
+        Guid InternalWorkspaceId,
+        string WorkspaceName,
+        bool Succeeded,
+        int WorkItemsProcessed,
+        int ParentLinkChangesProcessed,
+        int DependencyLinkChangesProcessed,
+        int DeletedWorkItemsProcessed,
+        bool HadPartialFailure,
+        string? Error)
+    {
+        public static WorkspaceSyncDetail FromSuccess(WorkspaceSyncTarget target, WorkspaceItemsSyncResult r) =>
+            new(target.InternalWorkspaceId, target.WorkspaceName, true,
+                r.WorkItemsProcessed, r.ParentLinkChangesProcessed, r.DependencyLinkChangesProcessed, r.DeletedWorkItemsProcessed,
+                r.HadPartialFailure, r.PartialFailureMessage);
+
+        public static WorkspaceSyncDetail FromFailure(WorkspaceSyncTarget target, string error) =>
+            new(target.InternalWorkspaceId, target.WorkspaceName, false, 0, 0, 0, 0, false, error);
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Queries/GetConnectionsQuery.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Queries/GetConnectionsQuery.cs
@@ -7,7 +7,10 @@ using Wayd.Common.Domain.Enums.AppIntegrations;
 
 namespace Wayd.AppIntegration.Application.Connections.Queries;
 
-public sealed record GetConnectionsQuery(bool IncludeInactive = false, Connector? Type = null) : IQuery<IReadOnlyList<ConnectionListDto>>;
+public sealed record GetConnectionsQuery(
+    bool IncludeInactive = false,
+    Connector? Type = null,
+    ConnectorCategory? Category = null) : IQuery<IReadOnlyList<ConnectionListDto>>;
 
 internal sealed class GetConnectionsQueryHandler(IAppIntegrationDbContext appIntegrationDbContext) : IQueryHandler<GetConnectionsQuery, IReadOnlyList<ConnectionListDto>>
 {
@@ -26,12 +29,17 @@ internal sealed class GetConnectionsQueryHandler(IAppIntegrationDbContext appInt
         // Load to memory first to avoid Mapster projection issues with ISyncableConnection interface
         var connections = await query.ToListAsync(cancellationToken);
 
+        // Category filter is evaluated in-memory because it depends on the GetCategory() lookup,
+        // which isn't translatable to SQL. The connection set is small (<1000 rows) so this is fine.
+        if (request.Category.HasValue)
+            connections = [.. connections.Where(c => c.Connector.GetCategory() == request.Category.Value)];
+
         // Map each connection to its appropriate derived DTO type for polymorphic serialization
-        return connections.Select(connection => connection switch
+        return [.. connections.Select(connection => connection switch
         {
             AzureDevOpsBoardsConnection azdo => (ConnectionListDto)azdo.Adapt<AzureDevOpsConnectionListDto>(),
             AzureOpenAIConnection aoai => aoai.Adapt<AzureOpenAIConnectionListDto>(),
             _ => connection.Adapt<ConnectionListDto>()
-        }).ToList();
+        })];
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Interfaces/IWorkSyncRunner.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Interfaces/IWorkSyncRunner.cs
@@ -1,0 +1,8 @@
+﻿using Wayd.Common.Application.Enums;
+
+namespace Wayd.AppIntegration.Application.Interfaces;
+
+public interface IWorkSyncRunner : ITransientService
+{
+    Task<Result> Run(SyncType syncType, SyncTriggerSource trigger, CancellationToken cancellationToken);
+}

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Persistence/IAppIntegrationDbContext.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Persistence/IAppIntegrationDbContext.cs
@@ -8,4 +8,5 @@ public interface IAppIntegrationDbContext : IWaydDbContext
     DbSet<Connection> Connections { get; }
     DbSet<AzureDevOpsBoardsConnection> AzureDevOpsBoardsConnections { get; }
     DbSet<AzureOpenAIConnection> AzureOpenAIConnections { get; }
+    DbSet<SyncRun> SyncRuns { get; }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Wayd.AppIntegration.Application.csproj
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Wayd.AppIntegration.Application.csproj
@@ -10,6 +10,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\..\..\Wayd.Common\src\Wayd.Common.Application\Wayd.Common.Application.csproj" />
         <ProjectReference Include="..\..\..\..\Wayd.Common\src\Wayd.Common\Wayd.Common.csproj" />
+        <ProjectReference Include="..\..\..\..\Wayd.Integrations\src\Wayd.Integrations.Abstractions\Wayd.Integrations.Abstractions.csproj" />
         <ProjectReference Include="..\Wayd.AppIntegration.Domain\Wayd.AppIntegration.Domain.csproj" />
     </ItemGroup>
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/SyncRun.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/SyncRun.cs
@@ -1,0 +1,104 @@
+﻿using Wayd.Common.Application.Enums;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+
+namespace Wayd.AppIntegration.Domain.Models;
+
+public enum SyncRunStatus
+{
+    Running = 0,
+    Succeeded = 1,
+    Failed = 2,
+    Cancelled = 3
+}
+
+public enum SyncTriggerSource
+{
+    Scheduled = 0,
+    Manual = 1,
+    Api = 2
+}
+
+/// <summary>
+/// Persisted record of a single sync run for one connection. Inserted at start with
+/// <see cref="SyncRunStatus.Running"/>; updated on completion (or failure / cancellation).
+/// History survives connection deletion — there is intentionally no FK to Connections.
+/// </summary>
+public sealed class SyncRun : BaseEntity
+{
+    private SyncRun() { }
+
+    public Guid ConnectionId { get; private set; }
+    public Connector ConnectorType { get; private set; }
+    public Instant StartedAt { get; private set; }
+    public Instant? FinishedAt { get; private set; }
+    public SyncRunStatus Status { get; private set; }
+    public SyncTriggerSource TriggerSource { get; private set; }
+    public SyncType SyncType { get; private set; }
+    public int WorkspacesPlanned { get; private set; }
+    public int WorkspacesSucceeded { get; private set; }
+    public int WorkspacesFailed { get; private set; }
+    public int WorkItemsProcessed { get; private set; }
+    public int ErrorsCount { get; private set; }
+    public string? ErrorMessage { get; private set; }
+    public string? DetailsJson { get; private set; }
+
+    public void SetWorkspacesPlanned(int count) => WorkspacesPlanned = count;
+
+    public void RecordWorkspaceSuccess(int workItemsProcessed)
+    {
+        WorkspacesSucceeded++;
+        WorkItemsProcessed += workItemsProcessed;
+    }
+
+    public void RecordWorkspaceFailure()
+    {
+        WorkspacesFailed++;
+        ErrorsCount++;
+    }
+
+    public void RecordError() => ErrorsCount++;
+
+    public Result MarkSucceeded(Instant now)
+    {
+        if (Status != SyncRunStatus.Running)
+            return Result.Failure($"Cannot mark a {Status} sync run as Succeeded.");
+        Status = SyncRunStatus.Succeeded;
+        FinishedAt = now;
+        return Result.Success();
+    }
+
+    public Result MarkFailed(Instant now, string error)
+    {
+        if (Status != SyncRunStatus.Running)
+            return Result.Failure($"Cannot mark a {Status} sync run as Failed.");
+        Status = SyncRunStatus.Failed;
+        FinishedAt = now;
+        ErrorMessage = error;
+        ErrorsCount++;
+        return Result.Success();
+    }
+
+    public Result MarkCancelled(Instant now)
+    {
+        if (Status != SyncRunStatus.Running)
+            return Result.Failure($"Cannot mark a {Status} sync run as Cancelled.");
+        Status = SyncRunStatus.Cancelled;
+        FinishedAt = now;
+        return Result.Success();
+    }
+
+    public void SetDetails(string json) => DetailsJson = json;
+
+    public static SyncRun Start(Guid connectionId, Connector connector, SyncType syncType, SyncTriggerSource trigger, Instant now)
+    {
+        return new SyncRun
+        {
+            ConnectionId = connectionId,
+            ConnectorType = connector,
+            SyncType = syncType,
+            TriggerSource = trigger,
+            StartedAt = now,
+            Status = SyncRunStatus.Running
+        };
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Infrastructure/FakeAppIntegrationDbContext.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Infrastructure/FakeAppIntegrationDbContext.cs
@@ -20,6 +20,7 @@ public class FakeAppIntegrationDbContext : IAppIntegrationDbContext, IDisposable
     private readonly List<Connection> _connections = [];
     private readonly List<AzureDevOpsBoardsConnection> _azureDevOpsBoardsConnections = [];
     private readonly List<AzureOpenAIConnection> _azureOpenAIConnections = [];
+    private readonly List<SyncRun> _syncRuns = [];
 
     // Common domain entities
     private readonly List<Employee> _employees = [];
@@ -32,6 +33,7 @@ public class FakeAppIntegrationDbContext : IAppIntegrationDbContext, IDisposable
     public DbSet<Connection> Connections => _connections.AsDbSet();
     public DbSet<AzureDevOpsBoardsConnection> AzureDevOpsBoardsConnections => _azureDevOpsBoardsConnections.AsDbSet();
     public DbSet<AzureOpenAIConnection> AzureOpenAIConnections => _azureOpenAIConnections.AsDbSet();
+    public DbSet<SyncRun> SyncRuns => _syncRuns.AsDbSet();
     public DbSet<Employee> Employees => _employees.AsDbSet();
     public DbSet<ExternalEmployeeBlacklistItem> ExternalEmployeeBlacklistItems => _externalEmployeeBlacklistItems.AsDbSet();
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
@@ -91,6 +93,7 @@ public class FakeAppIntegrationDbContext : IAppIntegrationDbContext, IDisposable
     {
         _connections.Clear();
         _azureDevOpsBoardsConnections.Clear();
+        _syncRuns.Clear();
         _employees.Clear();
         _externalEmployeeBlacklistItems.Clear();
         _personalAccessTokens.Clear();

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs
@@ -1,0 +1,565 @@
+﻿using CSharpFunctionalExtensions;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.AutoMock;
+using NodaTime;
+using Wayd.AppIntegration.Application.Connections.Dtos.AzureDevOps;
+using Wayd.AppIntegration.Application.Connections.Managers;
+using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
+using Wayd.AppIntegration.Application.Interfaces;
+using Wayd.AppIntegration.Domain.Models;
+using Wayd.Common.Application.Dtos;
+using Wayd.Common.Application.Enums;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Requests.Planning.Iterations;
+using Wayd.Common.Application.Requests.WorkManagement.Commands;
+using Wayd.Common.Application.Requests.WorkManagement.Interfaces;
+using Wayd.Common.Application.Requests.WorkManagement.Queries;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Wayd.Integrations.Abstractions;
+
+namespace Wayd.AppIntegration.Application.Tests.Sut.Connections.Managers;
+
+/// <summary>
+/// Adapter-level tests for <see cref="AzureDevOpsWorkItemSource"/>. Covers bind validation, plan
+/// flattening, work-process dedup, partial-failure semantics, and SyncType branching — the
+/// behaviour the source must preserve from the deleted <c>AzureDevOpsSyncManager</c>.
+/// </summary>
+public class AzureDevOpsWorkItemSourceTests
+{
+    private readonly AutoMocker _mocker;
+    private readonly AzureDevOpsWorkItemSource _sut;
+
+    public AzureDevOpsWorkItemSourceTests()
+    {
+        _mocker = new AutoMocker();
+        _mocker.Use<ILogger<AzureDevOpsWorkItemSource>>(Mock.Of<ILogger<AzureDevOpsWorkItemSource>>());
+        _sut = _mocker.CreateInstance<AzureDevOpsWorkItemSource>();
+    }
+
+    #region Helpers
+
+    private static SyncableConnectionDescriptor BuildDescriptor(
+        Guid? connectionId = null,
+        string? systemId = "system-1",
+        AzureDevOpsBoardsConnectionConfiguration? cfg = null,
+        AzureDevOpsBoardsTeamConfiguration? teamCfg = null)
+    {
+        return new SyncableConnectionDescriptor(
+            ConnectionId: connectionId ?? Guid.CreateVersion7(),
+            Connector: Connector.AzureDevOps,
+            SystemId: systemId,
+            Configuration: cfg ?? new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "test-pat"),
+            TeamConfiguration: teamCfg);
+    }
+
+    private static AzureDevOpsWorkProcessDto Process(Guid? externalId = null, Guid? internalId = null, bool isActive = true) =>
+        new()
+        {
+            ExternalId = externalId ?? Guid.CreateVersion7(),
+            Name = "Agile",
+            Description = "desc",
+            IntegrationState = isActive
+                ? new IntegrationStateDto { InternalId = internalId ?? Guid.CreateVersion7(), IsActive = true }
+                : null
+        };
+
+    private static AzureDevOpsWorkspaceDto Workspace(Guid workProcessExternalId, Guid? externalId = null, Guid? internalId = null, string name = "Project", bool isActive = true) =>
+        new()
+        {
+            ExternalId = externalId ?? Guid.CreateVersion7(),
+            Name = name,
+            Description = "desc",
+            WorkProcessId = workProcessExternalId,
+            IntegrationState = isActive
+                ? new IntegrationStateDto { InternalId = internalId ?? Guid.CreateVersion7(), IsActive = true }
+                : null
+        };
+
+    private static AzureDevOpsConnectionDetailsDto BuildConnectionDetails(
+        Guid connectionId,
+        List<AzureDevOpsWorkProcessDto> processes,
+        List<AzureDevOpsWorkspaceDto> workspaces,
+        List<AzureDevOpsWorkspaceTeamDto>? teams = null,
+        string systemId = "system-1") =>
+        new()
+        {
+            Id = connectionId,
+            Name = "Test Connection",
+            Connector = new SimpleNavigationDto { Id = (int)Connector.AzureDevOps, Name = "Azure DevOps" },
+            IsActive = true,
+            IsValidConfiguration = true,
+            SystemId = systemId,
+            IsSyncEnabled = true,
+            Configuration = new AzureDevOpsConnectionConfigurationDto
+            {
+                Organization = "TestOrg",
+                PersonalAccessToken = "test-pat",
+                OrganizationUrl = "https://dev.azure.com/TestOrg",
+                WorkProcesses = processes,
+                Workspaces = workspaces
+            },
+            TeamConfiguration = new AzureDevOpsTeamConfigurationDto { WorkspaceTeams = teams ?? [] }
+        };
+
+    private void StubWorkProcessSync()
+    {
+        var workProcessConfig = new Mock<IExternalWorkProcessConfiguration>();
+        workProcessConfig.Setup(p => p.Name).Returns("Agile");
+        workProcessConfig.Setup(p => p.WorkTypes).Returns(new List<IExternalWorkTypeWorkflow>());
+        workProcessConfig.Setup(p => p.WorkStatuses).Returns(new List<IExternalWorkStatus>());
+
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(workProcessConfig.Object));
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetWorkProcessSchemesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<IWorkProcessSchemeDto>().AsReadOnly() as IReadOnlyList<IWorkProcessSchemeDto>);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<UpdateExternalWorkProcessCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // SyncWorkspace
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetWorkspace(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new Mock<IExternalWorkspaceConfiguration>().Object));
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<UpdateExternalWorkspaceCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
+
+    private void StubWorkItemSubSteps()
+    {
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetWorkspaceWorkTypesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new List<IWorkTypeDto>().AsReadOnly() as IReadOnlyList<IWorkTypeDto>));
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetWorkspaceMostRecentChangeDateQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success<Instant?>(null));
+
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetWorkItems(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<Dictionary<Guid, Guid?>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new List<IExternalWorkItem>()));
+
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new List<IExternalWorkItemLink>()));
+
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetDependencyLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new List<IExternalWorkItemLink>()));
+
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(Array.Empty<int>()));
+    }
+
+    #endregion
+
+    // -------- Bind --------
+
+    [Fact]
+    public void Bind_RejectsWrongConnector()
+    {
+        var descriptor = new SyncableConnectionDescriptor(
+            Guid.CreateVersion7(),
+            Connector.OpenAI,
+            SystemId: null,
+            Configuration: new AzureDevOpsBoardsConnectionConfiguration("o", "p"),
+            TeamConfiguration: null);
+
+        var result = _sut.Bind(descriptor);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("OpenAI");
+    }
+
+    [Fact]
+    public void Bind_RejectsWrongConfigurationType()
+    {
+        var descriptor = new SyncableConnectionDescriptor(
+            Guid.CreateVersion7(),
+            Connector.AzureDevOps,
+            SystemId: null,
+            Configuration: "not-a-config",
+            TeamConfiguration: null);
+
+        var result = _sut.Bind(descriptor);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("AzureDevOpsBoardsConnectionConfiguration");
+    }
+
+    [Fact]
+    public void Bind_AcceptsValidDescriptor()
+    {
+        var result = _sut.Bind(BuildDescriptor());
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Connector_ReturnsAzureDevOps()
+    {
+        _sut.Connector.Should().Be(Connector.AzureDevOps);
+    }
+
+    // -------- GetSyncPlan --------
+
+    [Fact]
+    public async Task GetSyncPlan_EmitsFlatTargetsForActiveWorkspacesUnderActiveProcesses()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        var processId = Guid.CreateVersion7();
+        var workspaceId = Guid.CreateVersion7();
+        var details = BuildConnectionDetails(
+            descriptor.ConnectionId,
+            processes: [Process(externalId: processId)],
+            workspaces: [Workspace(processId, externalId: workspaceId, name: "ProjectA")]);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.Is<GetAzureDevOpsConnectionQuery>(q => q.ConnectionId == descriptor.ConnectionId), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var result = await _sut.GetSyncPlan(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(1);
+        var target = result.Value.Single();
+        target.ExternalWorkspaceId.Should().Be(workspaceId);
+        target.WorkspaceName.Should().Be("ProjectA");
+        target.Filters.AsDictionary.Should().ContainKey(AzureDevOpsWorkItemSource.TeamSettingsFilterKey);
+        // Runner never sees "work process" as a concept — verify only by absence of process-shaped fields on the target.
+        target.GetType().GetProperties().Select(p => p.Name).Should().NotContain("WorkProcessId");
+    }
+
+    [Fact]
+    public async Task GetSyncPlan_SkipsWorkspacesWithInactiveProcess()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        var inactiveProcessId = Guid.CreateVersion7();
+        var details = BuildConnectionDetails(
+            descriptor.ConnectionId,
+            processes: [Process(externalId: inactiveProcessId, isActive: false)],
+            workspaces: [Workspace(inactiveProcessId)]);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var result = await _sut.GetSyncPlan(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSyncPlan_SkipsInactiveWorkspaces()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        var processId = Guid.CreateVersion7();
+        var details = BuildConnectionDetails(
+            descriptor.ConnectionId,
+            processes: [Process(externalId: processId)],
+            workspaces: [Workspace(processId, isActive: false)]);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var result = await _sut.GetSyncPlan(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetSyncPlan_IncludesTeamSettingsForWorkspaceTeams()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        var processId = Guid.CreateVersion7();
+        var workspaceId = Guid.CreateVersion7();
+        var teamId = Guid.CreateVersion7();
+        var internalTeamId = Guid.CreateVersion7();
+        var boardId = Guid.CreateVersion7();
+
+        var details = BuildConnectionDetails(
+            descriptor.ConnectionId,
+            processes: [Process(externalId: processId)],
+            workspaces: [Workspace(processId, externalId: workspaceId)],
+            teams: [new AzureDevOpsWorkspaceTeamDto
+            {
+                WorkspaceId = workspaceId,
+                TeamId = teamId,
+                TeamName = "Alpha",
+                BoardId = boardId,
+                InternalTeamId = internalTeamId
+            }]);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var result = await _sut.GetSyncPlan(CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var target = result.Value.Single();
+        target.Filters.TryGet(AzureDevOpsWorkItemSource.TeamSettingsFilterKey, out var settingsJson).Should().BeTrue();
+        settingsJson.Should().Contain(teamId.ToString());
+        settingsJson.Should().Contain(boardId.ToString());
+    }
+
+    [Fact]
+    public async Task GetSyncPlan_ReturnsFailureWhenConnectionNotFound()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AzureDevOpsConnectionDetailsDto?)null);
+
+        var result = await _sut.GetSyncPlan(CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    // -------- PrepareWorkspaceForItemSync (work-process dedup) --------
+
+    [Fact]
+    public async Task PrepareWorkspaceForItemSync_OnlyCallsGetWorkProcessOncePerProcessAcrossMultipleWorkspaces()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        var processId = Guid.CreateVersion7();
+        var details = BuildConnectionDetails(
+            descriptor.ConnectionId,
+            processes: [Process(externalId: processId)],
+            workspaces: [
+                Workspace(processId, name: "ProjectA"),
+                Workspace(processId, name: "ProjectB")
+            ]);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        var planResult = await _sut.GetSyncPlan(CancellationToken.None);
+        planResult.Value.Should().HaveCount(2);
+
+        StubWorkProcessSync();
+
+        foreach (var target in planResult.Value)
+        {
+            var prepResult = await _sut.PrepareWorkspaceForItemSync(target, Guid.CreateVersion7(), CancellationToken.None);
+            prepResult.IsSuccess.Should().BeTrue();
+        }
+
+        // Same process across both workspaces: GetWorkProcess should only fire once.
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Verify(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+        // GetWorkspace is per-workspace.
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Verify(s => s.GetWorkspace(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task PrepareWorkspaceForItemSync_ResetsDedupOnRebind()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        var processId = Guid.CreateVersion7();
+        var details = BuildConnectionDetails(
+            descriptor.ConnectionId,
+            processes: [Process(externalId: processId)],
+            workspaces: [Workspace(processId)]);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        StubWorkProcessSync();
+
+        var plan1 = await _sut.GetSyncPlan(CancellationToken.None);
+        await _sut.PrepareWorkspaceForItemSync(plan1.Value.Single(), Guid.CreateVersion7(), CancellationToken.None);
+
+        // Rebind for a fresh sync cycle.
+        _sut.Bind(descriptor);
+        var plan2 = await _sut.GetSyncPlan(CancellationToken.None);
+        await _sut.PrepareWorkspaceForItemSync(plan2.Value.Single(), Guid.CreateVersion7(), CancellationToken.None);
+
+        // Each Bind cycle should re-sync the work process once.
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Verify(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    // -------- SyncWorkItems: SyncType branching --------
+
+    [Fact]
+    public async Task SyncWorkItems_Differential_CallsGetParentLinkChanges()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+        StubWorkItemSubSteps();
+
+        var target = new WorkspaceSyncTarget(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), "Project", "key", WorkItemSyncFilters.Empty);
+
+        var result = await _sut.SyncWorkItems(target, SyncType.Differential, Guid.CreateVersion7(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Verify(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task SyncWorkItems_Full_SkipsGetParentLinkChanges()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+        StubWorkItemSubSteps();
+
+        var target = new WorkspaceSyncTarget(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), "Project", "key", WorkItemSyncFilters.Empty);
+
+        var result = await _sut.SyncWorkItems(target, SyncType.Full, Guid.CreateVersion7(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Verify(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // -------- SyncWorkItems: partial-failure semantics --------
+
+    [Fact]
+    public async Task SyncWorkItems_SubStepFailure_ReturnsSuccessWithPartialFailureFlag()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+        StubWorkItemSubSteps();
+
+        // Override only the deletes call to fail.
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<int[]>("AzDO returned 500"));
+
+        var target = new WorkspaceSyncTarget(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), "Project", "key", WorkItemSyncFilters.Empty);
+
+        var result = await _sut.SyncWorkItems(target, SyncType.Differential, Guid.CreateVersion7(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.HadPartialFailure.Should().BeTrue();
+        result.Value.PartialFailureMessage.Should().Contain("deleted").And.Contain("AzDO returned 500");
+    }
+
+    [Fact]
+    public async Task SyncWorkItems_AllSubStepsSucceed_ReturnsAggregatedCounters()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetWorkspaceWorkTypesQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new List<IWorkTypeDto>().AsReadOnly() as IReadOnlyList<IWorkTypeDto>));
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetWorkspaceMostRecentChangeDateQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success<Instant?>(null));
+
+        var threeItems = new List<IExternalWorkItem>
+        {
+            Mock.Of<IExternalWorkItem>(), Mock.Of<IExternalWorkItem>(), Mock.Of<IExternalWorkItem>()
+        };
+        var twoParentChanges = new List<IExternalWorkItemLink>
+        {
+            Mock.Of<IExternalWorkItemLink>(), Mock.Of<IExternalWorkItemLink>()
+        };
+        var oneDepChange = new List<IExternalWorkItemLink> { Mock.Of<IExternalWorkItemLink>() };
+
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetWorkItems(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<Dictionary<Guid, Guid?>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(threeItems));
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(twoParentChanges));
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetDependencyLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(oneDepChange));
+        _mocker.GetMock<IAzureDevOpsService>()
+            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new[] { 1, 2, 3, 4 }));
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetIterationMappingsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<string, Guid>());
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<SyncExternalWorkItemsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<SyncExternalWorkItemParentChangesCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<SyncExternalWorkItemDependencyChangesCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<DeleteExternalWorkItemsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        var target = new WorkspaceSyncTarget(
+            Guid.CreateVersion7(), Guid.CreateVersion7(), "Project", "key", WorkItemSyncFilters.Empty);
+
+        var result = await _sut.SyncWorkItems(target, SyncType.Differential, Guid.CreateVersion7(), CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.WorkItemsProcessed.Should().Be(3);
+        result.Value.ParentLinkChangesProcessed.Should().Be(2);
+        result.Value.DependencyLinkChangesProcessed.Should().Be(1);
+        result.Value.DeletedWorkItemsProcessed.Should().Be(4);
+        result.Value.HadPartialFailure.Should().BeFalse();
+        result.Value.PartialFailureMessage.Should().BeNull();
+    }
+
+    // -------- RefreshOrganizationConfiguration delegates to init manager --------
+
+    [Fact]
+    public async Task RefreshOrganizationConfiguration_DelegatesToInitManager()
+    {
+        var descriptor = BuildDescriptor();
+        _sut.Bind(descriptor);
+        var syncId = Guid.CreateVersion7();
+
+        _mocker.GetMock<IAzureDevOpsInitManager>()
+            .Setup(m => m.SyncOrganizationConfiguration(descriptor.ConnectionId, It.IsAny<CancellationToken>(), syncId))
+            .ReturnsAsync(Result.Success())
+            .Verifiable();
+
+        var result = await _sut.RefreshOrganizationConfiguration(syncId, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _mocker.GetMock<IAzureDevOpsInitManager>().Verify();
+    }
+
+    [Fact]
+    public void SyncMethods_RequireBind()
+    {
+        // No Bind() call.
+        Action act = () => _sut.TestConnection(CancellationToken.None);
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Bind*");
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs
@@ -56,6 +56,14 @@ public class WorkSyncRunnerTests
             .Setup(f => f.Create(It.IsAny<SyncableConnectionDescriptor>()))
             .Returns(Result.Success(_source.Object));
 
+        // Exercise the real AzDO descriptor builder against the fake DbContext — same path
+        // production takes.
+        var descriptorBuilders = new ISyncableConnectionDescriptorBuilder[]
+        {
+            new AzureDevOpsConnectionDescriptorBuilder(_db)
+        };
+        _mocker.Use<IEnumerable<ISyncableConnectionDescriptorBuilder>>(descriptorBuilders);
+
         _sut = _mocker.CreateInstance<WorkSyncRunner>();
     }
 
@@ -386,6 +394,44 @@ public class WorkSyncRunnerTests
         run.WorkspacesSucceeded.Should().Be(1);
         run.WorkItemsProcessed.Should().Be(3);
         run.DetailsJson.Should().Contain("deps sub-step failed");
+        // Partial failure must bump ErrorsCount so dashboards can flag degraded runs without
+        // parsing DetailsJson.
+        run.ErrorsCount.Should().Be(1);
+    }
+
+    [Theory]
+    [InlineData(SyncTriggerSource.Manual)]
+    [InlineData(SyncTriggerSource.Scheduled)]
+    [InlineData(SyncTriggerSource.Api)]
+    public async Task Run_PersistsTriggerSourceOnSyncRun(SyncTriggerSource trigger)
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+
+        await _sut.Run(SyncType.Differential, trigger, CancellationToken.None);
+
+        _db.SyncRuns.Single().TriggerSource.Should().Be(trigger);
+    }
+
+    [Fact]
+    public async Task Run_NoDescriptorBuilderRegistered_SkipsConnectionAndStartsNoSyncRun()
+    {
+        // Re-create the SUT with an EMPTY descriptor-builder set, simulating a connector that
+        // has neither a builder nor an IWorkItemSource registered. The runner must skip the
+        // connection rather than throw or persist a half-baked SyncRun.
+        _mocker.Use<IEnumerable<ISyncableConnectionDescriptorBuilder>>(Array.Empty<ISyncableConnectionDescriptorBuilder>());
+        var sut = _mocker.CreateInstance<WorkSyncRunner>();
+
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+
+        var result = await sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        _db.SyncRuns.Should().BeEmpty();
+        _source.Verify(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs
@@ -1,0 +1,427 @@
+﻿using CSharpFunctionalExtensions;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.AutoMock;
+using Wayd.AppIntegration.Application.Connections.Dtos;
+using Wayd.AppIntegration.Application.Connections.Managers;
+using Wayd.AppIntegration.Application.Connections.Queries;
+using Wayd.AppIntegration.Application.Persistence;
+using Wayd.AppIntegration.Application.Tests.Infrastructure;
+using Wayd.AppIntegration.Domain.Models;
+using Wayd.Common.Application.Dtos;
+using Wayd.Common.Application.Enums;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Requests.WorkManagement.Commands;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Wayd.Common.Domain.Models;
+using Wayd.Integrations.Abstractions;
+using Wayd.Tests.Shared;
+
+namespace Wayd.AppIntegration.Application.Tests.Sut.Connections.Managers;
+
+/// <summary>
+/// Protocol tests for <see cref="WorkSyncRunner"/>. These assert the runner's contract with any
+/// <see cref="IWorkItemSource"/> implementation — the source itself is fully mocked. The AzDO
+/// entity is used only because <c>BuildDescriptor</c> currently knows how to construct a
+/// descriptor from <c>AzureDevOpsBoardsConnection</c>; the runner protocol assertions are
+/// connector-agnostic.
+/// </summary>
+public class WorkSyncRunnerTests
+{
+    private readonly AutoMocker _mocker;
+    private readonly FakeAppIntegrationDbContext _db;
+    private readonly TestingDateTimeProvider _clock;
+    private readonly Mock<IWorkItemSource> _source;
+    private readonly WorkSyncRunner _sut;
+
+    public WorkSyncRunnerTests()
+    {
+        _mocker = new AutoMocker();
+        _mocker.Use<ILogger<WorkSyncRunner>>(Mock.Of<ILogger<WorkSyncRunner>>());
+
+        _db = new FakeAppIntegrationDbContext();
+        _mocker.Use<IAppIntegrationDbContext>(_db);
+
+        _clock = new TestingDateTimeProvider(new DateTime(2026, 05, 24, 10, 0, 0, DateTimeKind.Utc));
+        _mocker.Use<IDateTimeProvider>(_clock);
+
+        _source = new Mock<IWorkItemSource>(MockBehavior.Strict);
+        _source.SetupGet(s => s.Connector).Returns(Connector.AzureDevOps);
+        _source.Setup(s => s.Bind(It.IsAny<SyncableConnectionDescriptor>()))
+            .Returns(Result.Success());
+
+        _mocker.GetMock<IWorkItemSourceFactory>()
+            .Setup(f => f.Create(It.IsAny<SyncableConnectionDescriptor>()))
+            .Returns(Result.Success(_source.Object));
+
+        _sut = _mocker.CreateInstance<WorkSyncRunner>();
+    }
+
+    #region Test helpers
+
+    private AzureDevOpsBoardsConnection SeedActiveAzdoConnection(string systemId = "system-1")
+    {
+        var processExternalId = Guid.CreateVersion7();
+        var processInternalId = Guid.CreateVersion7();
+        var workspaceExternalId = Guid.CreateVersion7();
+        var workspaceInternalId = Guid.CreateVersion7();
+
+        // Seed work process + workspace via the constructor (which accepts pre-built collections),
+        // then activate the integration state so HasActiveIntegrationObjects is true.
+        var config = new AzureDevOpsBoardsConnectionConfiguration(
+            "TestOrg", "test-pat",
+            workspaces: [AzureDevOpsBoardsWorkspace.Create(workspaceExternalId, "Project", "desc", processExternalId)],
+            processes: [AzureDevOpsBoardsWorkProcess.Create(processExternalId, "Agile", "desc")]);
+
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection", "desc", systemId, config, configurationIsValid: true,
+            teamConfiguration: null, timestamp: _clock.Now);
+
+        connection.Activate(_clock.Now);
+        connection.UpdateWorkProcessIntegrationState(
+            new IntegrationRegistration<Guid, Guid>(processExternalId, IntegrationState<Guid>.Create(processInternalId, true)),
+            _clock.Now);
+        connection.UpdateWorkspaceIntegrationState(
+            new IntegrationRegistration<Guid, Guid>(workspaceExternalId, IntegrationState<Guid>.Create(workspaceInternalId, true)),
+            _clock.Now);
+        connection.SetSyncState(true, _clock.Now);
+
+        _db.AddAzureDevOpsBoardsConnection(connection);
+        return connection;
+    }
+
+    private void SetupConnectionsQuery(params AzureDevOpsBoardsConnection[] entities)
+    {
+        var dtos = entities.Select(e => new ConnectionListDto
+        {
+            Id = e.Id,
+            Name = e.Name,
+            SystemId = e.SystemId,
+            Connector = new SimpleNavigationDto { Id = (int)e.Connector, Name = "Azure DevOps" },
+            IsActive = e.IsActive,
+            IsValidConfiguration = e.IsValidConfiguration,
+            IsSyncEnabled = e.IsSyncEnabled,
+            CanSync = e.CanSync
+        }).ToList().AsReadOnly() as IReadOnlyList<ConnectionListDto>;
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<GetConnectionsQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dtos);
+    }
+
+    private void StubHappyPathSource(int workspaceCount = 1, int workItemsPerWorkspace = 5)
+    {
+        var targets = Enumerable.Range(0, workspaceCount)
+            .Select(_ => new WorkspaceSyncTarget(
+                ExternalWorkspaceId: Guid.CreateVersion7(),
+                InternalWorkspaceId: Guid.CreateVersion7(),
+                WorkspaceName: "Workspace",
+                WorkspaceKey: "key",
+                Filters: WorkItemSyncFilters.Empty))
+            .ToList();
+
+        _source.Setup(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _source.Setup(s => s.GetSyncPlan(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success<IReadOnlyList<WorkspaceSyncTarget>>(targets));
+        _source.Setup(s => s.PrepareWorkspaceForItemSync(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _source.Setup(s => s.SyncIterations(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        _source.Setup(s => s.SyncWorkItems(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<SyncType>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new WorkspaceItemsSyncResult(workItemsPerWorkspace, 0, 0, 0)));
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<ProcessDependenciesCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+    }
+
+    #endregion
+
+    [Fact]
+    public async Task Run_WithNoActiveConnections_ReturnsFailure()
+    {
+        SetupConnectionsQuery(); // empty
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("No active syncable connections");
+        _db.SyncRuns.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Run_HappyPath_PersistsSyncRunAsSucceeded()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource(workspaceCount: 2, workItemsPerWorkspace: 7);
+
+        var result = await _sut.Run(SyncType.Full, SyncTriggerSource.Manual, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var runs = _db.SyncRuns.ToList();
+        runs.Should().HaveCount(1);
+        var run = runs.Single();
+        run.Status.Should().Be(SyncRunStatus.Succeeded);
+        run.ConnectionId.Should().Be(connection.Id);
+        run.ConnectorType.Should().Be(Connector.AzureDevOps);
+        run.SyncType.Should().Be(SyncType.Full);
+        run.TriggerSource.Should().Be(SyncTriggerSource.Manual);
+        run.WorkspacesPlanned.Should().Be(2);
+        run.WorkspacesSucceeded.Should().Be(2);
+        run.WorkspacesFailed.Should().Be(0);
+        run.WorkItemsProcessed.Should().Be(14);
+        run.StartedAt.Should().Be(_clock.Now);
+        run.FinishedAt.Should().Be(_clock.Now);
+        run.ErrorMessage.Should().BeNull();
+        run.DetailsJson.Should().NotBeNullOrWhiteSpace();
+    }
+
+    [Fact]
+    public async Task Run_HappyPath_CallsSourceInExpectedOrder()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource(workspaceCount: 1);
+
+        var sequence = new List<string>();
+        _source.Setup(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add(nameof(IWorkItemSource.RefreshOrganizationConfiguration)))
+            .ReturnsAsync(Result.Success());
+        _source.Setup(s => s.GetSyncPlan(It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add(nameof(IWorkItemSource.GetSyncPlan)))
+            .ReturnsAsync(Result.Success<IReadOnlyList<WorkspaceSyncTarget>>([new WorkspaceSyncTarget(
+                Guid.CreateVersion7(), Guid.CreateVersion7(), "w", "k", WorkItemSyncFilters.Empty)]));
+        _source.Setup(s => s.PrepareWorkspaceForItemSync(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add(nameof(IWorkItemSource.PrepareWorkspaceForItemSync)))
+            .ReturnsAsync(Result.Success());
+        _source.Setup(s => s.SyncIterations(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add(nameof(IWorkItemSource.SyncIterations)))
+            .ReturnsAsync(Result.Success());
+        _source.Setup(s => s.SyncWorkItems(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<SyncType>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add(nameof(IWorkItemSource.SyncWorkItems)))
+            .ReturnsAsync(Result.Success(WorkspaceItemsSyncResult.Zero));
+
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<ProcessDependenciesCommand>(), It.IsAny<CancellationToken>()))
+            .Callback(() => sequence.Add(nameof(ProcessDependenciesCommand)))
+            .ReturnsAsync(Result.Success());
+
+        await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        sequence.Should().Equal(
+            nameof(IWorkItemSource.RefreshOrganizationConfiguration),
+            nameof(IWorkItemSource.GetSyncPlan),
+            nameof(IWorkItemSource.PrepareWorkspaceForItemSync),
+            nameof(IWorkItemSource.SyncIterations),
+            nameof(IWorkItemSource.SyncWorkItems),
+            nameof(ProcessDependenciesCommand));
+    }
+
+    [Fact]
+    public async Task Run_SourceFactoryFailure_SkipsConnectionAndReturnsSuccess()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        _mocker.GetMock<IWorkItemSourceFactory>()
+            .Setup(f => f.Create(It.IsAny<SyncableConnectionDescriptor>()))
+            .Returns(Result.Failure<IWorkItemSource>("No source registered."));
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        // Skipping is not a top-level failure
+        result.IsSuccess.Should().BeTrue();
+        _db.SyncRuns.Should().BeEmpty(); // no run is started when the source can't be resolved
+        _source.Verify(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_RefreshOrganizationConfigurationFails_MarksRunAsFailed()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+        _source.Setup(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure("Unable to reach AzDO"));
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue(); // per-connection failure is not a job-level failure
+        var run = _db.SyncRuns.Single();
+        run.Status.Should().Be(SyncRunStatus.Failed);
+        run.ErrorMessage.Should().Contain("Unable to reach AzDO");
+        run.FinishedAt.Should().NotBeNull();
+        _source.Verify(s => s.GetSyncPlan(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_GetSyncPlanFails_MarksRunAsFailed()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+        _source.Setup(s => s.GetSyncPlan(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure<IReadOnlyList<WorkspaceSyncTarget>>("Plan unavailable"));
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var run = _db.SyncRuns.Single();
+        run.Status.Should().Be(SyncRunStatus.Failed);
+        run.ErrorMessage.Should().Contain("Plan unavailable");
+        _source.Verify(s => s.PrepareWorkspaceForItemSync(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Run_WorkspacePrepFails_ContinuesToOtherWorkspacesAndRecordsFailure()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource(workspaceCount: 2);
+
+        // First call fails, second succeeds.
+        _source.SetupSequence(s => s.PrepareWorkspaceForItemSync(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure("Schema refresh failed"))
+            .ReturnsAsync(Result.Success());
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var run = _db.SyncRuns.Single();
+        run.Status.Should().Be(SyncRunStatus.Succeeded);
+        run.WorkspacesPlanned.Should().Be(2);
+        run.WorkspacesSucceeded.Should().Be(1);
+        run.WorkspacesFailed.Should().Be(1);
+        // Iterations/items should still be called for the second (succeeded) workspace.
+        _source.Verify(s => s.SyncIterations(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+        _source.Verify(s => s.SyncWorkItems(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<SyncType>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_MultipleConnections_OneFailingDoesNotStopTheOther()
+    {
+        var connectionA = SeedActiveAzdoConnection(systemId: "system-a");
+        var connectionB = SeedActiveAzdoConnection(systemId: "system-b");
+        SetupConnectionsQuery(connectionA, connectionB);
+        StubHappyPathSource();
+
+        // First connection's GetSyncPlan throws; second runs normally.
+        _source.SetupSequence(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("boom"))
+            .ReturnsAsync(Result.Success());
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var runs = _db.SyncRuns.ToList();
+        runs.Should().HaveCount(2);
+        runs.Should().Contain(r => r.Status == SyncRunStatus.Failed && r.ErrorMessage == "boom");
+        runs.Should().Contain(r => r.Status == SyncRunStatus.Succeeded);
+    }
+
+    [Fact]
+    public async Task Run_Cancelled_MarksRunAsCancelledAndRethrows()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+
+        using var cts = new CancellationTokenSource();
+        _source.Setup(s => s.RefreshOrganizationConfiguration(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Callback(() => cts.Cancel())
+            .ThrowsAsync(new OperationCanceledException());
+
+        var act = async () => await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+        var run = _db.SyncRuns.Single();
+        run.Status.Should().Be(SyncRunStatus.Cancelled);
+        run.FinishedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Run_ProcessDependenciesFailure_StillMarksRunSucceededButRecordsError()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+        _mocker.GetMock<ISender>()
+            .Setup(s => s.Send(It.IsAny<ProcessDependenciesCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure("Dependencies failed"));
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var run = _db.SyncRuns.Single();
+        run.Status.Should().Be(SyncRunStatus.Succeeded);
+        run.ErrorsCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Run_PartialWorkspaceFailureInsideSource_PreservesSuccessButCountsAccurately()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+
+        // SyncWorkItems returns success with HadPartialFailure=true (e.g. parent-link sub-step failed).
+        _source.Setup(s => s.SyncWorkItems(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<SyncType>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success(new WorkspaceItemsSyncResult(
+                WorkItemsProcessed: 3,
+                ParentLinkChangesProcessed: 0,
+                DependencyLinkChangesProcessed: 0,
+                DeletedWorkItemsProcessed: 0,
+                HadPartialFailure: true,
+                PartialFailureMessage: "deps sub-step failed")));
+
+        var result = await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        result.IsSuccess.Should().BeTrue();
+        var run = _db.SyncRuns.Single();
+        run.Status.Should().Be(SyncRunStatus.Succeeded);
+        // Workspace counted as success because the source returned Result.Success
+        run.WorkspacesSucceeded.Should().Be(1);
+        run.WorkItemsProcessed.Should().Be(3);
+        run.DetailsJson.Should().Contain("deps sub-step failed");
+    }
+
+    [Fact]
+    public async Task Run_QueriesConnectionsFilteredByWorkSyncCategory()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+
+        await _sut.Run(SyncType.Differential, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        // Critical invariant: the runner must only see WorkSync connectors. If this assertion
+        // is changed to allow uncategorized queries, future People/AI-sync connectors will be
+        // pulled into the work-sync pipeline.
+        _mocker.GetMock<ISender>().Verify(s => s.Send(
+            It.Is<GetConnectionsQuery>(q =>
+                q.IncludeInactive == false
+                && q.Category == ConnectorCategory.WorkSync),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Run_BindCalledOncePerConnection()
+    {
+        var connection = SeedActiveAzdoConnection();
+        SetupConnectionsQuery(connection);
+        StubHappyPathSource();
+
+        await _sut.Run(SyncType.Full, SyncTriggerSource.Scheduled, CancellationToken.None);
+
+        _mocker.GetMock<IWorkItemSourceFactory>()
+            .Verify(f => f.Create(It.Is<SyncableConnectionDescriptor>(d =>
+                d.ConnectionId == connection.Id
+                && d.Connector == Connector.AzureDevOps
+                && d.SystemId == connection.SystemId)),
+                Times.Once);
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/BackgroundJobsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/BackgroundJobsController.cs
@@ -61,11 +61,11 @@ public class BackgroundJobsController : ControllerBase
             case BackgroundJobType.EmployeeSync:
                 _jobService.Enqueue(() => jobManager.RunSyncExternalEmployees(cancellationToken));
                 break;
-            case BackgroundJobType.AzdoBoardsFullSync:
-                _jobService.Enqueue(() => jobManager.RunSyncAzureDevOpsBoards(SyncType.Full, cancellationToken));
+            case BackgroundJobType.WorkFullSync:
+                _jobService.Enqueue(() => jobManager.RunWorkSync(SyncType.Full, cancellationToken));
                 break;
-            case BackgroundJobType.AzdoBoardsDiffSync:
-                _jobService.Enqueue(() => jobManager.RunSyncAzureDevOpsBoards(SyncType.Differential, cancellationToken));
+            case BackgroundJobType.WorkDiffSync:
+                _jobService.Enqueue(() => jobManager.RunWorkSync(SyncType.Differential, cancellationToken));
                 break;
             case BackgroundJobType.TeamGraphSync:
                 _jobService.Enqueue(() => jobManager.RunSyncTeamsWithGraphTables(cancellationToken));
@@ -105,8 +105,8 @@ public class BackgroundJobsController : ControllerBase
             return jobType switch
             {
                 BackgroundJobType.EmployeeSync => () => jobManager.RunSyncExternalEmployees(cancellationToken),
-                BackgroundJobType.AzdoBoardsFullSync => () => jobManager.RunSyncAzureDevOpsBoards(SyncType.Full, cancellationToken),
-                BackgroundJobType.AzdoBoardsDiffSync => () => jobManager.RunSyncAzureDevOpsBoards(SyncType.Differential, cancellationToken),
+                BackgroundJobType.WorkFullSync => () => jobManager.RunWorkSync(SyncType.Full, cancellationToken),
+                BackgroundJobType.WorkDiffSync => () => jobManager.RunWorkSync(SyncType.Differential, cancellationToken),
                 BackgroundJobType.TeamGraphSync => () => jobManager.RunSyncTeamsWithGraphTables(cancellationToken),
                 _ => throw new ArgumentOutOfRangeException(nameof(jobType), jobType, "Unknown job type requested")
             };

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/BackgroundJobsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/BackgroundJobsController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq.Expressions;
+using Wayd.AppIntegration.Domain.Models;
 using Wayd.Common.Application.BackgroundJobs;
 using Wayd.Common.Application.Enums;
 using Wayd.Web.Api.Extensions;
@@ -62,10 +63,10 @@ public class BackgroundJobsController : ControllerBase
                 _jobService.Enqueue(() => jobManager.RunSyncExternalEmployees(cancellationToken));
                 break;
             case BackgroundJobType.WorkFullSync:
-                _jobService.Enqueue(() => jobManager.RunWorkSync(SyncType.Full, cancellationToken));
+                _jobService.Enqueue(() => jobManager.RunWorkSync(SyncType.Full, SyncTriggerSource.Manual, cancellationToken));
                 break;
             case BackgroundJobType.WorkDiffSync:
-                _jobService.Enqueue(() => jobManager.RunWorkSync(SyncType.Differential, cancellationToken));
+                _jobService.Enqueue(() => jobManager.RunWorkSync(SyncType.Differential, SyncTriggerSource.Manual, cancellationToken));
                 break;
             case BackgroundJobType.TeamGraphSync:
                 _jobService.Enqueue(() => jobManager.RunSyncTeamsWithGraphTables(cancellationToken));
@@ -105,8 +106,8 @@ public class BackgroundJobsController : ControllerBase
             return jobType switch
             {
                 BackgroundJobType.EmployeeSync => () => jobManager.RunSyncExternalEmployees(cancellationToken),
-                BackgroundJobType.WorkFullSync => () => jobManager.RunWorkSync(SyncType.Full, cancellationToken),
-                BackgroundJobType.WorkDiffSync => () => jobManager.RunWorkSync(SyncType.Differential, cancellationToken),
+                BackgroundJobType.WorkFullSync => () => jobManager.RunWorkSync(SyncType.Full, SyncTriggerSource.Scheduled, cancellationToken),
+                BackgroundJobType.WorkDiffSync => () => jobManager.RunWorkSync(SyncType.Differential, SyncTriggerSource.Scheduled, cancellationToken),
                 BackgroundJobType.TeamGraphSync => () => jobManager.RunSyncTeamsWithGraphTables(cancellationToken),
                 _ => throw new ArgumentOutOfRangeException(nameof(jobType), jobType, "Unknown job type requested")
             };

--- a/Wayd.Web/src/Wayd.Web.Api/Interfaces/IJobManager.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Interfaces/IJobManager.cs
@@ -5,7 +5,7 @@ namespace Wayd.Web.Api.Interfaces;
 public interface IJobManager
 {
     Task RunSyncExternalEmployees(CancellationToken cancellationToken);
-    Task RunSyncAzureDevOpsBoards(SyncType syncType, CancellationToken cancellationToken);
+    Task RunWorkSync(SyncType syncType, CancellationToken cancellationToken);
     Task RunSyncTeamsWithGraphTables(CancellationToken cancellationToken);
     Task RunSyncIterations(CancellationToken cancellationToken);
     Task RunSyncStrategicThemes(CancellationToken cancellationToken);

--- a/Wayd.Web/src/Wayd.Web.Api/Interfaces/IJobManager.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Interfaces/IJobManager.cs
@@ -1,11 +1,12 @@
-﻿using Wayd.Common.Application.Enums;
+﻿using Wayd.AppIntegration.Domain.Models;
+using Wayd.Common.Application.Enums;
 
 namespace Wayd.Web.Api.Interfaces;
 
 public interface IJobManager
 {
     Task RunSyncExternalEmployees(CancellationToken cancellationToken);
-    Task RunWorkSync(SyncType syncType, CancellationToken cancellationToken);
+    Task RunWorkSync(SyncType syncType, SyncTriggerSource trigger, CancellationToken cancellationToken);
     Task RunSyncTeamsWithGraphTables(CancellationToken cancellationToken);
     Task RunSyncIterations(CancellationToken cancellationToken);
     Task RunSyncStrategicThemes(CancellationToken cancellationToken);

--- a/Wayd.Web/src/Wayd.Web.Api/Services/JobManager.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Services/JobManager.cs
@@ -1,5 +1,6 @@
 ﻿using Hangfire;
 using Wayd.AppIntegration.Application.Interfaces;
+using Wayd.AppIntegration.Domain.Models;
 using Wayd.Common.Application.Enums;
 using Wayd.Common.Application.Exceptions;
 using Wayd.Common.Application.Interfaces;
@@ -21,7 +22,7 @@ namespace Wayd.Web.Api.Services;
 public class JobManager(
     ILogger<JobManager> logger,
     IEmployeeService employeeService,
-    IAzureDevOpsSyncManager azdoBoardsSyncManager,
+    IWorkSyncRunner workSyncRunner,
     ISender sender)
     : IJobManager
 {
@@ -29,7 +30,7 @@ public class JobManager(
 
     private readonly ILogger<JobManager> _logger = logger;
     private readonly IEmployeeService _employeeService = employeeService;
-    private readonly IAzureDevOpsSyncManager _azdoBoardsSyncManager = azdoBoardsSyncManager;
+    private readonly IWorkSyncRunner _workSyncRunner = workSyncRunner;
     private readonly ISender _sender = sender;
 
     [DisableConcurrentExecution(60)]
@@ -48,16 +49,16 @@ public class JobManager(
 
     [DisableConcurrentExecution(60 * 3)]
     [AutomaticRetry(Attempts = 3, DelaysInSeconds = [30, 60, 120])]
-    public async Task RunSyncAzureDevOpsBoards(SyncType syncType, CancellationToken cancellationToken)
+    public async Task RunWorkSync(SyncType syncType, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Running {BackgroundJob} job", nameof(RunSyncAzureDevOpsBoards));
-        var result = await _azdoBoardsSyncManager.Sync(syncType, cancellationToken);
+        _logger.LogInformation("Running {BackgroundJob} job", nameof(RunWorkSync));
+        var result = await _workSyncRunner.Run(syncType, SyncTriggerSource.Scheduled, cancellationToken);
         if (result.IsFailure)
         {
-            _logger.LogError("Failed to sync Azure DevOps: {Error}", result.Error);
-            throw new InternalServerException($"Failed to sync Azure DevOps. Error: {result.Error}");
+            _logger.LogError("Failed to run work sync: {Error}", result.Error);
+            throw new InternalServerException($"Failed to run work sync. Error: {result.Error}");
         }
-        _logger.LogInformation("Completed {BackgroundJob} job", nameof(RunSyncAzureDevOpsBoards));
+        _logger.LogInformation("Completed {BackgroundJob} job", nameof(RunWorkSync));
     }
 
     [DisableConcurrentExecution(60 * 3)]

--- a/Wayd.Web/src/Wayd.Web.Api/Services/JobManager.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Services/JobManager.cs
@@ -49,10 +49,10 @@ public class JobManager(
 
     [DisableConcurrentExecution(60 * 3)]
     [AutomaticRetry(Attempts = 3, DelaysInSeconds = [30, 60, 120])]
-    public async Task RunWorkSync(SyncType syncType, CancellationToken cancellationToken)
+    public async Task RunWorkSync(SyncType syncType, SyncTriggerSource trigger, CancellationToken cancellationToken)
     {
-        _logger.LogInformation("Running {BackgroundJob} job", nameof(RunWorkSync));
-        var result = await _workSyncRunner.Run(syncType, SyncTriggerSource.Scheduled, cancellationToken);
+        _logger.LogInformation("Running {BackgroundJob} job (trigger={Trigger})", nameof(RunWorkSync), trigger);
+        var result = await _workSyncRunner.Run(syncType, trigger, cancellationToken);
         if (result.IsFailure)
         {
             _logger.LogError("Failed to run work sync: {Error}", result.Error);

--- a/Wayd.slnx
+++ b/Wayd.slnx
@@ -21,6 +21,7 @@
   </Folder>
   <Folder Name="/Wayd.Integrations/" />
   <Folder Name="/Wayd.Integrations/src/">
+    <Project Path="Wayd.Integrations/src/Wayd.Integrations.Abstractions/Wayd.Integrations.Abstractions.csproj" />
     <Project Path="Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Wayd.Integrations.AzureDevOps.csproj" />
     <Project Path="Wayd.Integrations/src/Wayd.Integrations.MicrosoftGraph/Wayd.Integrations.MicrosoftGraph.csproj" />
   </Folder>

--- a/docs/contributing/architecture.mdx
+++ b/docs/contributing/architecture.mdx
@@ -149,6 +149,18 @@ Customer-configured integrations (Azure DevOps, Azure OpenAI, future Jira / GitH
 | Polymorphic DTO | `Wayd.AppIntegration.Application/Connections/Dtos/ConnectionDetailsDto.cs` | Add a `[JsonDerivedType]` entry; controllers switch on the request/DTO type to dispatch to the right handler. |
 | External client | `Wayd.Integrations.\{SystemName\}/` | Only if the connector actually talks to a remote API. Pure AI providers can wrap an existing SDK directly inside the application layer. |
 | Persistence | `Wayd.Infrastructure/Persistence/Configuration/AppIntegrationConfiguration.cs` | TPH discriminator; one entity-config per concrete connection class. Use `HasEncryptedJsonConversion()` for the configuration column. |
+| Sync orchestration (work-sync connectors only) | `Wayd.Integrations.Abstractions/IWorkItemSource.cs` + `Wayd.AppIntegration.Application/Connections/Managers/\{Connector\}WorkItemSource.cs` | Implement `IWorkItemSource` for the connector. Register it keyed by `Connector` enum value (`AddKeyedTransient<IWorkItemSource, MySource>(Connector.X)`). The generic `WorkSyncRunner` calls every registered source on a single Hangfire schedule — no per-connector job. |
+
+### Sync orchestration
+
+Work-sync connectors (AzDO today, Jira/GitHub in future) plug into a single generic runner. The pieces:
+
+- **`IWorkItemSource`** ([Wayd.Integrations.Abstractions](https://github.com/destacey/Wayd/tree/main/Wayd.Integrations/src/Wayd.Integrations.Abstractions)) — connector-neutral contract: `TestConnection`, `GetSystemId`, `RefreshOrganizationConfiguration`, `GetSyncPlan` (returns a flat list of `WorkspaceSyncTarget`), `PrepareWorkspaceForItemSync`, `SyncIterations`, `SyncWorkItems`. Sources hide connector-specific hierarchy internally — AzDO's `WorkProcess → Workspace` walk happens inside `GetSyncPlan`, the runner only sees workspaces.
+- **`IWorkItemSourceFactory`** — resolves the right source per connection via keyed DI. Sources hold credentials internally after `Bind(descriptor)` so per-call signatures stay credential-free.
+- **`WorkSyncRunner`** ([Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs](https://github.com/destacey/Wayd/blob/main/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs)) — loops all active syncable connections, resolves each source via the factory, walks the flat plan, runs `ProcessDependenciesCommand`, and writes a `SyncRun` row per connection per run (`AppIntegrations.SyncRuns`). Per-connection failures don't kill the run; per-workspace failures don't kill the connection.
+- **Hangfire entry point**: `JobManager.RunWorkSync(SyncType, CancellationToken)` — one job for all work-sync connectors. Triggered manually via `BackgroundJobType.WorkFullSync` / `WorkDiffSync`.
+
+One-time initialization flows (e.g. AzDO's `InitWorkProcessIntegration` / `InitWorkspaceIntegration`) stay connector-specific in the existing init manager — they're user-triggered setup wizards with connector-specific payloads, not part of the generic runner.
 
 ### Frontend shape
 

--- a/docs/reference/integrations.mdx
+++ b/docs/reference/integrations.mdx
@@ -73,6 +73,10 @@ graph LR
         AAD["Azure AD"]
     end
     subgraph "Wayd"
+        subgraph "Sync Orchestration"
+            Runner["WorkSyncRunner"]
+            Sources["IWorkItemSource (keyed by Connector)"]
+        end
         subgraph "Integrations"
             ADOInt["AzureDevOps Integration"]
             AOAIInt["AzureOpenAI Integration"]
@@ -83,17 +87,18 @@ graph LR
             Org["Organization Domain"]
             AI["AI features"]
         end
-        HF["Hangfire Jobs"]
+        HF["Hangfire: RunWorkSync"]
     end
 
+    HF --> Runner
+    Runner --> Sources
+    Sources --> ADOInt
     ADO --> ADOInt
-    AOAIInt --> AOAI
-    AAD --> GraphInt
     ADOInt --> Work
+    AOAIInt --> AOAI
     AI --> AOAIInt
+    AAD --> GraphInt
     GraphInt --> Org
-    HF --> ADOInt
-    HF --> GraphInt
 ```
 
 ## Adding a New Connector
@@ -101,11 +106,11 @@ graph LR
 For sync-shaped or AI-provider connectors that customers configure in Settings → Connections:
 
 1. Add the connector type to `Connector` enum in `Wayd.Common.Domain.Enums.AppIntegrations`
-2. Create a domain configuration class (e.g. `JiraConnectionConfiguration`) and connection aggregate (`JiraConnection : Connection<JiraConnectionConfiguration>`). Mark credential fields with `[Encrypted]` for at-rest encryption — see [Architecture → Connector framework](../contributing/architecture.mdx#connector-framework)
+2. Create a domain configuration class (e.g. `JiraConnectionConfiguration`) and connection aggregate (`JiraConnection : Connection<JiraConnectionConfiguration>`). For sync-shaped connectors, also implement `ISyncableConnection`. Mark credential fields with `[Encrypted]` for at-rest encryption — see [Architecture → Connector framework](../contributing/architecture.mdx#connector-framework)
 3. Create command/query handlers under `Wayd.AppIntegration.Application/Connections/Commands/\{Connector\}/` following the AzDO and AOAI templates
 4. Register the EF entity configuration in `AppIntegrationConfiguration.cs` and add a migration
 5. Add a `Wayd.Integrations.\{SystemName\}` project for the low-level client (only if the connector actually talks to a remote system — pure AI providers can use an existing SDK directly)
-6. On the frontend, register the connector in `_components/connector-registry.ts` (create form) and `[id]/_components/detail-registry.tsx` (detail page) — see [Architecture → Connector framework](../contributing/architecture.mdx#connector-framework)
-7. Register Hangfire jobs for scheduled sync if applicable
+6. **For work-sync connectors only:** implement `IWorkItemSource` (in `Wayd.AppIntegration.Application/Connections/Managers/\{Connector\}WorkItemSource.cs`) and register it keyed by your `Connector` enum value: `services.AddKeyedTransient<IWorkItemSource, JiraWorkItemSource>(Connector.Jira)`. The generic `WorkSyncRunner` picks it up automatically — **do not** add a per-connector Hangfire job. See [Architecture → Sync orchestration](../contributing/architecture.mdx#sync-orchestration).
+7. On the frontend, register the connector in `_components/connector-registry.ts` (create form) and `[id]/_components/detail-registry.tsx` (detail page) — see [Architecture → Connector framework](../contributing/architecture.mdx#connector-framework)
 
-For always-on internal integrations (like Microsoft Graph) that aren't surfaced as connectors, skip steps 1–4 and 6 — those are just classes called directly from feature code.
+For always-on internal integrations (like Microsoft Graph) that aren't surfaced as connectors, skip steps 1–4, 6, and 7 — those are just classes called directly from feature code.


### PR DESCRIPTION
## Summary

Phase 3 of the connector roadmap from [.claude/plans/please-review-the-architecture-serene-crane.md](.claude/plans/please-review-the-architecture-serene-crane.md): replace the Azure-DevOps-specific sync pipeline with a generic runner that any work-sync connector can plug into.

Today, adding Jira or GitHub means copying `AzureDevOpsSyncManager` (543 lines) and adding `RunSyncJira` to `JobManager`. After this PR, it means: implement `IWorkItemSource`, register it keyed by `Connector`. Zero changes to the runner, zero new Hangfire jobs.

Also introduces:
- **`SyncRun` persistence** — every connection's sync run now writes a row with status, counters, errors, per-workspace details JSON. Operators can see what ran when and why a connection's last sync failed without log diving. Sets up Phase 4's "Sync History" UI tab.
- **`ConnectorCategory`** — explicit `WorkSync` / `PeopleSync` / `AiProvider` classification. The work-sync runner queries with `Category: WorkSync`, so when Workday lands as a `PeopleSync` connector it's automatically excluded — no per-connector filter to remember to add.

Companion to [#596](https://github.com/destacey/Wayd/pull/596) which delivered Phases 1 and 2. Phase 4 (operational UI surface) is the next PR.

## The seam

```text
Hangfire RunWorkSync(syncType)
        │
        ▼
WorkSyncRunner
        │  for each WorkSync-category connection that CanSync:
        │    insert SyncRun(Running)
        │    sourceFactory.Create(descriptor) ─keyed by Connector─▶ IWorkItemSource
        │    source.RefreshOrganizationConfiguration
        │    source.GetSyncPlan() ─▶ flat List<WorkspaceSyncTarget>
        │      for each target:
        │        source.PrepareWorkspaceForItemSync
        │        source.SyncIterations
        │        source.SyncWorkItems  ─▶ WorkspaceItemsSyncResult (counters)
        │    ProcessDependenciesCommand
        │    update SyncRun(Succeeded | Failed | Cancelled)
```

The runner is genuinely connector-agnostic — it doesn't know what a "work process" is. AzDO's `WorkProcess → Workspace` hierarchy is walked internally inside `AzureDevOpsWorkItemSource.GetSyncPlan()` and flattened to a list of `WorkspaceSyncTarget` the runner can iterate.

## Backend

### New abstractions

[Wayd.Integrations.Abstractions/](Wayd.Integrations/src/Wayd.Integrations.Abstractions/) — new project that connectors implement and the runner consumes. Sits in `Wayd.Integrations/` so the architecture rule "Application layer must not depend on concrete integrations" still holds (rule updated to allow this abstractions project explicitly).

- [IWorkItemSource.cs](Wayd.Integrations/src/Wayd.Integrations.Abstractions/IWorkItemSource.cs) — `Bind(descriptor)`, `TestConnection`, `GetSystemId`, `RefreshOrganizationConfiguration`, `GetSyncPlan`, `PrepareWorkspaceForItemSync`, `SyncIterations`, `SyncWorkItems`.
- [IWorkItemSourceFactory.cs](Wayd.Integrations/src/Wayd.Integrations.Abstractions/IWorkItemSourceFactory.cs) — resolves the right source by `Connector` enum via .NET 8 keyed services. Auto-registered via `IScopedService` marker.
- [WorkspaceSyncTarget.cs](Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkspaceSyncTarget.cs) — flat unit of work the runner iterates. Carries opaque `WorkItemSyncFilters` (string→string dict) so connectors can pass per-workspace context (e.g. AzDO's team-settings) without leaking shapes to the runner.
- [SyncableConnectionDescriptor.cs](Wayd.Integrations/src/Wayd.Integrations.Abstractions/SyncableConnectionDescriptor.cs) — connector-neutral connection snapshot with boxed config/team-config.
- [WorkspaceItemsSyncResult.cs](Wayd.Integrations/src/Wayd.Integrations.Abstractions/WorkspaceItemsSyncResult.cs) — counter record with `HadPartialFailure` flag, so sub-step failures inside a source aggregate without bubbling up as a top-level failure.

### Generic runner

[WorkSyncRunner.cs](Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs) — single Hangfire entry point for *all* work-sync connectors.

- Queries `GetConnectionsQuery(IncludeInactive: false, Category: ConnectorCategory.WorkSync)` so future PeopleSync / AiProvider connectors are physically excluded.
- Per-connection failure isolation: one connection throwing doesn't stop the others.
- Per-workspace failure isolation: one workspace's prep/iterations/items failing doesn't abort the connection's other workspaces.
- `OperationCanceledException` produces `SyncRunStatus.Cancelled` and rethrows so Hangfire honours the cancellation.

### Azure DevOps adapter

[AzureDevOpsWorkItemSource.cs](Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs) — wraps the existing `IAzureDevOpsService` facade. Preserves every existing behaviour:

- Work-process iteration happens internally, deduplicated via a `HashSet<Guid>` per Bind cycle so the same process isn't refetched once per workspace.
- `SyncType.Differential` calls `GetParentLinkChanges`; `SyncType.Full` skips it. Matches today's `AzureDevOpsSyncManager` semantics.
- The four work-item sub-steps (items, parent-links, dependency-links, deletes) aggregate into a single `WorkspaceItemsSyncResult` with `HadPartialFailure=true` when any sub-step fails. Same "attempt each step independently" behaviour as before.
- "Since" Instant for differential syncs is computed *inside* the source (via `GetWorkspaceMostRecentChangeDateQuery`), so the runner doesn't need to know `Wayd.Work` exists.

### SyncRun entity + migration

[SyncRun.cs](Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/SyncRun.cs) + new `AppIntegrations.SyncRuns` table:

- Columns: `Id`, `ConnectionId`, `ConnectorType`, `StartedAt`, `FinishedAt`, `Status`, `TriggerSource` (Scheduled/Manual/Api), `SyncType`, counter columns (`WorkspacesPlanned/Succeeded/Failed`, `WorkItemsProcessed`, `ErrorsCount`), `ErrorMessage`, `DetailsJson` (per-workspace breakdown for Phase 4 UI).
- Insert-at-start with `Running`, update-at-end. Stuck `Running` rows survive crashes for operational triage.
- Indexes on `(ConnectionId, StartedAt)` and `(Status, StartedAt)`.
- **No FK to Connections** — history survives connection deletion (audit requirement).

### Hangfire surface

- `JobManager.RunSyncAzureDevOpsBoards` → `JobManager.RunWorkSync(SyncType, CancellationToken)`. Same `[DisableConcurrentExecution(180s)]` and `[AutomaticRetry(3, [30,60,120])]` attributes.
- `BackgroundJobType.AzdoBoardsFullSync` → `WorkFullSync` (numeric value preserved as `1`).
- `BackgroundJobType.AzdoBoardsDiffSync` → `WorkDiffSync` (numeric value preserved as `2`).
- `BackgroundJobsController` enqueue + recurring-job switch branches updated.
- NSwag client regenerated automatically — frontend picks up the new names with no manual edits.

### ConnectorCategory

[ConnectorCategory.cs](Wayd.Common/src/Wayd.Common.Domain/Enums/AppIntegrations/ConnectorCategory.cs) + [ConnectorExtensions.cs](Wayd.Common/src/Wayd.Common.Domain/Enums/AppIntegrations/ConnectorExtensions.cs) — the explicit "Frame: three connector categories" concept from the roadmap. `Connector.GetCategory()` is a single switch — when Jira lands, add one case; when Workday lands, add one case. The work-sync runner filters by category so non-WorkSync connectors are never even considered.

## Tests

Two new files, **29 new tests, 0 regressions** across the solution.

- [WorkSyncRunnerTests.cs](Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs) — 13 protocol tests using a fully-mocked `IWorkItemSource`. Covers per-connection / per-workspace isolation, SyncRun lifecycle (Running → Succeeded / Failed / Cancelled), cancellation rethrow, ProcessDependencies-failure handling, partial-failure aggregation, multi-connection one-fails-the-other-runs, and explicit assertion that the runner queries with `Category: WorkSync`.
- [AzureDevOpsWorkItemSourceTests.cs](Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs) — 17 adapter-level tests. Covers Bind validation, plan flattening (active processes/workspaces only), team-settings carriage, work-process dedup across workspaces, SyncType branching, partial sub-step failure semantics, and the require-Bind contract.

One shared test helper change: [MockDbSetFactory.cs](Wayd.Common/tests/Wayd.Tests.Shared/Infrastructure/MockDbSetFactory.cs) now intercepts `Add` / `AddAsync` / `AddRange` / `Remove` / `RemoveRange` and persists into the underlying list, so handlers using `dbSet.Add(...)` (like the runner) can be asserted against in unit tests. Pre-existing tests don't rely on Add being a no-op, so this is strictly additive.

One architecture-test fix: `ApplicationLayer_ShouldNotDependOnIntegrations` in [CrossProjectDependencyTests.cs](Wayd.ArchitectureTests/Sut/CrossProjectDependencyTests.cs) was originally written assuming all `Wayd.Integrations.*` projects are concrete. `Wayd.Integrations.Abstractions` (added in this PR) is the *contract* the Application layer is meant to depend on. Renamed to `ApplicationLayer_ShouldNotDependOnConcreteIntegrations` and rewritten to forbid the three concrete integration packages explicitly (`AzureDevOps`, `AzureOpenAI`, `MicrosoftGraph`).

## Documentation

- [docs/contributing/architecture.mdx](docs/contributing/architecture.mdx) — new **Sync orchestration** subsection inside Connector framework: explains `IWorkItemSource` / `IWorkItemSourceFactory` / `WorkSyncRunner` / `SyncRun`. Existing backend-shape table extended with a row for `IWorkItemSource` registration. Notes that init flows stay connector-specific.
- [docs/reference/integrations.mdx](docs/reference/integrations.mdx) — "Adding a New Connector" checklist updated: step 7 ("Register Hangfire jobs for scheduled sync") was wrong post-Phase 3 and has been replaced with the *"implement `IWorkItemSource`, register keyed, **do not** add a per-connector Hangfire job"* step. Mermaid diagram updated to show the runner sitting between Hangfire and the integrations.

## What's deliberately not in this PR

- **Deletion of `AzureDevOpsSyncManager`** — still compiles, just no longer wired into JobManager. Leaving it in place for one PR makes rollback trivial (revert JobManager and DI). Removed in the next PR.
- **Sync History UI tab** — Phase 4 work. `SyncRun` data is being captured now so the UI has rows to read when it lands; the next PR will surface them on the connection detail page.
- **Stub-source genericity proof** — registering a `Connector.Stub = 99` value with a no-op `IWorkItemSource` and running the runner against two connectors at once is the load-bearing check that the abstraction actually works. Doing it manually pre-merge rather than committing a stub.
- **Hangfire recurring-job migration shim** — if a customer's `[Hangfire].[Set]` has a recurring job targeting the old `RunSyncAzureDevOpsBoards` method name, it'll fail to deserialize on first boot post-deploy. **Action required pre-deploy:** delete and recreate any recurring AzDO sync jobs through the admin UI, *or* run `DELETE FROM [HangFire].[Set] WHERE [Key] LIKE 'recurring-jobs:%azdo%'`. The job UI's `BackgroundJobType` enum values kept their numeric stability (`1`, `2`) so the dropdown stays valid.

## Test plan

- [x] `dotnet build Wayd.slnx` — clean
- [x] `dotnet test Wayd.slnx` — all suites pass, 0 failures across 19 assemblies
- [x] EF migration `Add-SyncRuns` applied cleanly to dev database; `[AppIntegrations].[SyncRuns]` table created with all indexes
- [x] NSwag client regenerated — `WorkFullSync` / `WorkDiffSync` appear in `wayd-api.ts`
- [x] Manual smoke: trigger `WorkFullSync` via the admin UI on a connection with an existing Azure DevOps configuration; confirm work items still sync into `[Work].[WorkItems]` exactly as before
- [x] Manual smoke: verify a `SyncRun` row appears in `[AppIntegrations].[SyncRuns]` with `Status=Succeeded`, populated counters, and `DetailsJson` containing per-workspace details
- [x] Manual smoke: trigger `WorkDiffSync`; verify only items changed since the last sync are pulled (since-cutoff is computed inside the AzDO source)
- [ ] **Pre-deploy: clear/recreate any Hangfire recurring jobs targeting `RunSyncAzureDevOpsBoards`** (see "not in this PR" section)
