### PR TITLE
Bug/connection integrationstate

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Extensions/PropertyBuilderExtensions.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Extensions/PropertyBuilderExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using Wayd.Infrastructure.DataProtection;
 using Wayd.Infrastructure.Persistence.Converters;
@@ -11,7 +12,9 @@ public static class PropertyBuilderExtensions
         this PropertyBuilder<TProperty> builder,
         JsonSerializerOptions? options = null)
     {
-        return builder.HasConversion(new JsonValueConverter<TProperty>(options));
+        builder.HasConversion(new JsonValueConverter<TProperty>(options));
+        builder.Metadata.SetValueComparer(CreateJsonValueComparer<TProperty>(options));
+        return builder;
     }
 
     /// <summary>
@@ -23,6 +26,21 @@ public static class PropertyBuilderExtensions
         this PropertyBuilder<TProperty> builder,
         JsonSerializerOptions? options = null)
     {
-        return builder.HasConversion(new EncryptingJsonValueConverter<TProperty>(options));
+        builder.HasConversion(new EncryptingJsonValueConverter<TProperty>(options));
+        builder.Metadata.SetValueComparer(CreateJsonValueComparer<TProperty>(options));
+        return builder;
+    }
+
+    // EF Core's default change tracking for converted properties uses reference equality,
+    // which silently drops in-place mutations to nested fields of a JSON-mapped value object
+    // (e.g. AzureDevOpsBoardsConnectionConfiguration.WorkProcesses[i].IntegrationState = null).
+    // Compare by serialized JSON so structural changes are detected; deep-clone via JSON
+    // round-trip so the snapshot can't be aliased by later mutations.
+    private static ValueComparer<TProperty> CreateJsonValueComparer<TProperty>(JsonSerializerOptions? options)
+    {
+        return new ValueComparer<TProperty>(
+            (a, b) => JsonSerializer.Serialize(a, options) == JsonSerializer.Serialize(b, options),
+            v => v == null ? 0 : JsonSerializer.Serialize(v, options).GetHashCode(),
+            v => v == null ? default! : JsonSerializer.Deserialize<TProperty>(JsonSerializer.Serialize(v, options), options)!);
     }
 }

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Persistence/Extensions/PropertyBuilderExtensionsTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Persistence/Extensions/PropertyBuilderExtensionsTests.cs
@@ -1,0 +1,208 @@
+﻿using System.Reflection;
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Wayd.Infrastructure.DataProtection;
+using Wayd.Infrastructure.Persistence.Extensions;
+
+namespace Wayd.Infrastructure.Tests.Sut.Persistence.Extensions;
+
+/// <summary>
+/// Regression tests for the JSON-conversion ValueComparer.
+///
+/// EF Core's default change tracking for converted properties uses reference
+/// equality, which silently drops in-place mutations to nested fields of a
+/// JSON-mapped value object (e.g. healing a dangling pointer inside
+/// AzureDevOpsBoardsConnection.Configuration). HasJsonConversion and
+/// HasEncryptedJsonConversion must attach a ValueComparer that compares
+/// by serialized JSON so structural mutations actually persist.
+/// </summary>
+public sealed class PropertyBuilderExtensionsTests
+{
+    public PropertyBuilderExtensionsTests()
+    {
+        // HasEncryptedJsonConversion's converter resolves the protector via the
+        // process-wide accessor. Initialize it once per test class with a fresh key.
+        var type = typeof(ISecretProtector).Assembly
+            .GetType("Wayd.Infrastructure.DataProtection.AesGcmSecretProtector", throwOnError: true)!;
+        var key = RandomNumberGenerator.GetBytes(32);
+        var protector = (ISecretProtector)Activator.CreateInstance(
+            type,
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public,
+            binder: null,
+            args: new object[] { key },
+            culture: null)!;
+
+        typeof(SecretProtectorAccessor)
+            .GetMethod("Set", BindingFlags.Static | BindingFlags.NonPublic)!
+            .Invoke(null, new object[] { protector });
+    }
+
+    private sealed class TestConfig
+    {
+        public string Organization { get; set; } = "";
+        public List<TestItem> Items { get; set; } = new();
+    }
+
+    private sealed class TestItem
+    {
+        public string Name { get; set; } = "";
+        public TestState? State { get; set; }
+    }
+
+    private sealed class TestState
+    {
+        public Guid InternalId { get; set; }
+        public bool IsActive { get; set; }
+    }
+
+    private sealed class TestEntity
+    {
+        public Guid Id { get; set; } = Guid.NewGuid();
+        public TestConfig Configuration { get; set; } = new();
+    }
+
+    private sealed class JsonConversionContext(DbContextOptions<JsonConversionContext> options) : DbContext(options)
+    {
+        public DbSet<TestEntity> Entities => Set<TestEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Configuration).HasJsonConversion();
+            });
+        }
+    }
+
+    private sealed class EncryptedJsonConversionContext(DbContextOptions<EncryptedJsonConversionContext> options) : DbContext(options)
+    {
+        public DbSet<TestEntity> Entities => Set<TestEntity>();
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<TestEntity>(b =>
+            {
+                b.HasKey(e => e.Id);
+                b.Property(e => e.Configuration).HasEncryptedJsonConversion();
+            });
+        }
+    }
+
+    private static DbContextOptions<T> InMemoryOptions<T>() where T : DbContext
+        => new DbContextOptionsBuilder<T>()
+            .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+            .Options;
+
+    private static IProperty GetConfigurationProperty(DbContext context)
+    {
+        var entityType = context.Model.FindEntityType(typeof(TestEntity))!;
+        return entityType.FindProperty(nameof(TestEntity.Configuration))!;
+    }
+
+    [Fact]
+    public void HasJsonConversion_ValueComparer_TreatsStructurallyEqualValuesAsEqual()
+    {
+        using var context = new JsonConversionContext(InMemoryOptions<JsonConversionContext>());
+        var comparer = GetConfigurationProperty(context).GetValueComparer()!;
+
+        var a = new TestConfig
+        {
+            Organization = "WAYD",
+            Items = [new TestItem { Name = "x", State = new TestState { InternalId = Guid.Parse("00000000-0000-0000-0000-000000000001"), IsActive = true } }]
+        };
+        var b = new TestConfig
+        {
+            Organization = "WAYD",
+            Items = [new TestItem { Name = "x", State = new TestState { InternalId = Guid.Parse("00000000-0000-0000-0000-000000000001"), IsActive = true } }]
+        };
+
+        comparer.Equals(a, b).Should().BeTrue();
+    }
+
+    [Fact]
+    public void HasJsonConversion_ValueComparer_DetectsInPlaceNestedMutation()
+    {
+        using var context = new JsonConversionContext(InMemoryOptions<JsonConversionContext>());
+        var comparer = GetConfigurationProperty(context).GetValueComparer()!;
+
+        var original = new TestConfig
+        {
+            Organization = "WAYD",
+            Items = [new TestItem { Name = "x", State = new TestState { InternalId = Guid.NewGuid(), IsActive = true } }]
+        };
+
+        // Deep clone via the comparer's snapshot — this is what EF stores when the entity loads.
+        var snapshot = (TestConfig)comparer.Snapshot(original)!;
+
+        // Mutate the live object in place (mirrors ClearWorkProcessIntegrationState).
+        original.Items[0].State = null;
+
+        comparer.Equals(snapshot, original).Should().BeFalse();
+    }
+
+    [Fact]
+    public void HasJsonConversion_ValueComparer_Snapshot_IsDeepClone()
+    {
+        using var context = new JsonConversionContext(InMemoryOptions<JsonConversionContext>());
+        var comparer = GetConfigurationProperty(context).GetValueComparer()!;
+
+        var original = new TestConfig
+        {
+            Organization = "WAYD",
+            Items = [new TestItem { Name = "x", State = new TestState { InternalId = Guid.NewGuid(), IsActive = true } }]
+        };
+
+        var snapshot = (TestConfig)comparer.Snapshot(original)!;
+
+        // Mutating the original must not affect the snapshot — otherwise EF can't detect the change.
+        original.Items[0].State!.IsActive = false;
+
+        snapshot.Items[0].State!.IsActive.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task HasEncryptedJsonConversion_DetectsInPlaceMutation_OnSaveChanges()
+    {
+        // End-to-end: load an entity, mutate a nested field, save. EF should detect
+        // the change via the ValueComparer and persist it without the caller having
+        // to set IsModified manually.
+        var dbName = Guid.NewGuid().ToString();
+        var entityId = Guid.NewGuid();
+        var staleInternalId = Guid.NewGuid();
+
+        var ct = TestContext.Current.CancellationToken;
+
+        using (var setup = new EncryptedJsonConversionContext(
+            new DbContextOptionsBuilder<EncryptedJsonConversionContext>().UseInMemoryDatabase(dbName).Options))
+        {
+            setup.Entities.Add(new TestEntity
+            {
+                Id = entityId,
+                Configuration = new TestConfig
+                {
+                    Organization = "WAYD",
+                    Items = [new TestItem { Name = "Agile", State = new TestState { InternalId = staleInternalId, IsActive = true } }]
+                }
+            });
+            await setup.SaveChangesAsync(ct);
+        }
+
+        using (var mutate = new EncryptedJsonConversionContext(
+            new DbContextOptionsBuilder<EncryptedJsonConversionContext>().UseInMemoryDatabase(dbName).Options))
+        {
+            var loaded = await mutate.Entities.FirstAsync(e => e.Id == entityId, ct);
+            loaded.Configuration.Items[0].State = null;
+            await mutate.SaveChangesAsync(ct);
+        }
+
+        using (var verify = new EncryptedJsonConversionContext(
+            new DbContextOptionsBuilder<EncryptedJsonConversionContext>().UseInMemoryDatabase(dbName).Options))
+        {
+            var reloaded = await verify.Entities.FirstAsync(e => e.Id == entityId, ct);
+            reloaded.Configuration.Items[0].State.Should().BeNull(
+                "the ValueComparer must detect the in-place mutation so EF persists the JSON column");
+        }
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommand.cs
@@ -63,15 +63,38 @@ internal sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppI
             return LogAndReturnFailure(importWorkProcessesResult);
         }
 
+        var liveInternalIds = request.WorkProcessIntegrationRegistrations
+            .Select(r => r.IntegrationState.InternalId)
+            .ToHashSet();
+
         foreach (var workProcess in connection.Configuration.WorkProcesses)
         {
             var workProcessIntegrationRegistration = request.WorkProcessIntegrationRegistrations.FirstOrDefault(w => w.ExternalId == workProcess.ExternalId);
-            if (workProcessIntegrationRegistration is null) continue;
-
-            var result = connection.UpdateWorkProcessIntegrationState(workProcessIntegrationRegistration, _timestamp);
-            if (result.IsFailure)
+            if (workProcessIntegrationRegistration is not null)
             {
-                return LogAndReturnFailure(result);
+                var result = connection.UpdateWorkProcessIntegrationState(workProcessIntegrationRegistration, _timestamp);
+                if (result.IsFailure)
+                {
+                    return LogAndReturnFailure(result);
+                }
+                continue;
+            }
+
+            // No registration found for this work process. If we still hold an IntegrationState
+            // pointing at a Wayd.Work.WorkProcess that no longer exists, clear the dangling
+            // pointer so the UI stops 404ing and the user can re-initialize.
+            if (workProcess.IntegrationState is null) continue;
+
+            if (liveInternalIds.Contains(workProcess.IntegrationState.InternalId)) continue;
+
+            _logger.LogWarning(
+                "Clearing dangling IntegrationState for Azure DevOps work process {WorkProcessExternalId} on connection {ConnectionId}. The referenced Wayd.Work.WorkProcess {WorkProcessInternalId} no longer exists.",
+                workProcess.ExternalId, connection.Id, workProcess.IntegrationState.InternalId);
+
+            var clearResult = connection.ClearWorkProcessIntegrationState(workProcess.ExternalId, _timestamp);
+            if (clearResult.IsFailure)
+            {
+                return LogAndReturnFailure(clearResult);
             }
         }
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
@@ -320,15 +320,28 @@ public sealed class AzureDevOpsBoardsConnection : Connection<AzureDevOpsBoardsCo
             // if already has integration, only update if the active flag changed
             if (workProcess.HasIntegration)
             {
-                if (workProcess.IntegrationState is not null && workProcess.IntegrationState.IsActive == registration.IntegrationState.IsActive)
+                // If the live registration points at a different InternalId than what we hold,
+                // the underlying Wayd.Work.WorkProcess was deleted and recreated. Rebind to
+                // the live row rather than continuing to point at a dead id.
+                if (workProcess.IntegrationState is not null
+                    && workProcess.IntegrationState.InternalId != registration.IntegrationState.InternalId)
                 {
-                    // no change
-                    return Result.Success();
+                    var replaceResult = workProcess.ReplaceIntegrationState(registration.IntegrationState);
+                    if (replaceResult.IsFailure)
+                        return replaceResult;
                 }
+                else
+                {
+                    if (workProcess.IntegrationState is not null && workProcess.IntegrationState.IsActive == registration.IntegrationState.IsActive)
+                    {
+                        // no change
+                        return Result.Success();
+                    }
 
-                var setResult = workProcess.UpdateIntegrationState(registration.IntegrationState.IsActive);
-                if (setResult.IsFailure)
-                    return setResult;
+                    var setResult = workProcess.UpdateIntegrationState(registration.IntegrationState.IsActive);
+                    if (setResult.IsFailure)
+                        return setResult;
+                }
             }
             else
             {

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/AzureDevOpsBoardsConnection.cs
@@ -348,6 +348,33 @@ public sealed class AzureDevOpsBoardsConnection : Connection<AzureDevOpsBoardsCo
         }
     }
 
