### PR TITLE
Feature/employee cycle time report

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,8 +13,9 @@ Built with Clean Architecture, Domain-Driven Design, and a modular monolith appr
 ## Quick Start for Agents
 
 1. **Read `CLAUDE.md`** for build commands, architecture, and coding conventions
-2. **Read `docs/llms-full.txt`** for comprehensive domain context (entities, relationships, business rules)
-3. **Read `docs/ai/domain-glossary.mdx`** for domain terminology
+2. **Read `docs/ai/agent-memory.md`** for compact repo-specific implementation lessons
+3. **Read `docs/llms-full.txt`** for comprehensive domain context (entities, relationships, business rules)
+4. **Read `docs/ai/domain-glossary.mdx`** for domain terminology
 
 ## Repository Structure
 

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Queries/GetEmployeeWorkItemsQuery.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkItems/Queries/GetEmployeeWorkItemsQuery.cs
@@ -1,0 +1,45 @@
+using Wayd.Common.Domain.Enums.Work;
+using Wayd.Work.Application.Persistence;
+using Wayd.Work.Application.WorkItems.Dtos;
+
+namespace Wayd.Work.Application.WorkItems.Queries;
+
+public sealed record GetEmployeeWorkItemsQuery(
+    Guid EmployeeId,
+    WorkStatusCategory[]? StatusCategories = null,
+    Instant? DoneFrom = null,
+    Instant? DoneTo = null)
+    : IQuery<List<WorkItemListDto>>;
+
+internal sealed class GetEmployeeWorkItemsQueryHandler(
+    IWorkDbContext workDbContext)
+    : IQueryHandler<GetEmployeeWorkItemsQuery, List<WorkItemListDto>>
+{
+    private readonly IWorkDbContext _workDbContext = workDbContext;
+
+    public async Task<List<WorkItemListDto>> Handle(GetEmployeeWorkItemsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _workDbContext.WorkItems
+            .Where(item => item.AssignedToId == request.EmployeeId)
+            .Where(item => item.Type.Level!.Tier == WorkTypeTier.Requirement);
+
+        if (request.StatusCategories?.Length > 0)
+        {
+            query = query.Where(item => request.StatusCategories.Contains(item.StatusCategory));
+        }
+
+        if (request.DoneFrom.HasValue)
+        {
+            query = query.Where(item => item.DoneTimestamp.HasValue && item.DoneTimestamp >= request.DoneFrom.Value);
+        }
+
+        if (request.DoneTo.HasValue)
+        {
+            query = query.Where(item => item.DoneTimestamp.HasValue && item.DoneTimestamp <= request.DoneTo.Value);
+        }
+
+        return await query
+            .ProjectToType<WorkItemListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Sut/WorkItems/Queries/GetEmployeeWorkItemsQueryTests.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Sut/WorkItems/Queries/GetEmployeeWorkItemsQueryTests.cs
@@ -1,0 +1,100 @@
+using Wayd.Common.Domain.Enums.Work;
+using Wayd.Common.Models;
+using Wayd.Work.Application.Tests.Infrastructure;
+using Wayd.Work.Application.WorkItems.Queries;
+using Wayd.Work.Domain.Models;
+using Wayd.Work.Domain.Tests.Data;
+using NodaTime;
+using Xunit;
+
+namespace Wayd.Work.Application.Tests.Sut.WorkItems.Queries;
+
+public sealed class GetEmployeeWorkItemsQueryTests
+{
+    [Fact]
+    public async Task Handle_ReturnsOnlyRequirementWorkItemsAssignedToEmployee()
+    {
+        using var context = new FakeWorkDbContext();
+        var employeeId = Guid.NewGuid();
+        var otherEmployeeId = Guid.NewGuid();
+        var requirementType = new WorkTypeFaker().AsStory().Generate();
+        var otherType = new WorkTypeFaker().AsOther().Generate();
+
+        var expected = CreateWorkItem(employeeId, requirementType, WorkStatusCategory.Done, 1);
+        var assignedToSomeoneElse = CreateWorkItem(otherEmployeeId, requirementType, WorkStatusCategory.Done, 2);
+        var nonRequirementType = CreateWorkItem(employeeId, otherType, WorkStatusCategory.Done, 3);
+
+        context.AddWorkItems([expected, assignedToSomeoneElse, nonRequirementType]);
+        var handler = new GetEmployeeWorkItemsQueryHandler(context);
+
+        var result = await handler.Handle(new GetEmployeeWorkItemsQuery(employeeId), CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal(expected.Id, result[0].Id);
+    }
+
+    [Fact]
+    public async Task Handle_AppliesStatusCategoryAndDoneDateFilters()
+    {
+        using var context = new FakeWorkDbContext();
+        var employeeId = Guid.NewGuid();
+        var requirementType = new WorkTypeFaker().AsStory().Generate();
+        var inRangeDone = Instant.FromUtc(2026, 1, 15, 0, 0);
+
+        var expected = CreateWorkItem(employeeId, requirementType, WorkStatusCategory.Done, 1, inRangeDone);
+        var activeItem = CreateWorkItem(employeeId, requirementType, WorkStatusCategory.Active, 2, null);
+        var beforeRange = CreateWorkItem(employeeId, requirementType, WorkStatusCategory.Done, 3, Instant.FromUtc(2025, 12, 31, 0, 0));
+        var afterRange = CreateWorkItem(employeeId, requirementType, WorkStatusCategory.Done, 4, Instant.FromUtc(2026, 2, 1, 0, 0));
+
+        context.AddWorkItems([expected, activeItem, beforeRange, afterRange]);
+        var handler = new GetEmployeeWorkItemsQueryHandler(context);
+
+        var result = await handler.Handle(
+            new GetEmployeeWorkItemsQuery(
+                employeeId,
+                [WorkStatusCategory.Done],
+                Instant.FromUtc(2026, 1, 1, 0, 0),
+                Instant.FromUtc(2026, 1, 31, 0, 0)),
+            CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal(expected.Id, result[0].Id);
+    }
+
+    private static WorkItem CreateWorkItem(
+        Guid employeeId,
+        WorkType workType,
+        WorkStatusCategory statusCategory,
+        int externalId,
+        Instant? doneTimestamp = null)
+    {
+        var workspace = new WorkspaceFaker()
+            .AsExternal()
+            .WithKey(new WorkspaceKey("TEST"))
+            .Generate();
+        var status = new WorkStatusFaker()
+            .WithName(statusCategory.ToString())
+            .Generate();
+        var created = Instant.FromUtc(2025, 12, 1, 0, 0);
+        Instant? activated = statusCategory is WorkStatusCategory.Proposed
+            ? null
+            : created.Plus(Duration.FromDays(1));
+        var done = doneTimestamp ?? (statusCategory is WorkStatusCategory.Done or WorkStatusCategory.Removed
+            ? created.Plus(Duration.FromDays(5))
+            : null);
+        var faker = new WorkItemFaker(workspace.Id)
+            .WithExternalId(externalId)
+            .WithData(
+                type: workType,
+                status: status,
+                statusCategory: statusCategory,
+                assignedToId: employeeId,
+                created: created,
+                activatedTimestamp: activated,
+                doneTimestamp: done);
+
+        faker.RuleFor(x => x.Workspace, workspace);
+
+        return faker.Generate();
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/EmployeesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/EmployeesController.cs
@@ -6,6 +6,9 @@ using Wayd.Organization.Application.Teams.Dtos;
 using Wayd.Organization.Application.Teams.Queries;
 using Wayd.Web.Api.Extensions;
 using Wayd.Web.Api.Models.Organizations.Employees;
+using Wayd.Common.Domain.Enums.Work;
+using Wayd.Work.Application.WorkItems.Dtos;
+using Wayd.Work.Application.WorkItems.Queries;
 
 namespace Wayd.Web.Api.Controllers.Organizations;
 
@@ -120,5 +123,37 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     public async Task<ActionResult<IEnumerable<TeamMemberDto>>> GetTeamMemberships(Guid id, CancellationToken cancellationToken)
     {
         return Ok(await _sender.Send(new GetEmployeeTeamMembershipsQuery(id), cancellationToken));
+    }
+
+    [HttpGet("{id}/work-items")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.WorkItems)]
+    [OpenApiOperation("Get the work items assigned to an employee.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<WorkItemListDto>>> GetEmployeeWorkItems(
+        Guid id,
+        [FromQuery] WorkStatusCategory[]? statusCategories,
+        [FromQuery] DateTime? doneFrom,
+        [FromQuery] DateTime? doneTo,
+        CancellationToken cancellationToken)
+    {
+        Instant? doneFromInstant = null;
+        Instant? doneToInstant = null;
+
+        if (doneFrom.HasValue)
+        {
+            var df = doneFrom.Value;
+            df = df.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(df, DateTimeKind.Utc) : df.ToUniversalTime();
+            doneFromInstant = Instant.FromDateTimeUtc(df);
+        }
+
+        if (doneTo.HasValue)
+        {
+            var dt = doneTo.Value;
+            dt = dt.Kind == DateTimeKind.Unspecified ? DateTime.SpecifyKind(dt, DateTimeKind.Utc) : dt.ToUniversalTime();
+            doneToInstant = Instant.FromDateTimeUtc(dt);
+        }
+
+        return Ok(await _sender.Send(new GetEmployeeWorkItemsQuery(id, statusCategories, doneFromInstant, doneToInstant), cancellationToken));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -17290,6 +17290,93 @@
         ]
       }
     },
+    "/api/organization/employees/{id}/work-items": {
+      "get": {
+        "tags": [
+          "Employees"
+        ],
+        "summary": "Get the work items assigned to an employee.",
+        "operationId": "Employees_GetEmployeeWorkItems",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "statusCategories",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "nullable": true,
+              "items": {
+                "$ref": "#/components/schemas/WorkStatusCategory"
+              }
+            },
+            "x-position": 2
+          },
+          {
+            "name": "doneFrom",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "doneTo",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "x-position": 4
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkItemListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
     "/api/organization/team-member-roles": {
       "get": {
         "tags": [
@@ -33311,6 +33398,22 @@
           }
         }
       },
+      "WorkStatusCategory": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "Proposed",
+          "Active",
+          "Done",
+          "Removed"
+        ],
+        "enum": [
+          "Proposed",
+          "Active",
+          "Done",
+          "Removed"
+        ]
+      },
       "TeamMemberRoleDto": {
         "type": "object",
         "additionalProperties": false,
@@ -33865,22 +33968,6 @@
             }
           }
         }
-      },
-      "WorkStatusCategory": {
-        "type": "string",
-        "description": "",
-        "x-enumNames": [
-          "Proposed",
-          "Active",
-          "Done",
-          "Removed"
-        ],
-        "enum": [
-          "Proposed",
-          "Active",
-          "Done",
-          "Removed"
-        ]
       },
       "DependencyDto": {
         "type": "object",

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/page.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/page.test.tsx
@@ -1,0 +1,167 @@
+import React, { Suspense } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import EmployeeDetailsPage from './page'
+
+const employee = {
+  id: 'employee-1',
+  key: 42,
+  displayName: 'Ada Lovelace',
+  isActive: true,
+}
+
+jest.mock('next/dynamic', () => {
+  return () => {
+    const DynamicComponent = ({ employeeId }: { employeeId: string }) => (
+      <div data-testid="employee-cycle-time-report">{employeeId}</div>
+    )
+    return DynamicComponent
+  }
+})
+
+jest.mock('antd', () => ({
+  Card: ({
+    tabList,
+    activeTabKey,
+    onTabChange,
+    children,
+  }: {
+    tabList: Array<{ key: string; tab: React.ReactNode }>
+    activeTabKey: string
+    onTabChange: (key: string) => void
+    children: React.ReactNode
+  }) => (
+    <div>
+      <div role="tablist">
+        {tabList.map((tab) => (
+          <button
+            key={tab.key}
+            aria-selected={activeTabKey === tab.key}
+            role="tab"
+            type="button"
+            onClick={() => onTabChange(tab.key)}
+          >
+            {tab.tab}
+          </button>
+        ))}
+      </div>
+      <div>{children}</div>
+    </div>
+  ),
+  Spin: () => <div>Loading</div>,
+}))
+
+jest.mock('@/src/components/common/page-title', () => {
+  const PageTitle = ({
+    title,
+    subtitle,
+    actions,
+  }: {
+    title: React.ReactNode
+    subtitle?: React.ReactNode
+    actions?: React.ReactNode
+  }) => (
+    <div>
+      <h1>{title}</h1>
+      {subtitle && <div>{subtitle}</div>}
+      {actions}
+    </div>
+  )
+  return PageTitle
+})
+
+jest.mock('@/src/components/common', () => ({
+  InactiveTag: ({ isActive }: { isActive: boolean }) => (
+    <span>{isActive ? 'Active' : 'Inactive'}</span>
+  ),
+  PageActions: ({ actionItems }: { actionItems: any[] }) => {
+    const buttons = actionItems.flatMap((item) => item.children ?? item)
+
+    return (
+      <div>
+        {buttons.map((item) => (
+          <button key={item.key} type="button" onClick={item.onClick}>
+            {item.label}
+          </button>
+        ))}
+      </div>
+    )
+  },
+}))
+
+jest.mock('@/src/components/contexts/auth', () => ({
+  __esModule: true,
+  default: () => ({
+    hasClaim: jest.fn(() => true),
+    hasPermissionClaim: jest.fn(() => false),
+  }),
+}))
+
+jest.mock('@/src/components/contexts/messaging', () => ({
+  useMessage: () => ({
+    error: jest.fn(),
+  }),
+}))
+
+jest.mock('@/src/hooks/use-document-title', () => ({
+  useDocumentTitle: jest.fn(),
+}))
+
+jest.mock('@/src/hooks', () => ({
+  useAppDispatch: () => jest.fn(),
+}))
+
+jest.mock('@/src/store/features/organizations/employee-api', () => ({
+  useGetEmployeeQuery: jest.fn(() => ({
+    data: employee,
+    isLoading: false,
+    error: undefined,
+  })),
+}))
+
+jest.mock('./employee-details', () => {
+  const EmployeeDetails = () => <div>Employee Details Content</div>
+  return EmployeeDetails
+})
+
+jest.mock('./_components/employee-teams-grid', () => {
+  const EmployeeTeamsGrid = () => <div>Employee Teams Grid</div>
+  return EmployeeTeamsGrid
+})
+
+jest.mock('../_components/delete-employee-form', () => {
+  const DeleteEmployeeForm = () => <div>Delete Employee Form</div>
+  return DeleteEmployeeForm
+})
+
+describe('EmployeeDetailsPage', () => {
+  it('opens the employee cycle time report from page actions', async () => {
+    const user = userEvent.setup()
+    const params = Promise.resolve({ key: '42' }) as Promise<{
+      key: string
+    }> & { status: string; value: { key: string } }
+    params.status = 'fulfilled'
+    params.value = { key: '42' }
+
+    render(
+      <Suspense fallback={<div>Loading employee page</div>}>
+        <EmployeeDetailsPage params={params} />
+      </Suspense>,
+    )
+
+    expect(
+      screen.queryByTestId('employee-cycle-time-report'),
+    ).not.toBeInTheDocument()
+
+    await user.click(
+      await screen.findByRole('button', { name: 'Cycle Time Report' }),
+    )
+
+    expect(
+      screen.getByRole('tab', { name: /Cycle Time Report/ }),
+    ).toHaveAttribute('aria-selected', 'true')
+    expect(screen.getByTestId('employee-cycle-time-report')).toHaveTextContent(
+      employee.id,
+    )
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/page.tsx
@@ -3,7 +3,7 @@
 import PageTitle from '@/src/components/common/page-title'
 import { use, useEffect, useState } from 'react'
 import EmployeeDetails from './employee-details'
-import { Card, MenuProps } from 'antd'
+import { Card, MenuProps, Spin } from 'antd'
 import { useDocumentTitle } from '@/src/hooks/use-document-title'
 import { authorizePage } from '@/src/components/hoc'
 import { notFound, usePathname, useRouter } from 'next/navigation'
@@ -17,10 +17,21 @@ import useAuth from '@/src/components/contexts/auth'
 import { ItemType } from 'antd/es/menu/interface'
 import DeleteEmployeeForm from '../_components/delete-employee-form'
 import EmployeeTeamsGrid from './_components/employee-teams-grid'
+import { CloseOutlined } from '@ant-design/icons'
+import dynamic from 'next/dynamic'
+
+const EmployeeCycleTimeReport = dynamic(
+  () =>
+    import('@/src/components/common/work/cycle-time-report').then((mod) => ({
+      default: mod.EmployeeCycleTimeReport,
+    })),
+  { ssr: false, loading: () => <Spin /> },
+)
 
 enum EmployeeTabs {
   Details = 'details',
   Teams = 'teams',
+  CycleTimeReport = 'cycle-time-report',
 }
 
 const tabs = [
@@ -41,6 +52,9 @@ const EmployeeDetailsPage = (props: { params: Promise<{ key: string }> }) => {
   const [activeTab, setActiveTab] = useState(EmployeeTabs.Details)
   const [openDeleteEmployeeForm, setOpenDeleteEmployeeForm] =
     useState<boolean>(false)
+  const [dynamicTabs, setDynamicTabs] = useState<
+    Array<{ key: string; tab: string; closable: boolean }>
+  >([])
 
   const messageApi = useMessage()
   const pathname = usePathname()
@@ -69,13 +83,43 @@ const EmployeeDetailsPage = (props: { params: Promise<{ key: string }> }) => {
         return <EmployeeDetails employee={employeeData!} />
       case EmployeeTabs.Teams:
         return <EmployeeTeamsGrid employeeId={employeeData!.id} />
+      case EmployeeTabs.CycleTimeReport:
+        return <EmployeeCycleTimeReport employeeId={employeeData!.id} />
       default:
         return null
     }
   }
 
+  const openCycleTimeReport = () => {
+    const cycleTimeTabExists = dynamicTabs.some(
+      (tab) => tab.key === EmployeeTabs.CycleTimeReport,
+    )
+
+    if (!cycleTimeTabExists) {
+      setDynamicTabs((prevTabs) => [
+        ...prevTabs,
+        {
+          key: EmployeeTabs.CycleTimeReport,
+          tab: 'Cycle Time Report',
+          closable: true,
+        },
+      ])
+    }
+
+    setActiveTab(EmployeeTabs.CycleTimeReport)
+  }
+
   const onTabChange = (tabKey: string) => {
     setActiveTab(tabKey as EmployeeTabs)
+  }
+
+  const closeTab = (tabKey: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setDynamicTabs((prevTabs) => prevTabs.filter((tab) => tab.key !== tabKey))
+
+    if (activeTab === tabKey) {
+      setActiveTab(EmployeeTabs.Details)
+    }
   }
 
   useEffect(() => {
@@ -98,7 +142,40 @@ const EmployeeDetailsPage = (props: { params: Promise<{ key: string }> }) => {
       })
     }
 
+    if (items.length > 0) {
+      items.push({ type: 'divider', key: 'divider-reports' })
+    }
+
+    items.push({
+      type: 'group',
+      label: 'Reports',
+      children: [
+        {
+          key: 'cycle-time-report',
+          label: 'Cycle Time Report',
+          onClick: openCycleTimeReport,
+        },
+      ],
+    })
+
     return items
+  })()
+
+  const allTabs = (() => {
+    const closableTabs = dynamicTabs.map((tab) => ({
+      key: tab.key,
+      tab: (
+        <span>
+          {tab.tab}
+          <CloseOutlined
+            style={{ marginLeft: 8 }}
+            onClick={(e) => closeTab(tab.key, e)}
+          />
+        </span>
+      ),
+    }))
+
+    return [...tabs, ...closableTabs]
   })()
 
   const onDeleteFormClosed = (wasDeleted: boolean) => {
@@ -126,7 +203,7 @@ const EmployeeDetailsPage = (props: { params: Promise<{ key: string }> }) => {
       />
       <Card
         style={{ width: '100%' }}
-        tabList={tabs}
+        tabList={allTabs}
         activeTabKey={activeTab}
         onTabChange={onTabChange}
       >

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/cycle-time-report.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/cycle-time-report.tsx
@@ -13,6 +13,7 @@ import {
 import dayjs, { Dayjs } from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { useGetTeamWorkItemsQuery } from '@/src/store/features/organizations/team-api'
+import { useGetEmployeeWorkItemsQuery } from '@/src/store/features/organizations/employee-api'
 import { WorkStatusCategory, WorkItemListDto } from '@/src/services/wayd-api'
 import { useDebounce } from '@/src/hooks'
 import { CycleTimeAnalysisChart, WorkItemsGrid } from '.'
@@ -36,16 +37,31 @@ export interface CycleTimeReportProps {
   teamCode: string
 }
 
-export const CycleTimeReport: FC<CycleTimeReportProps> = ({ teamCode }) => {
+export interface EmployeeCycleTimeReportProps {
+  employeeId: string
+}
+
+interface CycleTimeReportContentProps {
+  source:
+    | { type: 'team'; teamCode: string }
+    | { type: 'employee'; employeeId: string }
+  workItemsScope: string
+}
+
+const CycleTimeReportContent: FC<CycleTimeReportContentProps> = ({
+  source,
+  workItemsScope,
+}) => {
   const gridRef = useRef<AgGridReact<WorkItemListDto>>(null)
   const filterAnimationFrameRef = useRef<number | null>(null)
-  const defaultDoneFrom = dayjs().utc().subtract(90, 'days').startOf('day')
   const doneFromPresets = [30, 60, 90, 120, 180].map((days) => ({
     label: `${days} Days`,
     value: dayjs().utc().subtract(days, 'days').startOf('day'),
   }))
 
-  const [selectedDate, setSelectedDate] = useState<Dayjs>(defaultDoneFrom)
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(() =>
+    dayjs().utc().subtract(90, 'days').startOf('day'),
+  )
   const [chartWorkItems, setChartWorkItems] = useState<WorkItemListDto[]>([])
   const [percentileInputValue, setPercentileInputValue] = useState<number>(100)
   const [method, setMethod] = useState<CycleTimeOutlierMethod>('Balanced')
@@ -53,17 +69,28 @@ export const CycleTimeReport: FC<CycleTimeReportProps> = ({ teamCode }) => {
 
   const doneFrom = selectedDate.toISOString()
 
-  const {
-    data: workItemsData,
-    isLoading,
-    error,
-    refetch,
-  } = useGetTeamWorkItemsQuery({
-    idOrCode: teamCode,
-    statusCategories: [WorkStatusCategory.Done],
-    doneFrom,
-    doneTo: null,
-  })
+  const teamQuery = useGetTeamWorkItemsQuery(
+    {
+      idOrCode: source.type === 'team' ? source.teamCode : '',
+      statusCategories: [WorkStatusCategory.Done],
+      doneFrom,
+      doneTo: null,
+    },
+    { skip: source.type !== 'team' },
+  )
+
+  const employeeQuery = useGetEmployeeWorkItemsQuery(
+    {
+      employeeId: source.type === 'employee' ? source.employeeId : '',
+      statusCategories: [WorkStatusCategory.Done],
+      doneFrom,
+      doneTo: null,
+    },
+    { skip: source.type !== 'employee' },
+  )
+
+  const activeQuery = source.type === 'team' ? teamQuery : employeeQuery
+  const { data: workItemsData, isLoading, error, refetch } = activeQuery
 
   const cycleTimeItems = getCycleTimeWorkItems(workItemsData)
 
@@ -145,9 +172,10 @@ export const CycleTimeReport: FC<CycleTimeReportProps> = ({ teamCode }) => {
           <Tooltip
             title={
               <>
-                Shows cycle time analysis for team work items completed since
-                the selected date. Work items that were never activated and that
-                went straight to Done are excluded.
+                Shows cycle time analysis for work items completed since
+                the selected date.
+                {` ${workItemsScope}`} Work items that were never activated and
+                that went straight to Done are excluded.
                 <br />
                 <br />
                 The chart updates dynamically based on grid filters.
@@ -230,5 +258,25 @@ export const CycleTimeReport: FC<CycleTimeReportProps> = ({ teamCode }) => {
         onFilterChanged={onFilterChanged}
       />
     </Flex>
+  )
+}
+
+export const CycleTimeReport: FC<CycleTimeReportProps> = ({ teamCode }) => {
+  return (
+    <CycleTimeReportContent
+      source={{ type: 'team', teamCode }}
+      workItemsScope="Shows work items owned by the selected team."
+    />
+  )
+}
+
+export const EmployeeCycleTimeReport: FC<EmployeeCycleTimeReportProps> = ({
+  employeeId,
+}) => {
+  return (
+    <CycleTimeReportContent
+      source={{ type: 'employee', employeeId }}
+      workItemsScope="Shows work items assigned to this employee."
+    />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -21001,6 +21001,76 @@ export class EmployeesClient {
         }
         return Promise.resolve<TeamMemberDto[]>(null as any);
     }
+
+    /**
+     * Get the work items assigned to an employee.
+     * @param statusCategories (optional) 
+     * @param doneFrom (optional) 
+     * @param doneTo (optional) 
+     */
+    getEmployeeWorkItems(id: string, statusCategories?: WorkStatusCategory[] | null | undefined, doneFrom?: Date | null | undefined, doneTo?: Date | null | undefined, cancelToken?: CancelToken): Promise<WorkItemListDto[]> {
+        let url_ = this.baseUrl + "/api/organization/employees/{id}/work-items?";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (statusCategories !== undefined && statusCategories !== null)
+            statusCategories && statusCategories.forEach(item => { url_ += "statusCategories=" + encodeURIComponent("" + item) + "&"; });
+        if (doneFrom !== undefined && doneFrom !== null)
+            url_ += "doneFrom=" + encodeURIComponent(doneFrom ? "" + doneFrom.toISOString() : "") + "&";
+        if (doneTo !== undefined && doneTo !== null)
+            url_ += "doneTo=" + encodeURIComponent(doneTo ? "" + doneTo.toISOString() : "") + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetEmployeeWorkItems(_response);
+        });
+    }
+
+    protected processGetEmployeeWorkItems(response: AxiosResponse): Promise<WorkItemListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<WorkItemListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<WorkItemListDto[]>(null as any);
+    }
 }
 
 export class TeamMemberRolesClient {
@@ -29213,6 +29283,13 @@ export interface TeamMemberEmployeeDto {
     jobTitle?: string | undefined;
 }
 
+export enum WorkStatusCategory {
+    Proposed = "Proposed",
+    Active = "Active",
+    Done = "Done",
+    Removed = "Removed",
+}
+
 export interface TeamMemberRoleDto {
     id: string;
     key: number;
@@ -29341,13 +29418,6 @@ export interface WorkItemBacklogItemDto {
     stackRank: number;
     storyPoints?: number | undefined;
     tags: string[];
-}
-
-export enum WorkStatusCategory {
-    Proposed = "Proposed",
-    Active = "Active",
-    Done = "Done",
-    Removed = "Removed",
 }
 
 export interface DependencyDto {

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/organizations/employee-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/organizations/employee-api.ts
@@ -2,7 +2,12 @@ import { BaseOptionType } from 'antd/es/select'
 import { apiSlice } from '../apiSlice'
 import { QueryTags } from '../query-tags'
 import { getEmployeesClient } from '@/src/services/clients'
-import { EmployeeDetailsDto, EmployeeListDto } from '@/src/services/wayd-api'
+import {
+  EmployeeDetailsDto,
+  EmployeeListDto,
+  WorkItemListDto,
+  WorkStatusCategory,
+} from '@/src/services/wayd-api'
 
 export const employeeApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
@@ -36,6 +41,39 @@ export const employeeApi = apiSlice.injectEndpoints({
       },
       providesTags: (result, error, arg) => [
         { type: QueryTags.Employee, id: arg },
+      ],
+    }),
+    getEmployeeWorkItems: builder.query<
+      WorkItemListDto[],
+      {
+        employeeId: string
+        statusCategories?: WorkStatusCategory[] | null
+        /** ISO 8601 date string (e.g., "2025-08-25T00:00:00.000Z") */
+        doneFrom?: string | null
+        /** ISO 8601 date string (e.g., "2025-08-25T00:00:00.000Z") */
+        doneTo?: string | null
+      }
+    >({
+      queryFn: async ({ employeeId, statusCategories, doneFrom, doneTo }) => {
+        try {
+          const data = await getEmployeesClient().getEmployeeWorkItems(
+            employeeId,
+            statusCategories,
+            doneFrom ? new Date(doneFrom) : null,
+            doneTo ? new Date(doneTo) : null,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        QueryTags.EmployeeWorkItems,
+        {
+          type: QueryTags.EmployeeWorkItems,
+          id: `${arg.employeeId}-${arg.statusCategories?.join(',') ?? ''}-${arg.doneFrom ?? ''}-${arg.doneTo ?? ''}`,
+        },
       ],
     }),
     getEmployeeOptions: builder.query<BaseOptionType[], boolean | undefined>({
@@ -76,6 +114,7 @@ export const employeeApi = apiSlice.injectEndpoints({
 export const {
   useGetEmployeesQuery,
   useGetEmployeeQuery,
+  useGetEmployeeWorkItemsQuery,
   useGetEmployeeOptionsQuery,
   useDeleteEmployeeMutation,
 } = employeeApi

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
@@ -28,6 +28,7 @@ export enum QueryTags {
   // ORGANIZATIONS
   ActiveSprint = 'Organizations.ActiveSprint',
   Employee = 'Organizations.Employee',
+  EmployeeWorkItems = 'Organizations.EmployeeWorkItems',
   EmployeeOption = 'Organizations.EmployeeOption',
   Team = 'Organizations.Team',
   TeamOptions = 'Organizations.TeamOptions',

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -47,6 +47,7 @@ const sidebars: SidebarsConfig = {
           items: [
             'user-guide/work-management/work-items',
             'user-guide/work-management/work-configuration',
+            'user-guide/work-management/cycle-time-report',
           ],
         },
         {

--- a/docs/ai/agent-memory.md
+++ b/docs/ai/agent-memory.md
@@ -1,0 +1,59 @@
+# Agent Memory
+
+This file captures compact repo-specific lessons that future coding agents should read early. Keep it short and practical. Use `CLAUDE.md`, `AGENTS.md`, `docs/llms-full.txt`, and `docs/ai/domain-glossary.mdx` for full architecture and domain context.
+
+## Startup Checklist
+
+1. Read root `AGENTS.md` first.
+2. Read `CLAUDE.md` for build commands, architecture conventions, and generated-client rules.
+3. Read this file for recent implementation lessons and repo habits.
+4. For domain work, use `docs/llms-full.txt` and `docs/ai/domain-glossary.mdx`.
+
+## Generated API Client
+
+- Do not hand-edit `Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts`.
+- NSwag regenerates `wayd-api.ts` and `Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json` during a Debug build of the API project.
+- Useful command: `dotnet build "Wayd.Web/src/Wayd.Web.Api/Wayd.Web.Api.csproj"`.
+- Frontend RTK Query slices should call generated client methods from `src/services/clients.ts`; never use `authenticatedFetch()` directly.
+
+## Backend Patterns
+
+- Application handlers use EF Core DbContext directly, not repositories.
+- New async methods should not use an `Async` suffix.
+- Use NodaTime (`Instant`, `LocalDate`) in application/domain code. Convert API `DateTime` inputs at the controller boundary.
+- Controllers should stay thin and delegate to MediatR commands/queries.
+- Business validation should use `Result<T>` and FluentValidation where appropriate, not business exceptions.
+
+## Frontend Patterns
+
+- Use RTK Query for API data access and cache tags.
+- Optional/heavy reports and grids are commonly loaded with `next/dynamic` and `ssr: false`.
+- Existing details pages often open optional reports as closeable dynamic tabs from `PageActions`.
+- Ant Design theme tokens and CSS variables are preferred. Do not hardcode visual colors.
+- The frontend lint script runs `eslint .` even when file paths are passed, so unrelated warnings may appear.
+
+## Testing Notes
+
+- Domain fakers live in domain test projects and are referenced by application tests when useful. For Work items, use `Wayd.Work.Domain.Tests/Data/WorkItemFaker.cs`.
+- Application test projects often include fake DbContexts, for example `FakeWorkDbContext`.
+- React page tests can mock heavy Ant Design surfaces and dynamic imports when the behavior under test is page wiring rather than AntD itself.
+- Next.js route `params` are promises in app-router pages. In React 19 tests, a fulfilled thenable can avoid getting stuck in Suspense for unit-level page tests.
+
+## Cycle Time Report Rules
+
+- Cycle time is `DoneTimestamp - ActivatedTimestamp`.
+- Cycle-time report work items should remain aligned with the team report rules:
+  - Requirement-tier work items only.
+  - Done status category for the report query.
+  - Done date range filters on `DoneTimestamp`.
+  - Items without a valid `WorkItemListDto.CycleTime` are excluded by the shared frontend filtering.
+- Team cycle time uses team-owned work items.
+- Employee cycle time uses work items assigned to the employee via `AssignedToId`.
+
+## Recent Feature Notes
+
+- Employee cycle time report added:
+  - Query: `GetEmployeeWorkItemsQuery` in `Wayd.Work.Application/WorkItems/Queries`.
+  - Endpoint: `GET /api/organization/employees/{id}/work-items`.
+  - Frontend wrapper: `EmployeeCycleTimeReport` in `components/common/work/cycle-time-report.tsx`.
+  - Employee details page opens it from `Reports > Cycle Time Report`.

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -27,6 +27,7 @@ Wayd supports:
 - [Work Management Overview](docs/user-guide/work-management/index.mdx): How work items connect to teams, sprints, and projects
 - [Work Items & Workspaces](docs/user-guide/work-management/work-items.mdx): Work items, workspaces, dependencies, revisions, hierarchy
 - [Work Configuration](docs/user-guide/work-management/work-configuration.mdx): Work processes, types, tiers, levels, workflows, statuses
+- [Cycle Time Report](docs/user-guide/work-management/cycle-time-report.mdx): Cycle time analysis for team-owned and employee-assigned work items
 - [PPM Overview](docs/user-guide/ppm/index.mdx): How PPM connects strategy and execution
 - [Portfolios & Programs](docs/user-guide/ppm/portfolios-programs.mdx): Portfolio lifecycle, programs, roles
 - [Projects](docs/user-guide/ppm/projects.mdx): Project lifecycle, phases, tasks, dependencies, plan tab

--- a/docs/user-guide/organizations/index.mdx
+++ b/docs/user-guide/organizations/index.mdx
@@ -234,74 +234,9 @@ Only the current operating model can be edited or deleted (and deletion is only 
 
 ### Cycle Time Report (Report)
 
-Available from the **Reports** menu, the **Cycle Time Report** analyzes how long it takes the team to complete work items. It helps teams understand delivery cadence, identify bottlenecks, and forecast future work.
+Available from the **Reports** menu, the **Cycle Time Report** analyzes how long it takes the team's work items to complete. It uses the same report available on employee detail pages, but scoped to work items owned by the team.
 
-#### What is Cycle Time?
-
-**Cycle Time** measures the number of days between when work starts (moves to Active status) and when it finishes (moves to Done status):
-
-```
-Cycle Time = Done Timestamp − Activated Timestamp (in days)
-```
-
-Only **Requirement-tier** work items (e.g., User Stories, Bugs) with both an Activated and Done timestamp are included. Portfolio-tier items (Epics, Features) and items that were Removed without being completed are excluded.
-
-Related metrics shown on work item detail pages:
-- **Time to Start** — Days from creation to activation (how long work sits before starting)
-- **Lead Time** — Days from creation to completion (total time from request to delivery)
-
-#### Configuring the Report
-
-The report has three controls:
-
-**Done From (Date Range)**
-- Filters work items completed on or after this date
-- Presets: 30, 60, 90, 120, or 180 days (default: 90 days)
-- All dates are in UTC
-
-**Percentile (0-100%)**
-- Controls what percentage of work items to include after removing outliers
-- At 100%, all items are shown (no filtering)
-- Lower values remove extreme cycle times that skew averages
-
-**Outlier Method**
-- Determines *how* outliers are identified and removed when percentile is below 100%:
-
-| Method | How It Works | Best For |
-|--------|-------------|----------|
-| **Balanced** | Trims equally from both the fastest and slowest items. At 80th percentile, removes the top 10% and bottom 10%. | Understanding typical cycle time by excluding both unusually fast and slow items |
-| **Forecasting** | Removes only the slowest items. At 80th percentile, keeps the fastest 80% of items. | Predicting delivery dates — excludes only the outliers that would make forecasts unreliable |
-
-**Example:** With 10 items sorted by cycle time (1, 2, 3, 4, 5, 6, 7, 8, 9, 15 days) at the 80th percentile:
-- **Balanced** keeps items 2-9 (removes bottom 10% and top 10%)
-- **Forecasting** keeps items 1-8 (removes the slowest 20%)
-
-#### Chart Visualization
-
-The **Cycle Time Analysis Chart** is a column chart that groups completed work items by story points and shows the average cycle time for each group:
-
-- **X-axis** — Story point categories (1, 2, 3, 5, 8, etc.) plus "No Story Points" and "Overall"
-- **Y-axis** — Average cycle time in days
-- Color coding: primary blue for story point groups, orange for "No Story Points", green for "Overall"
-
-This helps teams answer questions like:
-- "Do our 8-point stories really take longer than 3-point stories?"
-- "Is our estimation accurate — do similarly-sized items have similar cycle times?"
-- "What's our average cycle time across all work?"
-
-#### Work Items Grid
-
-Below the chart, a sortable and filterable grid shows all included work items with columns for Key, Title, Type, Status, Story Points, Team, Sprint, Assigned To, Activated date, Done date, and Cycle Time (days).
-
-**Interactive filtering:** Applying column filters in the grid (e.g., filtering by a specific work type) dynamically updates the chart above. This lets you drill into cycle time by type, sprint, assignee, or any other dimension.
-
-#### Using Cycle Time for Improvement
-
-- **Track trends** — Run the report monthly to see if cycle time is improving
-- **Compare story point groups** — If 5-point and 8-point stories have similar cycle times, your estimation may need calibration
-- **Identify bottlenecks** — Items with unusually long cycle times may indicate process issues
-- **Forecast delivery** — Use the Forecasting method at the 85th percentile to estimate "most items will complete within X days"
-- **Set WIP limits** — High cycle times often indicate too much work in progress
+See [Cycle Time Report](../work-management/cycle-time-report.mdx) for calculation rules, report controls, chart behavior, and usage guidance.
 
 ## Functional Organization Chart
 
@@ -379,9 +314,17 @@ To update the current model without creating a new one:
 2. From the page actions menu, open **Reports > Cycle Time Report**
 3. Configure the date range and filters to analyze delivery performance
 
+### Viewing Employee Cycle Time
+
+1. Navigate to the employee's detail page
+2. From the page actions menu, open **Reports > Cycle Time Report**
+3. Configure the date range and filters to analyze completed work assigned to that employee
+
 ## Employee Detail Page
 
 Each employee's detail page includes a **Teams** tab showing all teams the employee is currently a member of, with columns for Team name, Team type, and Roles. Team names link to their respective detail pages.
+
+The employee detail page also includes a **Reports > Cycle Time Report** action. This opens the same [Cycle Time Report](../work-management/cycle-time-report.mdx) used on team pages, scoped to Requirement-tier work items assigned to the employee.
 
 ## Teams List Page
 

--- a/docs/user-guide/planning/sprints.mdx
+++ b/docs/user-guide/planning/sprints.mdx
@@ -94,7 +94,7 @@ Sprint average: Sum(all item cycle times) / Count(eligible Done items)
 
 Items that were moved directly to Done without being Activated, or items that were Removed, are excluded from the cycle time calculation.
 
-For a deeper analysis of cycle time patterns over longer periods, use the [Cycle Time Report](../organizations/index.mdx#cycle-time-report-report) on individual team pages.
+For a deeper analysis of cycle time patterns over longer periods, use the [Cycle Time Report](../work-management/cycle-time-report.mdx) on individual team or employee pages.
 
 ### PI Iteration Metric Aggregation
 

--- a/docs/user-guide/work-management/cycle-time-report.mdx
+++ b/docs/user-guide/work-management/cycle-time-report.mdx
@@ -1,0 +1,129 @@
+---
+title: Cycle Time Report
+description: Analyzing cycle time for team-owned or employee-assigned work items in Wayd.
+sidebar_position: 3
+audience: [user, agent]
+---
+
+# Cycle Time Report
+
+The **Cycle Time Report** analyzes how long it takes work items to complete. It helps teams and individuals understand delivery cadence, identify bottlenecks, compare estimates against actual delivery time, and forecast future work.
+
+The report is available from the **Reports** menu on:
+
+- **Team detail pages** — analyzes work items owned by the team
+- **Employee detail pages** — analyzes work items assigned to the employee
+
+## What Is Cycle Time?
+
+**Cycle Time** measures the number of days between when work starts and when it finishes:
+
+```
+Cycle Time = Done Timestamp - Activated Timestamp (in days)
+```
+
+Only **Requirement-tier** work items, such as User Stories and Bugs, are included. Portfolio-tier items, such as Epics and Features, are excluded because they are containers rather than team-delivered units of work.
+
+To contribute to the report, a work item must:
+
+- Be a Requirement-tier work item
+- Have a Done status category
+- Have both an Activated timestamp and a Done timestamp
+- Have a Done timestamp after the Activated timestamp
+- Fall within the selected Done date range
+
+Items that moved directly to Done without being activated, or items that were Removed instead of completed, are excluded.
+
+Related metrics shown on work item detail pages:
+
+- **Time to Start** — Days from creation to activation
+- **Lead Time** — Days from creation to completion
+
+## Report Scope
+
+The same report behaves differently based on where it is opened:
+
+| Location | Scope |
+|----------|-------|
+| Team detail page | Requirement-tier work items owned by the team |
+| Employee detail page | Requirement-tier work items assigned to the employee |
+
+The calculation rules, filters, chart, and grid behavior are the same for both scopes.
+
+## Configuring the Report
+
+The report has three controls.
+
+### Done From
+
+Filters work items completed on or after the selected date.
+
+- Default: 90 days ago
+- Presets: 30, 60, 90, 120, or 180 days
+- Dates are interpreted from the beginning of the day in UTC
+
+### Percentile
+
+Controls what percentage of work items to include after removing outliers.
+
+- `100%` includes all eligible items
+- Lower values remove extreme cycle times that can skew averages
+- `0%` excludes all items
+
+### Outlier Method
+
+Determines how outliers are removed when percentile is below `100%`.
+
+| Method | How It Works | Best For |
+|--------|--------------|----------|
+| **Balanced** | Trims equally from the fastest and slowest items. At 80th percentile, removes the top 10% and bottom 10%. | Understanding typical cycle time while excluding unusually fast and slow items |
+| **Forecasting** | Removes only the slowest items. At 80th percentile, keeps the fastest 80% of items. | Predicting delivery dates by excluding slow outliers that would make forecasts unreliable |
+
+Example: with 10 items sorted by cycle time as `1, 2, 3, 4, 5, 6, 7, 8, 9, 15` days at the 80th percentile:
+
+- **Balanced** keeps items 2-9
+- **Forecasting** keeps items 1-8
+
+## Chart
+
+The **Cycle Time Analysis Chart** groups completed work items by story points and shows average cycle time for each group.
+
+- **X-axis** — Story point categories, plus "No Story Points" and "Overall"
+- **Y-axis** — Average cycle time in days
+- **Overall** — Average cycle time across all included work items
+
+Use the chart to answer questions like:
+
+- Do similarly sized items have similar cycle times?
+- Are large estimates taking meaningfully longer than smaller estimates?
+- What is the average cycle time across the selected work?
+
+## Work Items Grid
+
+Below the chart, a sortable and filterable grid shows the included work items with columns for Key, Title, Type, Status, Story Points, Team, Sprint, Assigned To, Activated date, Done date, and Cycle Time.
+
+Applying grid filters dynamically updates the chart. This lets you drill into cycle time by work type, sprint, assignee, team, or other dimensions.
+
+## Using Cycle Time
+
+Use the report to:
+
+- **Track trends** — Run the report regularly to see whether cycle time is improving
+- **Compare estimates** — Check whether items with similar story points complete in similar time
+- **Identify bottlenecks** — Investigate items with unusually long cycle times
+- **Forecast delivery** — Use the Forecasting method at a percentile such as 85% to estimate likely completion ranges
+- **Tune WIP limits** — High cycle times can indicate too much work in progress
+
+## How To Open The Report
+
+### Team Cycle Time
+
+1. Navigate to the team's detail page
+2. Open **Reports > Cycle Time Report**
+3. Configure the date range and filters
+
+### Employee Cycle Time
+
+1. Navigate to the employee's detail page
+2. Open **Reports > Cycle Time Report**
+3. Configure the date range and filters

--- a/docs/user-guide/work-management/index.mdx
+++ b/docs/user-guide/work-management/index.mdx
@@ -39,7 +39,7 @@ graph LR
     WI -->|parent of| WI
 ```
 
-- **[Teams](../organizations/index.mdx#teams)** are assigned to work items and see them on the [Backlog tab](../organizations/index.mdx#backlog-tab). Team [dependencies](../organizations/index.mdx#dependency-management-tab) and [cycle time](../organizations/index.mdx#cycle-time-report-report) are also tracked.
+- **[Teams](../organizations/index.mdx#teams)** are assigned to work items and see them on the [Backlog tab](../organizations/index.mdx#backlog-tab). Team [dependencies](../organizations/index.mdx#dependency-management-tab) and [cycle time](./cycle-time-report.mdx) are also tracked.
 - **[Sprints](../planning/sprints.mdx)** provide time-boxed containers for work items. Sprint progress is measured via [sprint metrics](../planning/sprints.mdx#sprint-metrics).
 - **[Projects](../ppm/projects.mdx)** can be associated with portfolio-tier work items. Projects track work on their [Work Items tab](../ppm/projects.mdx#project-detail-page).
 
@@ -47,6 +47,7 @@ graph LR
 
 - **[Work Items & Workspaces](./work-items.mdx)** — Creating, viewing, and managing work items within workspaces
 - **[Work Configuration](./work-configuration.mdx)** — Work processes, work types, workflows, and work statuses
+- **[Cycle Time Report](./cycle-time-report.mdx)** — Analyze cycle time for team-owned and employee-assigned work items
 
 ## Business Rules Summary
 

--- a/docs/user-guide/work-management/work-configuration.mdx
+++ b/docs/user-guide/work-management/work-configuration.mdx
@@ -119,7 +119,7 @@ A **Work Status** represents a specific state within a [workflow](#workflows) (e
 | **Done** | 3 | Work has been completed |
 | **Removed** | 4 | Work has been removed from scope without completion |
 
-This normalization enables Wayd to calculate metrics like [cycle time](../organizations/index.mdx#cycle-time-report-report), throughput, and [completion rates](../planning/sprints.mdx#metric-definitions) across [teams](../organizations/index.mdx#teams) that may use different workflow configurations.
+This normalization enables Wayd to calculate metrics like [cycle time](./cycle-time-report.mdx), throughput, and [completion rates](../planning/sprints.mdx#metric-definitions) across [teams](../organizations/index.mdx#teams) that may use different workflow configurations.
 
 ## Configuration Tasks
 

--- a/docs/user-guide/work-management/work-items.mdx
+++ b/docs/user-guide/work-management/work-items.mdx
@@ -88,7 +88,7 @@ The work item detail page has multiple tabs that adapt based on the work item's 
 
 **Dashboard Tab** (hidden for Removed items):
 - **Time to Start** — Days from creation to activation (how long work waited before starting)
-- **Cycle Time** — Days from activation to completion (shows "Time Active" while still in progress). Calculated as `Done Timestamp − Activated Timestamp`. See also [Cycle Time Report](../organizations/index.mdx#cycle-time-report-report) for team-level analysis.
+- **Cycle Time** — Days from activation to completion (shows "Time Active" while still in progress). Calculated as `Done Timestamp − Activated Timestamp`. See also [Cycle Time Report](./cycle-time-report.mdx) for team- and employee-level analysis.
 - **Lead Time** — Total days from creation to completion (only shown for Done items)
 - For **[Portfolio tier](./work-configuration.mdx#work-type-tiers)** items (Epics, Features), also shows:
   - **Progress Pie Chart** — Distribution of child items by [status category](./work-configuration.mdx#work-status-categories) (Proposed, Active, Done) with percentages


### PR DESCRIPTION
## Summary

Adds Cycle Time Report support on employee detail pages, scoped to work items assigned to the employee.

Also extracts Cycle Time Report documentation into a dedicated Work Management doc so team and employee report entry points can reference the same source of truth.

## Changes

- Added `GetEmployeeWorkItemsQuery` for employee-assigned work items
- Added `GET /api/organization/employees/{id}/work-items`
- Regenerated OpenAPI spec and NSwag TypeScript client
- Added RTK Query support for employee work items
- Refactored the shared Cycle Time Report component to support team and employee scopes
- Added `Reports > Cycle Time Report` to employee detail pages with a closeable report tab
- Added backend query tests for employee assignment, work type tier, status category, and Done date filtering
- Added frontend page test for opening the employee cycle time report
- Added dedicated Cycle Time Report user documentation under Work Management
- Updated related docs links and sidebar entry

## Validation

- `dotnet build Wayd.Web/src/Wayd.Web.Api/Wayd.Web.Api.csproj`
- `dotnet test Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Wayd.Work.Application.Tests.csproj`
- `npm test -- cycle-time-report.filtering.test.ts cycle-time-analysis-chart.test.tsx --runInBand`
- `npx jest "src/app/organizations/employees/\[key\]/page.test.tsx" --runInBand --verbose`
- `npm run lint -- src/app/organizations/employees/[key]/page.tsx src/app/organizations/employees/[key]/page.test.tsx src/components/common/work/cycle-time-report.tsx src/store/features/organizations/employee-api.ts src/store/features/query-tags.ts`
- `npm run build` from `docs-site`