### PR TITLE
Feature/update httpclient timeouts

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
@@ -23,6 +23,7 @@ using Wayd.Integrations.Abstractions;
 using Wayd.Integrations.AzureDevOps;
 using Wayd.Integrations.MicrosoftGraph;
 using Wayd.Integrations.Workday;
+using Wayd.Integrations.Workday.Soap;
 using Wayd.Common.Application.Interfaces.ExternalPeople;
 using Wayd.Planning.Application.PokerSessions.Interfaces;
 using NodaTime;
@@ -43,8 +44,18 @@ public static class ConfigureServices
 
         builder.Services.ConfigureHttpClientDefaults(http =>
         {
-            // Turn on resilience by default
-            http.AddStandardResilienceHandler();
+            // Turn on resilience by default. The standard handler's default per-attempt timeout
+            // is 30s, which is too tight for our integration calls — many pull large datasets
+            // (Workday Get_Workers, ADO work-item batches) and routinely run past 30s, surfacing
+            // as "The operation didn't complete within the allowed timeout of '00:00:30'". Bump
+            // the per-attempt budget to 90s. Validation requires TotalRequestTimeout >= attempt
+            // timeout and CircuitBreaker.SamplingDuration >= 2x attempt timeout, so raise those too.
+            http.AddStandardResilienceHandler(options =>
+            {
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(90);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(5);
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(3);
+            });
 
             // Turn on service discovery by default
             http.AddServiceDiscovery();
@@ -79,7 +90,34 @@ public static class ConfigureServices
 
         // Workday: shared SOAP client used by both bulk sync and the init probe. The runner
         // resolves IWorkdayEmployeeSource; Create/Update/Init handlers resolve IWorkdayConnectionInitializer.
-        services.AddHttpClient<Wayd.Integrations.Workday.Soap.WorkdayStaffingClient>();
+        //
+        // A per-client standard resilience handler REPLACES the global default for this client, so we
+        // re-apply the longer integration timeouts here (90s/attempt) and additionally suppress retries
+        // for Workday's permanent faults. Workday wraps auth/validation faults in HTTP 500 bodies, which
+        // the default transient predicate would retry 3× to no effect; IsNonRetryableFault parses the
+        // SOAP fault and short-circuits those. Reading the body in the predicate is safe — fault bodies
+        // are tiny and ReadAsStringAsync buffers, so the client's own later read still sees the content.
+        services.AddHttpClient<WorkdayStaffingClient>()
+            .AddStandardResilienceHandler(options =>
+            {
+                options.AttemptTimeout.Timeout = TimeSpan.FromSeconds(90);
+                options.TotalRequestTimeout.Timeout = TimeSpan.FromMinutes(5);
+                options.CircuitBreaker.SamplingDuration = TimeSpan.FromMinutes(3);
+
+                var defaultShouldHandle = options.Retry.ShouldHandle;
+                options.Retry.ShouldHandle = async args =>
+                {
+                    var response = args.Outcome.Result;
+                    if (response is { IsSuccessStatusCode: false } && response.Content is not null)
+                    {
+                        var body = await response.Content.ReadAsStringAsync(args.Context.CancellationToken);
+                        if (WorkdayStaffingClient.IsNonRetryableFault(body))
+                            return false;
+                    }
+
+                    return await defaultShouldHandle(args);
+                };
+            });
         services.AddScoped<IWorkdayEmployeeSource, WorkdayStaffingService>();
         services.AddScoped<IWorkdayConnectionInitializer, WorkdayConnectionInitializer>();
 

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
@@ -95,8 +95,9 @@ public static class ConfigureServices
         // re-apply the longer integration timeouts here (90s/attempt) and additionally suppress retries
         // for Workday's permanent faults. Workday wraps auth/validation faults in HTTP 500 bodies, which
         // the default transient predicate would retry 3× to no effect; IsNonRetryableFault parses the
-        // SOAP fault and short-circuits those. Reading the body in the predicate is safe — fault bodies
-        // are tiny and ReadAsStringAsync buffers, so the client's own later read still sees the content.
+        // SOAP fault and short-circuits those. Reading the body in the predicate is cheap — fault bodies
+        // are tiny and ReadAsStringAsync buffers, so the client's own later read still sees the content —
+        // and guarded, so a read failure falls back to the default classification rather than escaping.
         services.AddHttpClient<WorkdayStaffingClient>()
             .AddStandardResilienceHandler(options =>
             {
@@ -110,9 +111,24 @@ public static class ConfigureServices
                     var response = args.Outcome.Result;
                     if (response is { IsSuccessStatusCode: false } && response.Content is not null)
                     {
-                        var body = await response.Content.ReadAsStringAsync(args.Context.CancellationToken);
-                        if (WorkdayStaffingClient.IsNonRetryableFault(body))
-                            return false;
+                        try
+                        {
+                            var body = await response.Content.ReadAsStringAsync(args.Context.CancellationToken);
+                            if (WorkdayStaffingClient.IsNonRetryableFault(body))
+                                return false;
+                        }
+                        catch (OperationCanceledException)
+                        {
+                            // Genuine cancellation (request aborted / total-timeout) — let it propagate
+                            // rather than turning it into a retry decision.
+                            throw;
+                        }
+                        catch
+                        {
+                            // Reading/classifying the body failed (I/O, disposed content). Don't let that
+                            // escape the predicate and corrupt the pipeline outcome — fall through to the
+                            // default transient classification below.
+                        }
                     }
 
                     return await defaultShouldHandle(args);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Middleware/ExceptionMiddleware.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Middleware/ExceptionMiddleware.cs
@@ -19,6 +19,16 @@ public sealed class ExceptionMiddleware(IProblemDetailsService problemDetailsSer
         {
             await next(httpContext);
         }
+        catch (Exception ex) when (IsClientDisconnect(ex, httpContext))
+        {
+            // The client gave up mid-request: it either sent a truncated body (BadHttpRequestException,
+            // "Unexpected end of request content") or cancelled an in-flight request (RequestAborted).
+            // This is not a server fault — most commonly it's the Hangfire dashboard's stats poller or
+            // a browser navigating away. Log it quietly and don't try to write a response: the socket is
+            // already gone, so a write would throw a second, more confusing exception.
+            Log.Debug(ex, "Request aborted by the client before completion ({Method} {Path}).",
+                httpContext.Request.Method, httpContext.Request.Path);
+        }
         catch (Exception ex)
         {
             using (LogContext.PushProperty("CorrelationId", httpContext.TraceIdentifier))
@@ -66,6 +76,26 @@ public sealed class ExceptionMiddleware(IProblemDetailsService problemDetailsSer
                 });
             }
         }
+    }
+
+    /// <summary>
+    /// True when the exception represents the client abandoning the request rather than a server
+    /// fault: a truncated/malformed request body (<see cref="BadHttpRequestException"/>) or a
+    /// cancellation that lines up with <see cref="HttpContext.RequestAborted"/> firing. These should
+    /// be logged quietly and never produce an error response — the connection is already gone.
+    /// </summary>
+    private static bool IsClientDisconnect(Exception exception, HttpContext httpContext)
+    {
+        // Kestrel surfaces a truncated/aborted request body as BadHttpRequestException (a client 400).
+        if (exception is BadHttpRequestException)
+            return true;
+
+        // A cancellation that coincides with the request being aborted is the client hanging up, not
+        // an internal timeout — distinguish on RequestAborted so we don't swallow genuine cancellations.
+        if (exception is OperationCanceledException && httpContext.RequestAborted.IsCancellationRequested)
+            return true;
+
+        return false;
     }
 
     public static int GetStatusCodeFromException(Exception exception)

--- a/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
@@ -271,8 +271,10 @@ public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<Workday
         if (string.IsNullOrWhiteSpace(fault)) return false;
 
         // Auth failures: same heuristics WorkdaySoapException.IsAuthFailure uses. Re-running with
-        // the same bad credentials will never succeed.
-        if (fault.Contains("authentication", StringComparison.OrdinalIgnoreCase)
+        // the same bad credentials will never succeed. Match on the "authenticat" stem so all of
+        // authenticate / authenticated / authentication classify the same (Workday phrases these
+        // inconsistently, e.g. "could not be authenticated").
+        if (fault.Contains("authenticat", StringComparison.OrdinalIgnoreCase)
             || fault.Contains("invalid user", StringComparison.OrdinalIgnoreCase)
             || fault.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
             return true;

--- a/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
@@ -83,6 +83,19 @@ public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<Workday
                     new XElement(Wd + "Updated_Through", now.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)))));
         }
 