+    public Result ClearWorkProcessIntegrationState(Guid workProcessExternalId, Instant timestamp)
+    {
+        try
+        {
+            Guard.Against.Null(Configuration, nameof(Configuration));
+
+            var workProcess = Configuration.WorkProcesses.FirstOrDefault(wp => wp.ExternalId == workProcessExternalId);
+            if (workProcess is null)
+                return Result.Failure($"Unable to find work process with id {workProcessExternalId} in Azure DevOps connection with id {Id}.");
+
+            if (!workProcess.HasIntegration)
+                return Result.Success();
+
+            var clearResult = workProcess.RemoveIntegrationState();
+            if (clearResult.IsFailure)
+                return clearResult;
+
+            AddDomainEvent(EntityUpdatedEvent.WithEntity(this, timestamp));
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            return Result.Failure(ex.ToString());
+        }
+    }
+
     public Result UpdateWorkspaceIntegrationState(IntegrationRegistration<Guid, Guid> registration, Instant timestamp)
     {
         try

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/IntegrationObject.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/IntegrationObject.cs
@@ -15,9 +15,9 @@ public abstract class IntegrationObject<TId>
     public Result UpdateIntegrationState(bool isActive)
     {
         if (IntegrationState is null)
-            Result.Failure("Integration state is not set.");
+            return Result.Failure("Integration state is not set.");
 
-        IntegrationState!.SetIsActive(isActive);
+        IntegrationState.SetIsActive(isActive);
 
         return Result.Success();
     }
@@ -25,8 +25,15 @@ public abstract class IntegrationObject<TId>
     public Result AddIntegrationState(IntegrationState<TId> integrationState)
     {
         if (IntegrationState is not null)
-            Result.Failure("Integration state is already set.");
+            return Result.Failure("Integration state is already set.");
 
+        IntegrationState = integrationState;
+
+        return Result.Success();
+    }
+
+    public Result ReplaceIntegrationState(IntegrationState<TId> integrationState)
+    {
         IntegrationState = integrationState;
 
         return Result.Success();

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/IntegrationObject.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Domain/Models/IntegrationObject.cs
@@ -31,4 +31,11 @@ public abstract class IntegrationObject<TId>
 
         return Result.Success();
     }
+
+    public Result RemoveIntegrationState()
+    {
+        IntegrationState = null;
+
+        return Result.Success();
+    }
 }

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Infrastructure/FakeAppIntegrationDbContext.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Infrastructure/FakeAppIntegrationDbContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.AppIntegration.Application.Persistence;

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
@@ -1,0 +1,140 @@
+using CSharpFunctionalExtensions;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NodaTime;
+using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
+using Wayd.AppIntegration.Application.Tests.Infrastructure;
+using Wayd.AppIntegration.Domain.Models;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Domain.Models;
+using Wayd.Tests.Shared;
+
+namespace Wayd.AppIntegration.Application.Tests.Sut.Connections.Commands.AzureDevOps;
+
+public class SyncAzureDevOpsConnectionConfigurationCommandHandlerTests
+{
+    private readonly FakeAppIntegrationDbContext _db = new();
+    private readonly TestingDateTimeProvider _clock = new(new DateTime(2026, 5, 1, 12, 0, 0));
+    private readonly Mock<IAzureDevOpsService> _azureDevOpsService = new();
+    private readonly Mock<ISender> _sender = new();
+    private readonly SyncAzureDevOpsConnectionConfigurationCommandHandler _sut;
+
+    public SyncAzureDevOpsConnectionConfigurationCommandHandlerTests()
+    {
+        _sut = new SyncAzureDevOpsConnectionConfigurationCommandHandler(
+            _db,
+            _clock,
+            Mock.Of<ILogger<SyncAzureDevOpsConnectionConfigurationCommandHandler>>(),
+            _azureDevOpsService.Object,
+            _sender.Object);
+    }
+
+    private AzureDevOpsBoardsConnection CreateConnectionWithProcess(Guid externalId, Guid internalId, bool integrationIsActive = true)
+    {
+        var process = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", "test");
+        process.AddIntegrationState(IntegrationState<Guid>.Create(internalId, integrationIsActive));
+
+        var config = new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "TestPAT", processes: [process]);
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection",
+            null,
+            "test-system-id",
+            config,
+            true,
+            null,
+            _clock.Now);
+
+        _db.AddAzureDevOpsBoardsConnection(connection);
+        return connection;
+    }
+
+    [Fact]
+    public async Task Handle_WhenIntegrationInternalIdIsMissingFromRegistrations_ClearsDanglingPointer()
+    {
+        // Arrange — connection has an IntegrationState pointing at internalId, but the
+        // registrations list (sourced from Wayd.Work) is empty -> the WorkProcess row was deleted.
+        var externalId = Guid.CreateVersion7();
+        var internalId = Guid.CreateVersion7();
+        var connection = CreateConnectionWithProcess(externalId, internalId);
+
+        var azdoProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", "test");
+
+        var command = new SyncAzureDevOpsConnectionConfigurationCommand(
+            connection.Id,
+            [azdoProcess],
+            [],
+            [], // no live registrations
+            []);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var process = connection.Configuration.WorkProcesses.Single();
+        process.IntegrationState.Should().BeNull();
+        process.HasIntegration.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_WhenIntegrationInternalIdMatchesRegistration_LeavesItIntact()
+    {
+        // Arrange — registrations list contains the live registration; nothing should be cleared.
+        var externalId = Guid.CreateVersion7();
+        var internalId = Guid.CreateVersion7();
+        var connection = CreateConnectionWithProcess(externalId, internalId);
+
+        var azdoProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", "test");
+
+        var liveRegistration = new IntegrationRegistration<Guid, Guid>(
+            externalId,
+            IntegrationState<Guid>.Create(internalId, true));
+
+        var command = new SyncAzureDevOpsConnectionConfigurationCommand(
+            connection.Id,
+            [azdoProcess],
+            [],
+            [liveRegistration],
+            []);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var process = connection.Configuration.WorkProcesses.Single();
+        process.IntegrationState.Should().NotBeNull();
+        process.IntegrationState!.InternalId.Should().Be(internalId);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoIntegrationState_DoesNotInvokeHealing()
+    {
+        // Arrange — work process has never been integrated; healing path should be a no-op.
+        var externalId = Guid.CreateVersion7();
+        var process = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", "test");
+        var config = new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "TestPAT", processes: [process]);
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection", null, "test-system-id", config, true, null, _clock.Now);
+        _db.AddAzureDevOpsBoardsConnection(connection);
+
+        var azdoProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", "test");
+
+        var command = new SyncAzureDevOpsConnectionConfigurationCommand(
+            connection.Id,
+            [azdoProcess],
+            [],
+            [],
+            []);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        connection.Configuration.WorkProcesses.Single().IntegrationState.Should().BeNull();
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
@@ -111,6 +111,40 @@ public class SyncAzureDevOpsConnectionConfigurationCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_WhenLiveRegistrationHasDifferentInternalId_RebindsToLiveRegistration()
+    {
+        // Arrange — the underlying Wayd.Work.WorkProcess was deleted and recreated
+        // (same ExternalId, new InternalId). The handler should rebind the connection
+        // to the live registration rather than leave the stale InternalId in place.
+        var externalId = Guid.CreateVersion7();
+        var staleInternalId = Guid.CreateVersion7();
+        var connection = CreateConnectionWithProcess(externalId, staleInternalId);
+
+        var azdoProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", "test");
+
+        var liveInternalId = Guid.CreateVersion7();
+        var liveRegistration = new IntegrationRegistration<Guid, Guid>(
+            externalId,
+            IntegrationState<Guid>.Create(liveInternalId, true));
+
+        var command = new SyncAzureDevOpsConnectionConfigurationCommand(
+            connection.Id,
+            [azdoProcess],
+            [],
+            [liveRegistration],
+            []);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var process = connection.Configuration.WorkProcesses.Single();
+        process.IntegrationState.Should().NotBeNull();
+        process.IntegrationState!.InternalId.Should().Be(liveInternalId);
+    }
+
+    [Fact]
     public async Task Handle_WhenNoIntegrationState_DoesNotInvokeHealing()
     {
         // Arrange — work process has never been integrated; healing path should be a no-op.

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
@@ -1,14 +1,11 @@
-using CSharpFunctionalExtensions;
-using FluentAssertions;
+﻿using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
-using NodaTime;
 using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
 using Wayd.AppIntegration.Application.Tests.Infrastructure;
 using Wayd.AppIntegration.Domain.Models;
 using Wayd.Common.Application.Interfaces;
-using Wayd.Common.Application.Interfaces.ExternalWork;
 using Wayd.Common.Domain.Models;
 using Wayd.Tests.Shared;
 

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Domain.Tests/Sut/Models/AzureDevOpsBoardsConnectionTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Domain.Tests/Sut/Models/AzureDevOpsBoardsConnectionTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Wayd.AppIntegration.Domain.Interfaces;
 using Wayd.AppIntegration.Domain.Models;
+using Wayd.Common.Domain.Models;
 using Wayd.Tests.Shared;
 
 namespace Wayd.AppIntegration.Domain.Tests.Sut.Models;
@@ -144,6 +145,82 @@ public class AzureDevOpsBoardsConnectionTests
 
         // Assert
         syncable!.CanSync.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClearWorkProcessIntegrationState_WhenIntegrationExists_ShouldRemoveIt()
+    {
+        // Arrange
+        var externalId = Guid.CreateVersion7();
+        var internalId = Guid.CreateVersion7();
+        var workProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", null);
+        workProcess.AddIntegrationState(IntegrationState<Guid>.Create(internalId, true));
+
+        var config = new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "TestPAT", processes: [workProcess]);
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection",
+            null,
+            "test-system-id",
+            config,
+            true,
+            null,
+            _dateTimeProvider.Now);
+
+        // Act
+        var result = connection.ClearWorkProcessIntegrationState(externalId, _dateTimeProvider.Now);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var process = connection.Configuration.WorkProcesses.Single();
+        process.IntegrationState.Should().BeNull();
+        process.HasIntegration.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ClearWorkProcessIntegrationState_WhenNoIntegration_ShouldNoOp()
+    {
+        // Arrange
+        var externalId = Guid.CreateVersion7();
+        var workProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", null);
+
+        var config = new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "TestPAT", processes: [workProcess]);
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection",
+            null,
+            "test-system-id",
+            config,
+            true,
+            null,
+            _dateTimeProvider.Now);
+
+        // Act
+        var result = connection.ClearWorkProcessIntegrationState(externalId, _dateTimeProvider.Now);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        connection.Configuration.WorkProcesses.Single().IntegrationState.Should().BeNull();
+    }
+
+    [Fact]
+    public void ClearWorkProcessIntegrationState_WhenWorkProcessNotFound_ShouldFail()
+    {
+        // Arrange
+        var config = new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "TestPAT");
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection",
+            null,
+            "test-system-id",
+            config,
+            true,
+            null,
+            _dateTimeProvider.Now);
+
+        // Act
+        var result = connection.ClearWorkProcessIntegrationState(Guid.CreateVersion7(), _dateTimeProvider.Now);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("Unable to find work process");
     }
 
     [Fact]

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Domain.Tests/Sut/Models/AzureDevOpsBoardsConnectionTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Domain.Tests/Sut/Models/AzureDevOpsBoardsConnectionTests.cs
@@ -148,6 +148,31 @@ public class AzureDevOpsBoardsConnectionTests
     }
 
     [Fact]
+    public void UpdateWorkProcessIntegrationState_WhenInternalIdDiffers_RebindsToNewState()
+    {
+        // The underlying Wayd.Work.WorkProcess was deleted and recreated with a new InternalId.
+        // The connection should rebind to the live registration rather than keep the stale id.
+        var externalId = Guid.CreateVersion7();
+        var staleInternalId = Guid.CreateVersion7();
+        var workProcess = AzureDevOpsBoardsWorkProcess.Create(externalId, "Agile", null);
+        workProcess.AddIntegrationState(IntegrationState<Guid>.Create(staleInternalId, true));
+
+        var config = new AzureDevOpsBoardsConnectionConfiguration("TestOrg", "TestPAT", processes: [workProcess]);
+        var connection = AzureDevOpsBoardsConnection.Create(
+            "Test Connection", null, "test-system-id", config, true, null, _dateTimeProvider.Now);
+
+        var liveInternalId = Guid.CreateVersion7();
+        var registration = new IntegrationRegistration<Guid, Guid>(
+            externalId,
+            IntegrationState<Guid>.Create(liveInternalId, true));
+
+        var result = connection.UpdateWorkProcessIntegrationState(registration, _dateTimeProvider.Now);
+
+        result.IsSuccess.Should().BeTrue();
+        connection.Configuration.WorkProcesses.Single().IntegrationState!.InternalId.Should().Be(liveInternalId);
+    }
+
+    [Fact]
     public void ClearWorkProcessIntegrationState_WhenIntegrationExists_ShouldRemoveIt()
     {
         // Arrange

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/_components/global-search/global-search-modal.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/_components/global-search/global-search-modal.test.tsx
@@ -90,13 +90,13 @@ const mockCategories = [
     items: [
       {
         title: 'Fix the login bug',
-        key: 'AHTG-100',
+        key: 'WAYD-100',
         entityType: 'WorkItem',
         auxKey: 'ws-1',
       },
       {
         title: 'Add dark mode',
-        key: 'AHTG-101',
+        key: 'WAYD-101',
         entityType: 'WorkItem',
         auxKey: 'ws-1',
         subtitle: 'My Workspace',
@@ -224,7 +224,7 @@ describe('GlobalSearchModal', () => {
     it('renders result items with key and title', async () => {
       await renderWithResults()
       expect(screen.getByText('Fix the login bug')).toBeInTheDocument()
-      expect(screen.getByText('AHTG-100')).toBeInTheDocument()
+      expect(screen.getByText('WAYD-100')).toBeInTheDocument()
     })
 
     it('renders subtitle when present', async () => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/_components/global-search/search-result-url.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/_components/global-search/search-result-url.test.ts
@@ -11,8 +11,8 @@ const item = (
 describe('getSearchResultUrl', () => {
   describe('Work', () => {
     it('returns work item url', () => {
-      expect(getSearchResultUrl(item('WorkItem', 'AHTG-123', 'ws-1'))).toBe(
-        '/work/workspaces/ws-1/work-items/AHTG-123',
+      expect(getSearchResultUrl(item('WorkItem', 'WAYD-123', 'ws-1'))).toBe(
+        '/work/workspaces/ws-1/work-items/WAYD-123',
       )
     })
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/connections/[id]/azure-devops/process.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/connections/[id]/azure-devops/process.tsx
@@ -30,14 +30,19 @@ const AzdoProcess = (props: AzdoProcessProps) => {
   const azdoConnection = useContext(AzdoConnectionContext)
 
   const skip = !props?.workProcess?.integrationState?.internalId
-  const { data: workProcessData } = useGetWorkProcessQuery(
-    props.workProcess.integrationState?.internalId ?? '',
-    { skip },
-  )
+  const { data: workProcessData, isSuccess: workProcessLoaded } =
+    useGetWorkProcessQuery(
+      props.workProcess.integrationState?.internalId ?? '',
+      { skip },
+    )
 
   const integrationExists = !!props.workProcess.integrationState
   const processIntegrationIsActive =
     props.workProcess.integrationState?.isActive
+  // The connection holds an IntegrationState pointer to a Wayd.Work.WorkProcess
+  // that no longer exists. Sync Org Config will clear the dangling pointer.
+  const integrationLinkIsStale =
+    integrationExists && workProcessLoaded && !workProcessData
 
   const onInitWorkProcessIntegrationFormClosed = (wasSaved: boolean) => {
     setOpenInitWorkProcessIntegrationForm(false)
@@ -90,6 +95,14 @@ const AzdoProcess = (props: AzdoProcessProps) => {
         >
           Initialize
         </Button>
+      )
+    }
+
+    if (integrationLinkIsStale) {
+      return (
+        <Text type="warning" title="Run Sync Org Config to clear the stale link, then re-initialize.">
+          Integration link is stale
+        </Text>
       )
     }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/app-integration/azdo-integration-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/app-integration/azdo-integration-api.ts
@@ -59,7 +59,11 @@ export const azdoIntegrationApi = apiSlice.injectEndpoints({
         }
       },
       invalidatesTags: (result, error, arg) => {
-        return [{ type: QueryTags.AzdoConnectionDetail, id: arg }]
+        return [
+          { type: QueryTags.AzdoConnectionDetail, id: arg },
+          { type: QueryTags.ConnectionDetail, id: arg },
+          { type: QueryTags.Connection, id: arg },
+        ]
       },
     }),
 
@@ -81,7 +85,11 @@ export const azdoIntegrationApi = apiSlice.injectEndpoints({
         }
       },
       invalidatesTags: (result, error, arg) => {
-        return [{ type: QueryTags.AzdoConnectionDetail, id: arg.id }]
+        return [
+          { type: QueryTags.AzdoConnectionDetail, id: arg.id },
+          { type: QueryTags.ConnectionDetail, id: arg.id },
+          { type: QueryTags.Connection, id: arg.id },
+        ]
       },
     }),
 
@@ -103,7 +111,11 @@ export const azdoIntegrationApi = apiSlice.injectEndpoints({
         }
       },
       invalidatesTags: (result, error, arg) => {
-        return [{ type: QueryTags.AzdoConnectionDetail, id: arg.id }]
+        return [
+          { type: QueryTags.AzdoConnectionDetail, id: arg.id },
+          { type: QueryTags.ConnectionDetail, id: arg.id },
+          { type: QueryTags.Connection, id: arg.id },
+        ]
       },
     }),
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/work-management/work-process-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/work-management/work-process-api.ts
@@ -45,12 +45,18 @@ export const workProcessApi = apiSlice.injectEndpoints({
         ...(result?.map(({ id }) => ({ type: QueryTags.WorkProcess, id })) ?? []),
       ],
     }),
-    getWorkProcess: builder.query<WorkProcessDto, string>({
+    getWorkProcess: builder.query<WorkProcessDto | null, string>({
       queryFn: async (idOrKey: string) => {
         try {
           const data = await getWorkProcessesClient().get(idOrKey)
           return { data }
-        } catch (error) {
+        } catch (error: any) {
+          // Return null for 404 so callers can render their own empty/not-found
+          // state without polluting the console. Happens when an AzDO connection
+          // still references a Wayd.Work.WorkProcess that no longer exists.
+          if (error?.status === 404) {
+            return { data: null }
+          }
           console.error('API Error:', error)
           return { error }
         }


### PR DESCRIPTION
## Summary

Fixes #600. AzDO connections held a dangling `IntegrationState.InternalId`
pointing at a `Wayd.Work.WorkProcess` row that no longer existed. The
connection detail page silently 404'd on `GET /api/work/work-processes/{id}`
and "Sync Org Config" never healed the pointer.

## Changes

**Backend — healing during Sync Org Config**
- `IntegrationObject.RemoveIntegrationState()` — clears the pointer.
- `AzureDevOpsBoardsConnection.ClearWorkProcessIntegrationState(externalId, timestamp)` — clears a specific work process's integration and raises an `EntityUpdatedEvent` so the change persists.
- `SyncAzureDevOpsConnectionConfigurationCommandHandler` — after applying live registrations, walks every work process; if a process still holds an `IntegrationState` whose `InternalId` is absent from the live registrations list, logs a warning and clears the dangling pointer.

**Frontend — kill the console noise + surface the broken state**
- `work-process-api.getWorkProcess` returns `data: null` on 404 instead of logging `API Error: {}` (mirrors the existing pattern in `team-api.ts`). The work-process detail page already calls `notFound()` on falsy data, so its behavior is unchanged.
- AzDO connection process card now shows "Integration link is stale" (with a tooltip explaining the recovery path) when the connection claims an integration exists but the underlying work process can't be loaded.

## Recovery path for affected users

1. Open the connection → click **Sync Org Config**.
2. The handler clears the dangling pointer; the card now shows the **Initialize** button.
3. Re-initialize the work process integration as normal.

## Tests

- 3 domain tests covering the new `ClearWorkProcessIntegrationState` (success, no-op when no integration, failure when work process not found).
- 3 handler tests covering the healing branch (clears when registration missing, leaves intact when present, no-op when no integration ever existed).

## Test plan

- [x] `dotnet build Wayd.slnx` — clean
- [x] `dotnet test` Wayd.AppIntegration.Domain.Tests — 15/15 pass
- [x] `dotnet test` Wayd.AppIntegration.Application.Tests — 71/71 pass
- [x] `dotnet test` Wayd.ArchitectureTests — 65/65 pass
- [x] `dotnet test` Wayd.Work.Application.Tests — 46/46 pass
- [ ] Manual: reproduce the bug per the issue's repro, then run Sync Org Config and confirm the card transitions from "Integration link is stale" → "Initialize"