+        // Response_Group controls how much Workday serializes per worker — the dominant driver of
+        // Get_Workers response time on large tenants. We request the four data areas the projector
+        // reads (reference, personal, employment, organizations) plus the management chain (the only
+        // place the direct-manager link lives).
+        //
+        // NOTE: org-data is the expensive area (Include_Organizations returns every org a worker is in
+        // plus full parent hierarchies). Workday offers Exclude_* sub-flags to trim it, but we can't
+        // blanket-apply them: the connector's Department source and exclusion rules both match on an
+        // admin-chosen Organization_Type_ID, and that catalog includes BOTH base org types AND
+        // hierarchy types — so any sub-category (including a *_Hierarchy) may be the exact data a
+        // tenant's config depends on. Excluding it would silently null departments / disable
+        // exclusions. Safe trimming has to be computed from the connection's config (only exclude
+        // sub-categories provably unused by this connector), which is a follow-up.
         var responseGroup = new XElement(Wd + "Response_Group",
             new XElement(Wd + "Include_Reference", "1"),
             new XElement(Wd + "Include_Personal_Information", "1"),

--- a/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
@@ -243,6 +243,39 @@ public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<Workday
         }
     }
 
+    /// <summary>
+    /// Classifies a non-success Workday SOAP response body as retryable or not. Workday wraps
+    /// semantic faults — bad ISU credentials, malformed requests, missing-permission errors — in
+    /// HTTP 500 bodies, which the resilience handler's default predicate would otherwise treat as
+    /// transient and retry 3× to no effect. We parse the SOAP fault and refuse retries for faults
+    /// that re-running can't fix (auth + validation). Anything we can't classify (no parseable
+    /// fault, genuine transient server error) falls through to the default transient handling.
+    /// </summary>
+    /// <returns><c>true</c> when the fault is permanent and the request should NOT be retried.</returns>
+    public static bool IsNonRetryableFault(string body)
+    {
+        var fault = TryReadFault(body);
+        if (string.IsNullOrWhiteSpace(fault)) return false;
+
+        // Auth failures: same heuristics WorkdaySoapException.IsAuthFailure uses. Re-running with
+        // the same bad credentials will never succeed.
+        if (fault.Contains("authentication", StringComparison.OrdinalIgnoreCase)
+            || fault.Contains("invalid user", StringComparison.OrdinalIgnoreCase)
+            || fault.Contains("unauthorized", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        // Validation faults: Workday rejects malformed envelopes / invalid criteria with
+        // "Validation error" / "invalid" / "is not a valid" reasons. These are deterministic —
+        // the same request will fail identically every time.
+        if (fault.Contains("validation error", StringComparison.OrdinalIgnoreCase)
+            || fault.Contains("is not a valid", StringComparison.OrdinalIgnoreCase)
+            || fault.Contains("invalid request", StringComparison.OrdinalIgnoreCase)
+            || fault.Contains("processing error", StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return false;
+    }
+
     private static int ParseIntOrDefault(string? value, int fallback) =>
         int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var n) ? n : fallback;
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkerFieldReader.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkerFieldReader.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -9,16 +10,58 @@ namespace Wayd.Integrations.Workday.Soap;
 /// First non-empty match wins. Used by both the bulk-sync parser and the init probe — the parser
 /// extracts data; the probe inspects field presence to detect ISSG permission gaps.
 /// </summary>
+/// <remarks>
+/// Performance: <see cref="Extensions.XPathSelectElement(XNode, string)"/> recompiles the XPath
+/// string on every call. A bulk sync evaluates ~18 fields per worker across hundreds of workers,
+/// so that recompilation dominated the projection cost. We compile each distinct XPath once into a
+/// reusable <see cref="XPathExpression"/> and cache it. Compiled expressions aren't safe for
+/// concurrent evaluation, so each lookup hands back a cheap <see cref="XPathExpression.Clone"/>
+/// rather than the shared instance — Clone is orders of magnitude cheaper than Compile.
+/// </remarks>
 internal static class WorkerFieldReader
 {
     private static readonly IXmlNamespaceResolver _ns = WorkdayNamespaceResolver.Instance;
+
+    // Keyed by the raw XPath string. Bounded by the number of distinct field paths (~20), so this
+    // grows to a small fixed size and never needs eviction.
+    private static readonly ConcurrentDictionary<string, XPathExpression> _compiled = new();
+
+    /// <summary>
+    /// Returns the first node matching <paramref name="xpath"/> using a cached compiled expression,
+    /// or null. Centralizes the compile-once-and-clone pattern so every reader method benefits.
+    /// </summary>
+    private static XPathNavigator? SelectSingleNode(XElement element, string xpath)
+    {
+        var expr = _compiled.GetOrAdd(xpath, static x => XPathExpression.Compile(x, _ns));
+        var navigator = element.CreateNavigator();
+        // Clone so concurrent syncs (or future parallelism) never share a live expression context.
+        return navigator.SelectSingleNode(expr.Clone());
+    }
+
+    /// <summary>
+    /// Enumerates the trimmed, non-empty string values of every node matching <paramref name="xpath"/>,
+    /// using a cached compiled expression. For multi-valued reads (e.g. a worker's org references)
+    /// where the caller needs to inspect all matches rather than just the first.
+    /// </summary>
+    public static IEnumerable<string> SelectValues(XElement element, string xpath)
+    {
+        var expr = _compiled.GetOrAdd(xpath, static x => XPathExpression.Compile(x, _ns));
+        var navigator = element.CreateNavigator();
+        var iterator = navigator.Select(expr.Clone());
+        while (iterator.MoveNext())
+        {
+            var value = iterator.Current?.Value?.Trim();
+            if (!string.IsNullOrEmpty(value))
+                yield return value;
+        }
+    }
 
     /// <summary>Returns the first non-empty string value matching any of <paramref name="xpathCandidates"/>.</summary>
     public static string? GetValue(XElement worker, params string[] xpathCandidates)
     {
         foreach (var xpath in xpathCandidates)
         {
-            var node = worker.XPathSelectElement(xpath, _ns);
+            var node = SelectSingleNode(worker, xpath);
             var value = node?.Value?.Trim();
             if (!string.IsNullOrEmpty(value))
                 return value;
@@ -36,7 +79,7 @@ internal static class WorkerFieldReader
     {
         foreach (var xpath in xpathCandidates)
         {
-            if (worker.XPathSelectElement(xpath, _ns) is not null)
+            if (SelectSingleNode(worker, xpath) is not null)
                 return true;
         }
         return false;
@@ -47,8 +90,9 @@ internal static class WorkerFieldReader
     {
         foreach (var xpath in xpathCandidates)
         {
-            var node = worker.XPathSelectElement(xpath, _ns);
-            if (node is not null)
+            // SelectSingleNode returns an XPathNavigator positioned on the match; UnderlyingObject
+            // gives back the original XElement the navigator was created over.
+            if (SelectSingleNode(worker, xpath)?.UnderlyingObject is XElement node)
                 return node;
         }
         return null;
@@ -59,8 +103,8 @@ internal static class WorkerFieldReader
     {
         foreach (var xpath in xpathCandidates)
         {
-            var node = worker.XPathSelectElement(xpath, _ns);
-            if (node is null) continue;
+            if (SelectSingleNode(worker, xpath)?.UnderlyingObject is not XElement node)
+                continue;
 
             // Match by local name to avoid pinning the attribute namespace.
             var attr = node.Attributes().FirstOrDefault(a => a.Name.LocalName == attributeLocalName);

--- a/Wayd.Integrations/src/Wayd.Integrations.Workday/WorkdayStaffingService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Workday/WorkdayStaffingService.cs
@@ -1,6 +1,6 @@
-﻿using System.Globalization;
+﻿using System.Diagnostics;
+using System.Globalization;
 using System.Xml.Linq;
-using System.Xml.XPath;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 using NodaTime;
@@ -19,9 +19,11 @@ namespace Wayd.Integrations.Workday;
 /// </summary>
 public sealed class WorkdayStaffingService(WorkdayStaffingClient client, ILogger<WorkdayStaffingService> logger) : IWorkdayEmployeeSource
 {
-    // 100 is the Workday-recommended max per page for Get_Workers; bumping further trades latency
-    // for throughput and tends to bump up against per-call timeouts on large tenants.
-    private const int SyncPageSize = 100;
+    // Workday caps Get_Workers Count at 999/page, but per-call latency scales with page size because
+    // Workday hydrates each worker server-side (the dominant cost). 200 keeps each call well under the
+    // 90s per-attempt resilience timeout (set in Infrastructure ConfigureServices) and pages small
+    // enough to overlap cleanly if/when pagination is parallelized.
+    private const int SyncPageSize = 200;
 
     private readonly WorkdayStaffingClient _client = client;
     private readonly ILogger<WorkdayStaffingService> _logger = logger;
@@ -44,18 +46,31 @@ public sealed class WorkdayStaffingService(WorkdayStaffingClient client, ILogger
             var page = 1;
             int totalPages;
 
+            // Phase timing: separate the Workday round-trip (network + Workday-side response assembly)
+            // from local projection (XPath reads + value-object construction). The bulk-sync wall clock
+            // is one or the other; logging the split tells us which to invest in rather than guessing.
+            // Stopwatch.GetTimestamp/GetElapsedTime times without allocating a Stopwatch instance and
+            // keeps sub-millisecond precision — matches the PerformanceBehavior convention.
+            double fetchMs = 0;
+            double projectMs = 0;
+
             do
             {
                 cancellationToken.ThrowIfCancellationRequested();
+
+                var fetchStart = Stopwatch.GetTimestamp();
                 var response = await _client.GetWorkers(context, page, SyncPageSize, cancellationToken);
+                var pageFetchMs = Stopwatch.GetElapsedTime(fetchStart).TotalMilliseconds;
+                fetchMs += pageFetchMs;
                 totalPages = response.TotalPages;
 
+                var projectStart = Stopwatch.GetTimestamp();
                 foreach (var worker in response.Workers)
                 {
                     // Drop workers in any excluded org before projection — projection runs name
                     // normalization, date parsing, etc., and there's no point doing that work for
                     // workers we're about to discard.
-                    var matchedExclusion = FindMatchingExclusion(worker, exclusionCounts.Keys);
+                    var matchedExclusion = FindMatchingExclusion(worker, exclusionCounts);
                     if (matchedExclusion is not null)
                     {
                         exclusionCounts[matchedExclusion].Count++;
@@ -66,13 +81,25 @@ public sealed class WorkdayStaffingService(WorkdayStaffingClient client, ILogger
                     if (projected is not null)
                         employees.Add(projected);
                 }
+                var pageProjectMs = Stopwatch.GetElapsedTime(projectStart).TotalMilliseconds;
+                projectMs += pageProjectMs;
 
-                _logger.LogInformation(
-                    "Workday Get_Workers page {Page}/{TotalPages} returned {Count} workers ({ProjectedCount} after projection, {ExcludedCount} excluded by rules).",
-                    page, totalPages, response.Workers.Count, employees.Count, exclusionCounts.Values.Sum(v => v.Count));
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug(
+                        "Workday Get_Workers page {Page}/{TotalPages} returned {Count} workers ({ProjectedCount} after projection, {ExcludedCount} excluded by rules) — fetch {FetchMs:F0}ms, project {ProjectMs:F1}ms.",
+                        page, totalPages, response.Workers.Count, employees.Count, exclusionCounts.Values.Sum(v => v.Count), pageFetchMs, pageProjectMs);
+                }
 
                 page++;
             } while (page <= totalPages);
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "Workday Get_Workers complete: {Projected} workers projected across {Pages} page(s) — total fetch {FetchMs:F0}ms, total project {ProjectMs:F1}ms.",
+                    employees.Count, totalPages, fetchMs, projectMs);
+            }
 
             EmitNullRateWarnings(employees);
 
@@ -98,32 +125,28 @@ public sealed class WorkdayStaffingService(WorkdayStaffingClient client, ILogger
         }
     }
 
+    // The worker's org-reference WIDs. Constant across the run, so it's compiled once and cached by
+    // WorkerFieldReader rather than recompiled per worker.
+    private const string OrgReferenceWidXPath =
+        "wd:Worker_Data/wd:Organization_Data/wd:Worker_Organization_Data/wd:Organization_Reference/wd:ID[@wd:type='WID']";
+
     /// <summary>
-    /// Returns the first excluded org-reference WID found on the worker, or null when none of the
-    /// configured exclusions match. We use an OrdinalIgnoreCase hash lookup on the worker's
-    /// Worker_Organization_Data WIDs so the cost is O(orgs-per-worker) per worker rather than
-    /// O(rules × orgs-per-worker). Workday emits WIDs in a single canonical case but matching
-    /// case-insensitively is defensive against tenant exports / copy-paste.
+    /// Returns the WID of the first excluded org the worker belongs to, or null when none of the
+    /// configured exclusions match. Both sides are case-insensitive: the worker's WIDs come from a
+    /// cached compiled XPath, and the exclusion check is an O(1) probe against the
+    /// OrdinalIgnoreCase-keyed accumulator dictionary — so the cost is O(orgs-per-worker), not
+    /// O(rules × orgs-per-worker). The returned WID is a valid lookup key for the caller's indexer
+    /// precisely because that dictionary ignores case. Workday emits WIDs in a single canonical case
+    /// but matching case-insensitively is defensive against tenant exports / copy-paste.
     /// </summary>
-    private static string? FindMatchingExclusion(XElement worker, ICollection<string> excludedReferences)
+    private static string? FindMatchingExclusion(XElement worker, Dictionary<string, ExclusionAccumulator> exclusions)
     {
-        if (excludedReferences.Count == 0) return null;
+        if (exclusions.Count == 0) return null;
 
-        var orgRefs = worker.XPathSelectElements(
-            "wd:Worker_Data/wd:Organization_Data/wd:Worker_Organization_Data/wd:Organization_Reference/wd:ID[@wd:type='WID']",
-            WorkdayNamespaceResolver.Instance);
-
-        foreach (var refEl in orgRefs)
+        foreach (var wid in WorkerFieldReader.SelectValues(worker, OrgReferenceWidXPath))
         {
-            var value = refEl?.Value?.Trim();
-            if (string.IsNullOrEmpty(value)) continue;
-
-            // Return the exact key that's in the dictionary so the caller indexes correctly.
-            foreach (var key in excludedReferences)
-            {
-                if (string.Equals(key, value, StringComparison.OrdinalIgnoreCase))
-                    return key;
-            }
+            if (exclusions.ContainsKey(wid))
+                return wid;
         }
         return null;
     }

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayFaultClassificationTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayFaultClassificationTests.cs
@@ -30,6 +30,10 @@ public class WorkdayFaultClassificationTests
     [InlineData("Invalid username or password. The request could not be authenticated.")]
     [InlineData("Authentication failed for the supplied credentials.")]
     [InlineData("Unauthorized: the integration system user lacks the required security group.")]
+    // Stem coverage: "authenticated" with no "user"/"unauthorized" substring must still classify —
+    // it only matches via the "authenticat" stem, not the longer "authentication".
+    [InlineData("The request could not be authenticated.")]
+    [InlineData("Unable to authenticate the integration system security group.")]
     public void IsNonRetryableFault_authFault_returnsTrue(string reason)
     {
         WorkdayStaffingClient.IsNonRetryableFault(FaultBody(reason)).Should().BeTrue();

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayFaultClassificationTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayFaultClassificationTests.cs
@@ -1,0 +1,87 @@
+using FluentAssertions;
+using Wayd.Integrations.Workday.Soap;
+using Xunit;
+
+namespace Wayd.Integrations.Workday.Tests;
+
+/// <summary>
+/// Covers <see cref="WorkdayStaffingClient.IsNonRetryableFault"/>, the predicate the per-client
+/// resilience handler uses to suppress retries on Workday's permanent (auth/validation) faults.
+/// Workday wraps these in HTTP 500 bodies that the default transient predicate would otherwise
+/// retry 3× to no effect. Fault bodies here are composed from first principles, not real payloads.
+/// </summary>
+public class WorkdayFaultClassificationTests
+{
+    // Minimal SOAP 1.1 fault envelope. faultstring carries the human-readable reason that Workday
+    // populates on validation/auth failures; that's what the classifier keys off.
+    private static string FaultBody(string faultString) =>
+        $"""
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+          <soapenv:Body>
+            <soapenv:Fault>
+              <faultcode>soapenv:Server</faultcode>
+              <faultstring>{faultString}</faultstring>
+            </soapenv:Fault>
+          </soapenv:Body>
+        </soapenv:Envelope>
+        """;
+
+    [Theory]
+    [InlineData("Invalid username or password. The request could not be authenticated.")]
+    [InlineData("Authentication failed for the supplied credentials.")]
+    [InlineData("Unauthorized: the integration system user lacks the required security group.")]
+    public void IsNonRetryableFault_authFault_returnsTrue(string reason)
+    {
+        WorkdayStaffingClient.IsNonRetryableFault(FaultBody(reason)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("Validation error processing the Get_Workers request.")]
+    [InlineData("The value 'XYZ' is not a valid Organization_Type_ID.")]
+    [InlineData("Invalid request: Updated_From and Updated_Through must both be supplied.")]
+    [InlineData("Processing error occurred while evaluating the request criteria.")]
+    public void IsNonRetryableFault_validationFault_returnsTrue(string reason)
+    {
+        WorkdayStaffingClient.IsNonRetryableFault(FaultBody(reason)).Should().BeTrue();
+    }
+
+    [Theory]
+    [InlineData("The server is temporarily unavailable. Please try again later.")]
+    [InlineData("An unexpected internal error occurred.")]
+    [InlineData("Service timeout while contacting the persistence layer.")]
+    public void IsNonRetryableFault_transientLookingFault_returnsFalse(string reason)
+    {
+        // Faults we can't positively classify as permanent fall through to the default transient
+        // handling so genuine server hiccups still get retried.
+        WorkdayStaffingClient.IsNonRetryableFault(FaultBody(reason)).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsNonRetryableFault_nonFaultBody_returnsFalse()
+    {
+        // A successful-looking Get_Workers body (no Fault element) is not a permanent failure.
+        var body = """
+            <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wd="urn:com.workday/bsvc">
+              <soapenv:Body>
+                <wd:Get_Workers_Response>
+                  <wd:Response_Results><wd:Total_Pages>1</wd:Total_Pages></wd:Response_Results>
+                </wd:Get_Workers_Response>
+              </soapenv:Body>
+            </soapenv:Envelope>
+            """;
+
+        WorkdayStaffingClient.IsNonRetryableFault(body).Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("this is not xml at all")]
+    [InlineData("<unclosed>")]
+    public void IsNonRetryableFault_emptyOrUnparseableBody_returnsFalse(string body)
+    {
+        // Unparseable bodies can't be classified; default to retryable rather than swallowing a
+        // potentially-transient failure.
+        WorkdayStaffingClient.IsNonRetryableFault(body).Should().BeFalse();
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/PeopleSyncRunner.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/PeopleSyncRunner.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics;
+using System.Text.Json;
 using MediatR;
 using Wayd.AppIntegration.Application.Interfaces;
 using Wayd.AppIntegration.Domain.Interfaces;
@@ -136,11 +137,19 @@ public sealed class PeopleSyncRunner(
 
         var details = new PeopleSyncDetail();
 
+        // Per-stage wall-clock timing. The connection run spans four sequential stages (fetch →
+        // upsert → user-link → user-sync); any of them could dominate the total. Timing each one
+        // tells us where to invest rather than optimizing the wrong stage on a hunch.
+        var stageTimer = Stopwatch.StartNew();
+        long fetchMs = 0, upsertMs = 0, userLinkMs = 0, userSyncMs = 0;
+
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
 
+            stageTimer.Restart();
             var fetchResult = await FetchEmployees(connectionId, connector, lastSuccessfulRunAt, cancellationToken);
+            fetchMs = stageTimer.ElapsedMilliseconds;
             if (fetchResult.IsFailure)
             {
                 details.Errors.Add(fetchResult.Error);
@@ -187,9 +196,11 @@ public sealed class PeopleSyncRunner(
 
             var matchBy = await ResolveMatchProperty(connectionId, connector, cancellationToken);
 
+            stageTimer.Restart();
             var upsertResult = await _sender.Send(
                 new BulkUpsertEmployeesCommand(employees, matchBy: matchBy, deactivateMissing: !incremental),
                 cancellationToken);
+            upsertMs = stageTimer.ElapsedMilliseconds;
             if (upsertResult.IsFailure)
             {
                 details.Errors.Add($"BulkUpsertEmployees failed: {upsertResult.Error}");
@@ -199,18 +210,29 @@ public sealed class PeopleSyncRunner(
             }
             details.EmployeesUpserted = employees.Count;
 
+            stageTimer.Restart();
             var userLinkResult = await _userService.UpdateMissingEmployeeIds(cancellationToken);
+            userLinkMs = stageTimer.ElapsedMilliseconds;
             if (userLinkResult.IsFailure)
             {
                 details.Errors.Add($"UpdateMissingEmployeeIds failed: {userLinkResult.Error}");
                 run.RecordError();
             }
 
+            stageTimer.Restart();
             var userUpdateResult = await _userService.SyncUsersFromEmployeeRecords(employees, cancellationToken);
+            userSyncMs = stageTimer.ElapsedMilliseconds;
             if (userUpdateResult.IsFailure)
             {
                 details.Errors.Add($"SyncUsersFromEmployeeRecords failed: {userUpdateResult.Error}");
                 run.RecordError();
+            }
+
+            if (_logger.IsEnabled(LogLevel.Debug))
+            {
+                _logger.LogDebug(
+                    "People sync stages for connection {ConnectionId} ({EmployeeCount} employees): fetch {FetchMs}ms, upsert {UpsertMs}ms, user-link {UserLinkMs}ms, user-sync {UserSyncMs}ms.",
+                    connectionId, employees.Count, fetchMs, upsertMs, userLinkMs, userSyncMs);
             }
 
             run.MarkSucceeded(_clock.Now);


### PR DESCRIPTION
- Increase HTTP client timeouts for Workday integration to handle large datasets and prevent timeout errors
- Add fault classification logic for non-retryable Workday SOAP responses and corresponding tests
- Enhance error handling in ExceptionMiddleware and improve logging for client disconnects; optimize XPath expression caching in WorkerFieldReader; adjust WorkdayStaffingService for better performance metrics logging during employee sync stages.