### PR TITLE
Feature/priority scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -162,9 +162,12 @@ Single shared `WaydDbContext`. Entity configs in `Wayd.Infrastructure/Persistenc
 ### Testing
 
 - Test naming: `{ProjectName}.Tests`
-- Domain fakers in `Wayd.Tests.Shared`
-- Fake DbContext implementations for each application area
+- Domain fakers live in the domain test project they belong to (each `{ServiceName}.Domain.Tests/Data/` folder), NOT in `Wayd.Tests.Shared` — only the `PrivateConstructorFaker<T>` base lives there. Use per-property `With{Property}` builder extensions.
+- One test class per system-under-test, named after its file; mark every test with `// Arrange` / `// Act` / `// Assert`
+- Pass `TestContext.Current.CancellationToken` to every cancellable call (handler `Handle(...)` and EF queries) — not `CancellationToken.None`
+- Fake DbContext implementations for each application area (e.g. `FakeWaydDbContext`); assert on `SaveChangesCallCount`
 - Moq.AutoMock for automatic dependency mocking
+- See [docs/contributing/testing.mdx](docs/contributing/testing.mdx) for the full conventions
 
 ## Important Considerations
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,7 @@
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.10.0" />
     <PackageVersion Include="Microsoft.Identity.Web.MicrosoftGraph" Version="4.10.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="NCalcSync" Version="5.12.0" />
     <PackageVersion Include="NodaTime" Version="3.3.2" />
     <PackageVersion Include="NodaTime.Serialization.SystemTextJson" Version="1.3.1" />
     <PackageVersion Include="NSwag.AspNetCore" Version="14.7.1" />

--- a/Wayd.Common/src/Wayd.Common.Application/Persistence/IWaydDbContext.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Persistence/IWaydDbContext.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 
 namespace Wayd.Common.Application.Persistence;
 
@@ -20,4 +21,5 @@ public interface IWaydDbContext
     DbSet<OidcProvider> OidcProviders { get; }
     DbSet<PersonalAccessToken> PersonalAccessTokens { get; }
     DbSet<User> WaydUsers { get; }
+    DbSet<ScoringModel> ScoringModels { get; }
 }

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ActivateScoringModelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ActivateScoringModelCommand.cs
@@ -1,0 +1,63 @@
+using Wayd.Common.Application.Persistence;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record ActivateScoringModelCommand(Guid Id) : ICommand;
+
+public sealed class ActivateScoringModelCommandValidator : AbstractValidator<ActivateScoringModelCommand>
+{
+    public ActivateScoringModelCommandValidator()
+    {
+        RuleFor(v => v.Id)
+            .NotEmpty();
+    }
+}
+
+internal sealed class ActivateScoringModelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<ActivateScoringModelCommandHandler> logger)
+    : ICommandHandler<ActivateScoringModelCommand>
+{
+    private const string AppRequestName = nameof(ActivateScoringModelCommand);
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<ActivateScoringModelCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ActivateScoringModelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Scales).ThenInclude(s => s.Levels)
+                .Include(x => x.Outputs)
+                .FirstOrDefaultAsync(s => s.Id == request.Id, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.Id);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var activateResult = model.Activate();
+            if (activateResult.IsFailure)
+            {
+                // Reset the entity
+                await _waydDbContext.Entry(model).ReloadAsync(cancellationToken);
+                model.ClearDomainEvents();
+
+                _logger.LogError("Unable to activate Scoring Model {ScoringModelId}.  Error message: {Error}", request.Id, activateResult.Error);
+
+                return Result.Failure(activateResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scoring Model {ScoringModelId} activated.", request.Id);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringModelCriterionCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringModelCriterionCommand.cs
@@ -1,0 +1,81 @@
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record AddScoringModelCriterionCommand(
+    Guid ScoringModelId,
+    string Name,
+    string Token,
+    string? Description,
+    decimal? Weight,
+    Guid? ScaleId)
+    : ICommand<Guid>;
+
+public sealed class AddScoringModelCriterionCommandValidator : AbstractValidator<AddScoringModelCriterionCommand>
+{
+    public AddScoringModelCriterionCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(ScoringToken.MaxLength)
+            .Must(ScoringToken.IsValid)
+            .WithMessage("'{PropertyValue}' is not a valid token.");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(1024);
+    }
+}
+
+internal sealed class AddScoringModelCriterionCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<AddScoringModelCriterionCommandHandler> logger)
+    : ICommandHandler<AddScoringModelCriterionCommand, Guid>
+{
+    private const string AppRequestName = nameof(AddScoringModelCriterionCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<AddScoringModelCriterionCommandHandler> _logger = logger;
+
+    public async Task<Result<Guid>> Handle(AddScoringModelCriterionCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Outputs)
+                .Include(x => x.Scales)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure<Guid>("Scoring Model not found.");
+            }
+
+            var addResult = model.AddCriterion(request.Name, request.Token, request.Description, request.Weight, request.ScaleId);
+            if (addResult.IsFailure)
+            {
+                _logger.LogError("Unable to add criterion to Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, addResult.Error);
+                return Result.Failure<Guid>(addResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Criterion {CriterionId} added to Scoring Model {ScoringModelId}.", addResult.Value.Id, request.ScoringModelId);
+
+            return Result.Success(addResult.Value.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure<Guid>($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringModelOutputCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringModelOutputCommand.cs
@@ -1,0 +1,80 @@
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record AddScoringModelOutputCommand(
+    Guid ScoringModelId,
+    string Name,
+    string Token,
+    string Formula,
+    bool IsPrimary)
+    : ICommand<Guid>;
+
+public sealed class AddScoringModelOutputCommandValidator : AbstractValidator<AddScoringModelOutputCommand>
+{
+    public AddScoringModelOutputCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(ScoringToken.MaxLength)
+            .Must(ScoringToken.IsValid)
+            .WithMessage("'{PropertyValue}' is not a valid token.");
+
+        RuleFor(x => x.Formula)
+            .NotEmpty()
+            .MaximumLength(ScoringFormulaEvaluator.MaxFormulaLength);
+    }
+}
+
+internal sealed class AddScoringModelOutputCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<AddScoringModelOutputCommandHandler> logger)
+    : ICommandHandler<AddScoringModelOutputCommand, Guid>
+{
+    private const string AppRequestName = nameof(AddScoringModelOutputCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<AddScoringModelOutputCommandHandler> _logger = logger;
+
+    public async Task<Result<Guid>> Handle(AddScoringModelOutputCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Outputs)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure<Guid>("Scoring Model not found.");
+            }
+
+            var addResult = model.AddOutput(request.Name, request.Token, request.Formula, request.IsPrimary);
+            if (addResult.IsFailure)
+            {
+                _logger.LogError("Unable to add output to Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, addResult.Error);
+                return Result.Failure<Guid>(addResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Output {OutputId} added to Scoring Model {ScoringModelId}.", addResult.Value.Id, request.ScoringModelId);
+
+            return Result.Success(addResult.Value.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure<Guid>($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringScaleCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringScaleCommand.cs
@@ -1,0 +1,65 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record AddScoringScaleCommand(
+    Guid ScoringModelId,
+    string Name)
+    : ICommand<Guid>;
+
+public sealed class AddScoringScaleCommandValidator : AbstractValidator<AddScoringScaleCommand>
+{
+    public AddScoringScaleCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}
+
+internal sealed class AddScoringScaleCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<AddScoringScaleCommandHandler> logger)
+    : ICommandHandler<AddScoringScaleCommand, Guid>
+{
+    private const string AppRequestName = nameof(AddScoringScaleCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<AddScoringScaleCommandHandler> _logger = logger;
+
+    public async Task<Result<Guid>> Handle(AddScoringScaleCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure<Guid>("Scoring Model not found.");
+            }
+
+            var addResult = model.AddScale(request.Name);
+            if (addResult.IsFailure)
+            {
+                _logger.LogError("Unable to add scale to Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, addResult.Error);
+                return Result.Failure<Guid>(addResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scale {ScaleId} added to Scoring Model {ScoringModelId}.", addResult.Value.Id, request.ScoringModelId);
+
+            return Result.Success(addResult.Value.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure<Guid>($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringScaleLevelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/AddScoringScaleLevelCommand.cs
@@ -1,0 +1,70 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record AddScoringScaleLevelCommand(
+    Guid ScoringModelId,
+    Guid ScaleId,
+    string Label,
+    decimal Value)
+    : ICommand<Guid>;
+
+public sealed class AddScoringScaleLevelCommandValidator : AbstractValidator<AddScoringScaleLevelCommand>
+{
+    public AddScoringScaleLevelCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.ScaleId)
+            .NotEmpty();
+
+        RuleFor(x => x.Label)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}
+
+internal sealed class AddScoringScaleLevelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<AddScoringScaleLevelCommandHandler> logger)
+    : ICommandHandler<AddScoringScaleLevelCommand, Guid>
+{
+    private const string AppRequestName = nameof(AddScoringScaleLevelCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<AddScoringScaleLevelCommandHandler> _logger = logger;
+
+    public async Task<Result<Guid>> Handle(AddScoringScaleLevelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales).ThenInclude(s => s.Levels)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure<Guid>("Scoring Model not found.");
+            }
+
+            var addResult = model.AddScaleLevel(request.ScaleId, request.Label, request.Value);
+            if (addResult.IsFailure)
+            {
+                _logger.LogError("Unable to add rating level to Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, addResult.Error);
+                return Result.Failure<Guid>(addResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Rating level {LevelId} added to scale {ScaleId} on Scoring Model {ScoringModelId}.", addResult.Value.Id, request.ScaleId, request.ScoringModelId);
+
+            return Result.Success(addResult.Value.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure<Guid>($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ArchiveScoringModelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ArchiveScoringModelCommand.cs
@@ -1,0 +1,55 @@
+using Wayd.Common.Application.Persistence;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record ArchiveScoringModelCommand(Guid Id) : ICommand;
+
+public sealed class ArchiveScoringModelCommandValidator : AbstractValidator<ArchiveScoringModelCommand>
+{
+    public ArchiveScoringModelCommandValidator()
+    {
+        RuleFor(v => v.Id)
+            .NotEmpty();
+    }
+}
+
+internal sealed class ArchiveScoringModelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<ArchiveScoringModelCommandHandler> logger)
+    : ICommandHandler<ArchiveScoringModelCommand>
+{
+    private const string AppRequestName = nameof(ArchiveScoringModelCommand);
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<ArchiveScoringModelCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ArchiveScoringModelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .FirstOrDefaultAsync(s => s.Id == request.Id, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.Id);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var archiveResult = model.Archive();
+            if (archiveResult.IsFailure)
+            {
+                _logger.LogError("Unable to archive Scoring Model {ScoringModelId}.  Error message: {Error}", request.Id, archiveResult.Error);
+                return Result.Failure(archiveResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scoring Model {ScoringModelId} archived.", request.Id);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/CreateScoringModelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/CreateScoringModelCommand.cs
@@ -1,0 +1,130 @@
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record CreateScoringModelCommand(
+    string Name,
+    string Description,
+    List<CreateScoringModelCommand.ScaleInput>? Scales,
+    List<CreateScoringModelCommand.CriterionInput>? Criteria,
+    List<CreateScoringModelCommand.OutputInput>? Outputs)
+    : ICommand<Guid>
+{
+    public sealed record ScaleInput(string Name, List<ScaleLevelInput> Levels);
+    public sealed record ScaleLevelInput(string Label, decimal Value);
+    public sealed record CriterionInput(string Name, string Token, string? Description, decimal? Weight, string? ScaleName);
+    public sealed record OutputInput(string Name, string Token, string Formula, bool IsPrimary);
+}
+
+public sealed class CreateScoringModelCommandValidator : AbstractValidator<CreateScoringModelCommand>
+{
+    public CreateScoringModelCommandValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Description)
+            .NotEmpty()
+            .MaximumLength(1024);
+
+        RuleForEach(x => x.Criteria).ChildRules(criterion =>
+        {
+            criterion.RuleFor(c => c.Name)
+                .NotEmpty()
+                .MaximumLength(128);
+
+            criterion.RuleFor(c => c.Token)
+                .NotEmpty()
+                .MaximumLength(ScoringToken.MaxLength)
+                .Must(ScoringToken.IsValid)
+                .WithMessage("'{PropertyValue}' is not a valid token.");
+
+            criterion.RuleFor(c => c.Description)
+                .MaximumLength(1024);
+        });
+
+        RuleForEach(x => x.Scales).ChildRules(scale =>
+        {
+            scale.RuleFor(s => s.Name)
+                .NotEmpty()
+                .MaximumLength(64);
+
+            scale.RuleForEach(s => s.Levels).ChildRules(level =>
+            {
+                level.RuleFor(l => l.Label)
+                    .NotEmpty()
+                    .MaximumLength(64);
+            });
+        });
+
+        RuleForEach(x => x.Outputs).ChildRules(output =>
+        {
+            output.RuleFor(o => o.Name)
+                .NotEmpty()
+                .MaximumLength(128);
+
+            output.RuleFor(o => o.Token)
+                .NotEmpty()
+                .MaximumLength(ScoringToken.MaxLength)
+                .Must(ScoringToken.IsValid)
+                .WithMessage("'{PropertyValue}' is not a valid token.");
+
+            output.RuleFor(o => o.Formula)
+                .NotEmpty()
+                .MaximumLength(ScoringFormulaEvaluator.MaxFormulaLength);
+        });
+    }
+}
+
+internal sealed class CreateScoringModelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<CreateScoringModelCommandHandler> logger)
+    : ICommandHandler<CreateScoringModelCommand, Guid>
+{
+    private const string AppRequestName = nameof(CreateScoringModelCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<CreateScoringModelCommandHandler> _logger = logger;
+
+    public async Task<Result<Guid>> Handle(CreateScoringModelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var scales = request.Scales?
+                .Select(s => (s.Name, (IEnumerable<(string Label, decimal Value)>)s.Levels
+                    .Select(l => (l.Label, l.Value))
+                    .ToList()))
+                .ToList();
+
+            var criteria = request.Criteria?
+                .Select(c => (c.Name, c.Token, c.Description, c.Weight, c.ScaleName))
+                .ToList();
+
+            var outputs = request.Outputs?
+                .Select(o => (o.Name, o.Token, o.Formula, o.IsPrimary))
+                .ToList();
+
+            var model = ScoringModel.Create(
+                request.Name,
+                request.Description,
+                scales,
+                criteria,
+                outputs
+                );
+
+            await _waydDbContext.ScoringModels.AddAsync(model, cancellationToken);
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scoring Model {ScoringModelId} created.", model.Id);
+
+            return Result.Success(model.Id);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure<Guid>($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/DeleteScoringModelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/DeleteScoringModelCommand.cs
@@ -1,0 +1,55 @@
+using Wayd.Common.Application.Persistence;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record DeleteScoringModelCommand(Guid Id) : ICommand;
+
+public sealed class DeleteScoringModelCommandValidator : AbstractValidator<DeleteScoringModelCommand>
+{
+    public DeleteScoringModelCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty();
+    }
+}
+
+internal sealed class DeleteScoringModelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<DeleteScoringModelCommandHandler> logger)
+    : ICommandHandler<DeleteScoringModelCommand>
+{
+    private const string AppRequestName = nameof(DeleteScoringModelCommand);
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<DeleteScoringModelCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(DeleteScoringModelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .FirstOrDefaultAsync(r => r.Id == request.Id, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.Id);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            if (!model.CanBeDeleted())
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} cannot be deleted.", request.Id);
+                return Result.Failure("Scoring Model cannot be deleted.");
+            }
+
+            _waydDbContext.ScoringModels.Remove(model);
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scoring Model {ScoringModelId} deleted.", request.Id);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringModelCriterionCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringModelCriterionCommand.cs
@@ -1,0 +1,63 @@
+using Wayd.Common.Application.Persistence;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record RemoveScoringModelCriterionCommand(
+    Guid ScoringModelId,
+    Guid CriterionId)
+    : ICommand;
+
+public sealed class RemoveScoringModelCriterionCommandValidator : AbstractValidator<RemoveScoringModelCriterionCommand>
+{
+    public RemoveScoringModelCriterionCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.CriterionId)
+            .NotEmpty();
+    }
+}
+
+internal sealed class RemoveScoringModelCriterionCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<RemoveScoringModelCriterionCommandHandler> logger)
+    : ICommandHandler<RemoveScoringModelCriterionCommand>
+{
+    private const string AppRequestName = nameof(RemoveScoringModelCriterionCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<RemoveScoringModelCriterionCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(RemoveScoringModelCriterionCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var removeResult = model.RemoveCriterion(request.CriterionId);
+            if (removeResult.IsFailure)
+            {
+                _logger.LogError("Unable to remove criterion from Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, removeResult.Error);
+                return Result.Failure(removeResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Criterion {CriterionId} removed from Scoring Model {ScoringModelId}.", request.CriterionId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringModelOutputCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringModelOutputCommand.cs
@@ -1,0 +1,64 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record RemoveScoringModelOutputCommand(
+    Guid ScoringModelId,
+    Guid OutputId)
+    : ICommand;
+
+public sealed class RemoveScoringModelOutputCommandValidator : AbstractValidator<RemoveScoringModelOutputCommand>
+{
+    public RemoveScoringModelOutputCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.OutputId)
+            .NotEmpty();
+    }
+}
+
+internal sealed class RemoveScoringModelOutputCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<RemoveScoringModelOutputCommandHandler> logger)
+    : ICommandHandler<RemoveScoringModelOutputCommand>
+{
+    private const string AppRequestName = nameof(RemoveScoringModelOutputCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<RemoveScoringModelOutputCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(RemoveScoringModelOutputCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Outputs)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var removeResult = model.RemoveOutput(request.OutputId);
+            if (removeResult.IsFailure)
+            {
+                _logger.LogError("Unable to remove output from Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, removeResult.Error);
+                return Result.Failure(removeResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Output {OutputId} removed from Scoring Model {ScoringModelId}.", request.OutputId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringScaleCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringScaleCommand.cs
@@ -1,0 +1,65 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record RemoveScoringScaleCommand(
+    Guid ScoringModelId,
+    Guid ScaleId)
+    : ICommand;
+
+public sealed class RemoveScoringScaleCommandValidator : AbstractValidator<RemoveScoringScaleCommand>
+{
+    public RemoveScoringScaleCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.ScaleId)
+            .NotEmpty();
+    }
+}
+
+internal sealed class RemoveScoringScaleCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<RemoveScoringScaleCommandHandler> logger)
+    : ICommandHandler<RemoveScoringScaleCommand>
+{
+    private const string AppRequestName = nameof(RemoveScoringScaleCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<RemoveScoringScaleCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(RemoveScoringScaleCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales)
+                .Include(x => x.Criteria)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var removeResult = model.RemoveScale(request.ScaleId);
+            if (removeResult.IsFailure)
+            {
+                _logger.LogError("Unable to remove scale from Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, removeResult.Error);
+                return Result.Failure(removeResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scale {ScaleId} removed from Scoring Model {ScoringModelId}.", request.ScaleId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringScaleLevelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/RemoveScoringScaleLevelCommand.cs
@@ -1,0 +1,68 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record RemoveScoringScaleLevelCommand(
+    Guid ScoringModelId,
+    Guid ScaleId,
+    Guid LevelId)
+    : ICommand;
+
+public sealed class RemoveScoringScaleLevelCommandValidator : AbstractValidator<RemoveScoringScaleLevelCommand>
+{
+    public RemoveScoringScaleLevelCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.ScaleId)
+            .NotEmpty();
+
+        RuleFor(x => x.LevelId)
+            .NotEmpty();
+    }
+}
+
+internal sealed class RemoveScoringScaleLevelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<RemoveScoringScaleLevelCommandHandler> logger)
+    : ICommandHandler<RemoveScoringScaleLevelCommand>
+{
+    private const string AppRequestName = nameof(RemoveScoringScaleLevelCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<RemoveScoringScaleLevelCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(RemoveScoringScaleLevelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales).ThenInclude(s => s.Levels)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var removeResult = model.RemoveScaleLevel(request.ScaleId, request.LevelId);
+            if (removeResult.IsFailure)
+            {
+                _logger.LogError("Unable to remove rating level from Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, removeResult.Error);
+                return Result.Failure(removeResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Rating level {LevelId} removed from scale {ScaleId} on Scoring Model {ScoringModelId}.", request.LevelId, request.ScaleId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringModelCriteriaCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringModelCriteriaCommand.cs
@@ -1,0 +1,63 @@
+using Wayd.Common.Application.Persistence;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record ReorderScoringModelCriteriaCommand(
+    Guid ScoringModelId,
+    List<Guid> OrderedCriterionIds)
+    : ICommand;
+
+public sealed class ReorderScoringModelCriteriaCommandValidator : AbstractValidator<ReorderScoringModelCriteriaCommand>
+{
+    public ReorderScoringModelCriteriaCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.OrderedCriterionIds)
+            .NotEmpty();
+    }
+}
+
+internal sealed class ReorderScoringModelCriteriaCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<ReorderScoringModelCriteriaCommandHandler> logger)
+    : ICommandHandler<ReorderScoringModelCriteriaCommand>
+{
+    private const string AppRequestName = nameof(ReorderScoringModelCriteriaCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<ReorderScoringModelCriteriaCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ReorderScoringModelCriteriaCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var reorderResult = model.ReorderCriteria(request.OrderedCriterionIds);
+            if (reorderResult.IsFailure)
+            {
+                _logger.LogError("Unable to reorder criteria on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, reorderResult.Error);
+                return Result.Failure(reorderResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Criteria reordered on Scoring Model {ScoringModelId}.", request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringModelOutputsCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringModelOutputsCommand.cs
@@ -1,0 +1,65 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record ReorderScoringModelOutputsCommand(
+    Guid ScoringModelId,
+    List<Guid> OrderedOutputIds)
+    : ICommand;
+
+public sealed class ReorderScoringModelOutputsCommandValidator : AbstractValidator<ReorderScoringModelOutputsCommand>
+{
+    public ReorderScoringModelOutputsCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.OrderedOutputIds)
+            .NotEmpty();
+    }
+}
+
+internal sealed class ReorderScoringModelOutputsCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<ReorderScoringModelOutputsCommandHandler> logger)
+    : ICommandHandler<ReorderScoringModelOutputsCommand>
+{
+    private const string AppRequestName = nameof(ReorderScoringModelOutputsCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<ReorderScoringModelOutputsCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ReorderScoringModelOutputsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Outputs)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var reorderResult = model.ReorderOutputs(request.OrderedOutputIds);
+            if (reorderResult.IsFailure)
+            {
+                _logger.LogError("Unable to reorder outputs on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, reorderResult.Error);
+                return Result.Failure(reorderResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Outputs reordered on Scoring Model {ScoringModelId}.", request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringScaleLevelsCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringScaleLevelsCommand.cs
@@ -1,0 +1,68 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record ReorderScoringScaleLevelsCommand(
+    Guid ScoringModelId,
+    Guid ScaleId,
+    List<Guid> OrderedLevelIds)
+    : ICommand;
+
+public sealed class ReorderScoringScaleLevelsCommandValidator : AbstractValidator<ReorderScoringScaleLevelsCommand>
+{
+    public ReorderScoringScaleLevelsCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.ScaleId)
+            .NotEmpty();
+
+        RuleFor(x => x.OrderedLevelIds)
+            .NotEmpty();
+    }
+}
+
+internal sealed class ReorderScoringScaleLevelsCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<ReorderScoringScaleLevelsCommandHandler> logger)
+    : ICommandHandler<ReorderScoringScaleLevelsCommand>
+{
+    private const string AppRequestName = nameof(ReorderScoringScaleLevelsCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<ReorderScoringScaleLevelsCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ReorderScoringScaleLevelsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales).ThenInclude(s => s.Levels)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var reorderResult = model.ReorderScaleLevels(request.ScaleId, request.OrderedLevelIds);
+            if (reorderResult.IsFailure)
+            {
+                _logger.LogError("Unable to reorder rating levels on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, reorderResult.Error);
+                return Result.Failure(reorderResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Rating levels reordered on scale {ScaleId} on Scoring Model {ScoringModelId}.", request.ScaleId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringScalesCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/ReorderScoringScalesCommand.cs
@@ -1,0 +1,64 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record ReorderScoringScalesCommand(
+    Guid ScoringModelId,
+    List<Guid> OrderedScaleIds)
+    : ICommand;
+
+public sealed class ReorderScoringScalesCommandValidator : AbstractValidator<ReorderScoringScalesCommand>
+{
+    public ReorderScoringScalesCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.OrderedScaleIds)
+            .NotEmpty();
+    }
+}
+
+internal sealed class ReorderScoringScalesCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<ReorderScoringScalesCommandHandler> logger)
+    : ICommandHandler<ReorderScoringScalesCommand>
+{
+    private const string AppRequestName = nameof(ReorderScoringScalesCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<ReorderScoringScalesCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(ReorderScoringScalesCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var reorderResult = model.ReorderScales(request.OrderedScaleIds);
+            if (reorderResult.IsFailure)
+            {
+                _logger.LogError("Unable to reorder scales on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, reorderResult.Error);
+                return Result.Failure(reorderResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scales reordered on Scoring Model {ScoringModelId}.", request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringModelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringModelCommand.cs
@@ -1,0 +1,71 @@
+using Wayd.Common.Application.Persistence;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record UpdateScoringModelCommand(
+    Guid Id,
+    string Name,
+    string Description)
+    : ICommand;
+
+public sealed class UpdateScoringModelCommandValidator : AbstractValidator<UpdateScoringModelCommand>
+{
+    public UpdateScoringModelCommandValidator()
+    {
+        RuleFor(x => x.Id)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Description)
+            .NotEmpty()
+            .MaximumLength(1024);
+    }
+}
+
+internal sealed class UpdateScoringModelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<UpdateScoringModelCommandHandler> logger)
+    : ICommandHandler<UpdateScoringModelCommand>
+{
+    private const string AppRequestName = nameof(UpdateScoringModelCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<UpdateScoringModelCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateScoringModelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .FirstOrDefaultAsync(r => r.Id == request.Id, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.Id);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var updateResult = model.Update(
+                request.Name,
+                request.Description
+                );
+            if (updateResult.IsFailure)
+            {
+                _logger.LogError("Unable to update Scoring Model {ScoringModelId}.  Error message: {Error}", model.Id, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scoring Model {ScoringModelId} updated.", request.Id);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringModelCriterionCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringModelCriterionCommand.cs
@@ -1,0 +1,85 @@
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record UpdateScoringModelCriterionCommand(
+    Guid ScoringModelId,
+    Guid CriterionId,
+    string Name,
+    string Token,
+    string? Description,
+    decimal? Weight,
+    Guid? ScaleId)
+    : ICommand;
+
+public sealed class UpdateScoringModelCriterionCommandValidator : AbstractValidator<UpdateScoringModelCriterionCommand>
+{
+    public UpdateScoringModelCriterionCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.CriterionId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(ScoringToken.MaxLength)
+            .Must(ScoringToken.IsValid)
+            .WithMessage("'{PropertyValue}' is not a valid token.");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(1024);
+    }
+}
+
+internal sealed class UpdateScoringModelCriterionCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<UpdateScoringModelCriterionCommandHandler> logger)
+    : ICommandHandler<UpdateScoringModelCriterionCommand>
+{
+    private const string AppRequestName = nameof(UpdateScoringModelCriterionCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<UpdateScoringModelCriterionCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateScoringModelCriterionCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Outputs)
+                .Include(x => x.Scales)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var updateResult = model.UpdateCriterion(request.CriterionId, request.Name, request.Token, request.Description, request.Weight, request.ScaleId);
+            if (updateResult.IsFailure)
+            {
+                _logger.LogError("Unable to update criterion on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Criterion {CriterionId} updated on Scoring Model {ScoringModelId}.", request.CriterionId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringModelOutputCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringModelOutputCommand.cs
@@ -1,0 +1,84 @@
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record UpdateScoringModelOutputCommand(
+    Guid ScoringModelId,
+    Guid OutputId,
+    string Name,
+    string Token,
+    string Formula,
+    bool IsPrimary)
+    : ICommand;
+
+public sealed class UpdateScoringModelOutputCommandValidator : AbstractValidator<UpdateScoringModelOutputCommand>
+{
+    public UpdateScoringModelOutputCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.OutputId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(ScoringToken.MaxLength)
+            .Must(ScoringToken.IsValid)
+            .WithMessage("'{PropertyValue}' is not a valid token.");
+
+        RuleFor(x => x.Formula)
+            .NotEmpty()
+            .MaximumLength(ScoringFormulaEvaluator.MaxFormulaLength);
+    }
+}
+
+internal sealed class UpdateScoringModelOutputCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<UpdateScoringModelOutputCommandHandler> logger)
+    : ICommandHandler<UpdateScoringModelOutputCommand>
+{
+    private const string AppRequestName = nameof(UpdateScoringModelOutputCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<UpdateScoringModelOutputCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateScoringModelOutputCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Outputs)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var updateResult = model.UpdateOutput(request.OutputId, request.Name, request.Token, request.Formula, request.IsPrimary);
+            if (updateResult.IsFailure)
+            {
+                _logger.LogError("Unable to update output on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Output {OutputId} updated on Scoring Model {ScoringModelId}.", request.OutputId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringScaleCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringScaleCommand.cs
@@ -1,0 +1,69 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record UpdateScoringScaleCommand(
+    Guid ScoringModelId,
+    Guid ScaleId,
+    string Name)
+    : ICommand;
+
+public sealed class UpdateScoringScaleCommandValidator : AbstractValidator<UpdateScoringScaleCommand>
+{
+    public UpdateScoringScaleCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.ScaleId)
+            .NotEmpty();
+
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}
+
+internal sealed class UpdateScoringScaleCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<UpdateScoringScaleCommandHandler> logger)
+    : ICommandHandler<UpdateScoringScaleCommand>
+{
+    private const string AppRequestName = nameof(UpdateScoringScaleCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<UpdateScoringScaleCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateScoringScaleCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var updateResult = model.UpdateScale(request.ScaleId, request.Name);
+            if (updateResult.IsFailure)
+            {
+                _logger.LogError("Unable to update scale on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Scale {ScaleId} updated on Scoring Model {ScoringModelId}.", request.ScaleId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringScaleLevelCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Commands/UpdateScoringScaleLevelCommand.cs
@@ -1,0 +1,74 @@
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+public sealed record UpdateScoringScaleLevelCommand(
+    Guid ScoringModelId,
+    Guid ScaleId,
+    Guid LevelId,
+    string Label,
+    decimal Value)
+    : ICommand;
+
+public sealed class UpdateScoringScaleLevelCommandValidator : AbstractValidator<UpdateScoringScaleLevelCommand>
+{
+    public UpdateScoringScaleLevelCommandValidator()
+    {
+        RuleFor(x => x.ScoringModelId)
+            .NotEmpty();
+
+        RuleFor(x => x.ScaleId)
+            .NotEmpty();
+
+        RuleFor(x => x.LevelId)
+            .NotEmpty();
+
+        RuleFor(x => x.Label)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}
+
+internal sealed class UpdateScoringScaleLevelCommandHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<UpdateScoringScaleLevelCommandHandler> logger)
+    : ICommandHandler<UpdateScoringScaleLevelCommand>
+{
+    private const string AppRequestName = nameof(UpdateScoringScaleLevelCommand);
+
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<UpdateScoringScaleLevelCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateScoringScaleLevelCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Scales).ThenInclude(s => s.Levels)
+                .FirstOrDefaultAsync(r => r.Id == request.ScoringModelId, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.ScoringModelId);
+                return Result.Failure("Scoring Model not found.");
+            }
+
+            var updateResult = model.UpdateScaleLevel(request.ScaleId, request.LevelId, request.Label, request.Value);
+            if (updateResult.IsFailure)
+            {
+                _logger.LogError("Unable to update rating level on Scoring Model {ScoringModelId}.  Error message: {Error}", request.ScoringModelId, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _waydDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Rating level {LevelId} updated on scale {ScaleId} on Scoring Model {ScoringModelId}.", request.LevelId, request.ScaleId, request.ScoringModelId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelCriterionDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelCriterionDto.cs
@@ -1,0 +1,15 @@
+using Wayd.Common.Domain.Scoring;
+
+using Mapster;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+public sealed record ScoringModelCriterionDto : IMapFrom<ScoringModelCriterion>
+{
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required string Token { get; set; }
+    public string? Description { get; set; }
+    public decimal? Weight { get; set; }
+    public Guid? ScaleId { get; set; }
+    public int Order { get; set; }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelDetailsDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelDetailsDto.cs
@@ -1,0 +1,26 @@
+using Wayd.Common.Application.Dtos;
+using Wayd.Common.Domain.Scoring;
+
+using Mapster;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+public sealed record ScoringModelDetailsDto : IMapFrom<ScoringModel>
+{
+    public Guid Id { get; set; }
+    public int Key { get; set; }
+    public required string Name { get; set; }
+    public required string Description { get; set; }
+    public required SimpleNavigationDto State { get; set; }
+    public required List<ScoringModelCriterionDto> Criteria { get; set; }
+    public required List<ScoringScaleDto> Scales { get; set; }
+    public required List<ScoringModelOutputDto> Outputs { get; set; }
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<ScoringModel, ScoringModelDetailsDto>()
+            .Map(dest => dest.State, src => SimpleNavigationDto.FromEnum(src.State))
+            .Map(dest => dest.Criteria, src => src.Criteria.OrderBy(c => c.Order))
+            .Map(dest => dest.Scales, src => src.Scales.OrderBy(s => s.Order))
+            .Map(dest => dest.Outputs, src => src.Outputs.OrderBy(o => o.Order));
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelEvaluationDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelEvaluationDto.cs
@@ -1,0 +1,23 @@
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+/// <summary>
+/// The result of evaluating a scoring model against a set of supplied criterion values. Carries every
+/// output value (in evaluation order) plus the primary score, so callers can preview formula results.
+/// </summary>
+public sealed record ScoringModelEvaluationDto
+{
+    public decimal PrimaryValue { get; set; }
+    public required List<ScoringModelOutputValueDto> Outputs { get; set; }
+}
+
+/// <summary>
+/// A single named output value produced by an evaluation.
+/// </summary>
+public sealed record ScoringModelOutputValueDto
+{
+    public required string Token { get; set; }
+    public required string Name { get; set; }
+    public decimal Value { get; set; }
+    public bool IsPrimary { get; set; }
+    public int Order { get; set; }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelListDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelListDto.cs
@@ -1,0 +1,26 @@
+using Wayd.Common.Application.Dtos;
+using Wayd.Common.Domain.Scoring;
+
+using Mapster;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+public sealed record ScoringModelListDto : IMapFrom<ScoringModel>
+{
+    public Guid Id { get; set; }
+    public int Key { get; set; }
+    public required string Name { get; set; }
+    public required string Description { get; set; }
+    public required SimpleNavigationDto State { get; set; }
+    public int CriterionCount { get; set; }
+    public int ScaleCount { get; set; }
+    public int OutputCount { get; set; }
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<ScoringModel, ScoringModelListDto>()
+            .Map(dest => dest.State, src => SimpleNavigationDto.FromEnum(src.State))
+            .Map(dest => dest.CriterionCount, src => src.Criteria.Count)
+            .Map(dest => dest.ScaleCount, src => src.Scales.Count)
+            .Map(dest => dest.OutputCount, src => src.Outputs.Count);
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelOutputDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringModelOutputDto.cs
@@ -1,0 +1,14 @@
+using Mapster;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+public sealed record ScoringModelOutputDto : IMapFrom<ScoringModelOutput>
+{
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required string Token { get; set; }
+    public required string Formula { get; set; }
+    public bool IsPrimary { get; set; }
+    public int Order { get; set; }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringRatingLevelDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringRatingLevelDto.cs
@@ -1,0 +1,12 @@
+using Wayd.Common.Domain.Scoring;
+
+using Mapster;
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+public sealed record ScoringRatingLevelDto : IMapFrom<ScoringRatingLevel>
+{
+    public Guid Id { get; set; }
+    public required string Label { get; set; }
+    public decimal Value { get; set; }
+    public int Order { get; set; }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringScaleDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Dtos/ScoringScaleDto.cs
@@ -1,0 +1,18 @@
+using Mapster;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+public sealed record ScoringScaleDto : IMapFrom<ScoringScale>
+{
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public int Order { get; set; }
+    public required List<ScoringRatingLevelDto> Levels { get; set; }
+
+    public void ConfigureMapping(TypeAdapterConfig config)
+    {
+        config.NewConfig<ScoringScale, ScoringScaleDto>()
+            .Map(dest => dest.Levels, src => src.Levels.OrderBy(l => l.Order));
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Queries/EvaluateScoringModelQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Queries/EvaluateScoringModelQuery.cs
@@ -1,0 +1,87 @@
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Queries;
+
+/// <summary>
+/// Evaluates a scoring model against a set of supplied criterion values, returning every output value
+/// and the primary score. Used by the model's "test" panel to preview formula results without persisting
+/// anything. Each entry pairs a criterion id with the raw value to plug in for that criterion's token.
+/// </summary>
+public sealed record EvaluateScoringModelQuery(Guid Id, IReadOnlyList<EvaluateScoringModelQuery.CriterionValue> CriterionValues)
+    : IQuery<Result<ScoringModelEvaluationDto>>
+{
+    public sealed record CriterionValue(Guid CriterionId, decimal Value);
+}
+
+public sealed class EvaluateScoringModelQueryValidator : AbstractValidator<EvaluateScoringModelQuery>
+{
+    public EvaluateScoringModelQueryValidator()
+    {
+        RuleFor(v => v.Id).NotEmpty();
+        RuleFor(v => v.CriterionValues).NotNull();
+        RuleForEach(v => v.CriterionValues).ChildRules(cv =>
+            cv.RuleFor(c => c.CriterionId).NotEmpty());
+    }
+}
+
+internal sealed class EvaluateScoringModelQueryHandler(
+    IWaydDbContext waydDbContext,
+    ILogger<EvaluateScoringModelQueryHandler> logger)
+    : IQueryHandler<EvaluateScoringModelQuery, Result<ScoringModelEvaluationDto>>
+{
+    private const string AppRequestName = nameof(EvaluateScoringModelQuery);
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+    private readonly ILogger<EvaluateScoringModelQueryHandler> _logger = logger;
+
+    public async Task<Result<ScoringModelEvaluationDto>> Handle(EvaluateScoringModelQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Raw token values are supplied, so scales/levels aren't needed — only criteria and outputs.
+            var model = await _waydDbContext.ScoringModels
+                .Include(x => x.Criteria)
+                .Include(x => x.Outputs)
+                .AsNoTracking()
+                .FirstOrDefaultAsync(s => s.Id == request.Id, cancellationToken);
+            if (model is null)
+            {
+                _logger.LogInformation("Scoring Model {ScoringModelId} not found.", request.Id);
+                return Result.Failure<ScoringModelEvaluationDto>("Scoring Model not found.");
+            }
+
+            var ratingValuesByCriterionId = request.CriterionValues
+                .GroupBy(cv => cv.CriterionId)
+                .ToDictionary(g => g.Key, g => g.Last().Value);
+
+            var result = model.CalculateScore(ratingValuesByCriterionId);
+            if (result.IsFailure)
+            {
+                return Result.Failure<ScoringModelEvaluationDto>(result.Error);
+            }
+
+            var outputs = model.Outputs
+                .OrderBy(o => o.Order)
+                .Select(o => new ScoringModelOutputValueDto
+                {
+                    Token = o.Token,
+                    Name = o.Name,
+                    Value = result.Value.OutputValues[o.Token],
+                    IsPrimary = o.IsPrimary,
+                    Order = o.Order,
+                })
+                .ToList();
+
+            return Result.Success(new ScoringModelEvaluationDto
+            {
+                PrimaryValue = result.Value.PrimaryValue,
+                Outputs = outputs,
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {QueryName} query for request {@Request}.", AppRequestName, request);
+            return Result.Failure<ScoringModelEvaluationDto>($"Error handling {AppRequestName} query.");
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Queries/GetScoringModelQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Queries/GetScoringModelQuery.cs
@@ -1,0 +1,35 @@
+using System.Linq.Expressions;
+using Wayd.Common.Application.Models;
+using Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+using Wayd.Common.Domain.Scoring;
+using Mapster;
+using Wayd.Common.Application.Persistence;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Queries;
+
+public sealed record GetScoringModelQuery : IQuery<ScoringModelDetailsDto?>
+{
+    public GetScoringModelQuery(IdOrKey idOrKey)
+    {
+        IdOrKeyFilter = idOrKey.CreateFilter<ScoringModel>();
+    }
+
+    public Expression<Func<ScoringModel, bool>> IdOrKeyFilter { get; }
+}
+
+internal sealed class GetScoringModelQueryHandler(IWaydDbContext waydDbContext)
+    : IQueryHandler<GetScoringModelQuery, ScoringModelDetailsDto?>
+{
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+
+    public async Task<ScoringModelDetailsDto?> Handle(GetScoringModelQuery request, CancellationToken cancellationToken)
+    {
+        // No Include() — ProjectToType compiles child collections into the SQL projection,
+        // and child ordering is handled in the DTO mapping config. Includes would be ignored
+        // by the projection and only emit redundant joins.
+        return await _waydDbContext.ScoringModels
+            .Where(request.IdOrKeyFilter)
+            .ProjectToType<ScoringModelDetailsDto>()
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Queries/GetScoringModelsQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Scoring/ScoringModels/Queries/GetScoringModelsQuery.cs
@@ -1,0 +1,28 @@
+﻿using Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+using Mapster;
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Domain.Scoring.Enums;
+
+namespace Wayd.Common.Application.Scoring.ScoringModels.Queries;
+
+public sealed record GetScoringModelsQuery(ScoringModelState? StateFilter = null) : IQuery<List<ScoringModelListDto>>;
+
+internal sealed class GetScoringModelsQueryHandler(IWaydDbContext waydDbContext)
+    : IQueryHandler<GetScoringModelsQuery, List<ScoringModelListDto>>
+{
+    private readonly IWaydDbContext _waydDbContext = waydDbContext;
+
+    public async Task<List<ScoringModelListDto>> Handle(GetScoringModelsQuery request, CancellationToken cancellationToken)
+    {
+        var query = _waydDbContext.ScoringModels.AsQueryable();
+
+        if (request.StateFilter.HasValue)
+        {
+            query = query.Where(x => x.State == request.StateFilter.Value);
+        }
+
+        return await query
+            .ProjectToType<ScoringModelListDto>()
+            .ToListAsync(cancellationToken);
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Authorization/ApplicationPermissions.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Authorization/ApplicationPermissions.cs
@@ -34,6 +34,8 @@ public static class ApplicationResource
     public const string Permissions = nameof(Permissions);
     public const string OidcProviders = nameof(OidcProviders);
 
+    public const string ScoringModels = nameof(ScoringModels);
+
     public const string Connections = nameof(Connections);
     public const string Connectors = nameof(Connectors);
 
@@ -80,6 +82,20 @@ public static class ApplicationResource
 public static class ApplicationPermissions
 {
     private static readonly ApplicationPermission[] _common = [];
+
+    private const string ApplicationCategory = "Application";
+    private static readonly ApplicationPermission[] _application =
+    [
+        new ("View Scoring Models", ApplicationAction.View, ApplicationResource.ScoringModels, ApplicationCategory),
+        new ("Create Scoring Models", ApplicationAction.Create, ApplicationResource.ScoringModels, ApplicationCategory),
+        new ("Update Scoring Models", ApplicationAction.Update, ApplicationResource.ScoringModels, ApplicationCategory),
+        new ("Delete Scoring Models", ApplicationAction.Delete, ApplicationResource.ScoringModels, ApplicationCategory),
+
+        new("View Feature Flags", ApplicationAction.View, ApplicationResource.FeatureFlags, ApplicationCategory),
+        new("Create Feature Flags", ApplicationAction.Create, ApplicationResource.FeatureFlags, ApplicationCategory),
+        new("Update Feature Flags", ApplicationAction.Update, ApplicationResource.FeatureFlags, ApplicationCategory),
+        new("Delete Feature Flags", ApplicationAction.Delete, ApplicationResource.FeatureFlags, ApplicationCategory),
+    ];
 
     private const string BackgroundJobsCategory = "Background Jobs";
     private static readonly ApplicationPermission[] _backgroundJobs =
@@ -297,18 +313,9 @@ public static class ApplicationPermissions
         new("Delete WorkTypes", ApplicationAction.Delete, ApplicationResource.WorkTypes, WorkManagementCategory),
     ];
 
-    private const string FeatureManagementCategory = "Feature Management";
-    private static readonly ApplicationPermission[] _featureManagement =
-    [
-        new("View Feature Flags", ApplicationAction.View, ApplicationResource.FeatureFlags, FeatureManagementCategory),
-        new("Create Feature Flags", ApplicationAction.Create, ApplicationResource.FeatureFlags, FeatureManagementCategory),
-        new("Update Feature Flags", ApplicationAction.Update, ApplicationResource.FeatureFlags, FeatureManagementCategory),
-        new("Delete Feature Flags", ApplicationAction.Delete, ApplicationResource.FeatureFlags, FeatureManagementCategory),
-    ];
-
     private static readonly ApplicationPermission[] _all = [.. _common
+        .Union(_application)
         .Union(_backgroundJobs)
-        .Union(_featureManagement)
         .Union(_identity)
         .Union(_appIntegration)
         .Union(_healthChecks)

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/Enums/ScoringModelState.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/Enums/ScoringModelState.cs
@@ -1,0 +1,17 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace Wayd.Common.Domain.Scoring.Enums;
+
+// max length of 32 characters
+
+public enum ScoringModelState
+{
+    [Display(Name = "Proposed", Description = "The scoring model is being defined and is not yet available for use.", Order = 1)]
+    Proposed = 1,
+
+    [Display(Name = "Active", Description = "The scoring model is approved and available for scoring.", Order = 2)]
+    Active = 2,
+
+    [Display(Name = "Archived", Description = "The scoring model is no longer available for new assignments but remains for historical reference.", Order = 3)]
+    Archived = 3
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringFormulaEvaluator.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringFormulaEvaluator.cs
@@ -1,0 +1,165 @@
+using System.Globalization;
+using CSharpFunctionalExtensions;
+using NCalc;
+using NCalc.Exceptions;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// Validates and evaluates scoring formula expressions over named criterion/output tokens.
+/// </summary>
+/// <remarks>
+/// Backed by NCalc, restricted to pure arithmetic over named parameters (decimal math). No function
+/// calls, reflection, or code execution are permitted — any function reference in a formula is rejected,
+/// so this is safe for admin-authored (semi-trusted) input. Formulas are validated at definition time and
+/// evaluated at scoring time; both surface failures as <see cref="Result"/> rather than throwing.
+/// </remarks>
+public static class ScoringFormulaEvaluator
+{
+    /// <summary>
+    /// Upper bound on formula length, as a guard against pathological parse input.
+    /// </summary>
+    public const int MaxFormulaLength = 1000;
+
+    /// <summary>
+    /// Validates that <paramref name="formula"/> is a well-formed arithmetic expression referencing only
+    /// tokens in <paramref name="allowedTokens"/>. Does not evaluate.
+    /// </summary>
+    public static Result Validate(string formula, IReadOnlyCollection<string> allowedTokens)
+    {
+        if (string.IsNullOrWhiteSpace(formula))
+        {
+            return Result.Failure("Formula must not be empty.");
+        }
+
+        if (formula.Length > MaxFormulaLength)
+        {
+            return Result.Failure($"Formula must not exceed {MaxFormulaLength} characters.");
+        }
+
+        Expression expression;
+        try
+        {
+            expression = CreateExpression(formula);
+
+            if (expression.HasErrors())
+            {
+                return Result.Failure($"Formula is not a valid expression: {expression.Error?.Message ?? "unknown parse error"}.");
+            }
+        }
+        catch (NCalcException ex)
+        {
+            return Result.Failure($"Formula is not a valid expression: {ex.Message}.");
+        }
+
+        List<string> referenced;
+        List<string> functions;
+        try
+        {
+            referenced = expression.GetParameterNames();
+            functions = expression.GetFunctionNames();
+        }
+        catch (NCalcException ex)
+        {
+            return Result.Failure($"Formula is not a valid expression: {ex.Message}.");
+        }
+
+        if (functions.Count > 0)
+        {
+            return Result.Failure($"Formula must not call functions: {string.Join(", ", functions.Distinct(StringComparer.Ordinal))}.");
+        }
+
+        var allowed = new HashSet<string>(allowedTokens, StringComparer.Ordinal);
+        var unknown = referenced.Where(r => !allowed.Contains(r)).Distinct(StringComparer.Ordinal).ToList();
+        if (unknown.Count > 0)
+        {
+            return Result.Failure($"Formula references unknown token(s): {string.Join(", ", unknown)}.");
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Returns the distinct token names referenced by <paramref name="formula"/>, or a failure if it does not parse.
+    /// </summary>
+    public static Result<IReadOnlyCollection<string>> GetReferencedTokens(string formula)
+    {
+        if (string.IsNullOrWhiteSpace(formula))
+        {
+            return Result.Failure<IReadOnlyCollection<string>>("Formula must not be empty.");
+        }
+
+        try
+        {
+            var expression = CreateExpression(formula);
+            if (expression.HasErrors())
+            {
+                return Result.Failure<IReadOnlyCollection<string>>(
+                    $"Formula is not a valid expression: {expression.Error?.Message ?? "unknown parse error"}.");
+            }
+
+            var names = expression.GetParameterNames().Distinct(StringComparer.Ordinal).ToArray();
+            return Result.Success<IReadOnlyCollection<string>>(names);
+        }
+        catch (NCalcException ex)
+        {
+            return Result.Failure<IReadOnlyCollection<string>>($"Formula is not a valid expression: {ex.Message}.");
+        }
+    }
+
+    /// <summary>
+    /// Evaluates <paramref name="formula"/> with the supplied token values, returning the resulting decimal.
+    /// </summary>
+    public static Result<decimal> Evaluate(string formula, IReadOnlyDictionary<string, decimal> tokenValues)
+    {
+        if (string.IsNullOrWhiteSpace(formula))
+        {
+            return Result.Failure<decimal>("Formula must not be empty.");
+        }
+
+        try
+        {
+            var expression = CreateExpression(formula);
+
+            if (expression.HasErrors())
+            {
+                return Result.Failure<decimal>(
+                    $"Formula is not a valid expression: {expression.Error?.Message ?? "unknown parse error"}.");
+            }
+
+            foreach (var (token, value) in tokenValues)
+            {
+                expression.Parameters[token] = value;
+            }
+
+            var result = expression.Evaluate();
+
+            return result is null
+                ? Result.Failure<decimal>("Formula evaluated to no value.")
+                : Result.Success(Convert.ToDecimal(result, CultureInfo.InvariantCulture));
+        }
+        catch (DivideByZeroException)
+        {
+            return Result.Failure<decimal>("Formula evaluation divided by zero.");
+        }
+        catch (NCalcException ex)
+        {
+            return Result.Failure<decimal>($"Formula could not be evaluated: {ex.Message}.");
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+        {
+            return Result.Failure<decimal>($"Formula could not be evaluated: {ex.Message}.");
+        }
+    }
+
+    private static Expression CreateExpression(string formula)
+    {
+        var expression = new Expression(formula, ExpressionOptions.DecimalAsDefault, CultureInfo.InvariantCulture);
+
+        // Reject any function reference — formulas are pure arithmetic over named tokens only.
+        expression.EvaluateFunction += (name, _) =>
+            throw new NCalcEvaluationException($"Function '{name}' is not allowed in scoring formulas.");
+
+        return expression;
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringModel.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringModel.cs
@@ -1,0 +1,936 @@
+﻿using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+using Wayd.Common.Domain.Data;
+using Wayd.Common.Domain.Scoring.Enums;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// Represents a reusable scoring model defined by an administrator. A model is made up of rated
+/// <see cref="Criteria"/> (the inputs) and a set of named <see cref="Outputs"/> (formulas over criterion
+/// and earlier-output tokens). Exactly one output is the primary score; the rest are intermediate values
+/// (e.g. Cost of Delay) retained for display and ranking. Consumers assign an active model to score and
+/// rank items.
+/// </summary>
+/// <remarks>
+/// Models follow a Proposed → Active → Archived lifecycle. Only Proposed models can be edited or
+/// deleted; once Active, a model is locked so that scores produced from it stay stable. To change an
+/// in-use model, archive it and create a new one.
+/// </remarks>
+public sealed class ScoringModel : BaseAuditableEntity, IHasIdAndKey
+{
+    private const string NotProposedError = "Only proposed scoring models can be modified.";
+
+    private readonly List<ScoringModelCriterion> _criteria = [];
+    private readonly List<ScoringScale> _scales = [];
+    private readonly List<ScoringModelOutput> _outputs = [];
+
+    private ScoringModel() { }
+
+    private ScoringModel(string name, string description)
+    {
+        Name = name;
+        Description = description;
+        State = ScoringModelState.Proposed;
+    }
+
+    /// <summary>
+    /// The unique auto-generated key of the scoring model. This is an alternate key to the Id.
+    /// </summary>
+    public int Key { get; private init; }
+
+    /// <summary>
+    /// The name of the scoring model (e.g., "Weighted Criteria Matrix", "WSJF").
+    /// </summary>
+    public string Name
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Name)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// A description of the model's purpose and recommended use cases.
+    /// </summary>
+    public string Description
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Description)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The current state of the scoring model (Proposed, Active, Archived).
+    /// </summary>
+    public ScoringModelState State { get; private set; }
+
+    /// <summary>
+    /// The rated criteria (inputs) that make up this scoring model.
+    /// </summary>
+    public IReadOnlyCollection<ScoringModelCriterion> Criteria => _criteria.AsReadOnly();
+
+    /// <summary>
+    /// The named, reusable rating scales defined on this model. Criteria reference a scale to constrain
+    /// how they are rated.
+    /// </summary>
+    public IReadOnlyCollection<ScoringScale> Scales => _scales.AsReadOnly();
+
+    /// <summary>
+    /// The named output formulas of this model, in evaluation order.
+    /// </summary>
+    public IReadOnlyCollection<ScoringModelOutput> Outputs => _outputs.AsReadOnly();
+
+    /// <summary>
+    /// Indicates whether the model can be deleted. Only proposed models can be deleted.
+    /// </summary>
+    public bool CanBeDeleted() => State is ScoringModelState.Proposed;
+
+    /// <summary>
+    /// Updates the model details. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result Update(string name, string description)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure(NotProposedError);
+        }
+
+        Name = name;
+        Description = description;
+
+        return Result.Success();
+    }
+
+    #region State Transitions
+
+    /// <summary>
+    /// Activates the model, making it available for assignment. Requires at least one criterion, every
+    /// scale-referencing criterion to point at a scale with at least two levels, and a valid set of
+    /// outputs with exactly one primary, where each output formula references only tokens defined before it.
+    /// </summary>
+    public Result Activate()
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Only proposed scoring models can be activated.");
+        }
+
+        if (_criteria.Count < 1)
+        {
+            return Result.Failure("A scoring model must have at least one criterion before it can be activated.");
+        }
+
+        var scalesValidation = ValidateReferencedScales();
+        if (scalesValidation.IsFailure)
+        {
+            return scalesValidation;
+        }
+
+        var outputsValidation = ValidateOutputs();
+        if (outputsValidation.IsFailure)
+        {
+            return outputsValidation;
+        }
+
+        State = ScoringModelState.Active;
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Archives the model, preventing it from being assigned. Existing scores and assignments are not affected.
+    /// </summary>
+    public Result Archive()
+    {
+        if (State != ScoringModelState.Active)
+        {
+            return Result.Failure("Only active scoring models can be archived.");
+        }
+
+        State = ScoringModelState.Archived;
+
+        return Result.Success();
+    }
+
+    #endregion State Transitions
+
+    #region Criteria Management
+
+    /// <summary>
+    /// Adds a new criterion to the model. Only allowed when the model is in the Proposed state.
+    /// The criterion is appended at the end of the existing criteria.
+    /// </summary>
+    public Result<ScoringModelCriterion> AddCriterion(string name, string token, string? description, decimal? weight, Guid? scaleId)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure<ScoringModelCriterion>("Criteria can only be added to proposed scoring models.");
+        }
+
+        var tokenResult = ValidateNewToken(token);
+        if (tokenResult.IsFailure)
+        {
+            return Result.Failure<ScoringModelCriterion>(tokenResult.Error);
+        }
+
+        var scaleResult = ValidateScaleReference(scaleId);
+        if (scaleResult.IsFailure)
+        {
+            return Result.Failure<ScoringModelCriterion>(scaleResult.Error);
+        }
+
+        var order = _criteria.Count > 0 ? _criteria.Max(c => c.Order) + 1 : 1;
+
+        var criterion = new ScoringModelCriterion(Id, name, token.Trim(), description, weight, scaleId, order);
+        _criteria.Add(criterion);
+
+        return Result.Success(criterion);
+    }
+
+    /// <summary>
+    /// Updates the details of an existing criterion. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result UpdateCriterion(Guid criterionId, string name, string token, string? description, decimal? weight, Guid? scaleId)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Criteria can only be updated on proposed scoring models.");
+        }
+
+        var criterion = _criteria.FirstOrDefault(c => c.Id == criterionId);
+        if (criterion is null)
+        {
+            return Result.Failure("Criterion not found.");
+        }
+
+        var tokenResult = ValidateNewToken(token, exceptCriterionId: criterionId);
+        if (tokenResult.IsFailure)
+        {
+            return tokenResult;
+        }
+
+        var scaleResult = ValidateScaleReference(scaleId);
+        if (scaleResult.IsFailure)
+        {
+            return scaleResult;
+        }
+
+        return criterion.Update(name, token.Trim(), description, weight, scaleId);
+    }
+
+    /// <summary>
+    /// Removes a criterion from the model and reorders the remaining criteria.
+    /// Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result RemoveCriterion(Guid criterionId)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Criteria can only be removed from proposed scoring models.");
+        }
+
+        var criterion = _criteria.FirstOrDefault(c => c.Id == criterionId);
+        if (criterion is null)
+        {
+            return Result.Failure("Criterion not found.");
+        }
+
+        _criteria.Remove(criterion);
+
+        ReorderCriteria();
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Reorders the criteria based on the provided ordered list of criterion IDs.
+    /// Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result ReorderCriteria(List<Guid> orderedCriterionIds)
+    {
+        Guard.Against.Null(orderedCriterionIds, nameof(orderedCriterionIds));
+
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Criteria can only be reordered on proposed scoring models.");
+        }
+
+        if (orderedCriterionIds.Count != _criteria.Count)
+        {
+            return Result.Failure("The number of criterion IDs must match the number of existing criteria.");
+        }
+
+        if (orderedCriterionIds.Distinct().Count() != orderedCriterionIds.Count)
+        {
+            return Result.Failure("Duplicate criterion IDs are not allowed.");
+        }
+
+        for (int i = 0; i < orderedCriterionIds.Count; i++)
+        {
+            var criterion = _criteria.FirstOrDefault(c => c.Id == orderedCriterionIds[i]);
+            if (criterion is null)
+            {
+                return Result.Failure($"Criterion with ID '{orderedCriterionIds[i]}' not found.");
+            }
+
+            criterion.Order = i + 1;
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Resets criteria ordering to eliminate gaps after removal.
+    /// </summary>
+    private void ReorderCriteria()
+    {
+        int order = 1;
+        foreach (var criterion in _criteria.OrderBy(c => c.Order))
+        {
+            criterion.Order = order;
+            order++;
+        }
+    }
+
+    #endregion Criteria Management
+
+    #region Scale Management
+
+    /// <summary>
+    /// Adds a new named rating scale to the model. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result<ScoringScale> AddScale(string name)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure<ScoringScale>("Scales can only be added to proposed scoring models.");
+        }
+
+        var nameResult = ValidateNewScaleName(name);
+        if (nameResult.IsFailure)
+        {
+            return Result.Failure<ScoringScale>(nameResult.Error);
+        }
+
+        var order = _scales.Count > 0 ? _scales.Max(s => s.Order) + 1 : 1;
+
+        var scale = new ScoringScale(Id, name.Trim(), order);
+        _scales.Add(scale);
+
+        return Result.Success(scale);
+    }
+
+    /// <summary>
+    /// Renames an existing scale. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result UpdateScale(Guid scaleId, string name)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Scales can only be updated on proposed scoring models.");
+        }
+
+        var scale = _scales.FirstOrDefault(s => s.Id == scaleId);
+        if (scale is null)
+        {
+            return Result.Failure("Scale not found.");
+        }
+
+        var nameResult = ValidateNewScaleName(name, exceptScaleId: scaleId);
+        if (nameResult.IsFailure)
+        {
+            return nameResult;
+        }
+
+        return scale.Update(name.Trim());
+    }
+
+    /// <summary>
+    /// Removes a scale and reorders the remaining scales. Only allowed when the model is in the Proposed
+    /// state, and only when no criterion references the scale.
+    /// </summary>
+    public Result RemoveScale(Guid scaleId)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Scales can only be removed from proposed scoring models.");
+        }
+
+        var scale = _scales.FirstOrDefault(s => s.Id == scaleId);
+        if (scale is null)
+        {
+            return Result.Failure("Scale not found.");
+        }
+
+        if (_criteria.Any(c => c.ScaleId == scaleId))
+        {
+            return Result.Failure("This scale is referenced by one or more criteria. Reassign those criteria before removing the scale.");
+        }
+
+        _scales.Remove(scale);
+
+        ReorderScales();
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Reorders the scales based on the provided ordered list of scale IDs.
+    /// Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result ReorderScales(List<Guid> orderedScaleIds)
+    {
+        Guard.Against.Null(orderedScaleIds, nameof(orderedScaleIds));
+
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Scales can only be reordered on proposed scoring models.");
+        }
+
+        if (orderedScaleIds.Count != _scales.Count)
+        {
+            return Result.Failure("The number of scale IDs must match the number of existing scales.");
+        }
+
+        if (orderedScaleIds.Distinct().Count() != orderedScaleIds.Count)
+        {
+            return Result.Failure("Duplicate scale IDs are not allowed.");
+        }
+
+        for (int i = 0; i < orderedScaleIds.Count; i++)
+        {
+            var scale = _scales.FirstOrDefault(s => s.Id == orderedScaleIds[i]);
+            if (scale is null)
+            {
+                return Result.Failure($"Scale with ID '{orderedScaleIds[i]}' not found.");
+            }
+
+            scale.Order = i + 1;
+        }
+
+        return Result.Success();
+    }
+
+    private void ReorderScales()
+    {
+        int order = 1;
+        foreach (var scale in _scales.OrderBy(s => s.Order))
+        {
+            scale.Order = order;
+            order++;
+        }
+    }
+
+    #endregion Scale Management
+
+    #region Scale Level Management
+
+    /// <summary>
+    /// Adds a rating level to a scale. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result<ScoringRatingLevel> AddScaleLevel(Guid scaleId, string label, decimal value)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure<ScoringRatingLevel>("Rating levels can only be added to proposed scoring models.");
+        }
+
+        var scale = _scales.FirstOrDefault(s => s.Id == scaleId);
+        if (scale is null)
+        {
+            return Result.Failure<ScoringRatingLevel>("Scale not found.");
+        }
+
+        return Result.Success(scale.AddLevel(label, value));
+    }
+
+    /// <summary>
+    /// Updates a rating level on a scale. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result UpdateScaleLevel(Guid scaleId, Guid levelId, string label, decimal value)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Rating levels can only be updated on proposed scoring models.");
+        }
+
+        var scale = _scales.FirstOrDefault(s => s.Id == scaleId);
+        if (scale is null)
+        {
+            return Result.Failure("Scale not found.");
+        }
+
+        return scale.UpdateLevel(levelId, label, value);
+    }
+
+    /// <summary>
+    /// Removes a rating level from a scale. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result RemoveScaleLevel(Guid scaleId, Guid levelId)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Rating levels can only be removed from proposed scoring models.");
+        }
+
+        var scale = _scales.FirstOrDefault(s => s.Id == scaleId);
+        if (scale is null)
+        {
+            return Result.Failure("Scale not found.");
+        }
+
+        return scale.RemoveLevel(levelId);
+    }
+
+    /// <summary>
+    /// Reorders the rating levels within a scale. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result ReorderScaleLevels(Guid scaleId, List<Guid> orderedLevelIds)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Rating levels can only be reordered on proposed scoring models.");
+        }
+
+        var scale = _scales.FirstOrDefault(s => s.Id == scaleId);
+        if (scale is null)
+        {
+            return Result.Failure("Scale not found.");
+        }
+
+        return scale.ReorderLevels(orderedLevelIds);
+    }
+
+    #endregion Scale Level Management
+
+    #region Output Management
+
+    /// <summary>
+    /// Adds a new output formula to the model. Only allowed when the model is in the Proposed state.
+    /// The formula may reference criterion tokens and the tokens of outputs already defined. If this is
+    /// the first output, it becomes primary by default; marking it primary transfers the flag.
+    /// </summary>
+    public Result<ScoringModelOutput> AddOutput(string name, string token, string formula, bool isPrimary)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure<ScoringModelOutput>("Outputs can only be added to proposed scoring models.");
+        }
+
+        var tokenResult = ValidateNewToken(token);
+        if (tokenResult.IsFailure)
+        {
+            return Result.Failure<ScoringModelOutput>(tokenResult.Error);
+        }
+
+        var order = _outputs.Count > 0 ? _outputs.Max(o => o.Order) + 1 : 1;
+
+        // The formula may reference criteria and outputs ordered before this one.
+        var allowedTokens = TokensAvailableBefore(order);
+        var formulaResult = ScoringFormulaEvaluator.Validate(formula, allowedTokens);
+        if (formulaResult.IsFailure)
+        {
+            return Result.Failure<ScoringModelOutput>(formulaResult.Error);
+        }
+
+        var makePrimary = isPrimary || _outputs.Count == 0;
+
+        var output = new ScoringModelOutput(Id, name, token.Trim(), formula.Trim(), makePrimary, order);
+        _outputs.Add(output);
+
+        if (makePrimary)
+        {
+            DemoteOtherPrimaries(output);
+        }
+
+        return Result.Success(output);
+    }
+
+    /// <summary>
+    /// Updates an existing output. Only allowed when the model is in the Proposed state.
+    /// </summary>
+    public Result UpdateOutput(Guid outputId, string name, string token, string formula, bool isPrimary)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Outputs can only be updated on proposed scoring models.");
+        }
+
+        var output = _outputs.FirstOrDefault(o => o.Id == outputId);
+        if (output is null)
+        {
+            return Result.Failure("Output not found.");
+        }
+
+        var tokenResult = ValidateNewToken(token, exceptOutputId: outputId);
+        if (tokenResult.IsFailure)
+        {
+            return tokenResult;
+        }
+
+        var allowedTokens = TokensAvailableBefore(output.Order, exceptOutputId: outputId);
+        var formulaResult = ScoringFormulaEvaluator.Validate(formula, allowedTokens);
+        if (formulaResult.IsFailure)
+        {
+            return formulaResult;
+        }
+
+        var makePrimary = isPrimary || (output.IsPrimary && _outputs.Count == 1);
+
+        var updateResult = output.Update(name, token.Trim(), formula.Trim(), makePrimary);
+        if (updateResult.IsFailure)
+        {
+            return updateResult;
+        }
+
+        if (makePrimary)
+        {
+            DemoteOtherPrimaries(output);
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Removes an output and reorders the remaining outputs. Only allowed when the model is in the
+    /// Proposed state. If the primary output is removed, the first remaining output becomes primary.
+    /// </summary>
+    public Result RemoveOutput(Guid outputId)
+    {
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Outputs can only be removed from proposed scoring models.");
+        }
+
+        var output = _outputs.FirstOrDefault(o => o.Id == outputId);
+        if (output is null)
+        {
+            return Result.Failure("Output not found.");
+        }
+
+        var wasPrimary = output.IsPrimary;
+
+        _outputs.Remove(output);
+
+        ReorderOutputsInternal();
+
+        if (wasPrimary)
+        {
+            var first = _outputs.OrderBy(o => o.Order).FirstOrDefault();
+            first?.SetPrimary(true);
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Reorders the outputs based on the provided ordered list of output IDs. Only allowed when the model
+    /// is in the Proposed state. The new order must keep each output's formula referencing only tokens
+    /// that precede it.
+    /// </summary>
+    public Result ReorderOutputs(List<Guid> orderedOutputIds)
+    {
+        Guard.Against.Null(orderedOutputIds, nameof(orderedOutputIds));
+
+        if (State != ScoringModelState.Proposed)
+        {
+            return Result.Failure("Outputs can only be reordered on proposed scoring models.");
+        }
+
+        if (orderedOutputIds.Count != _outputs.Count)
+        {
+            return Result.Failure("The number of output IDs must match the number of existing outputs.");
+        }
+
+        if (orderedOutputIds.Distinct().Count() != orderedOutputIds.Count)
+        {
+            return Result.Failure("Duplicate output IDs are not allowed.");
+        }
+
+        // Validate the proposed ordering keeps every formula referencing only earlier tokens.
+        var criterionTokens = _criteria.Select(c => c.Token).ToHashSet(StringComparer.Ordinal);
+        var availableSoFar = new HashSet<string>(criterionTokens, StringComparer.Ordinal);
+        foreach (var outputId in orderedOutputIds)
+        {
+            var output = _outputs.FirstOrDefault(o => o.Id == outputId);
+            if (output is null)
+            {
+                return Result.Failure($"Output with ID '{outputId}' not found.");
+            }
+
+            var formulaResult = ScoringFormulaEvaluator.Validate(output.Formula, availableSoFar);
+            if (formulaResult.IsFailure)
+            {
+                return Result.Failure($"Output '{output.Name}' would reference a token not yet defined in this order: {formulaResult.Error}");
+            }
+
+            availableSoFar.Add(output.Token);
+        }
+
+        for (int i = 0; i < orderedOutputIds.Count; i++)
+        {
+            _outputs.First(o => o.Id == orderedOutputIds[i]).Order = i + 1;
+        }
+
+        return Result.Success();
+    }
+
+    private void ReorderOutputsInternal()
+    {
+        int order = 1;
+        foreach (var output in _outputs.OrderBy(o => o.Order))
+        {
+            output.Order = order;
+            order++;
+        }
+    }
+
+    private void DemoteOtherPrimaries(ScoringModelOutput primary)
+    {
+        foreach (var other in _outputs.Where(o => o.Id != primary.Id && o.IsPrimary))
+        {
+            other.SetPrimary(false);
+        }
+    }
+
+    /// <summary>
+    /// The criterion tokens plus the tokens of outputs ordered before <paramref name="order"/>.
+    /// Used to constrain a formula to referencing only previously-defined tokens.
+    /// </summary>
+    private HashSet<string> TokensAvailableBefore(int order, Guid? exceptOutputId = null)
+    {
+        var tokens = _criteria.Select(c => c.Token).ToHashSet(StringComparer.Ordinal);
+        foreach (var output in _outputs.Where(o => o.Order < order && o.Id != exceptOutputId))
+        {
+            tokens.Add(output.Token);
+        }
+        return tokens;
+    }
+
+    #endregion Output Management
+
+    #region Scoring
+
+    /// <summary>
+    /// Calculates the model's outputs for a set of selected rating values keyed by criterion ID. Outputs
+    /// are evaluated in order — each may use criterion values and prior output values — and the result
+    /// carries every output value plus the primary score. Returns a failure if any criterion is unrated,
+    /// the model is not evaluable, or a formula fails (e.g. division by zero).
+    /// </summary>
+    /// <param name="ratingValuesByCriterionId">
+    /// The selected rating <see cref="ScoringRatingLevel.Value"/> for each criterion, keyed by criterion ID.
+    /// </param>
+    public Result<ScoringResult> CalculateScore(IReadOnlyDictionary<Guid, decimal> ratingValuesByCriterionId)
+    {
+        Guard.Against.Null(ratingValuesByCriterionId, nameof(ratingValuesByCriterionId));
+
+        if (_criteria.Count == 0)
+        {
+            return Result.Failure<ScoringResult>("The scoring model has no criteria to score.");
+        }
+
+        if (_outputs.Count == 0)
+        {
+            return Result.Failure<ScoringResult>("The scoring model has no outputs to calculate.");
+        }
+
+        var primary = _outputs.SingleOrDefault(o => o.IsPrimary);
+        if (primary is null)
+        {
+            return Result.Failure<ScoringResult>("The scoring model must have exactly one primary output.");
+        }
+
+        // Seed the token map with each criterion's rated value.
+        var values = new Dictionary<string, decimal>(StringComparer.Ordinal);
+        foreach (var criterion in _criteria)
+        {
+            if (!ratingValuesByCriterionId.TryGetValue(criterion.Id, out var value))
+            {
+                return Result.Failure<ScoringResult>($"Criterion '{criterion.Name}' has not been rated.");
+            }
+
+            values[criterion.Token] = value;
+        }
+
+        // Evaluate outputs in order, making each available to later formulas.
+        var outputValues = new Dictionary<string, decimal>(StringComparer.Ordinal);
+        foreach (var output in _outputs.OrderBy(o => o.Order))
+        {
+            var evaluation = ScoringFormulaEvaluator.Evaluate(output.Formula, values);
+            if (evaluation.IsFailure)
+            {
+                return Result.Failure<ScoringResult>($"Output '{output.Name}' could not be calculated: {evaluation.Error}");
+            }
+
+            values[output.Token] = evaluation.Value;
+            outputValues[output.Token] = evaluation.Value;
+        }
+
+        return Result.Success(new ScoringResult(outputValues[primary.Token], outputValues));
+    }
+
+    #endregion Scoring
+
+    #region Validation Helpers
+
+    private Result ValidateNewToken(string token, Guid? exceptCriterionId = null, Guid? exceptOutputId = null)
+    {
+        var formatResult = ScoringToken.Validate(token);
+        if (formatResult.IsFailure)
+        {
+            return formatResult;
+        }
+
+        var trimmed = token.Trim();
+
+        var collides =
+            _criteria.Any(c => c.Id != exceptCriterionId && string.Equals(c.Token, trimmed, StringComparison.Ordinal))
+            || _outputs.Any(o => o.Id != exceptOutputId && string.Equals(o.Token, trimmed, StringComparison.Ordinal));
+
+        return collides
+            ? Result.Failure($"Token '{trimmed}' is already used by another criterion or output.")
+            : Result.Success();
+    }
+
+    private Result ValidateNewScaleName(string name, Guid? exceptScaleId = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            return Result.Failure("Scale name must not be empty.");
+        }
+
+        var trimmed = name.Trim();
+
+        return _scales.Any(s => s.Id != exceptScaleId && string.Equals(s.Name, trimmed, StringComparison.OrdinalIgnoreCase))
+            ? Result.Failure($"A scale named '{trimmed}' already exists.")
+            : Result.Success();
+    }
+
+    private Result ValidateScaleReference(Guid? scaleId)
+    {
+        if (scaleId is null)
+        {
+            return Result.Success();
+        }
+
+        return _scales.Any(s => s.Id == scaleId.Value)
+            ? Result.Success()
+            : Result.Failure("The specified scale does not belong to this model.");
+    }
+
+    private Result ValidateReferencedScales()
+    {
+        foreach (var criterion in _criteria.Where(c => c.ScaleId is not null))
+        {
+            var scale = _scales.FirstOrDefault(s => s.Id == criterion.ScaleId!.Value);
+            if (scale is null)
+            {
+                return Result.Failure($"Criterion '{criterion.Name}' references a scale that no longer exists.");
+            }
+
+            if (scale.Levels.Count < 2)
+            {
+                return Result.Failure($"Scale '{scale.Name}' (used by criterion '{criterion.Name}') must have at least two rating levels.");
+            }
+        }
+
+        return Result.Success();
+    }
+
+    private Result ValidateOutputs()
+    {
+        if (_outputs.Count == 0)
+        {
+            return Result.Failure("A scoring model must have at least one output before it can be activated.");
+        }
+
+        if (_outputs.Count(o => o.IsPrimary) != 1)
+        {
+            return Result.Failure("A scoring model must have exactly one primary output.");
+        }
+
+        var availableSoFar = _criteria.Select(c => c.Token).ToHashSet(StringComparer.Ordinal);
+        foreach (var output in _outputs.OrderBy(o => o.Order))
+        {
+            var formulaResult = ScoringFormulaEvaluator.Validate(output.Formula, availableSoFar);
+            if (formulaResult.IsFailure)
+            {
+                return Result.Failure($"Output '{output.Name}' has an invalid formula: {formulaResult.Error}");
+            }
+
+            availableSoFar.Add(output.Token);
+        }
+
+        return Result.Success();
+    }
+
+    #endregion Validation Helpers
+
+    /// <summary>
+    /// Creates a new scoring model in the Proposed state, optionally with initial scales, criteria, and
+    /// outputs. Criteria reference a scale by name (must match one of the supplied scales) or omit it for
+    /// free numeric entry.
+    /// </summary>
+    /// <param name="name">The name of the scoring model.</param>
+    /// <param name="description">A description of the model's purpose and use cases.</param>
+    /// <param name="scales">Optional initial scales, each a name plus its ordered (label, value) levels.</param>
+    /// <param name="criteria">Optional initial criteria, each as (name, token, description, weight, scaleName?).</param>
+    /// <param name="outputs">Optional initial outputs, each as (name, token, formula, isPrimary).</param>
+    public static ScoringModel Create(
+        string name,
+        string description,
+        IEnumerable<(string Name, IEnumerable<(string Label, decimal Value)> Levels)>? scales = null,
+        IEnumerable<(string Name, string Token, string? Description, decimal? Weight, string? ScaleName)>? criteria = null,
+        IEnumerable<(string Name, string Token, string Formula, bool IsPrimary)>? outputs = null)
+    {
+        var model = new ScoringModel(name, description);
+
+        var scalesByName = new Dictionary<string, ScoringScale>(StringComparer.OrdinalIgnoreCase);
+        if (scales is not null)
+        {
+            int scaleOrder = 1;
+            foreach (var (scaleName, levels) in scales)
+            {
+                var scale = new ScoringScale(model.Id, scaleName, scaleOrder);
+                int levelOrder = 1;
+                foreach (var (label, value) in levels)
+                {
+                    scale.SeedLevel(label, value, levelOrder);
+                    levelOrder++;
+                }
+                model._scales.Add(scale);
+                scalesByName[scale.Name] = scale;
+                scaleOrder++;
+            }
+        }
+
+        if (criteria is not null)
+        {
+            int order = 1;
+            foreach (var (criterionName, token, criterionDescription, weight, scaleName) in criteria)
+            {
+                Guid? scaleId = scaleName is not null && scalesByName.TryGetValue(scaleName, out var scale)
+                    ? scale.Id
+                    : null;
+                model._criteria.Add(new ScoringModelCriterion(model.Id, criterionName, token, criterionDescription, weight, scaleId, order));
+                order++;
+            }
+        }
+
+        if (outputs is not null)
+        {
+            int order = 1;
+            foreach (var (outputName, token, formula, isPrimary) in outputs)
+            {
+                model._outputs.Add(new ScoringModelOutput(model.Id, outputName, token, formula, isPrimary, order));
+                order++;
+            }
+
+            // If no output was flagged primary, default the first to primary.
+            if (model._outputs.Count > 0 && !model._outputs.Any(o => o.IsPrimary))
+            {
+                model._outputs.OrderBy(o => o.Order).First().SetPrimary(true);
+            }
+        }
+
+        return model;
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringModelCriterion.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringModelCriterion.cs
@@ -1,0 +1,87 @@
+﻿using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+using Wayd.Common.Domain.Data;
+using Wayd.Common.Extensions;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// Represents a single rated input within a scoring model (e.g., "Business Value"). Each criterion is
+/// rated against the model's shared rating scale, and exposes a <see cref="Token"/> that the model's
+/// output formulas reference. An optional <see cref="Weight"/> is retained for the weighted-formula
+/// scaffolding convenience but is not authoritative — the output formulas determine the score.
+/// </summary>
+public sealed class ScoringModelCriterion : BaseAuditableEntity
+{
+    private ScoringModelCriterion() { }
+
+    internal ScoringModelCriterion(Guid scoringModelId, string name, string token, string? description, decimal? weight, Guid? scaleId, int order)
+    {
+        ScoringModelId = scoringModelId;
+        Name = name;
+        Token = token;
+        Description = description;
+        Weight = weight;
+        ScaleId = scaleId;
+        Order = order;
+    }
+
+    /// <summary>
+    /// The ID of the scoring model this criterion belongs to.
+    /// </summary>
+    public Guid ScoringModelId { get; private init; }
+
+    /// <summary>
+    /// The name of the criterion (e.g., "Business Value", "Job Size").
+    /// </summary>
+    public string Name
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Name)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The short identifier referenced by the model's output formulas (e.g., "BV", "JS").
+    /// Unique within the model across criteria and outputs.
+    /// </summary>
+    public string Token
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Token)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// An optional description clarifying what the criterion measures.
+    /// </summary>
+    public string? Description { get; private set => field = value.NullIfWhiteSpacePlusTrim(); }
+
+    /// <summary>
+    /// An optional, non-authoritative weight (used only by the weighted-formula scaffolder).
+    /// The output formulas, not weights, determine the score.
+    /// </summary>
+    public decimal? Weight { get; private set; }
+
+    /// <summary>
+    /// The optional rating scale this criterion is rated against. When set, scorers must pick a level
+    /// from the scale; when null, the criterion is rated by free numeric entry.
+    /// </summary>
+    public Guid? ScaleId { get; private set; }
+
+    /// <summary>
+    /// The display order of the criterion within the scoring model.
+    /// </summary>
+    public int Order { get; internal set; }
+
+    /// <summary>
+    /// Updates the criterion details.
+    /// </summary>
+    internal Result Update(string name, string token, string? description, decimal? weight, Guid? scaleId)
+    {
+        Name = name;
+        Token = token;
+        Description = description;
+        Weight = weight;
+        ScaleId = scaleId;
+        return Result.Success();
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringModelOutput.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringModelOutput.cs
@@ -1,0 +1,85 @@
+using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+using Wayd.Common.Domain.Data;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// Represents a named, computed output of a scoring model — a formula over criterion tokens and
+/// earlier output tokens (e.g. "CoD = BV + TC + RR", then "WSJF = CoD / JS"). Exactly one output per
+/// model is the <see cref="IsPrimary"/> score; the others are intermediate values retained for display
+/// and ranking (e.g. Cost of Delay).
+/// </summary>
+public sealed class ScoringModelOutput : BaseAuditableEntity
+{
+    private ScoringModelOutput() { }
+
+    internal ScoringModelOutput(Guid scoringModelId, string name, string token, string formula, bool isPrimary, int order)
+    {
+        ScoringModelId = scoringModelId;
+        Name = name;
+        Token = token;
+        Formula = formula;
+        IsPrimary = isPrimary;
+        Order = order;
+    }
+
+    /// <summary>
+    /// The ID of the scoring model this output belongs to.
+    /// </summary>
+    public Guid ScoringModelId { get; private init; }
+
+    /// <summary>
+    /// The name of the output (e.g., "Cost of Delay", "WSJF").
+    /// </summary>
+    public string Name
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Name)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The short identifier other output formulas can reference (e.g., "CoD", "WSJF").
+    /// Unique within the model across criteria and outputs.
+    /// </summary>
+    public string Token
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Token)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The arithmetic formula computing this output, referencing criterion tokens and the tokens of
+    /// outputs ordered before it.
+    /// </summary>
+    public string Formula
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Formula)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// Whether this output is the model's primary score. Exactly one output per model is primary.
+    /// </summary>
+    public bool IsPrimary { get; private set; }
+
+    /// <summary>
+    /// The evaluation/display order of the output within the scoring model. Outputs evaluate in this
+    /// order so a later output may reference an earlier one.
+    /// </summary>
+    public int Order { get; internal set; }
+
+    internal void SetPrimary(bool isPrimary) => IsPrimary = isPrimary;
+
+    /// <summary>
+    /// Updates the output details.
+    /// </summary>
+    internal Result Update(string name, string token, string formula, bool isPrimary)
+    {
+        Name = name;
+        Token = token;
+        Formula = formula;
+        IsPrimary = isPrimary;
+        return Result.Success();
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringRatingLevel.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringRatingLevel.cs
@@ -1,0 +1,57 @@
+using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+using Wayd.Common.Domain.Data;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// Represents a single rating level on a <see cref="ScoringScale"/> (e.g., "Very High" = 5, "Low" = 2).
+/// The numeric <see cref="Value"/> is what a chosen rating contributes to a criterion's value; the
+/// <see cref="Label"/> is shown in the rating dropdown.
+/// </summary>
+public sealed class ScoringRatingLevel : BaseAuditableEntity
+{
+    private ScoringRatingLevel() { }
+
+    internal ScoringRatingLevel(Guid scoringScaleId, string label, decimal value, int order)
+    {
+        ScoringScaleId = scoringScaleId;
+        Label = label;
+        Value = value;
+        Order = order;
+    }
+
+    /// <summary>
+    /// The ID of the scale this rating level belongs to.
+    /// </summary>
+    public Guid ScoringScaleId { get; private init; }
+
+    /// <summary>
+    /// The human-readable label for this rating level (e.g., "Very High", "Medium").
+    /// </summary>
+    public string Label
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Label)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The numeric value used in the weighted score calculation.
+    /// </summary>
+    public decimal Value { get; private set; }
+
+    /// <summary>
+    /// The display order of the rating level within the scale.
+    /// </summary>
+    public int Order { get; internal set; }
+
+    /// <summary>
+    /// Updates the rating level details.
+    /// </summary>
+    internal Result Update(string label, decimal value)
+    {
+        Label = label;
+        Value = value;
+        return Result.Success();
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringResult.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringResult.cs
@@ -1,0 +1,8 @@
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// The outcome of evaluating a scoring model against a set of rated criteria: the primary score plus
+/// every computed output value (keyed by output token), so intermediate values such as Cost of Delay
+/// can be displayed and ranked alongside the score.
+/// </summary>
+public sealed record ScoringResult(decimal PrimaryValue, IReadOnlyDictionary<string, decimal> OutputValues);

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringScale.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringScale.cs
@@ -1,0 +1,131 @@
+using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+using Wayd.Common.Domain.Data;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// A named, reusable rating scale on a scoring model (e.g., "Fibonacci" = 1,2,3,5,8,13; "Impact" =
+/// Very High..Very Low). A scale owns an ordered list of <see cref="ScoringRatingLevel"/> options, and
+/// criteria reference a scale to constrain how they are rated. A criterion with no scale is rated by
+/// free numeric entry instead.
+/// </summary>
+public sealed class ScoringScale : BaseAuditableEntity
+{
+    private readonly List<ScoringRatingLevel> _levels = [];
+
+    private ScoringScale() { }
+
+    internal ScoringScale(Guid scoringModelId, string name, int order)
+    {
+        ScoringModelId = scoringModelId;
+        Name = name;
+        Order = order;
+    }
+
+    /// <summary>
+    /// The ID of the scoring model this scale belongs to.
+    /// </summary>
+    public Guid ScoringModelId { get; private init; }
+
+    /// <summary>
+    /// The name of the scale (e.g., "Fibonacci", "Impact"). Unique within the model.
+    /// </summary>
+    public string Name
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Name)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The display order of the scale within the model.
+    /// </summary>
+    public int Order { get; internal set; }
+
+    /// <summary>
+    /// The ordered rating levels that make up this scale.
+    /// </summary>
+    public IReadOnlyCollection<ScoringRatingLevel> Levels => _levels.AsReadOnly();
+
+    internal Result Update(string name)
+    {
+        Name = name;
+        return Result.Success();
+    }
+
+    internal ScoringRatingLevel AddLevel(string label, decimal value)
+    {
+        var order = _levels.Count > 0 ? _levels.Max(l => l.Order) + 1 : 1;
+        var level = new ScoringRatingLevel(Id, label, value, order);
+        _levels.Add(level);
+        return level;
+    }
+
+    internal Result UpdateLevel(Guid levelId, string label, decimal value)
+    {
+        var level = _levels.FirstOrDefault(l => l.Id == levelId);
+        if (level is null)
+        {
+            return Result.Failure("Rating level not found.");
+        }
+
+        return level.Update(label, value);
+    }
+
+    internal Result RemoveLevel(Guid levelId)
+    {
+        var level = _levels.FirstOrDefault(l => l.Id == levelId);
+        if (level is null)
+        {
+            return Result.Failure("Rating level not found.");
+        }
+
+        _levels.Remove(level);
+        ReorderLevels();
+        return Result.Success();
+    }
+
+    internal Result ReorderLevels(List<Guid> orderedLevelIds)
+    {
+        Guard.Against.Null(orderedLevelIds, nameof(orderedLevelIds));
+
+        if (orderedLevelIds.Count != _levels.Count)
+        {
+            return Result.Failure("The number of rating level IDs must match the number of existing rating levels.");
+        }
+
+        if (orderedLevelIds.Distinct().Count() != orderedLevelIds.Count)
+        {
+            return Result.Failure("Duplicate rating level IDs are not allowed.");
+        }
+
+        for (int i = 0; i < orderedLevelIds.Count; i++)
+        {
+            var level = _levels.FirstOrDefault(l => l.Id == orderedLevelIds[i]);
+            if (level is null)
+            {
+                return Result.Failure($"Rating level with ID '{orderedLevelIds[i]}' not found.");
+            }
+
+            level.Order = i + 1;
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Adds a level during construction (factory use), preserving the supplied order.
+    /// </summary>
+    internal void SeedLevel(string label, decimal value, int order)
+        => _levels.Add(new ScoringRatingLevel(Id, label, value, order));
+
+    private void ReorderLevels()
+    {
+        int order = 1;
+        foreach (var level in _levels.OrderBy(l => l.Order))
+        {
+            level.Order = order;
+            order++;
+        }
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringToken.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Scoring/ScoringToken.cs
@@ -1,0 +1,39 @@
+using System.Text.RegularExpressions;
+using CSharpFunctionalExtensions;
+
+namespace Wayd.Common.Domain.Scoring;
+
+/// <summary>
+/// Validation for scoring tokens — the short identifiers (e.g. "BV", "JS") that criteria and outputs
+/// expose for use in formulas. A token must be a valid expression identifier so it can be referenced
+/// unambiguously: a letter or underscore followed by letters, digits, or underscores.
+/// </summary>
+public static partial class ScoringToken
+{
+    public const int MaxLength = 32;
+
+    [GeneratedRegex("^[A-Za-z_][A-Za-z0-9_]*$", RegexOptions.CultureInvariant)]
+    private static partial Regex TokenPattern();
+
+    public static bool IsValid(string token) =>
+        !string.IsNullOrWhiteSpace(token)
+        && token.Length <= MaxLength
+        && TokenPattern().IsMatch(token);
+
+    public static Result Validate(string token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return Result.Failure("Token must not be empty.");
+        }
+
+        if (token.Length > MaxLength)
+        {
+            return Result.Failure($"Token must not exceed {MaxLength} characters.");
+        }
+
+        return TokenPattern().IsMatch(token)
+            ? Result.Success()
+            : Result.Failure($"Token '{token}' is invalid. Tokens must start with a letter or underscore and contain only letters, digits, or underscores.");
+    }
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Wayd.Common.Domain.csproj
+++ b/Wayd.Common/src/Wayd.Common.Domain/Wayd.Common.Domain.csproj
@@ -4,6 +4,7 @@
         <PackageReference Include="CSharpFunctionalExtensions" />
         <PackageReference Include="FluentValidation" />
         <PackageReference Include="MediatR.Contracts" />
+        <PackageReference Include="NCalcSync" />
         <PackageReference Include="NodaTime" />
     </ItemGroup>
 

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Infrastructure/FakeWaydDbContext.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Infrastructure/FakeWaydDbContext.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Application.Persistence;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Tests.Shared.Infrastructure;
 
 namespace Wayd.Common.Application.Tests.Infrastructure;
@@ -20,6 +21,7 @@ public class FakeWaydDbContext : IWaydDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Employee> Employees => _employees.AsDbSet();
@@ -27,6 +29,7 @@ public class FakeWaydDbContext : IWaydDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding (_dbContext.ChangeTracker?.Clear())
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/ActivateScoringModelCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/ActivateScoringModelCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Scoring.Enums;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class ActivateScoringModelCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly ScoringModelFaker _faker = new();
+
+    private ActivateScoringModelCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<ActivateScoringModelCommandHandler>.Instance);
+
+    private ScoringModel SeedProposedModel()
+    {
+        var model = _faker.AsProposedWsjf();
+        _dbContext.ScoringModels.Add(model);
+        return model;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldTransitionProposedModelToActive()
+    {
+        // Arrange
+        var model = SeedProposedModel();
+        var command = new ActivateScoringModelCommand(model.Id);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        model.State.Should().Be(ScoringModelState.Active);
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelNotFound()
+    {
+        // Arrange
+        SeedProposedModel();
+        var command = new ActivateScoringModelCommand(Guid.NewGuid());
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/AddScoringModelCriterionCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/AddScoringModelCriterionCommandHandlerTests.cs
@@ -1,0 +1,79 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class AddScoringModelCriterionCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly ScoringModelFaker _faker = new();
+
+    private AddScoringModelCriterionCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<AddScoringModelCriterionCommandHandler>.Instance);
+
+    // A bare proposed model with no criteria yet, so the command under test does the adding.
+    private ScoringModel SeedEmptyModel()
+    {
+        var model = _faker.AsProposedWith([], [], []);
+        _dbContext.ScoringModels.Add(model);
+        return model;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldAddCriterionAndReturnItsId()
+    {
+        // Arrange
+        var model = SeedEmptyModel();
+        var command = new AddScoringModelCriterionCommand(
+            model.Id, "Business Value", "BV", "Value to the business.", null, ScaleId: null);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        var criterion = model.Criteria.Single();
+        criterion.Id.Should().Be(result.Value);
+        criterion.Token.Should().Be("BV");
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenTokenDuplicatesExistingCriterion()
+    {
+        // Arrange — the model already has a "BV" criterion; adding another must surface the domain
+        // failure and not save.
+        var model = _faker.AsProposedWsjf();
+        _dbContext.ScoringModels.Add(model);
+        var command = new AddScoringModelCriterionCommand(
+            model.Id, "Duplicate", "BV", null, null, ScaleId: null);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelNotFound()
+    {
+        // Arrange
+        SeedEmptyModel();
+        var command = new AddScoringModelCriterionCommand(
+            Guid.NewGuid(), "Business Value", "BV", null, null, ScaleId: null);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/AddScoringModelOutputCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/AddScoringModelOutputCommandHandlerTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class AddScoringModelOutputCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly ScoringModelFaker _faker = new();
+
+    private static readonly (string Name, (string Label, decimal Value)[] Levels)[] Scales =
+        [("Impact", [("High", 8m), ("Medium", 5m), ("Low", 1m)])];
+
+    private static readonly (string Name, string Token, decimal? Weight, string? ScaleName)[] Criteria =
+    [
+        ("Business Value", "BV", null, "Impact"),
+        ("Job Size", "JS", null, "Impact")
+    ];
+
+    private AddScoringModelOutputCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<AddScoringModelOutputCommandHandler>.Instance);
+
+    // A model with criteria but no outputs yet, so the command under test adds the first (primary) output.
+    private ScoringModel SeedModelWithoutOutputs()
+    {
+        var model = _faker.AsProposedWith(Scales, Criteria, []);
+        _dbContext.ScoringModels.Add(model);
+        return model;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldAddOutputAndReturnItsId()
+    {
+        // Arrange
+        var model = SeedModelWithoutOutputs();
+        var command = new AddScoringModelOutputCommand(
+            model.Id, "WSJF", "WSJF", "BV / JS", IsPrimary: true);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        var output = model.Outputs.Single();
+        output.Id.Should().Be(result.Value);
+        output.IsPrimary.Should().BeTrue();
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenFormulaReferencesUnknownToken()
+    {
+        // Arrange
+        var model = SeedModelWithoutOutputs();
+        var command = new AddScoringModelOutputCommand(
+            model.Id, "Bad", "BAD", "BV + NOPE", IsPrimary: true);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelNotFound()
+    {
+        // Arrange
+        SeedModelWithoutOutputs();
+        var command = new AddScoringModelOutputCommand(
+            Guid.NewGuid(), "WSJF", "WSJF", "BV / JS", IsPrimary: true);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/ArchiveScoringModelCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/ArchiveScoringModelCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Scoring.Enums;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class ArchiveScoringModelCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly ScoringModelFaker _faker = new();
+
+    private ArchiveScoringModelCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<ArchiveScoringModelCommandHandler>.Instance);
+
+    private ScoringModel SeedActiveModel()
+    {
+        var model = _faker.AsActiveWsjf();
+        _dbContext.ScoringModels.Add(model);
+        return model;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldTransitionActiveModelToArchived()
+    {
+        // Arrange
+        var model = SeedActiveModel();
+        var command = new ArchiveScoringModelCommand(model.Id);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        model.State.Should().Be(ScoringModelState.Archived);
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelNotFound()
+    {
+        // Arrange
+        SeedActiveModel();
+        var command = new ArchiveScoringModelCommand(Guid.NewGuid());
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/CreateScoringModelCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/CreateScoringModelCommandHandlerTests.cs
@@ -1,0 +1,53 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring.Enums;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class CreateScoringModelCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+
+    private CreateScoringModelCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<CreateScoringModelCommandHandler>.Instance);
+
+    [Fact]
+    public async Task Handle_ShouldPersistModelAndReturnItsId()
+    {
+        // Arrange — a complete WSJF definition supplied as command input.
+        var command = new CreateScoringModelCommand(
+            "WSJF",
+            "Weighted shortest job first.",
+            Scales: [new("Impact", [new("High", 8m), new("Medium", 5m), new("Low", 1m)])],
+            Criteria:
+            [
+                new("Business Value", "BV", null, null, "Impact"),
+                new("Time Criticality", "TC", null, null, "Impact"),
+                new("Risk Reduction", "RR", null, null, "Impact"),
+                new("Job Size", "JS", null, null, "Impact"),
+            ],
+            Outputs:
+            [
+                new("Cost of Delay", "CoD", "BV + TC + RR", false),
+                new("WSJF", "WSJF", "CoD / JS", true),
+            ]);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+
+        var persisted = await _dbContext.ScoringModels.SingleAsync(TestContext.Current.CancellationToken);
+        persisted.Id.Should().Be(result.Value);
+        persisted.Name.Should().Be("WSJF");
+        persisted.State.Should().Be(ScoringModelState.Proposed);
+        persisted.Criteria.Should().HaveCount(4);
+        persisted.Outputs.Should().HaveCount(2);
+        persisted.Outputs.Single(o => o.IsPrimary).Token.Should().Be("WSJF");
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/DeleteScoringModelCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/DeleteScoringModelCommandHandlerTests.cs
@@ -1,0 +1,76 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class DeleteScoringModelCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly ScoringModelFaker _faker = new();
+
+    private DeleteScoringModelCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<DeleteScoringModelCommandHandler>.Instance);
+
+    private ScoringModel SeedProposedModel()
+    {
+        var model = _faker.AsProposedWsjf();
+        _dbContext.ScoringModels.Add(model);
+        return model;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldRemoveProposedModel()
+    {
+        // Arrange
+        var model = SeedProposedModel();
+        var command = new DeleteScoringModelCommand(model.Id);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        (await _dbContext.ScoringModels.AnyAsync(TestContext.Current.CancellationToken)).Should().BeFalse();
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelIsActive()
+    {
+        // Arrange — an active model cannot be deleted; the handler's CanBeDeleted guard should reject it
+        // and leave the row in place.
+        var model = _faker.AsActiveWsjf();
+        _dbContext.ScoringModels.Add(model);
+        var command = new DeleteScoringModelCommand(model.Id);
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("cannot be deleted");
+        (await _dbContext.ScoringModels.AnyAsync(TestContext.Current.CancellationToken)).Should().BeTrue();
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelNotFound()
+    {
+        // Arrange
+        SeedProposedModel();
+        var command = new DeleteScoringModelCommand(Guid.NewGuid());
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/UpdateScoringModelCommandHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Scoring/ScoringModels/Commands/UpdateScoringModelCommandHandlerTests.cs
@@ -1,0 +1,57 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Scoring.ScoringModels.Commands;
+
+public class UpdateScoringModelCommandHandlerTests
+{
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly ScoringModelFaker _faker = new();
+
+    private UpdateScoringModelCommandHandler CreateHandler() =>
+        new(_dbContext, NullLogger<UpdateScoringModelCommandHandler>.Instance);
+
+    private ScoringModel SeedProposedModel()
+    {
+        var model = _faker.AsProposedWsjf();
+        _dbContext.ScoringModels.Add(model);
+        return model;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldChangeNameAndDescription()
+    {
+        // Arrange
+        var model = SeedProposedModel();
+        var command = new UpdateScoringModelCommand(model.Id, "Renamed", "New description.");
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        model.Name.Should().Be("Renamed");
+        model.Description.Should().Be("New description.");
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenModelNotFound()
+    {
+        // Arrange
+        SeedProposedModel();
+        var command = new UpdateScoringModelCommand(Guid.NewGuid(), "Renamed", "New description.");
+
+        // Act
+        var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Wayd.Common.Application.Tests.csproj
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Wayd.Common.Application.Tests.csproj
@@ -22,6 +22,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Wayd.Common.Application\Wayd.Common.Application.csproj" />
+    <ProjectReference Include="..\Wayd.Common.Domain.Tests\Wayd.Common.Domain.Tests.csproj" />
     <ProjectReference Include="..\Wayd.Tests.Shared\Wayd.Tests.Shared.csproj" />
   </ItemGroup>
 

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelCriterionFaker.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelCriterionFaker.cs
@@ -1,0 +1,69 @@
+using Wayd.Common.Domain.Scoring;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Common.Domain.Tests.Data;
+
+public sealed class ScoringModelCriterionFaker : PrivateConstructorFaker<ScoringModelCriterion>
+{
+    public ScoringModelCriterionFaker()
+    {
+        RuleFor(x => x.Id, f => f.Random.Guid());
+        RuleFor(x => x.ScoringModelId, f => f.Random.Guid());
+        RuleFor(x => x.Name, f => f.Commerce.Department());
+        RuleFor(x => x.Token, f => "C" + f.Random.AlphaNumeric(5));
+        RuleFor(x => x.Description, f => f.Random.Bool() ? f.Lorem.Sentence() : null);
+        RuleFor(x => x.Weight, f => f.Random.Decimal(0m, 100m));
+        RuleFor(x => x.Order, f => f.Random.Int(1, 10));
+    }
+}
+
+public static class ScoringModelCriterionFakerExtensions
+{
+    public static ScoringModelCriterionFaker WithId(this ScoringModelCriterionFaker faker, Guid id)
+    {
+        faker.RuleFor(x => x.Id, id);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithScoringModelId(this ScoringModelCriterionFaker faker, Guid scoringModelId)
+    {
+        faker.RuleFor(x => x.ScoringModelId, scoringModelId);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithName(this ScoringModelCriterionFaker faker, string name)
+    {
+        faker.RuleFor(x => x.Name, name);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithToken(this ScoringModelCriterionFaker faker, string token)
+    {
+        faker.RuleFor(x => x.Token, token);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithDescription(this ScoringModelCriterionFaker faker, string? description)
+    {
+        faker.RuleFor(x => x.Description, description);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithWeight(this ScoringModelCriterionFaker faker, decimal? weight)
+    {
+        faker.RuleFor(x => x.Weight, weight);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithScaleId(this ScoringModelCriterionFaker faker, Guid? scaleId)
+    {
+        faker.RuleFor(x => x.ScaleId, scaleId);
+        return faker;
+    }
+
+    public static ScoringModelCriterionFaker WithOrder(this ScoringModelCriterionFaker faker, int order)
+    {
+        faker.RuleFor(x => x.Order, order);
+        return faker;
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelFaker.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelFaker.cs
@@ -79,6 +79,38 @@ public static class ScoringModelFakerExtensions
         return model;
     }
 
+    // The canonical WSJF fixture: an "Impact" scale, the four WSJF criteria rated on it, an intermediate
+    // Cost of Delay output, and the primary WSJF output. The conventional worked example for this domain.
+    private static readonly (string Name, (string Label, decimal Value)[] Levels)[] WsjfScales =
+        [("Impact", [("High", 8m), ("Medium", 5m), ("Low", 1m)])];
+
+    private static readonly (string Name, string Token, decimal? Weight, string? ScaleName)[] WsjfCriteria =
+    [
+        ("Business Value", "BV", null, "Impact"),
+        ("Time Criticality", "TC", null, "Impact"),
+        ("Risk Reduction", "RR", null, "Impact"),
+        ("Job Size", "JS", null, "Impact")
+    ];
+
+    private static readonly (string Name, string Token, string Formula, bool IsPrimary)[] WsjfOutputs =
+    [
+        ("Cost of Delay", "CoD", "BV + TC + RR", false),
+        ("WSJF", "WSJF", "CoD / JS", true)
+    ];
+
+    /// <summary>
+    /// Generates a complete, valid WSJF model in the Proposed state — scale, four criteria, and the
+    /// CoD/WSJF output chain — so tests that just need "a realistic model" don't repeat the fixture.
+    /// </summary>
+    public static ScoringModel AsProposedWsjf(this ScoringModelFaker faker)
+        => faker.AsProposedWith(WsjfScales, WsjfCriteria, WsjfOutputs);
+
+    /// <summary>
+    /// Generates the same WSJF model as <see cref="AsProposedWsjf"/>, activated.
+    /// </summary>
+    public static ScoringModel AsActiveWsjf(this ScoringModelFaker faker)
+        => faker.AsActiveWith(WsjfScales, WsjfCriteria, WsjfOutputs);
+
     /// <summary>
     /// Adds scales (and their levels) to an existing model using the model's own methods.
     /// </summary>

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelFaker.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelFaker.cs
@@ -1,0 +1,131 @@
+﻿using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Scoring.Enums;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Common.Domain.Tests.Data;
+
+public sealed class ScoringModelFaker : PrivateConstructorFaker<ScoringModel>
+{
+    public ScoringModelFaker()
+    {
+        RuleFor(x => x.Id, f => f.Random.Guid());
+        RuleFor(x => x.Key, f => f.Random.Int(1, 10000));
+        RuleFor(x => x.Name, f => f.Commerce.ProductName());
+        RuleFor(x => x.Description, f => f.Lorem.Paragraph());
+        RuleFor(x => x.State, f => ScoringModelState.Proposed);
+    }
+}
+
+public static class ScoringModelFakerExtensions
+{
+    public static ScoringModelFaker WithId(this ScoringModelFaker faker, Guid id)
+    {
+        faker.RuleFor(x => x.Id, id);
+        return faker;
+    }
+
+    public static ScoringModelFaker WithKey(this ScoringModelFaker faker, int key)
+    {
+        faker.RuleFor(x => x.Key, key);
+        return faker;
+    }
+
+    public static ScoringModelFaker WithName(this ScoringModelFaker faker, string name)
+    {
+        faker.RuleFor(x => x.Name, name);
+        return faker;
+    }
+
+    public static ScoringModelFaker WithDescription(this ScoringModelFaker faker, string description)
+    {
+        faker.RuleFor(x => x.Description, description);
+        return faker;
+    }
+
+    public static ScoringModelFaker WithState(this ScoringModelFaker faker, ScoringModelState state)
+    {
+        faker.RuleFor(x => x.State, state);
+        return faker;
+    }
+
+    /// <summary>
+    /// Generates a proposed model with the specified scales, criteria, and outputs, built via the
+    /// aggregate's own methods so invariants and ordering hold. Criteria reference a scale by name.
+    /// </summary>
+    public static ScoringModel AsProposedWith(
+        this ScoringModelFaker faker,
+        (string Name, (string Label, decimal Value)[] Levels)[] scales,
+        (string Name, string Token, decimal? Weight, string? ScaleName)[] criteria,
+        (string Name, string Token, string Formula, bool IsPrimary)[] outputs)
+    {
+        var model = faker.Generate();
+        return model
+            .WithScales(scales)
+            .WithCriteria(criteria)
+            .WithOutputs(outputs);
+    }
+
+    /// <summary>
+    /// Generates an active model with the specified scales, criteria, and outputs.
+    /// </summary>
+    public static ScoringModel AsActiveWith(
+        this ScoringModelFaker faker,
+        (string Name, (string Label, decimal Value)[] Levels)[] scales,
+        (string Name, string Token, decimal? Weight, string? ScaleName)[] criteria,
+        (string Name, string Token, string Formula, bool IsPrimary)[] outputs)
+    {
+        var model = faker.AsProposedWith(scales, criteria, outputs);
+        model.Activate();
+        return model;
+    }
+
+    /// <summary>
+    /// Adds scales (and their levels) to an existing model using the model's own methods.
+    /// </summary>
+    public static ScoringModel WithScales(
+        this ScoringModel model,
+        params (string Name, (string Label, decimal Value)[] Levels)[] scales)
+    {
+        foreach (var (name, levels) in scales)
+        {
+            var scale = model.AddScale(name).Value;
+            foreach (var (label, value) in levels)
+            {
+                model.AddScaleLevel(scale.Id, label, value);
+            }
+        }
+        return model;
+    }
+
+    /// <summary>
+    /// Adds criteria to an existing model using the model's AddCriterion method, resolving a referenced
+    /// scale by name.
+    /// </summary>
+    public static ScoringModel WithCriteria(
+        this ScoringModel model,
+        params (string Name, string Token, decimal? Weight, string? ScaleName)[] criteria)
+    {
+        foreach (var (name, token, weight, scaleName) in criteria)
+        {
+            Guid? scaleId = scaleName is null
+                ? null
+                : model.Scales.FirstOrDefault(s => s.Name == scaleName)?.Id;
+            model.AddCriterion(name, token, null, weight, scaleId);
+        }
+        return model;
+    }
+
+    /// <summary>
+    /// Adds outputs to an existing model using the model's AddOutput method.
+    /// </summary>
+    public static ScoringModel WithOutputs(
+        this ScoringModel model,
+        params (string Name, string Token, string Formula, bool IsPrimary)[] outputs)
+    {
+        foreach (var (name, token, formula, isPrimary) in outputs)
+        {
+            model.AddOutput(name, token, formula, isPrimary);
+        }
+        return model;
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelOutputFaker.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringModelOutputFaker.cs
@@ -1,0 +1,63 @@
+using Wayd.Common.Domain.Scoring;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Common.Domain.Tests.Data;
+
+public sealed class ScoringModelOutputFaker : PrivateConstructorFaker<ScoringModelOutput>
+{
+    public ScoringModelOutputFaker()
+    {
+        RuleFor(x => x.Id, f => f.Random.Guid());
+        RuleFor(x => x.ScoringModelId, f => f.Random.Guid());
+        RuleFor(x => x.Name, f => f.Commerce.ProductName());
+        RuleFor(x => x.Token, f => "O" + f.Random.AlphaNumeric(5));
+        RuleFor(x => x.Formula, f => "1 + 1");
+        RuleFor(x => x.IsPrimary, true);
+        RuleFor(x => x.Order, f => f.Random.Int(1, 10));
+    }
+}
+
+public static class ScoringModelOutputFakerExtensions
+{
+    public static ScoringModelOutputFaker WithId(this ScoringModelOutputFaker faker, Guid id)
+    {
+        faker.RuleFor(x => x.Id, id);
+        return faker;
+    }
+
+    public static ScoringModelOutputFaker WithScoringModelId(this ScoringModelOutputFaker faker, Guid scoringModelId)
+    {
+        faker.RuleFor(x => x.ScoringModelId, scoringModelId);
+        return faker;
+    }
+
+    public static ScoringModelOutputFaker WithName(this ScoringModelOutputFaker faker, string name)
+    {
+        faker.RuleFor(x => x.Name, name);
+        return faker;
+    }
+
+    public static ScoringModelOutputFaker WithToken(this ScoringModelOutputFaker faker, string token)
+    {
+        faker.RuleFor(x => x.Token, token);
+        return faker;
+    }
+
+    public static ScoringModelOutputFaker WithFormula(this ScoringModelOutputFaker faker, string formula)
+    {
+        faker.RuleFor(x => x.Formula, formula);
+        return faker;
+    }
+
+    public static ScoringModelOutputFaker WithIsPrimary(this ScoringModelOutputFaker faker, bool isPrimary)
+    {
+        faker.RuleFor(x => x.IsPrimary, isPrimary);
+        return faker;
+    }
+
+    public static ScoringModelOutputFaker WithOrder(this ScoringModelOutputFaker faker, int order)
+    {
+        faker.RuleFor(x => x.Order, order);
+        return faker;
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringRatingLevelFaker.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringRatingLevelFaker.cs
@@ -1,0 +1,49 @@
+using Wayd.Common.Domain.Scoring;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Common.Domain.Tests.Data;
+
+public sealed class ScoringRatingLevelFaker : PrivateConstructorFaker<ScoringRatingLevel>
+{
+    public ScoringRatingLevelFaker()
+    {
+        RuleFor(x => x.Id, f => f.Random.Guid());
+        RuleFor(x => x.ScoringScaleId, f => f.Random.Guid());
+        RuleFor(x => x.Label, f => f.Lorem.Word());
+        RuleFor(x => x.Value, f => f.Random.Decimal(1m, 5m));
+        RuleFor(x => x.Order, f => f.Random.Int(1, 10));
+    }
+}
+
+public static class ScoringRatingLevelFakerExtensions
+{
+    public static ScoringRatingLevelFaker WithId(this ScoringRatingLevelFaker faker, Guid id)
+    {
+        faker.RuleFor(x => x.Id, id);
+        return faker;
+    }
+
+    public static ScoringRatingLevelFaker WithScoringScaleId(this ScoringRatingLevelFaker faker, Guid scoringScaleId)
+    {
+        faker.RuleFor(x => x.ScoringScaleId, scoringScaleId);
+        return faker;
+    }
+
+    public static ScoringRatingLevelFaker WithLabel(this ScoringRatingLevelFaker faker, string label)
+    {
+        faker.RuleFor(x => x.Label, label);
+        return faker;
+    }
+
+    public static ScoringRatingLevelFaker WithValue(this ScoringRatingLevelFaker faker, decimal value)
+    {
+        faker.RuleFor(x => x.Value, value);
+        return faker;
+    }
+
+    public static ScoringRatingLevelFaker WithOrder(this ScoringRatingLevelFaker faker, int order)
+    {
+        faker.RuleFor(x => x.Order, order);
+        return faker;
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringScaleFaker.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Data/ScoringScaleFaker.cs
@@ -1,0 +1,42 @@
+using Wayd.Common.Domain.Scoring;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Common.Domain.Tests.Data;
+
+public sealed class ScoringScaleFaker : PrivateConstructorFaker<ScoringScale>
+{
+    public ScoringScaleFaker()
+    {
+        RuleFor(x => x.Id, f => f.Random.Guid());
+        RuleFor(x => x.ScoringModelId, f => f.Random.Guid());
+        RuleFor(x => x.Name, f => f.Commerce.ProductName());
+        RuleFor(x => x.Order, f => f.Random.Int(1, 10));
+    }
+}
+
+public static class ScoringScaleFakerExtensions
+{
+    public static ScoringScaleFaker WithId(this ScoringScaleFaker faker, Guid id)
+    {
+        faker.RuleFor(x => x.Id, id);
+        return faker;
+    }
+
+    public static ScoringScaleFaker WithScoringModelId(this ScoringScaleFaker faker, Guid scoringModelId)
+    {
+        faker.RuleFor(x => x.ScoringModelId, scoringModelId);
+        return faker;
+    }
+
+    public static ScoringScaleFaker WithName(this ScoringScaleFaker faker, string name)
+    {
+        faker.RuleFor(x => x.Name, name);
+        return faker;
+    }
+
+    public static ScoringScaleFaker WithOrder(this ScoringScaleFaker faker, int order)
+    {
+        faker.RuleFor(x => x.Order, order);
+        return faker;
+    }
+}

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Scoring/ScoringModelTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Scoring/ScoringModelTests.cs
@@ -1,0 +1,365 @@
+﻿using FluentAssertions;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Scoring.Enums;
+using Wayd.Common.Domain.Tests.Data;
+
+namespace Wayd.Common.Domain.Tests.Sut.Scoring;
+
+public class ScoringModelTests
+{
+    private readonly ScoringModelFaker _faker = new();
+
+    // One shared scale used by the criteria below.
+    private static readonly (string Name, (string Label, decimal Value)[] Levels)[] DefaultScales =
+    [
+        ("Impact", [("High", 8m), ("Medium", 5m), ("Low", 1m)])
+    ];
+
+    // A WSJF model: rated criteria BV/TC/RR/JS, an intermediate CoD output, and a primary WSJF output.
+    private static readonly (string Name, string Token, decimal? Weight, string? ScaleName)[] WsjfCriteria =
+    [
+        ("Business Value", "BV", null, "Impact"),
+        ("Time Criticality", "TC", null, "Impact"),
+        ("Risk Reduction", "RR", null, "Impact"),
+        ("Job Size", "JS", null, "Impact")
+    ];
+
+    private static readonly (string Name, string Token, string Formula, bool IsPrimary)[] WsjfOutputs =
+    [
+        ("Cost of Delay", "CoD", "BV + TC + RR", false),
+        ("WSJF", "WSJF", "CoD / JS", true)
+    ];
+
+    // A weighted-sum model expressed as a single primary output (regression against the old behavior).
+    private static readonly (string Name, string Token, decimal? Weight, string? ScaleName)[] WeightedCriteria =
+    [
+        ("Strategic Alignment", "SA", 60m, null),
+        ("ROI Potential", "ROI", 40m, null)
+    ];
+
+    private static readonly (string Name, string Token, string Formula, bool IsPrimary)[] WeightedOutputs =
+    [
+        ("Weighted Score", "Score", "(SA * 60 + ROI * 40) / 100", true)
+    ];
+
+    private ScoringModel CreateWsjfModel()
+        => _faker.AsProposedWith(DefaultScales, WsjfCriteria, WsjfOutputs);
+
+    #region Create
+
+    [Fact]
+    public void Create_ShouldCreateProposedModelWithoutChildren()
+    {
+        var model = ScoringModel.Create("WSJF", "Weighted shortest job first.");
+
+        model.Should().NotBeNull();
+        model.Name.Should().Be("WSJF");
+        model.State.Should().Be(ScoringModelState.Proposed);
+        model.Criteria.Should().BeEmpty();
+        model.Scales.Should().BeEmpty();
+        model.Outputs.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Create_ShouldResolveCriterionScaleByName()
+    {
+        var model = CreateWsjfModel();
+
+        var impact = model.Scales.Single(s => s.Name == "Impact");
+        model.Criteria.Should().OnlyContain(c => c.ScaleId == impact.Id);
+        impact.Levels.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void Create_ShouldDefaultFirstOutputToPrimary_WhenNoneFlagged()
+    {
+        var model = ScoringModel.Create(
+            "M", "d",
+            outputs: [("A", "A", "1", false), ("B", "B", "2", false)]);
+
+        model.Outputs.Count(o => o.IsPrimary).Should().Be(1);
+        model.Outputs.OrderBy(o => o.Order).First().IsPrimary.Should().BeTrue();
+    }
+
+    #endregion Create
+
+    #region Activate
+
+    [Fact]
+    public void Activate_ShouldSucceed_ForValidWsjfModel()
+    {
+        var model = CreateWsjfModel();
+
+        var result = model.Activate();
+
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        model.State.Should().Be(ScoringModelState.Active);
+    }
+
+    [Fact]
+    public void Activate_ShouldSucceed_WhenCriteriaHaveNoScale()
+    {
+        // Weighted model: no scales, criteria use free numeric entry.
+        var model = _faker.AsProposedWith([], WeightedCriteria, WeightedOutputs);
+
+        var result = model.Activate();
+
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+    }
+
+    [Fact]
+    public void Activate_ShouldFail_WhenReferencedScaleHasFewerThanTwoLevels()
+    {
+        var model = _faker.AsProposedWith(
+            [("Skimpy", [("Only", 1m)])],
+            [("A", "A", null, "Skimpy"), ("B", "B", null, "Skimpy")],
+            [("Out", "Out", "A + B", true)]);
+
+        var result = model.Activate();
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("at least two rating levels");
+    }
+
+    [Fact]
+    public void Activate_ShouldFail_WhenNoOutputs()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, WsjfCriteria, []);
+
+        var result = model.Activate();
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("at least one output");
+    }
+
+    [Fact]
+    public void Activate_ShouldFail_WhenNoCriteria()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, [], []);
+
+        var result = model.Activate();
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("at least one criterion");
+    }
+
+    [Fact]
+    public void Activate_ShouldSucceed_WithSingleCriterion()
+    {
+        var model = _faker.AsProposedWith(
+            DefaultScales,
+            [("Only", "X", null, "Impact")],
+            [("Out", "Y", "X", true)]);
+
+        var result = model.Activate();
+
+        result.IsSuccess.Should().BeTrue();
+        model.State.Should().Be(ScoringModelState.Active);
+    }
+
+    #endregion Activate
+
+    #region Scales
+
+    [Fact]
+    public void AddScale_ShouldFail_WhenDuplicateName()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, [], []);
+
+        var result = model.AddScale("Impact");
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("already exists");
+    }
+
+    [Fact]
+    public void RemoveScale_ShouldFail_WhenReferencedByCriterion()
+    {
+        var model = CreateWsjfModel();
+        var impact = model.Scales.Single(s => s.Name == "Impact");
+
+        var result = model.RemoveScale(impact.Id);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("referenced");
+    }
+
+    [Fact]
+    public void RemoveScale_ShouldSucceed_WhenUnreferenced()
+    {
+        var model = _faker.AsProposedWith(
+            [("Impact", [("High", 8m), ("Low", 1m)]), ("Unused", [("A", 1m), ("B", 2m)])],
+            [("A", "A", null, "Impact"), ("B", "B", null, "Impact")],
+            [("Out", "Out", "A + B", true)]);
+        var unused = model.Scales.Single(s => s.Name == "Unused");
+
+        var result = model.RemoveScale(unused.Id);
+
+        result.IsSuccess.Should().BeTrue();
+        model.Scales.Should().ContainSingle();
+    }
+
+    [Fact]
+    public void AddCriterion_ShouldFail_WhenScaleNotInModel()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, [], []);
+
+        var result = model.AddCriterion("X", "X", null, null, Guid.NewGuid());
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("does not belong to this model");
+    }
+
+    #endregion Scales
+
+    #region Editing gated by state
+
+    [Fact]
+    public void AddOutput_ShouldFail_WhenNotProposed()
+    {
+        var model = _faker.AsActiveWith(DefaultScales, WsjfCriteria, WsjfOutputs);
+
+        var result = model.AddOutput("Extra", "E", "BV", false);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanBeDeleted_ShouldBeTrue_OnlyWhenProposed()
+    {
+        var model = CreateWsjfModel();
+        model.CanBeDeleted().Should().BeTrue();
+
+        model.Activate();
+        model.CanBeDeleted().Should().BeFalse();
+    }
+
+    #endregion Editing gated by state
+
+    #region Outputs
+
+    [Fact]
+    public void AddOutput_ShouldFail_WhenFormulaReferencesUnknownToken()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, WsjfCriteria, []);
+
+        var result = model.AddOutput("Bad", "B", "BV + NOPE", true);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("unknown token");
+    }
+
+    [Fact]
+    public void AddOutput_ShouldRejectFunctionCalls()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, WsjfCriteria, []);
+
+        var result = model.AddOutput("Bad", "B", "Sin(BV)", true);
+
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddOutput_ShouldFail_WhenTokenCollidesWithCriterion()
+    {
+        var model = _faker.AsProposedWith(DefaultScales, WsjfCriteria, []);
+
+        var result = model.AddOutput("Dup", "BV", "BV + 1", true);
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("already used");
+    }
+
+    [Fact]
+    public void RemoveOutput_ShouldPromoteFirstRemaining_WhenPrimaryRemoved()
+    {
+        var model = CreateWsjfModel(); // CoD (not primary), WSJF (primary)
+        var primary = model.Outputs.Single(o => o.IsPrimary);
+
+        model.RemoveOutput(primary.Id);
+
+        model.Outputs.Count(o => o.IsPrimary).Should().Be(1);
+        model.Outputs.Single(o => o.IsPrimary).Token.Should().Be("CoD");
+    }
+
+    #endregion Outputs
+
+    #region CalculateScore
+
+    [Fact]
+    public void CalculateScore_ShouldComputeWsjfChain_AndReturnAllOutputs()
+    {
+        var model = CreateWsjfModel();
+        var bv = model.Criteria.Single(c => c.Token == "BV");
+        var tc = model.Criteria.Single(c => c.Token == "TC");
+        var rr = model.Criteria.Single(c => c.Token == "RR");
+        var js = model.Criteria.Single(c => c.Token == "JS");
+
+        // CoD = 8 + 5 + 3 = 16 ; WSJF = 16 / 5 = 3.2
+        var result = model.CalculateScore(new Dictionary<Guid, decimal>
+        {
+            [bv.Id] = 8m,
+            [tc.Id] = 5m,
+            [rr.Id] = 3m,
+            [js.Id] = 5m
+        });
+
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        result.Value.OutputValues["CoD"].Should().Be(16m);
+        result.Value.OutputValues["WSJF"].Should().Be(3.2m);
+        result.Value.PrimaryValue.Should().Be(3.2m);
+    }
+
+    [Fact]
+    public void CalculateScore_ShouldMatchWeightedSum_Regression()
+    {
+        var model = _faker.AsProposedWith([], WeightedCriteria, WeightedOutputs);
+        var sa = model.Criteria.Single(c => c.Token == "SA");
+        var roi = model.Criteria.Single(c => c.Token == "ROI");
+
+        // (5*60 + 2*40) / 100 = (300 + 80)/100 = 3.8
+        var result = model.CalculateScore(new Dictionary<Guid, decimal>
+        {
+            [sa.Id] = 5m,
+            [roi.Id] = 2m
+        });
+
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        result.Value.PrimaryValue.Should().Be(3.8m);
+    }
+
+    [Fact]
+    public void CalculateScore_ShouldFail_WhenCriterionUnrated()
+    {
+        var model = CreateWsjfModel();
+        var bv = model.Criteria.Single(c => c.Token == "BV");
+
+        var result = model.CalculateScore(new Dictionary<Guid, decimal> { [bv.Id] = 8m });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("has not been rated");
+    }
+
+    [Fact]
+    public void CalculateScore_ShouldFail_WhenDivisionByZero()
+    {
+        var model = CreateWsjfModel();
+        var bv = model.Criteria.Single(c => c.Token == "BV");
+        var tc = model.Criteria.Single(c => c.Token == "TC");
+        var rr = model.Criteria.Single(c => c.Token == "RR");
+        var js = model.Criteria.Single(c => c.Token == "JS");
+
+        var result = model.CalculateScore(new Dictionary<Guid, decimal>
+        {
+            [bv.Id] = 8m,
+            [tc.Id] = 5m,
+            [rr.Id] = 3m,
+            [js.Id] = 0m // JS = 0 → WSJF divides by zero
+        });
+
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("divided by zero");
+    }
+
+    #endregion CalculateScore
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260605002707_AddScoringModels.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260605002707_AddScoringModels.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260605002707_AddScoringModels")]
+    partial class AddScoringModels
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260605002707_AddScoringModels.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260605002707_AddScoringModels.cs
@@ -1,0 +1,218 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddScoringModels : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.EnsureSchema(
+                name: "App");
+
+            migrationBuilder.CreateTable(
+                name: "ScoringModels",
+                schema: "App",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Key = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("SqlServer:Identity", "1, 1"),
+                    Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    State = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    SystemCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemCreatedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    SystemLastModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemLastModifiedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoringModels", x => x.Id);
+                    table.UniqueConstraint("AK_ScoringModels_Key", x => x.Key);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ScoringModelOutputs",
+                schema: "App",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ScoringModelId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Token = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Formula = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: false),
+                    IsPrimary = table.Column<bool>(type: "bit", nullable: false),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    SystemCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemCreatedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    SystemLastModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemLastModifiedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoringModelOutputs", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScoringModelOutputs_ScoringModels_ScoringModelId",
+                        column: x => x.ScoringModelId,
+                        principalSchema: "App",
+                        principalTable: "ScoringModels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ScoringScales",
+                schema: "App",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ScoringModelId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    SystemCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemCreatedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    SystemLastModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemLastModifiedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoringScales", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScoringScales_ScoringModels_ScoringModelId",
+                        column: x => x.ScoringModelId,
+                        principalSchema: "App",
+                        principalTable: "ScoringModels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ScoringModelCriteria",
+                schema: "App",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ScoringModelId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Name = table.Column<string>(type: "nvarchar(128)", maxLength: 128, nullable: false),
+                    Token = table.Column<string>(type: "varchar(32)", maxLength: 32, nullable: false),
+                    Description = table.Column<string>(type: "nvarchar(1024)", maxLength: 1024, nullable: true),
+                    Weight = table.Column<decimal>(type: "decimal(5,2)", nullable: true),
+                    ScaleId = table.Column<Guid>(type: "uniqueidentifier", nullable: true),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    SystemCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemCreatedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    SystemLastModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemLastModifiedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoringModelCriteria", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScoringModelCriteria_ScoringModels_ScoringModelId",
+                        column: x => x.ScoringModelId,
+                        principalSchema: "App",
+                        principalTable: "ScoringModels",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ScoringModelCriteria_ScoringScales_ScaleId",
+                        column: x => x.ScaleId,
+                        principalSchema: "App",
+                        principalTable: "ScoringScales",
+                        principalColumn: "Id");
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ScoringRatingLevels",
+                schema: "App",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    ScoringScaleId = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    Label = table.Column<string>(type: "nvarchar(64)", maxLength: 64, nullable: false),
+                    Value = table.Column<decimal>(type: "decimal(9,4)", nullable: false),
+                    Order = table.Column<int>(type: "int", nullable: false),
+                    SystemCreated = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemCreatedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true),
+                    SystemLastModified = table.Column<DateTime>(type: "datetime2", nullable: false),
+                    SystemLastModifiedBy = table.Column<string>(type: "nvarchar(450)", maxLength: 450, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ScoringRatingLevels", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ScoringRatingLevels_ScoringScales_ScoringScaleId",
+                        column: x => x.ScoringScaleId,
+                        principalSchema: "App",
+                        principalTable: "ScoringScales",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoringModelCriteria_ScaleId",
+                schema: "App",
+                table: "ScoringModelCriteria",
+                column: "ScaleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoringModelCriteria_ScoringModelId",
+                schema: "App",
+                table: "ScoringModelCriteria",
+                column: "ScoringModelId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoringModelOutputs_ScoringModelId",
+                schema: "App",
+                table: "ScoringModelOutputs",
+                column: "ScoringModelId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoringModels_State",
+                schema: "App",
+                table: "ScoringModels",
+                column: "State");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoringRatingLevels_ScoringScaleId",
+                schema: "App",
+                table: "ScoringRatingLevels",
+                column: "ScoringScaleId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ScoringScales_ScoringModelId",
+                schema: "App",
+                table: "ScoringScales",
+                column: "ScoringModelId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ScoringModelCriteria",
+                schema: "App");
+
+            migrationBuilder.DropTable(
+                name: "ScoringModelOutputs",
+                schema: "App");
+
+            migrationBuilder.DropTable(
+                name: "ScoringRatingLevels",
+                schema: "App");
+
+            migrationBuilder.DropTable(
+                name: "ScoringScales",
+                schema: "App");
+
+            migrationBuilder.DropTable(
+                name: "ScoringModels",
+                schema: "App");
+        }
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/SchemaNames.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/SchemaNames.cs
@@ -3,6 +3,7 @@
 // These values are also used in the audit trails
 internal static class SchemaNames
 {
+    public static string App = "App";
     public static string AppIntegration = "AppIntegrations";
     public static string Auditing = "Auditing";
     public static string FeatureManagement = "FeatureManagement";

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/ScoringConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/ScoringConfiguration.cs
@@ -1,0 +1,131 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Wayd.Common.Domain.Scoring;
+using Wayd.Common.Domain.Scoring.Enums;
+using Wayd.Infrastructure.Persistence.Converters;
+
+namespace Wayd.Infrastructure.Persistence.Configuration;
+
+public class ScoringModelConfiguration : IEntityTypeConfiguration<ScoringModel>
+{
+    public void Configure(EntityTypeBuilder<ScoringModel> builder)
+    {
+        builder.ToTable("ScoringModels", SchemaNames.App);
+
+        builder.HasKey(m => m.Id);
+        builder.HasAlternateKey(m => m.Key);
+
+        builder.HasIndex(m => m.State);
+
+        builder.Property(m => m.Id).ValueGeneratedNever();
+        builder.Property(m => m.Key).ValueGeneratedOnAdd();
+        builder.Property(m => m.Name).HasMaxLength(128).IsRequired();
+        builder.Property(m => m.Description).HasMaxLength(1024).IsRequired();
+
+        builder.Property(m => m.State).IsRequired()
+            .HasConversion<EnumConverter<ScoringModelState>>()
+            .HasMaxLength(32)
+            .HasColumnType("varchar");
+
+        // Relationships
+        builder.HasMany(m => m.Criteria)
+            .WithOne()
+            .HasForeignKey(c => c.ScoringModelId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(m => m.Scales)
+            .WithOne()
+            .HasForeignKey(s => s.ScoringModelId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(m => m.Outputs)
+            .WithOne()
+            .HasForeignKey(o => o.ScoringModelId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+
+public class ScoringModelCriterionConfiguration : IEntityTypeConfiguration<ScoringModelCriterion>
+{
+    public void Configure(EntityTypeBuilder<ScoringModelCriterion> builder)
+    {
+        builder.ToTable("ScoringModelCriteria", SchemaNames.App);
+
+        builder.HasKey(c => c.Id);
+
+        builder.HasIndex(c => c.ScoringModelId);
+
+        builder.Property(c => c.Id).ValueGeneratedNever();
+        builder.Property(c => c.Name).HasMaxLength(128).IsRequired();
+        builder.Property(c => c.Token).HasMaxLength(32).HasColumnType("varchar").IsRequired();
+        builder.Property(c => c.Description).HasMaxLength(1024);
+        builder.Property(c => c.Weight).HasColumnType("decimal(5,2)");
+        builder.Property(c => c.ScaleId);
+        builder.Property(c => c.Order).IsRequired();
+
+        builder.HasIndex(c => c.ScaleId);
+
+        // A criterion may reference a scale; the aggregate guards removal of referenced scales.
+        builder.HasOne<ScoringScale>()
+            .WithMany()
+            .HasForeignKey(c => c.ScaleId)
+            .OnDelete(DeleteBehavior.NoAction);
+    }
+}
+
+public class ScoringScaleConfiguration : IEntityTypeConfiguration<ScoringScale>
+{
+    public void Configure(EntityTypeBuilder<ScoringScale> builder)
+    {
+        builder.ToTable("ScoringScales", SchemaNames.App);
+
+        builder.HasKey(s => s.Id);
+
+        builder.HasIndex(s => s.ScoringModelId);
+
+        builder.Property(s => s.Id).ValueGeneratedNever();
+        builder.Property(s => s.Name).HasMaxLength(64).IsRequired();
+        builder.Property(s => s.Order).IsRequired();
+
+        builder.HasMany(s => s.Levels)
+            .WithOne()
+            .HasForeignKey(l => l.ScoringScaleId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}
+
+public class ScoringRatingLevelConfiguration : IEntityTypeConfiguration<ScoringRatingLevel>
+{
+    public void Configure(EntityTypeBuilder<ScoringRatingLevel> builder)
+    {
+        builder.ToTable("ScoringRatingLevels", SchemaNames.App);
+
+        builder.HasKey(l => l.Id);
+
+        builder.HasIndex(l => l.ScoringScaleId);
+
+        builder.Property(l => l.Id).ValueGeneratedNever();
+        builder.Property(l => l.Label).HasMaxLength(64).IsRequired();
+        builder.Property(l => l.Value).HasColumnType("decimal(9,4)").IsRequired();
+        builder.Property(l => l.Order).IsRequired();
+    }
+}
+
+public class ScoringModelOutputConfiguration : IEntityTypeConfiguration<ScoringModelOutput>
+{
+    public void Configure(EntityTypeBuilder<ScoringModelOutput> builder)
+    {
+        builder.ToTable("ScoringModelOutputs", SchemaNames.App);
+
+        builder.HasKey(o => o.Id);
+
+        builder.HasIndex(o => o.ScoringModelId);
+
+        builder.Property(o => o.Id).ValueGeneratedNever();
+        builder.Property(o => o.Name).HasMaxLength(128).IsRequired();
+        builder.Property(o => o.Token).HasMaxLength(32).HasColumnType("varchar").IsRequired();
+        builder.Property(o => o.Formula).HasMaxLength(1024).IsRequired();
+        builder.Property(o => o.IsPrimary).IsRequired();
+        builder.Property(o => o.Order).IsRequired();
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Context/WaydDbContext.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Context/WaydDbContext.cs
@@ -18,6 +18,7 @@ using Wayd.Planning.Domain.Models.Iterations;
 using Wayd.Planning.Domain.Models.PlanningPoker;
 using Wayd.Planning.Domain.Models.Roadmaps;
 using Wayd.ProjectPortfolioManagement.Application;
+using Wayd.Common.Domain.Scoring;
 using Wayd.ProjectPortfolioManagement.Domain.Models;
 using Wayd.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 using Wayd.StrategicManagement.Application;
@@ -115,6 +116,7 @@ public class WaydDbContext : BaseDbContext, IAppIntegrationDbContext, IFeatureMa
     public DbSet<StrategicInitiative> StrategicInitiatives => Set<StrategicInitiative>();
     public DbSet<ProjectLifecycle> ProjectLifecycles => Set<ProjectLifecycle>();
     public DbSet<ProjectPhase> ProjectPhases => Set<ProjectPhase>();
+    public DbSet<ScoringModel> ScoringModels => Set<ScoringModel>();
 
     #endregion IProjectPortfolioManagementDbContext
 

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Initialization/ScoringModelSeeder.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Initialization/ScoringModelSeeder.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Infrastructure.Persistence.Initialization;
+
+public class ScoringModelSeeder : ICustomSeeder
+{
+    public async Task Initialize(WaydDbContext dbContext, IDateTimeProvider dateTimeProvider, CancellationToken cancellationToken)
+    {
+        // Initial seed only: provide a starter WSJF model when no scoring models exist yet.
+        // Once any model is present (seeded or admin-created) this seeder stays out of the way.
+        if (await dbContext.ScoringModels.AnyAsync(cancellationToken))
+            return;
+
+        dbContext.ScoringModels.Add(CreateWsjfModel());
+
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Weighted Shortest Job First (SAFe). Business Value, Time Criticality and Risk Reduction /
+    /// Opportunity Enablement are rated on a shared relative scale and summed into the Cost of Delay;
+    /// Job Size is rated on the same scale, and WSJF = Cost of Delay / Job Size is the primary score.
+    /// Seeded in the Proposed state so an admin can review and activate it.
+    /// </summary>
+    private static ScoringModel CreateWsjfModel()
+    {
+        // Modified-Fibonacci relative scale, the conventional choice for WSJF inputs.
+        (string Label, decimal Value)[] relativeScale =
+        [
+            ("1", 1m),
+            ("2", 2m),
+            ("3", 3m),
+            ("5", 5m),
+            ("8", 8m),
+            ("13", 13m),
+            ("20", 20m),
+        ];
+
+        return ScoringModel.Create(
+            "WSJF",
+            "Weighted Shortest Job First (SAFe). Prioritizes by Cost of Delay relative to Job Size; "
+                + "the highest WSJF score is the most economically valuable to deliver next.",
+            scales:
+            [
+                ("Relative (Fibonacci)", relativeScale),
+            ],
+            criteria:
+            [
+                ("Business Value", "BV", "Value to the business or customer of delivering this item.", null, "Relative (Fibonacci)"),
+                ("Time Criticality", "TC", "How the value decays over time, or any fixed deadline.", null, "Relative (Fibonacci)"),
+                ("Risk Reduction / Opportunity Enablement", "RR", "Risk this reduces or future opportunity it unlocks.", null, "Relative (Fibonacci)"),
+                ("Job Size", "JS", "Relative effort or duration to deliver this item.", null, "Relative (Fibonacci)"),
+            ],
+            outputs:
+            [
+                ("Cost of Delay", "CoD", "BV + TC + RR", false),
+                ("WSJF", "WSJF", "CoD / JS", true),
+            ]);
+    }
+}

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Infrastructure/FakeAppIntegrationDbContext.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Infrastructure/FakeAppIntegrationDbContext.cs
@@ -8,6 +8,7 @@ using Wayd.AppIntegration.Domain.Models.Entra;
 using Wayd.AppIntegration.Domain.Models.Workday;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Tests.Shared.Infrastructure;
 
 namespace Wayd.AppIntegration.Application.Tests.Infrastructure;
@@ -32,6 +33,7 @@ public class FakeAppIntegrationDbContext : IAppIntegrationDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Connection> Connections => _connections.AsDbSet();
@@ -45,6 +47,7 @@ public class FakeAppIntegrationDbContext : IAppIntegrationDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Services/Wayd.Goals/tests/Wayd.Goals.Application.Tests/Infrastructure/FakeGoalsDbContext.cs
+++ b/Wayd.Services/Wayd.Goals/tests/Wayd.Goals.Application.Tests/Infrastructure/FakeGoalsDbContext.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Common.Domain.Models.Goals;
 using Wayd.Goals.Application.Persistence;
 using Wayd.Tests.Shared.Infrastructure;
@@ -24,6 +25,7 @@ public class FakeGoalsDbContext : IGoalsDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Objective> Objectives => _objectives.AsDbSet();
@@ -32,6 +34,7 @@ public class FakeGoalsDbContext : IGoalsDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Services/Wayd.Links/tests/Wayd.Links.Tests/Infrastructure/FakeLinksDbContext.cs
+++ b/Wayd.Services/Wayd.Links/tests/Wayd.Links.Tests/Infrastructure/FakeLinksDbContext.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Links.Models;
 using Wayd.Tests.Shared.Infrastructure;
 
@@ -23,6 +24,7 @@ public class FakeLinksDbContext : ILinksDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Link> Links => _links.AsDbSet();
@@ -31,6 +33,7 @@ public class FakeLinksDbContext : ILinksDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.Application.Tests/Infrastructure/FakeOrganizationDbContext.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.Application.Tests/Infrastructure/FakeOrganizationDbContext.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Organization.Application.Persistence;
 using Wayd.Organization.Application.Teams.Models;
 using Wayd.Organization.Domain.Models;
@@ -30,6 +31,7 @@ public class FakeOrganizationDbContext : IOrganizationDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<BaseTeam> BaseTeams => _baseTeams.AsDbSet();
@@ -43,6 +45,7 @@ public class FakeOrganizationDbContext : IOrganizationDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Infrastructure/FakePlanningDbContext.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Infrastructure/FakePlanningDbContext.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Planning.Application.Persistence;
 using Wayd.Planning.Domain.Models;
 using Wayd.Planning.Domain.Models.Iterations;
@@ -36,6 +37,7 @@ public class FakePlanningDbContext : IPlanningDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Iteration> Iterations => _iterations.AsDbSet();
@@ -53,6 +55,7 @@ public class FakePlanningDbContext : IPlanningDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Services/Wayd.ProjectPortfolioManagement/tests/Wayd.ProjectPortfolioManagement.Application.Tests/Infrastructure/FakeProjectPortfolioManagementDbContext.cs
+++ b/Wayd.Services/Wayd.ProjectPortfolioManagement/tests/Wayd.ProjectPortfolioManagement.Application.Tests/Infrastructure/FakeProjectPortfolioManagementDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.ProjectPortfolioManagement.Domain.Models;
 using Wayd.ProjectPortfolioManagement.Domain.Models.StrategicInitiatives;
 using Wayd.Tests.Shared.Infrastructure;
@@ -28,6 +29,7 @@ public class FakeProjectPortfolioManagementDbContext : IProjectPortfolioManageme
     private readonly List<StrategicInitiative> _strategicInitiatives = [];
     private readonly List<ProjectLifecycle> _projectLifecycles = [];
     private readonly List<ProjectPhase> _projectPhases = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // Common domain entities
     private readonly List<Employee> _employees = [];
@@ -49,6 +51,7 @@ public class FakeProjectPortfolioManagementDbContext : IProjectPortfolioManageme
     public DbSet<StrategicInitiative> StrategicInitiatives => _strategicInitiatives.AsDbSet();
     public DbSet<ProjectLifecycle> ProjectLifecycles => _projectLifecycles.AsDbSet();
     public DbSet<ProjectPhase> ProjectPhases => _projectPhases.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
     public DbSet<Employee> Employees => _employees.AsDbSet();
     public DbSet<ExternalEmployeeBlacklistItem> ExternalEmployeeBlacklistItems => _externalEmployeeBlacklistItems.AsDbSet();
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
@@ -138,6 +141,10 @@ public class FakeProjectPortfolioManagementDbContext : IProjectPortfolioManageme
     public void AddProjectPhase(ProjectPhase phase) => _projectPhases.Add(phase);
     public void AddProjectPhases(IEnumerable<ProjectPhase> phases) => _projectPhases.AddRange(phases);
 
+    // ScoringModel
+    public void AddScoringModel(ScoringModel model) => _scoringModels.Add(model);
+    public void AddScoringModels(IEnumerable<ScoringModel> models) => _scoringModels.AddRange(models);
+
     // Employee
     public void AddEmployee(Employee employee) => _employees.Add(employee);
     public void AddEmployees(IEnumerable<Employee> employees) => _employees.AddRange(employees);
@@ -160,6 +167,7 @@ public class FakeProjectPortfolioManagementDbContext : IProjectPortfolioManageme
         _strategicInitiatives.Clear();
         _projectLifecycles.Clear();
         _projectPhases.Clear();
+        _scoringModels.Clear();
         _employees.Clear();
         _externalEmployeeBlacklistItems.Clear();
         _personalAccessTokens.Clear();

--- a/Wayd.Services/Wayd.StrategicManagement/tests/Wayd.StrategicManagement.Application.Tests/Infrastructure/FakeStrategicManagementDbContext.cs
+++ b/Wayd.Services/Wayd.StrategicManagement/tests/Wayd.StrategicManagement.Application.Tests/Infrastructure/FakeStrategicManagementDbContext.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.StrategicManagement.Domain.Models;
 using Wayd.Tests.Shared.Infrastructure;
 
@@ -25,6 +26,7 @@ public class FakeStrategicManagementDbContext : IStrategicManagementDbContext, I
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Strategy> Strategies => _strategies.AsDbSet();
@@ -35,6 +37,7 @@ public class FakeStrategicManagementDbContext : IStrategicManagementDbContext, I
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Infrastructure/FakeWorkDbContext.cs
+++ b/Wayd.Services/Wayd.Work/tests/Wayd.Work.Application.Tests/Infrastructure/FakeWorkDbContext.cs
@@ -1,8 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Wayd.Common.Domain.Employees;
 using Wayd.Common.Domain.Identity;
+using Wayd.Common.Domain.Scoring;
 using Wayd.Tests.Shared.Infrastructure;
 using Wayd.Work.Application.Persistence;
 using Wayd.Work.Domain.Models;
@@ -36,6 +37,7 @@ public class FakeWorkDbContext : IWorkDbContext, IDisposable
     private readonly List<OidcProvider> _oidcProviders = [];
     private readonly List<PersonalAccessToken> _personalAccessTokens = [];
     private readonly List<User> _waydUsers = [];
+    private readonly List<ScoringModel> _scoringModels = [];
 
     // DbSet properties
     public DbSet<Workspace> Workspaces => _workspaces.AsDbSet();
@@ -56,6 +58,7 @@ public class FakeWorkDbContext : IWorkDbContext, IDisposable
     public DbSet<OidcProvider> OidcProviders => _oidcProviders.AsDbSet();
     public DbSet<PersonalAccessToken> PersonalAccessTokens => _personalAccessTokens.AsDbSet();
     public DbSet<User> WaydUsers => _waydUsers.AsDbSet();
+    public DbSet<ScoringModel> ScoringModels => _scoringModels.AsDbSet();
 
     // ChangeTracker - we can't create a real one, so we return null and the handler uses defensive coding (_workDbContext.ChangeTracker?.Clear())
     public ChangeTracker ChangeTracker => null!;

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/ScoringModelsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/ScoringModelsController.cs
@@ -113,6 +113,21 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
             : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
+    [HttpPost("{id}/evaluate")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Evaluate (test) a scoring model against supplied criterion values.", "")]
+    [ProducesResponseType(typeof(ScoringModelEvaluationDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult<ScoringModelEvaluationDto>> Evaluate(Guid id, [FromBody] EvaluateScoringModelRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToQuery(id), cancellationToken);
+
+        return result.IsSuccess
+            ? Ok(result.Value)
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
     #region Criteria
 
     [HttpPost("{id}/criteria")]

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/ScoringModelsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/ScoringModelsController.cs
@@ -1,0 +1,359 @@
+﻿using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Application.Scoring.ScoringModels.Dtos;
+using Wayd.Common.Application.Scoring.ScoringModels.Queries;
+using Wayd.Common.Domain.Scoring.Enums;
+using Wayd.Web.Api.Extensions;
+using Wayd.Web.Api.Models.Admin.ScoringModels;
+
+namespace Wayd.Web.Api.Controllers.Admin;
+
+[Route("api/scoring-models")]
+[ApiVersionNeutral]
+[ApiController]
+public class ScoringModelsController(ILogger<ScoringModelsController> logger, ISender sender) : ControllerBase
+{
+    private readonly ILogger<ScoringModelsController> _logger = logger;
+    private readonly ISender _sender = sender;
+
+    [HttpGet]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Get a list of scoring models.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult<IEnumerable<ScoringModelListDto>>> GetScoringModels([FromQuery] ScoringModelState? state, CancellationToken cancellationToken)
+    {
+        var models = await _sender.Send(new GetScoringModelsQuery(state), cancellationToken);
+
+        return Ok(models);
+    }
+
+    [HttpGet("{idOrKey}")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Get scoring model details.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<ScoringModelDetailsDto>> GetScoringModel(string idOrKey, CancellationToken cancellationToken)
+    {
+        var model = await _sender.Send(new GetScoringModelQuery(idOrKey), cancellationToken);
+
+        return model is not null
+            ? Ok(model)
+            : NotFound();
+    }
+
+    [HttpPost]
+    [MustHavePermission(ApplicationAction.Create, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Create a scoring model.", "")]
+    [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
+    public async Task<ActionResult<Guid>> Create([FromBody] CreateScoringModelRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToCreateScoringModelCommand(), cancellationToken);
+
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = result.Value }, result.Value)
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPut("{id}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Update a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> Update(Guid id, [FromBody] UpdateScoringModelRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToUpdateScoringModelCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpDelete("{id}")]
+    [MustHavePermission(ApplicationAction.Delete, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Delete a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new DeleteScoringModelCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPost("{id}/activate")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Activate a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new ActivateScoringModelCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPost("{id}/archive")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Archive a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new ArchiveScoringModelCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    #region Criteria
+
+    [HttpPost("{id}/criteria")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Add a criterion to a scoring model.", "")]
+    [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
+    public async Task<ActionResult<Guid>> AddCriterion(Guid id, [FromBody] ScoringModelCriterionRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPut("{id}/criteria/{criterionId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Update a criterion in a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> UpdateCriterion(Guid id, Guid criterionId, [FromBody] ScoringModelCriterionRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToUpdateCommand(id, criterionId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpDelete("{id}/criteria/{criterionId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Remove a criterion from a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> RemoveCriterion(Guid id, Guid criterionId, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new RemoveScoringModelCriterionCommand(id, criterionId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPost("{id}/criteria/reorder")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Reorder criteria in a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> ReorderCriteria(Guid id, [FromBody] ReorderScoringModelCriteriaRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToReorderScoringModelCriteriaCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    #endregion Criteria
+
+    #region Scales
+
+    [HttpPost("{id}/scales")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Add a rating scale to a scoring model.", "")]
+    [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
+    public async Task<ActionResult<Guid>> AddScale(Guid id, [FromBody] ScoringScaleRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPut("{id}/scales/{scaleId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Rename a rating scale in a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> UpdateScale(Guid id, Guid scaleId, [FromBody] ScoringScaleRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToUpdateCommand(id, scaleId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpDelete("{id}/scales/{scaleId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Remove a rating scale from a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> RemoveScale(Guid id, Guid scaleId, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new RemoveScoringScaleCommand(id, scaleId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPost("{id}/scales/reorder")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Reorder rating scales in a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> ReorderScales(Guid id, [FromBody] ReorderScoringScalesRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToReorderScoringScalesCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    #endregion Scales
+
+    #region Scale Levels
+
+    [HttpPost("{id}/scales/{scaleId}/levels")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Add a rating level to a scale.", "")]
+    [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
+    public async Task<ActionResult<Guid>> AddScaleLevel(Guid id, Guid scaleId, [FromBody] ScoringScaleLevelRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToAddCommand(id, scaleId), cancellationToken);
+
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPut("{id}/scales/{scaleId}/levels/{levelId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Update a rating level on a scale.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> UpdateScaleLevel(Guid id, Guid scaleId, Guid levelId, [FromBody] ScoringScaleLevelRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToUpdateCommand(id, scaleId, levelId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpDelete("{id}/scales/{scaleId}/levels/{levelId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Remove a rating level from a scale.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> RemoveScaleLevel(Guid id, Guid scaleId, Guid levelId, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new RemoveScoringScaleLevelCommand(id, scaleId, levelId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPost("{id}/scales/{scaleId}/levels/reorder")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Reorder rating levels on a scale.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> ReorderScaleLevels(Guid id, Guid scaleId, [FromBody] ReorderScoringScaleLevelsRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToReorderScoringScaleLevelsCommand(id, scaleId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    #endregion Scale Levels
+
+    #region Outputs
+
+    [HttpPost("{id}/outputs")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Add an output formula to a scoring model.", "")]
+    [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
+    public async Task<ActionResult<Guid>> AddOutput(Guid id, [FromBody] ScoringModelOutputRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPut("{id}/outputs/{outputId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Update an output formula in a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> UpdateOutput(Guid id, Guid outputId, [FromBody] ScoringModelOutputRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToUpdateCommand(id, outputId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpDelete("{id}/outputs/{outputId}")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Remove an output formula from a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<ActionResult> RemoveOutput(Guid id, Guid outputId, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(new RemoveScoringModelOutputCommand(id, outputId), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    [HttpPost("{id}/outputs/reorder")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.ScoringModels)]
+    [OpenApiOperation("Reorder output formulas in a scoring model.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> ReorderOutputs(Guid id, [FromBody] ReorderScoringModelOutputsRequest request, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(request.ToReorderScoringModelOutputsCommand(id), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
+    #endregion Outputs
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/CreateScoringModelRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/CreateScoringModelRequest.cs
@@ -1,0 +1,163 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record CreateScoringModelRequest
+{
+    /// <summary>
+    /// The name of the scoring model.
+    /// </summary>
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// The description of the scoring model.
+    /// </summary>
+    public string Description { get; set; } = default!;
+
+    /// <summary>
+    /// Optional initial rating scales for the scoring model.
+    /// </summary>
+    public List<ScaleInput>? Scales { get; set; }
+
+    /// <summary>
+    /// Optional initial criteria (rated inputs) for the scoring model.
+    /// </summary>
+    public List<CriterionInput>? Criteria { get; set; }
+
+    /// <summary>
+    /// Optional initial output formulas for the scoring model.
+    /// </summary>
+    public List<OutputInput>? Outputs { get; set; }
+
+    public sealed record ScaleInput
+    {
+        /// <summary>The name of the scale (e.g., "Fibonacci", "Impact").</summary>
+        public string Name { get; set; } = default!;
+
+        /// <summary>The ordered rating levels of the scale.</summary>
+        public List<ScaleLevelInput> Levels { get; set; } = [];
+    }
+
+    public sealed record ScaleLevelInput
+    {
+        /// <summary>The label for the rating level (e.g., "Very High").</summary>
+        public string Label { get; set; } = default!;
+
+        /// <summary>The numeric value a chosen rating contributes.</summary>
+        public decimal Value { get; set; }
+    }
+
+    public sealed record CriterionInput
+    {
+        /// <summary>The name of the criterion.</summary>
+        public string Name { get; set; } = default!;
+
+        /// <summary>The token used to reference this criterion in formulas (e.g., "BV").</summary>
+        public string Token { get; set; } = default!;
+
+        /// <summary>An optional description of the criterion.</summary>
+        public string? Description { get; set; }
+
+        /// <summary>An optional, non-authoritative weight (used only by the weighted-formula scaffolder).</summary>
+        public decimal? Weight { get; set; }
+
+        /// <summary>The name of a scale (from Scales) this criterion is rated against, or null for free numeric entry.</summary>
+        public string? ScaleName { get; set; }
+    }
+
+    public sealed record OutputInput
+    {
+        /// <summary>The name of the output (e.g., "Cost of Delay", "WSJF").</summary>
+        public string Name { get; set; } = default!;
+
+        /// <summary>The token other output formulas can reference (e.g., "CoD").</summary>
+        public string Token { get; set; } = default!;
+
+        /// <summary>The arithmetic formula over criterion and earlier-output tokens.</summary>
+        public string Formula { get; set; } = default!;
+
+        /// <summary>Whether this output is the model's primary score.</summary>
+        public bool IsPrimary { get; set; }
+    }
+
+    public CreateScoringModelCommand ToCreateScoringModelCommand()
+    {
+        var scales = Scales?
+            .Select(s => new CreateScoringModelCommand.ScaleInput(
+                s.Name,
+                s.Levels.Select(l => new CreateScoringModelCommand.ScaleLevelInput(l.Label, l.Value)).ToList()))
+            .ToList();
+
+        var criteria = Criteria?
+            .Select(c => new CreateScoringModelCommand.CriterionInput(c.Name, c.Token, c.Description, c.Weight, c.ScaleName))
+            .ToList();
+
+        var outputs = Outputs?
+            .Select(o => new CreateScoringModelCommand.OutputInput(o.Name, o.Token, o.Formula, o.IsPrimary))
+            .ToList();
+
+        return new CreateScoringModelCommand(Name, Description, scales, criteria, outputs);
+    }
+}
+
+public sealed class CreateScoringModelRequestValidator : AbstractValidator<CreateScoringModelRequest>
+{
+    public CreateScoringModelRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Description)
+            .NotEmpty()
+            .MaximumLength(1024);
+
+        RuleForEach(x => x.Criteria).ChildRules(criterion =>
+        {
+            criterion.RuleFor(c => c.Name)
+                .NotEmpty()
+                .MaximumLength(128);
+
+            criterion.RuleFor(c => c.Token)
+                .NotEmpty()
+                .MaximumLength(ScoringToken.MaxLength)
+                .Must(ScoringToken.IsValid)
+                .WithMessage("'{PropertyValue}' is not a valid token.");
+
+            criterion.RuleFor(c => c.Description)
+                .MaximumLength(1024);
+        });
+
+        RuleForEach(x => x.Scales).ChildRules(scale =>
+        {
+            scale.RuleFor(s => s.Name)
+                .NotEmpty()
+                .MaximumLength(64);
+
+            scale.RuleForEach(s => s.Levels).ChildRules(level =>
+            {
+                level.RuleFor(l => l.Label)
+                    .NotEmpty()
+                    .MaximumLength(64);
+            });
+        });
+
+        RuleForEach(x => x.Outputs).ChildRules(output =>
+        {
+            output.RuleFor(o => o.Name)
+                .NotEmpty()
+                .MaximumLength(128);
+
+            output.RuleFor(o => o.Token)
+                .NotEmpty()
+                .MaximumLength(ScoringToken.MaxLength)
+                .Must(ScoringToken.IsValid)
+                .WithMessage("'{PropertyValue}' is not a valid token.");
+
+            output.RuleFor(o => o.Formula)
+                .NotEmpty()
+                .MaximumLength(ScoringFormulaEvaluator.MaxFormulaLength);
+        });
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/EvaluateScoringModelRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/EvaluateScoringModelRequest.cs
@@ -1,0 +1,39 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Queries;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+/// <summary>
+/// A request to evaluate (test) a scoring model against a set of supplied criterion values, returning
+/// the resulting output values without persisting anything.
+/// </summary>
+public sealed record EvaluateScoringModelRequest
+{
+    /// <summary>
+    /// The value to plug in for each criterion, keyed by criterion id.
+    /// </summary>
+    public List<CriterionValue> CriterionValues { get; set; } = [];
+
+    public EvaluateScoringModelQuery ToQuery(Guid scoringModelId)
+    {
+        return new EvaluateScoringModelQuery(
+            scoringModelId,
+            CriterionValues
+                .Select(cv => new EvaluateScoringModelQuery.CriterionValue(cv.CriterionId, cv.Value))
+                .ToList());
+    }
+
+    public sealed record CriterionValue
+    {
+        public Guid CriterionId { get; set; }
+        public decimal Value { get; set; }
+    }
+}
+
+public sealed class EvaluateScoringModelRequestValidator : AbstractValidator<EvaluateScoringModelRequest>
+{
+    public EvaluateScoringModelRequestValidator()
+    {
+        RuleForEach(x => x.CriterionValues).ChildRules(cv =>
+            cv.RuleFor(c => c.CriterionId).NotEmpty());
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringModelCriteriaRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringModelCriteriaRequest.cs
@@ -1,0 +1,25 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ReorderScoringModelCriteriaRequest
+{
+    /// <summary>
+    /// The ordered list of criterion IDs representing the desired order.
+    /// </summary>
+    public List<Guid> OrderedCriterionIds { get; set; } = [];
+
+    public ReorderScoringModelCriteriaCommand ToReorderScoringModelCriteriaCommand(Guid scoringModelId)
+    {
+        return new ReorderScoringModelCriteriaCommand(scoringModelId, OrderedCriterionIds);
+    }
+}
+
+public sealed class ReorderScoringModelCriteriaRequestValidator : AbstractValidator<ReorderScoringModelCriteriaRequest>
+{
+    public ReorderScoringModelCriteriaRequestValidator()
+    {
+        RuleFor(x => x.OrderedCriterionIds)
+            .NotEmpty();
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringModelOutputsRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringModelOutputsRequest.cs
@@ -1,0 +1,25 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ReorderScoringModelOutputsRequest
+{
+    /// <summary>
+    /// The ordered list of output IDs representing the desired evaluation order.
+    /// </summary>
+    public List<Guid> OrderedOutputIds { get; set; } = [];
+
+    public ReorderScoringModelOutputsCommand ToReorderScoringModelOutputsCommand(Guid scoringModelId)
+    {
+        return new ReorderScoringModelOutputsCommand(scoringModelId, OrderedOutputIds);
+    }
+}
+
+public sealed class ReorderScoringModelOutputsRequestValidator : AbstractValidator<ReorderScoringModelOutputsRequest>
+{
+    public ReorderScoringModelOutputsRequestValidator()
+    {
+        RuleFor(x => x.OrderedOutputIds)
+            .NotEmpty();
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringScaleLevelsRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringScaleLevelsRequest.cs
@@ -1,0 +1,25 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ReorderScoringScaleLevelsRequest
+{
+    /// <summary>
+    /// The ordered list of rating level IDs representing the desired order.
+    /// </summary>
+    public List<Guid> OrderedLevelIds { get; set; } = [];
+
+    public ReorderScoringScaleLevelsCommand ToReorderScoringScaleLevelsCommand(Guid scoringModelId, Guid scaleId)
+    {
+        return new ReorderScoringScaleLevelsCommand(scoringModelId, scaleId, OrderedLevelIds);
+    }
+}
+
+public sealed class ReorderScoringScaleLevelsRequestValidator : AbstractValidator<ReorderScoringScaleLevelsRequest>
+{
+    public ReorderScoringScaleLevelsRequestValidator()
+    {
+        RuleFor(x => x.OrderedLevelIds)
+            .NotEmpty();
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringScalesRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ReorderScoringScalesRequest.cs
@@ -1,0 +1,25 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ReorderScoringScalesRequest
+{
+    /// <summary>
+    /// The ordered list of scale IDs representing the desired order.
+    /// </summary>
+    public List<Guid> OrderedScaleIds { get; set; } = [];
+
+    public ReorderScoringScalesCommand ToReorderScoringScalesCommand(Guid scoringModelId)
+    {
+        return new ReorderScoringScalesCommand(scoringModelId, OrderedScaleIds);
+    }
+}
+
+public sealed class ReorderScoringScalesRequestValidator : AbstractValidator<ReorderScoringScalesRequest>
+{
+    public ReorderScoringScalesRequestValidator()
+    {
+        RuleFor(x => x.OrderedScaleIds)
+            .NotEmpty();
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringModelCriterionRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringModelCriterionRequest.cs
@@ -1,0 +1,61 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ScoringModelCriterionRequest
+{
+    /// <summary>
+    /// The name of the criterion.
+    /// </summary>
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// The token used to reference this criterion in output formulas (e.g., "BV").
+    /// </summary>
+    public string Token { get; set; } = default!;
+
+    /// <summary>
+    /// An optional description of the criterion.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// An optional, non-authoritative weight (used only by the weighted-formula scaffolder).
+    /// </summary>
+    public decimal? Weight { get; set; }
+
+    /// <summary>
+    /// The optional rating scale this criterion is rated against. Null = free numeric entry.
+    /// </summary>
+    public Guid? ScaleId { get; set; }
+
+    public AddScoringModelCriterionCommand ToAddCommand(Guid scoringModelId)
+    {
+        return new AddScoringModelCriterionCommand(scoringModelId, Name, Token, Description, Weight, ScaleId);
+    }
+
+    public UpdateScoringModelCriterionCommand ToUpdateCommand(Guid scoringModelId, Guid criterionId)
+    {
+        return new UpdateScoringModelCriterionCommand(scoringModelId, criterionId, Name, Token, Description, Weight, ScaleId);
+    }
+}
+
+public sealed class ScoringModelCriterionRequestValidator : AbstractValidator<ScoringModelCriterionRequest>
+{
+    public ScoringModelCriterionRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(ScoringToken.MaxLength)
+            .Must(ScoringToken.IsValid)
+            .WithMessage("'{PropertyValue}' is not a valid token.");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(1024);
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringModelOutputRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringModelOutputRequest.cs
@@ -1,0 +1,57 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+using Wayd.Common.Domain.Scoring;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ScoringModelOutputRequest
+{
+    /// <summary>
+    /// The name of the output (e.g., "Cost of Delay", "WSJF").
+    /// </summary>
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// The token other output formulas can reference (e.g., "CoD").
+    /// </summary>
+    public string Token { get; set; } = default!;
+
+    /// <summary>
+    /// The arithmetic formula over criterion and earlier-output tokens.
+    /// </summary>
+    public string Formula { get; set; } = default!;
+
+    /// <summary>
+    /// Whether this output is the model's primary score.
+    /// </summary>
+    public bool IsPrimary { get; set; }
+
+    public AddScoringModelOutputCommand ToAddCommand(Guid scoringModelId)
+    {
+        return new AddScoringModelOutputCommand(scoringModelId, Name, Token, Formula, IsPrimary);
+    }
+
+    public UpdateScoringModelOutputCommand ToUpdateCommand(Guid scoringModelId, Guid outputId)
+    {
+        return new UpdateScoringModelOutputCommand(scoringModelId, outputId, Name, Token, Formula, IsPrimary);
+    }
+}
+
+public sealed class ScoringModelOutputRequestValidator : AbstractValidator<ScoringModelOutputRequest>
+{
+    public ScoringModelOutputRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .MaximumLength(ScoringToken.MaxLength)
+            .Must(ScoringToken.IsValid)
+            .WithMessage("'{PropertyValue}' is not a valid token.");
+
+        RuleFor(x => x.Formula)
+            .NotEmpty()
+            .MaximumLength(ScoringFormulaEvaluator.MaxFormulaLength);
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringScaleLevelRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringScaleLevelRequest.cs
@@ -1,0 +1,36 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ScoringScaleLevelRequest
+{
+    /// <summary>
+    /// The label for the rating level (e.g., "Very High").
+    /// </summary>
+    public string Label { get; set; } = default!;
+
+    /// <summary>
+    /// The numeric value a chosen rating contributes to the criterion.
+    /// </summary>
+    public decimal Value { get; set; }
+
+    public AddScoringScaleLevelCommand ToAddCommand(Guid scoringModelId, Guid scaleId)
+    {
+        return new AddScoringScaleLevelCommand(scoringModelId, scaleId, Label, Value);
+    }
+
+    public UpdateScoringScaleLevelCommand ToUpdateCommand(Guid scoringModelId, Guid scaleId, Guid levelId)
+    {
+        return new UpdateScoringScaleLevelCommand(scoringModelId, scaleId, levelId, Label, Value);
+    }
+}
+
+public sealed class ScoringScaleLevelRequestValidator : AbstractValidator<ScoringScaleLevelRequest>
+{
+    public ScoringScaleLevelRequestValidator()
+    {
+        RuleFor(x => x.Label)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringScaleRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/ScoringScaleRequest.cs
@@ -1,0 +1,31 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record ScoringScaleRequest
+{
+    /// <summary>
+    /// The name of the scale (e.g., "Fibonacci", "Impact").
+    /// </summary>
+    public string Name { get; set; } = default!;
+
+    public AddScoringScaleCommand ToAddCommand(Guid scoringModelId)
+    {
+        return new AddScoringScaleCommand(scoringModelId, Name);
+    }
+
+    public UpdateScoringScaleCommand ToUpdateCommand(Guid scoringModelId, Guid scaleId)
+    {
+        return new UpdateScoringScaleCommand(scoringModelId, scaleId, Name);
+    }
+}
+
+public sealed class ScoringScaleRequestValidator : AbstractValidator<ScoringScaleRequest>
+{
+    public ScoringScaleRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(64);
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/UpdateScoringModelRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/ScoringModels/UpdateScoringModelRequest.cs
@@ -1,0 +1,35 @@
+using Wayd.Common.Application.Scoring.ScoringModels.Commands;
+
+namespace Wayd.Web.Api.Models.Admin.ScoringModels;
+
+public sealed record UpdateScoringModelRequest
+{
+    /// <summary>
+    /// The name of the scoring model.
+    /// </summary>
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// The description of the scoring model.
+    /// </summary>
+    public string Description { get; set; } = default!;
+
+    public UpdateScoringModelCommand ToUpdateScoringModelCommand(Guid id)
+    {
+        return new UpdateScoringModelCommand(id, Name, Description);
+    }
+}
+
+public sealed class UpdateScoringModelRequestValidator : AbstractValidator<UpdateScoringModelRequest>
+{
+    public UpdateScoringModelRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(128);
+
+        RuleFor(x => x.Description)
+            .NotEmpty()
+            .MaximumLength(1024);
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Program.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Program.cs
@@ -86,8 +86,14 @@ try
 
     var app = builder.Build();
 
-    await app.Services.InitializeDatabases();
-    await app.Services.RunBootstrapCheck();
+    // Skip startup-only database work when the EF Core tooling builds the host
+    // (migrations add/remove/update). Otherwise the tooling would re-apply
+    // pending migrations on boot, fighting the very command being run.
+    if (!Microsoft.EntityFrameworkCore.EF.IsDesignTime)
+    {
+        await app.Services.InitializeDatabases();
+        await app.Services.RunBootstrapCheck();
+    }
 
     app.UseInfrastructure(builder.Configuration);
     app.MapDefaultEndpoints();

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -22728,6 +22728,78 @@
         ]
       }
     },
+    "/api/scoring-models/{id}/evaluate": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Evaluate (test) a scoring model against supplied criterion values.",
+        "operationId": "ScoringModels_Evaluate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EvaluateScoringModelRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoringModelEvaluationDto"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
     "/api/scoring-models/{id}/criteria": {
       "post": {
         "tags": [
@@ -38279,6 +38351,93 @@
             "maxLength": 1024,
             "minLength": 1,
             "nullable": false
+          }
+        }
+      },
+      "ScoringModelEvaluationDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "outputs",
+          "primaryValue"
+        ],
+        "properties": {
+          "primaryValue": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScoringModelOutputValueDto"
+            }
+          }
+        }
+      },
+      "ScoringModelOutputValueDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "token",
+          "name",
+          "value",
+          "isPrimary",
+          "order"
+        ],
+        "properties": {
+          "token": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "EvaluateScoringModelRequest": {
+        "type": "object",
+        "description": "A request to evaluate (test) a scoring model against a set of supplied criterion values, returning\nthe resulting output values without persisting anything.",
+        "additionalProperties": false,
+        "required": [
+          "criterionValues"
+        ],
+        "properties": {
+          "criterionValues": {
+            "type": "array",
+            "description": "The value to plug in for each criterion, keyed by criterion id.",
+            "items": {
+              "$ref": "#/components/schemas/CriterionValue"
+            }
+          }
+        }
+      },
+      "CriterionValue": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "criterionId",
+          "value"
+        ],
+        "properties": {
+          "criterionId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "value": {
+            "type": "number",
+            "format": "decimal"
           }
         }
       },

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -22365,6 +22365,1456 @@
           }
         ]
       }
+    },
+    "/api/scoring-models": {
+      "get": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Get a list of scoring models.",
+        "operationId": "ScoringModels_GetScoringModels",
+        "parameters": [
+          {
+            "name": "state",
+            "in": "query",
+            "schema": {
+              "nullable": true,
+              "oneOf": [
+                {
+                  "$ref": "#/components/schemas/ScoringModelState"
+                }
+              ]
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ScoringModelListDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Create a scoring model.",
+        "operationId": "ScoringModels_Create",
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateScoringModelRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "guid",
+                  "nullable": false,
+                  "example": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{idOrKey}": {
+      "get": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Get scoring model details.",
+        "operationId": "ScoringModels_GetScoringModel",
+        "parameters": [
+          {
+            "name": "idOrKey",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScoringModelDetailsDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}": {
+      "put": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Update a scoring model.",
+        "operationId": "ScoringModels_Update",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateScoringModelRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Delete a scoring model.",
+        "operationId": "ScoringModels_Delete",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/activate": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Activate a scoring model.",
+        "operationId": "ScoringModels_Activate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/archive": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Archive a scoring model.",
+        "operationId": "ScoringModels_Archive",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/criteria": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Add a criterion to a scoring model.",
+        "operationId": "ScoringModels_AddCriterion",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringModelCriterionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "guid",
+                  "nullable": false,
+                  "example": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/criteria/{criterionId}": {
+      "put": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Update a criterion in a scoring model.",
+        "operationId": "ScoringModels_UpdateCriterion",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "criterionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringModelCriterionRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Remove a criterion from a scoring model.",
+        "operationId": "ScoringModels_RemoveCriterion",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "criterionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/criteria/reorder": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Reorder criteria in a scoring model.",
+        "operationId": "ScoringModels_ReorderCriteria",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderScoringModelCriteriaRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/scales": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Add a rating scale to a scoring model.",
+        "operationId": "ScoringModels_AddScale",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringScaleRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "guid",
+                  "nullable": false,
+                  "example": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/scales/{scaleId}": {
+      "put": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Rename a rating scale in a scoring model.",
+        "operationId": "ScoringModels_UpdateScale",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scaleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringScaleRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Remove a rating scale from a scoring model.",
+        "operationId": "ScoringModels_RemoveScale",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scaleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/scales/reorder": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Reorder rating scales in a scoring model.",
+        "operationId": "ScoringModels_ReorderScales",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderScoringScalesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/scales/{scaleId}/levels": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Add a rating level to a scale.",
+        "operationId": "ScoringModels_AddScaleLevel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scaleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringScaleLevelRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "guid",
+                  "nullable": false,
+                  "example": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/scales/{scaleId}/levels/{levelId}": {
+      "put": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Update a rating level on a scale.",
+        "operationId": "ScoringModels_UpdateScaleLevel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scaleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "levelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 3
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringScaleLevelRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 4
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Remove a rating level from a scale.",
+        "operationId": "ScoringModels_RemoveScaleLevel",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scaleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          },
+          {
+            "name": "levelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 3
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/scales/{scaleId}/levels/reorder": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Reorder rating levels on a scale.",
+        "operationId": "ScoringModels_ReorderScaleLevels",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "scaleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderScoringScaleLevelsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/outputs": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Add an output formula to a scoring model.",
+        "operationId": "ScoringModels_AddOutput",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringModelOutputRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "201": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "guid",
+                  "nullable": false,
+                  "example": "00000000-0000-0000-0000-000000000000"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/outputs/{outputId}": {
+      "put": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Update an output formula in a scoring model.",
+        "operationId": "ScoringModels_UpdateOutput",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "outputId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ScoringModelOutputRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 3
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Remove an output formula from a scoring model.",
+        "operationId": "ScoringModels_RemoveOutput",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          },
+          {
+            "name": "outputId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 2
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/scoring-models/{id}/outputs/reorder": {
+      "post": {
+        "tags": [
+          "ScoringModels"
+        ],
+        "summary": "Reorder output formulas in a scoring model.",
+        "operationId": "ScoringModels_ReorderOutputs",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReorderScoringModelOutputsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -36402,6 +37852,636 @@
           },
           "isEnabled": {
             "type": "boolean"
+          }
+        }
+      },
+      "ScoringModelListDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "description",
+          "state",
+          "id",
+          "key",
+          "criterionCount",
+          "scaleCount",
+          "outputCount"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SimpleNavigationDto"
+          },
+          "criterionCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "scaleCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "outputCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ScoringModelState": {
+        "type": "string",
+        "description": "",
+        "x-enumNames": [
+          "Proposed",
+          "Active",
+          "Archived"
+        ],
+        "enum": [
+          "Proposed",
+          "Active",
+          "Archived"
+        ]
+      },
+      "ScoringModelDetailsDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "description",
+          "state",
+          "criteria",
+          "scales",
+          "outputs",
+          "id",
+          "key"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "key": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "state": {
+            "$ref": "#/components/schemas/SimpleNavigationDto"
+          },
+          "criteria": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScoringModelCriterionDto"
+            }
+          },
+          "scales": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScoringScaleDto"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScoringModelOutputDto"
+            }
+          }
+        }
+      },
+      "ScoringModelCriterionDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "token",
+          "id",
+          "order"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "name": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "format": "decimal",
+            "nullable": true
+          },
+          "scaleId": {
+            "type": "string",
+            "format": "guid",
+            "nullable": true,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ScoringScaleDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "levels",
+          "id",
+          "order"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "name": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "levels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ScoringRatingLevelDto"
+            }
+          }
+        }
+      },
+      "ScoringRatingLevelDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "label",
+          "id",
+          "value",
+          "order"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "number",
+            "format": "decimal"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ScoringModelOutputDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "token",
+          "formula",
+          "id",
+          "isPrimary",
+          "order"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "name": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "formula": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "CreateScoringModelRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "description"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the scoring model.",
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": false
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the scoring model.",
+            "maxLength": 1024,
+            "minLength": 1,
+            "nullable": false
+          },
+          "scales": {
+            "type": "array",
+            "description": "Optional initial rating scales for the scoring model.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/ScaleInput"
+            }
+          },
+          "criteria": {
+            "type": "array",
+            "description": "Optional initial criteria (rated inputs) for the scoring model.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/CriterionInput"
+            }
+          },
+          "outputs": {
+            "type": "array",
+            "description": "Optional initial output formulas for the scoring model.",
+            "nullable": true,
+            "items": {
+              "$ref": "#/components/schemas/OutputInput"
+            }
+          }
+        }
+      },
+      "ScaleInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "levels"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the scale (e.g., \"Fibonacci\", \"Impact\")."
+          },
+          "levels": {
+            "type": "array",
+            "description": "The ordered rating levels of the scale.",
+            "items": {
+              "$ref": "#/components/schemas/ScaleLevelInput"
+            }
+          }
+        }
+      },
+      "ScaleLevelInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "label",
+          "value"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "The label for the rating level (e.g., \"Very High\")."
+          },
+          "value": {
+            "type": "number",
+            "description": "The numeric value a chosen rating contributes.",
+            "format": "decimal"
+          }
+        }
+      },
+      "CriterionInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "token"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the criterion."
+          },
+          "token": {
+            "type": "string",
+            "description": "The token used to reference this criterion in formulas (e.g., \"BV\")."
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the criterion.",
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "description": "An optional, non-authoritative weight (used only by the weighted-formula scaffolder).",
+            "format": "decimal",
+            "nullable": true
+          },
+          "scaleName": {
+            "type": "string",
+            "description": "The name of a scale (from Scales) this criterion is rated against, or null for free numeric entry.",
+            "nullable": true
+          }
+        }
+      },
+      "OutputInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "token",
+          "formula",
+          "isPrimary"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the output (e.g., \"Cost of Delay\", \"WSJF\")."
+          },
+          "token": {
+            "type": "string",
+            "description": "The token other output formulas can reference (e.g., \"CoD\")."
+          },
+          "formula": {
+            "type": "string",
+            "description": "The arithmetic formula over criterion and earlier-output tokens."
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "description": "Whether this output is the model's primary score."
+          }
+        }
+      },
+      "UpdateScoringModelRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "description"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the scoring model.",
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": false
+          },
+          "description": {
+            "type": "string",
+            "description": "The description of the scoring model.",
+            "maxLength": 1024,
+            "minLength": 1,
+            "nullable": false
+          }
+        }
+      },
+      "ScoringModelCriterionRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "token"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the criterion.",
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": false
+          },
+          "token": {
+            "type": "string",
+            "description": "The token used to reference this criterion in output formulas (e.g., \"BV\").",
+            "maxLength": 32,
+            "minLength": 1,
+            "nullable": false
+          },
+          "description": {
+            "type": "string",
+            "description": "An optional description of the criterion.",
+            "maxLength": 1024,
+            "minLength": 0,
+            "nullable": true
+          },
+          "weight": {
+            "type": "number",
+            "description": "An optional, non-authoritative weight (used only by the weighted-formula scaffolder).",
+            "format": "decimal",
+            "nullable": true
+          },
+          "scaleId": {
+            "type": "string",
+            "description": "The optional rating scale this criterion is rated against. Null = free numeric entry.",
+            "format": "guid",
+            "nullable": true,
+            "example": "00000000-0000-0000-0000-000000000000"
+          }
+        }
+      },
+      "ReorderScoringModelCriteriaRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "orderedCriterionIds"
+        ],
+        "properties": {
+          "orderedCriterionIds": {
+            "type": "array",
+            "description": "The ordered list of criterion IDs representing the desired order.",
+            "minLength": 1,
+            "nullable": false,
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      },
+      "ScoringScaleRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the scale (e.g., \"Fibonacci\", \"Impact\").",
+            "maxLength": 64,
+            "minLength": 1,
+            "nullable": false
+          }
+        }
+      },
+      "ReorderScoringScalesRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "orderedScaleIds"
+        ],
+        "properties": {
+          "orderedScaleIds": {
+            "type": "array",
+            "description": "The ordered list of scale IDs representing the desired order.",
+            "minLength": 1,
+            "nullable": false,
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      },
+      "ScoringScaleLevelRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "label",
+          "value"
+        ],
+        "properties": {
+          "label": {
+            "type": "string",
+            "description": "The label for the rating level (e.g., \"Very High\").",
+            "maxLength": 64,
+            "minLength": 1,
+            "nullable": false
+          },
+          "value": {
+            "type": "number",
+            "description": "The numeric value a chosen rating contributes to the criterion.",
+            "format": "decimal"
+          }
+        }
+      },
+      "ReorderScoringScaleLevelsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "orderedLevelIds"
+        ],
+        "properties": {
+          "orderedLevelIds": {
+            "type": "array",
+            "description": "The ordered list of rating level IDs representing the desired order.",
+            "minLength": 1,
+            "nullable": false,
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
+          }
+        }
+      },
+      "ScoringModelOutputRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "name",
+          "token",
+          "formula",
+          "isPrimary"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "The name of the output (e.g., \"Cost of Delay\", \"WSJF\").",
+            "maxLength": 128,
+            "minLength": 1,
+            "nullable": false
+          },
+          "token": {
+            "type": "string",
+            "description": "The token other output formulas can reference (e.g., \"CoD\").",
+            "maxLength": 32,
+            "minLength": 1,
+            "nullable": false
+          },
+          "formula": {
+            "type": "string",
+            "description": "The arithmetic formula over criterion and earlier-output tokens.",
+            "maxLength": 1000,
+            "minLength": 1,
+            "nullable": false
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "description": "Whether this output is the model's primary score."
+          }
+        }
+      },
+      "ReorderScoringModelOutputsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "orderedOutputIds"
+        ],
+        "properties": {
+          "orderedOutputIds": {
+            "type": "array",
+            "description": "The ordered list of output IDs representing the desired evaluation order.",
+            "minLength": 1,
+            "nullable": false,
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
           }
         }
       }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/_components/settings-menu.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/_components/settings-menu.tsx
@@ -26,6 +26,7 @@ enum SettingsTab {
   // project portfolio management
   ExpenditureCategories = 'expenditure-categories',
   ProjectLifecycles = 'project-lifecycles',
+  ScoringModels = 'scoring-models',
 
   // work-management
   WorkTypes = 'work-types',
@@ -204,6 +205,15 @@ const buildSettingsMenuItems = (featureFlags: {
       'Project Lifecycles',
       SettingsTab.ProjectLifecycles,
       '/settings/ppm/project-lifecycles',
+    ),
+  ]),
+
+  getSectionMenuItem('Scoring', 'scoring', [
+    getRestrictedMenuItem(
+      'Permissions.ScoringModels.View',
+      'Scoring Models',
+      SettingsTab.ScoringModels,
+      '/settings/scoring/scoring-models',
     ),
   ]),
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/[key]/loading.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/[key]/loading.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import PageTitle from '@/src/components/common/page-title'
+import { Skeleton } from 'antd'
+
+export default function ScoringModelDetailsLoading() {
+  return (
+    <>
+      <PageTitle title="Scoring Model" />
+      <Skeleton active />
+    </>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/[key]/page.tsx
@@ -1,0 +1,296 @@
+'use client'
+
+import { PageActions, PageTitle } from '@/src/components/common'
+import BasicBreadcrumb from '@/src/components/common/basic-breadcrumb'
+import useAuth from '@/src/components/contexts/auth'
+import { authorizePage } from '@/src/components/hoc'
+import { Card, MenuProps } from 'antd'
+import { use, useEffect, useState } from 'react'
+import ScoringModelDetailsLoading from './loading'
+import { notFound, useRouter } from 'next/navigation'
+import ScoringModelDetails from '../_components/scoring-model-details'
+import { useGetScoringModelQuery } from '@/src/store/features/scoring/scoring-models-api'
+import { ItemType } from 'antd/es/menu/interface'
+import { useMessage } from '@/src/components/contexts/messaging'
+import EditScoringModelForm from '../_components/edit-scoring-model-form'
+import DeleteScoringModelForm from '../_components/delete-scoring-model-form'
+import ChangeScoringModelStateForm, {
+  ScoringModelStateAction,
+} from '../_components/change-scoring-model-state-form'
+import ScoringModelCriteriaList from '../_components/scoring-model-criteria-list'
+import ScoringScalesList from '../_components/scoring-scales-list'
+import ScoringModelOutputsList from '../_components/scoring-model-outputs-list'
+import { useDocumentTitle } from '@/src/hooks/use-document-title'
+import { isApiError } from '@/src/utils'
+
+enum ScoringModelTabs {
+  Details = 'details',
+  Criteria = 'criteria',
+  RatingScale = 'rating-scale',
+  Outputs = 'outputs',
+}
+
+const tabs = [
+  {
+    key: ScoringModelTabs.Details,
+    tab: 'Details',
+  },
+  {
+    key: ScoringModelTabs.Criteria,
+    tab: 'Criteria',
+  },
+  {
+    key: ScoringModelTabs.RatingScale,
+    tab: 'Rating Scales',
+  },
+  {
+    key: ScoringModelTabs.Outputs,
+    tab: 'Outputs',
+  },
+]
+
+enum MenuActions {
+  Edit = 'Edit',
+  Delete = 'Delete',
+  Activate = 'Activate',
+  Archive = 'Archive',
+}
+
+const ScoringModelDetailsPage = (props: {
+  params: Promise<{ key: number }>
+}) => {
+  const { key } = use(props.params)
+
+  const [activeTab, setActiveTab] = useState(ScoringModelTabs.Details)
+  const [openEditForm, setOpenEditForm] = useState<boolean>(false)
+  const [openActivateForm, setOpenActivateForm] = useState<boolean>(false)
+  const [openArchiveForm, setOpenArchiveForm] = useState<boolean>(false)
+  const [openDeleteForm, setOpenDeleteForm] = useState<boolean>(false)
+
+  const messageApi = useMessage()
+
+  const router = useRouter()
+
+  const {
+    data: scoringModelData,
+    isLoading,
+    error,
+    refetch,
+  } = useGetScoringModelQuery(key.toString())
+
+  const { hasPermissionClaim } = useAuth()
+  const canUpdate = hasPermissionClaim('Permissions.ScoringModels.Update')
+  const canDelete = hasPermissionClaim('Permissions.ScoringModels.Delete')
+
+  const isProposed = scoringModelData?.state?.name === 'Proposed'
+  const canManage = canUpdate && isProposed
+
+  const title = scoringModelData
+    ? `${scoringModelData.name} - Scoring Model Details`
+    : 'Scoring Model Details'
+  useDocumentTitle(title)
+
+  const renderTabContent = () => {
+    switch (activeTab) {
+      case ScoringModelTabs.Details:
+        return <ScoringModelDetails scoringModel={scoringModelData!} />
+      case ScoringModelTabs.Criteria:
+        return (
+          <ScoringModelCriteriaList
+            scoringModel={scoringModelData!}
+            canManage={canManage}
+            loadData={refetch}
+          />
+        )
+      case ScoringModelTabs.RatingScale:
+        return (
+          <ScoringScalesList
+            scoringModel={scoringModelData!}
+            canManage={canManage}
+            loadData={refetch}
+          />
+        )
+      case ScoringModelTabs.Outputs:
+        return (
+          <ScoringModelOutputsList
+            scoringModel={scoringModelData!}
+            canManage={canManage}
+            loadData={refetch}
+          />
+        )
+      default:
+        return null
+    }
+  }
+
+  const onTabChange = (tabKey: string) => {
+    setActiveTab(tabKey as ScoringModelTabs)
+  }
+
+  const actionsMenuItems: MenuProps['items'] = (() => {
+    const currentState = scoringModelData?.state?.name
+    const availableActions =
+      currentState === 'Proposed'
+        ? [MenuActions.Delete, MenuActions.Activate]
+        : currentState === 'Active'
+          ? [MenuActions.Archive]
+          : []
+
+    const items: ItemType[] = []
+    if (canUpdate && currentState === 'Proposed') {
+      items.push({
+        key: 'edit',
+        label: MenuActions.Edit,
+        onClick: () => setOpenEditForm(true),
+      })
+    }
+    if (canDelete && availableActions.includes(MenuActions.Delete)) {
+      items.push({
+        key: 'delete',
+        label: MenuActions.Delete,
+        onClick: () => setOpenDeleteForm(true),
+      })
+    }
+
+    const hasStateActions =
+      (canUpdate && availableActions.includes(MenuActions.Activate)) ||
+      (canUpdate && availableActions.includes(MenuActions.Archive))
+
+    if (hasStateActions && items.length > 0) {
+      items.push({
+        key: 'manage-divider',
+        type: 'divider',
+      })
+    }
+
+    if (canUpdate && availableActions.includes(MenuActions.Activate)) {
+      items.push({
+        key: 'activate',
+        label: MenuActions.Activate,
+        onClick: () => setOpenActivateForm(true),
+      })
+    }
+
+    if (canUpdate && availableActions.includes(MenuActions.Archive)) {
+      items.push({
+        key: 'archive',
+        label: MenuActions.Archive,
+        onClick: () => setOpenArchiveForm(true),
+      })
+    }
+
+    return items
+  })()
+
+  useEffect(() => {
+    if (error) {
+      messageApi.error(
+        (isApiError(error) ? error.detail : undefined) ??
+          'An error occurred while loading scoring model details',
+      )
+      console.error(error)
+    }
+  }, [error, messageApi])
+
+  const onEditFormClosed = (wasSaved: boolean) => {
+    setOpenEditForm(false)
+    if (wasSaved) {
+      refetch()
+    }
+  }
+
+  const onActivateFormClosed = (wasSaved: boolean) => {
+    setOpenActivateForm(false)
+    if (wasSaved) {
+      refetch()
+    }
+  }
+
+  const onArchiveFormClosed = (wasSaved: boolean) => {
+    setOpenArchiveForm(false)
+    if (wasSaved) {
+      refetch()
+    }
+  }
+
+  const onDeleteFormClosed = (wasDeleted: boolean) => {
+    setOpenDeleteForm(false)
+    if (wasDeleted) {
+      router.push('/settings/scoring/scoring-models')
+    }
+  }
+
+  if (isLoading) {
+    return <ScoringModelDetailsLoading />
+  }
+
+  if (!scoringModelData) {
+    return notFound()
+  }
+
+  return (
+    <>
+      <BasicBreadcrumb
+        items={[
+          { title: 'Settings' },
+          { title: 'Scoring' },
+          { title: 'Scoring Models', href: './' },
+          { title: 'Details' },
+        ]}
+      />
+      <PageTitle
+        title={`${scoringModelData?.key} - ${scoringModelData?.name}`}
+        subtitle="Scoring Model Details"
+        actions={<PageActions actionItems={actionsMenuItems} />}
+      />
+      <Card
+        style={{ width: '100%' }}
+        tabList={tabs}
+        activeTabKey={activeTab}
+        onTabChange={onTabChange}
+      >
+        {renderTabContent()}
+      </Card>
+
+      {openEditForm && (
+        <EditScoringModelForm
+          scoringModelId={scoringModelData?.id}
+          onFormComplete={() => onEditFormClosed(true)}
+          onFormCancel={() => onEditFormClosed(false)}
+        />
+      )}
+      {openActivateForm && (
+        <ChangeScoringModelStateForm
+          scoringModel={scoringModelData}
+          stateAction={ScoringModelStateAction.Activate}
+          onFormComplete={() => onActivateFormClosed(true)}
+          onFormCancel={() => onActivateFormClosed(false)}
+        />
+      )}
+      {openArchiveForm && (
+        <ChangeScoringModelStateForm
+          scoringModel={scoringModelData}
+          stateAction={ScoringModelStateAction.Archive}
+          onFormComplete={() => onArchiveFormClosed(true)}
+          onFormCancel={() => onArchiveFormClosed(false)}
+        />
+      )}
+      {openDeleteForm && (
+        <DeleteScoringModelForm
+          scoringModel={scoringModelData}
+          onFormComplete={() => onDeleteFormClosed(true)}
+          onFormCancel={() => onDeleteFormClosed(false)}
+        />
+      )}
+    </>
+  )
+}
+
+const ScoringModelDetailsPageWithAuthorization = authorizePage(
+  ScoringModelDetailsPage,
+  'Permission',
+  'Permissions.ScoringModels.View',
+)
+
+export default ScoringModelDetailsPageWithAuthorization
+

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/[key]/page.tsx
@@ -20,6 +20,7 @@ import ChangeScoringModelStateForm, {
 import ScoringModelCriteriaList from '../_components/scoring-model-criteria-list'
 import ScoringScalesList from '../_components/scoring-scales-list'
 import ScoringModelOutputsList from '../_components/scoring-model-outputs-list'
+import ScoringModelTestPanel from '../_components/scoring-model-test-panel'
 import { useDocumentTitle } from '@/src/hooks/use-document-title'
 import { isApiError } from '@/src/utils'
 
@@ -28,6 +29,7 @@ enum ScoringModelTabs {
   Criteria = 'criteria',
   RatingScale = 'rating-scale',
   Outputs = 'outputs',
+  Test = 'test',
 }
 
 const tabs = [
@@ -46,6 +48,10 @@ const tabs = [
   {
     key: ScoringModelTabs.Outputs,
     tab: 'Outputs',
+  },
+  {
+    key: ScoringModelTabs.Test,
+    tab: 'Test',
   },
 ]
 
@@ -118,6 +124,8 @@ const ScoringModelDetailsPage = (props: {
             loadData={refetch}
           />
         )
+      case ScoringModelTabs.Test:
+        return <ScoringModelTestPanel scoringModel={scoringModelData!} />
       default:
         return null
     }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-model-criterion-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-model-criterion-form.tsx
@@ -1,0 +1,160 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelCriterionRequest,
+  ScoringScaleDto,
+} from '@/src/services/wayd-api'
+import { useAddScoringModelCriterionMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Input, InputNumber, Modal, Select } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface AddScoringModelCriterionFormProps {
+  scoringModelId: string
+  scales: ScoringScaleDto[]
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface AddScoringModelCriterionFormValues {
+  name: string
+  token: string
+  description?: string
+  weight?: number
+  scaleId?: string
+}
+
+const mapToRequestValues = (
+  values: AddScoringModelCriterionFormValues,
+): ScoringModelCriterionRequest => {
+  return {
+    name: values.name,
+    token: values.token,
+    description: values.description,
+    weight: values.weight,
+    scaleId: values.scaleId,
+  } as ScoringModelCriterionRequest
+}
+
+const AddScoringModelCriterionForm = ({
+  scoringModelId,
+  scales,
+  onFormComplete,
+  onFormCancel,
+}: AddScoringModelCriterionFormProps) => {
+  const messageApi = useMessage()
+
+  const [addScoringModelCriterion] = useAddScoringModelCriterionMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<AddScoringModelCriterionFormValues>({
+      onSubmit: async (values: AddScoringModelCriterionFormValues, form) => {
+        try {
+          const request = mapToRequestValues(values)
+          const response = await addScoringModelCriterion({
+            scoringModelId,
+            ...request,
+          })
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Criterion added successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while adding the criterion. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while adding the criterion. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  return (
+    <Modal
+      title="Add Criterion"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Add"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="add-scoring-model-criterion-form"
+      >
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 128 }]}
+        >
+          <Input showCount maxLength={128} />
+        </Item>
+        <Item
+          label="Token"
+          name="token"
+          tooltip="The short identifier used to reference this criterion in output formulas (e.g., BV)."
+          rules={[
+            { required: true, message: 'Token is required' },
+            { max: 32 },
+            {
+              pattern: /^[A-Za-z_][A-Za-z0-9_]*$/,
+              message:
+                'Tokens must start with a letter or underscore and contain only letters, digits, or underscores.',
+            },
+          ]}
+        >
+          <Input maxLength={32} />
+        </Item>
+        <Item
+          label="Rating Scale"
+          name="scaleId"
+          tooltip="The scale this criterion is rated against. Leave as free numeric entry to type a number when scoring."
+        >
+          <Select
+            allowClear
+            placeholder="Free numeric entry"
+            options={scales.map((s) => ({ value: s.id, label: s.name }))}
+          />
+        </Item>
+        <Item
+          label="Weight (%)"
+          name="weight"
+          tooltip="Optional. Only used by the weighted-formula scaffolder; the output formulas determine the score."
+        >
+          <InputNumber min={0} max={100} style={{ width: '100%' }} />
+        </Item>
+        <Item name="description" label="Description" rules={[{ max: 1024 }]}>
+          <TextArea
+            autoSize={{ minRows: 3, maxRows: 6 }}
+            showCount
+            maxLength={1024}
+          />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default AddScoringModelCriterionForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-model-output-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-model-output-form.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { ScoringModelOutputRequest } from '@/src/services/wayd-api'
+import { useAddScoringModelOutputMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Checkbox, Form, Input, Modal, Typography } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+const { Text } = Typography
+
+export interface AddScoringModelOutputFormProps {
+  scoringModelId: string
+  availableTokens: string[]
+  initialValues?: Partial<AddScoringModelOutputFormValues>
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface AddScoringModelOutputFormValues {
+  name: string
+  token: string
+  formula: string
+  isPrimary: boolean
+}
+
+const mapToRequestValues = (
+  values: AddScoringModelOutputFormValues,
+): ScoringModelOutputRequest => {
+  return {
+    name: values.name,
+    token: values.token,
+    formula: values.formula,
+    isPrimary: values.isPrimary ?? false,
+  } as ScoringModelOutputRequest
+}
+
+const AddScoringModelOutputForm = ({
+  scoringModelId,
+  availableTokens,
+  initialValues,
+  onFormComplete,
+  onFormCancel,
+}: AddScoringModelOutputFormProps) => {
+  const messageApi = useMessage()
+
+  const [addScoringModelOutput] = useAddScoringModelOutputMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<AddScoringModelOutputFormValues>({
+      onSubmit: async (values: AddScoringModelOutputFormValues, form) => {
+        try {
+          const request = mapToRequestValues(values)
+          const response = await addScoringModelOutput({
+            scoringModelId,
+            ...request,
+          })
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Output added successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while adding the output. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while adding the output. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  return (
+    <Modal
+      title="Add Output"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Add"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="add-scoring-model-output-form"
+        initialValues={{ isPrimary: false, ...initialValues }}
+      >
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 128 }]}
+        >
+          <Input showCount maxLength={128} />
+        </Item>
+        <Item
+          label="Token"
+          name="token"
+          tooltip="The short identifier later output formulas can reference (e.g., CoD)."
+          rules={[
+            { required: true, message: 'Token is required' },
+            { max: 32 },
+            {
+              pattern: /^[A-Za-z_][A-Za-z0-9_]*$/,
+              message:
+                'Tokens must start with a letter or underscore and contain only letters, digits, or underscores.',
+            },
+          ]}
+        >
+          <Input maxLength={32} />
+        </Item>
+        <Item
+          label="Formula"
+          name="formula"
+          tooltip="An arithmetic expression over criterion tokens and earlier output tokens (e.g., (BV + TC + RR) / JS)."
+          rules={[
+            { required: true, message: 'Formula is required' },
+            { max: 1000 },
+          ]}
+          extra={
+            availableTokens.length > 0 ? (
+              <Text type="secondary">
+                Available tokens: {availableTokens.join(', ')}
+              </Text>
+            ) : undefined
+          }
+        >
+          <TextArea autoSize={{ minRows: 2, maxRows: 4 }} maxLength={1000} />
+        </Item>
+        <Item name="isPrimary" valuePropName="checked">
+          <Checkbox>Primary score (the model&apos;s ranking value)</Checkbox>
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default AddScoringModelOutputForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-scale-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-scale-form.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { ScoringScaleRequest } from '@/src/services/wayd-api'
+import { useAddScoringScaleMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Input, Modal } from 'antd'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface AddScoringScaleFormProps {
+  scoringModelId: string
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface AddScoringScaleFormValues {
+  name: string
+}
+
+const AddScoringScaleForm = ({
+  scoringModelId,
+  onFormComplete,
+  onFormCancel,
+}: AddScoringScaleFormProps) => {
+  const messageApi = useMessage()
+
+  const [addScoringScale] = useAddScoringScaleMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<AddScoringScaleFormValues>({
+      onSubmit: async (values: AddScoringScaleFormValues, form) => {
+        try {
+          const response = await addScoringScale({
+            scoringModelId,
+            name: values.name,
+          } as { scoringModelId: string } & ScoringScaleRequest)
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Scale added successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while adding the scale. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while adding the scale. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  return (
+    <Modal
+      title="Add Scale"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Add"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form form={form} size="small" layout="vertical" name="add-scoring-scale-form">
+        <Item
+          label="Name"
+          name="name"
+          tooltip="A reusable scale (e.g., Fibonacci, Impact) that criteria can be rated against."
+          rules={[{ required: true, message: 'Name is required' }, { max: 64 }]}
+        >
+          <Input showCount maxLength={64} />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default AddScoringScaleForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-scale-level-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/add-scoring-scale-level-form.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { ScoringScaleLevelRequest } from '@/src/services/wayd-api'
+import { useAddScoringScaleLevelMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Input, InputNumber, Modal } from 'antd'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface AddScoringScaleLevelFormProps {
+  scoringModelId: string
+  scaleId: string
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface AddScoringScaleLevelFormValues {
+  label: string
+  value: number
+}
+
+const AddScoringScaleLevelForm = ({
+  scoringModelId,
+  scaleId,
+  onFormComplete,
+  onFormCancel,
+}: AddScoringScaleLevelFormProps) => {
+  const messageApi = useMessage()
+
+  const [addScoringScaleLevel] = useAddScoringScaleLevelMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<AddScoringScaleLevelFormValues>({
+      onSubmit: async (values: AddScoringScaleLevelFormValues, form) => {
+        try {
+          const response = await addScoringScaleLevel({
+            scoringModelId,
+            scaleId,
+            label: values.label,
+            value: values.value,
+          } as {
+            scoringModelId: string
+            scaleId: string
+          } & ScoringScaleLevelRequest)
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Rating level added successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while adding the rating level. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while adding the rating level. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  return (
+    <Modal
+      title="Add Rating Level"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Add"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="add-scoring-scale-level-form"
+      >
+        <Item
+          label="Label"
+          name="label"
+          rules={[{ required: true, message: 'Label is required' }, { max: 64 }]}
+        >
+          <Input showCount maxLength={64} />
+        </Item>
+        <Item
+          label="Value"
+          name="value"
+          rules={[{ required: true, message: 'Value is required' }]}
+        >
+          <InputNumber style={{ width: '100%' }} />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default AddScoringScaleLevelForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/change-scoring-model-state-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/change-scoring-model-state-form.tsx
@@ -1,0 +1,99 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { ScoringModelDetailsDto } from '@/src/services/wayd-api'
+import {
+  useActivateScoringModelMutation,
+  useArchiveScoringModelMutation,
+} from '@/src/store/features/scoring/scoring-models-api'
+import { Modal, Space } from 'antd'
+import { useConfirmModal } from '@/src/hooks'
+import { isApiError, type ApiError } from '@/src/utils'
+
+export enum ScoringModelStateAction {
+  Activate = 'Activate',
+  Archive = 'Archive',
+}
+
+export interface ChangeScoringModelStateFormProps {
+  scoringModel: ScoringModelDetailsDto
+  stateAction: ScoringModelStateAction
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+const ChangeScoringModelStateForm = ({
+  scoringModel,
+  stateAction,
+  onFormComplete,
+  onFormCancel,
+}: ChangeScoringModelStateFormProps) => {
+  const messageApi = useMessage()
+
+  const [activateScoringModelMutation] = useActivateScoringModelMutation()
+  const [archiveScoringModelMutation] = useArchiveScoringModelMutation()
+
+  const { isOpen, isSaving, handleOk, handleCancel } = useConfirmModal({
+    onSubmit: async () => {
+      try {
+        let response = null
+        if (stateAction === ScoringModelStateAction.Activate) {
+          response = await activateScoringModelMutation(scoringModel.id)
+        } else if (stateAction === ScoringModelStateAction.Archive) {
+          response = await archiveScoringModelMutation(scoringModel.id)
+        }
+
+        if (response?.error) {
+          throw response.error
+        }
+
+        const pastTense =
+          stateAction === ScoringModelStateAction.Activate
+            ? 'activated'
+            : 'archived'
+        messageApi.success(`Successfully ${pastTense} scoring model.`)
+        return true
+      } catch (error) {
+        const apiError: ApiError = isApiError(error) ? error : {}
+        const gerund =
+          stateAction === ScoringModelStateAction.Activate
+            ? 'activating'
+            : 'archiving'
+        messageApi.error(
+          apiError.detail ??
+            `An unexpected error occurred while ${gerund} the scoring model.`,
+        )
+        console.log(error)
+        return false
+      }
+    },
+    onComplete: onFormComplete,
+    onCancel: onFormCancel,
+    errorMessage: `An unexpected error occurred while ${stateAction}ing the scoring model.`,
+    permission: 'Permissions.ScoringModels.Update',
+  })
+
+  return (
+    <Modal
+      title={`Are you sure you want to ${stateAction} this Scoring Model?`}
+      open={isOpen}
+      onOk={handleOk}
+      okText={stateAction}
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Space vertical>
+        <div>
+          {scoringModel?.key} - {scoringModel?.name}
+        </div>
+        {stateAction === ScoringModelStateAction.Activate
+          ? 'Activating locks the model so it can no longer be edited.'
+          : 'This action cannot be undone.'}
+      </Space>
+    </Modal>
+  )
+}
+
+export default ChangeScoringModelStateForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/change-scoring-model-state-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/change-scoring-model-state-form.tsx
@@ -30,6 +30,10 @@ const ChangeScoringModelStateForm = ({
 }: ChangeScoringModelStateFormProps) => {
   const messageApi = useMessage()
 
+  // `${stateAction}ing` would produce "Archiveing"; map to the correct gerund instead.
+  const gerund =
+    stateAction === ScoringModelStateAction.Activate ? 'activating' : 'archiving'
+
   const [activateScoringModelMutation] = useActivateScoringModelMutation()
   const [archiveScoringModelMutation] = useArchiveScoringModelMutation()
 
@@ -55,10 +59,6 @@ const ChangeScoringModelStateForm = ({
         return true
       } catch (error) {
         const apiError: ApiError = isApiError(error) ? error : {}
-        const gerund =
-          stateAction === ScoringModelStateAction.Activate
-            ? 'activating'
-            : 'archiving'
         messageApi.error(
           apiError.detail ??
             `An unexpected error occurred while ${gerund} the scoring model.`,
@@ -69,7 +69,7 @@ const ChangeScoringModelStateForm = ({
     },
     onComplete: onFormComplete,
     onCancel: onFormCancel,
-    errorMessage: `An unexpected error occurred while ${stateAction}ing the scoring model.`,
+    errorMessage: `An unexpected error occurred while ${gerund} the scoring model.`,
     permission: 'Permissions.ScoringModels.Update',
   })
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/create-scoring-model-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/create-scoring-model-form.tsx
@@ -1,0 +1,123 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { CreateScoringModelRequest } from '@/src/services/wayd-api'
+import { useCreateScoringModelMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Modal } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface CreateScoringModelFormProps {
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface CreateScoringModelFormValues {
+  name: string
+  description: string
+}
+
+const mapToRequestValues = (
+  values: CreateScoringModelFormValues,
+): CreateScoringModelRequest => {
+  return {
+    name: values.name,
+    description: values.description,
+  } as CreateScoringModelRequest
+}
+
+const CreateScoringModelForm = ({
+  onFormComplete,
+  onFormCancel,
+}: CreateScoringModelFormProps) => {
+  const messageApi = useMessage()
+
+  const [createScoringModel] = useCreateScoringModelMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<CreateScoringModelFormValues>({
+      onSubmit: async (values: CreateScoringModelFormValues, form) => {
+        try {
+          const request = mapToRequestValues(values)
+          const response = await createScoringModel(request)
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success(
+            'Scoring Model created successfully. Key: ' + response.data,
+          )
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while creating the scoring model. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while creating the scoring model. Please try again.',
+      permission: 'Permissions.ScoringModels.Create',
+    })
+
+  return (
+    <Modal
+      title="Create Scoring Model"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Create"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="create-scoring-model-form"
+      >
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 128 }]}
+        >
+          <TextArea
+            autoSize={{ minRows: 1, maxRows: 2 }}
+            showCount
+            maxLength={128}
+          />
+        </Item>
+        <Item
+          name="description"
+          label="Description"
+          rules={[
+            { required: true, message: 'Description is required' },
+            { max: 1024 },
+          ]}
+        >
+          <TextArea
+            autoSize={{ minRows: 6, maxRows: 8 }}
+            showCount
+            maxLength={1024}
+          />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default CreateScoringModelForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/delete-scoring-model-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/delete-scoring-model-form.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { ScoringModelDetailsDto } from '@/src/services/wayd-api'
+import { useDeleteScoringModelMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { Modal } from 'antd'
+import { useConfirmModal } from '@/src/hooks'
+import { isApiError, type ApiError } from '@/src/utils'
+
+export interface DeleteScoringModelFormProps {
+  scoringModel: ScoringModelDetailsDto
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+const DeleteScoringModelForm = ({
+  scoringModel,
+  onFormComplete,
+  onFormCancel,
+}: DeleteScoringModelFormProps) => {
+  const messageApi = useMessage()
+
+  const [deleteScoringModel] = useDeleteScoringModelMutation()
+
+  const { isOpen, isSaving, handleOk, handleCancel } = useConfirmModal({
+    onSubmit: async () => {
+      try {
+        const response = await deleteScoringModel(scoringModel.id)
+        if (response.error) {
+          throw response.error
+        }
+        messageApi.success('Successfully deleted scoring model.')
+        return true
+      } catch (error) {
+        const apiError: ApiError = isApiError(error) ? error : {}
+        messageApi.error(
+          apiError.detail ??
+            'An unexpected error occurred while deleting the scoring model.',
+        )
+        console.log(error)
+        return false
+      }
+    },
+    onComplete: onFormComplete,
+    onCancel: onFormCancel,
+    errorMessage:
+      'An unexpected error occurred while deleting the scoring model.',
+    permission: 'Permissions.ScoringModels.Delete',
+  })
+
+  return (
+    <Modal
+      title="Are you sure you want to delete this Scoring Model?"
+      open={isOpen}
+      onOk={handleOk}
+      okText="Delete"
+      okType="danger"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      {scoringModel?.key} - {scoringModel?.name}
+    </Modal>
+  )
+}
+
+export default DeleteScoringModelForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-model-criterion-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-model-criterion-form.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelCriterionDto,
+  ScoringModelCriterionRequest,
+  ScoringScaleDto,
+} from '@/src/services/wayd-api'
+import { useUpdateScoringModelCriterionMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Input, InputNumber, Modal, Select } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { useEffect } from 'react'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface EditScoringModelCriterionFormProps {
+  scoringModelId: string
+  scales: ScoringScaleDto[]
+  criterion: ScoringModelCriterionDto
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface UpdateScoringModelCriterionFormValues {
+  name: string
+  token: string
+  description?: string
+  weight?: number
+  scaleId?: string
+}
+
+const mapToRequestValues = (
+  values: UpdateScoringModelCriterionFormValues,
+): ScoringModelCriterionRequest => {
+  return {
+    name: values.name,
+    token: values.token,
+    description: values.description,
+    weight: values.weight,
+    scaleId: values.scaleId,
+  } as ScoringModelCriterionRequest
+}
+
+const EditScoringModelCriterionForm = ({
+  scoringModelId,
+  scales,
+  criterion,
+  onFormComplete,
+  onFormCancel,
+}: EditScoringModelCriterionFormProps) => {
+  const messageApi = useMessage()
+
+  const [updateScoringModelCriterion] =
+    useUpdateScoringModelCriterionMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<UpdateScoringModelCriterionFormValues>({
+      onSubmit: async (values: UpdateScoringModelCriterionFormValues, form) => {
+        try {
+          const request = mapToRequestValues(values)
+          const response = await updateScoringModelCriterion({
+            scoringModelId,
+            criterionId: criterion.id,
+            ...request,
+          })
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Criterion updated successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while updating the criterion. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while updating the criterion. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  useEffect(() => {
+    if (!criterion) return
+    form.setFieldsValue({
+      name: criterion.name,
+      token: criterion.token,
+      description: criterion.description ?? undefined,
+      weight: criterion.weight,
+      scaleId: criterion.scaleId ?? undefined,
+    })
+  }, [criterion, form])
+
+  return (
+    <Modal
+      title="Edit Criterion"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="update-scoring-model-criterion-form"
+      >
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 128 }]}
+        >
+          <Input showCount maxLength={128} />
+        </Item>
+        <Item
+          label="Token"
+          name="token"
+          tooltip="The short identifier used to reference this criterion in output formulas (e.g., BV)."
+          rules={[
+            { required: true, message: 'Token is required' },
+            { max: 32 },
+            {
+              pattern: /^[A-Za-z_][A-Za-z0-9_]*$/,
+              message:
+                'Tokens must start with a letter or underscore and contain only letters, digits, or underscores.',
+            },
+          ]}
+        >
+          <Input maxLength={32} />
+        </Item>
+        <Item
+          label="Rating Scale"
+          name="scaleId"
+          tooltip="The scale this criterion is rated against. Leave as free numeric entry to type a number when scoring."
+        >
+          <Select
+            allowClear
+            placeholder="Free numeric entry"
+            options={scales.map((s) => ({ value: s.id, label: s.name }))}
+          />
+        </Item>
+        <Item
+          label="Weight (%)"
+          name="weight"
+          tooltip="Optional. Only used by the weighted-formula scaffolder; the output formulas determine the score."
+        >
+          <InputNumber min={0} max={100} style={{ width: '100%' }} />
+        </Item>
+        <Item name="description" label="Description" rules={[{ max: 1024 }]}>
+          <TextArea
+            autoSize={{ minRows: 3, maxRows: 6 }}
+            showCount
+            maxLength={1024}
+          />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default EditScoringModelCriterionForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-model-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-model-form.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { UpdateScoringModelRequest } from '@/src/services/wayd-api'
+import {
+  useGetScoringModelQuery,
+  useUpdateScoringModelMutation,
+} from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Modal } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { useEffect } from 'react'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface EditScoringModelFormProps {
+  scoringModelId: string
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface UpdateScoringModelFormValues {
+  name: string
+  description: string
+}
+
+const mapToRequestValues = (
+  values: UpdateScoringModelFormValues,
+): UpdateScoringModelRequest => {
+  return {
+    name: values.name,
+    description: values.description,
+  } as UpdateScoringModelRequest
+}
+
+const EditScoringModelForm = ({
+  scoringModelId,
+  onFormComplete,
+  onFormCancel,
+}: EditScoringModelFormProps) => {
+  const messageApi = useMessage()
+
+  const { data: scoringModelData, error } =
+    useGetScoringModelQuery(scoringModelId)
+
+  const [updateScoringModel] = useUpdateScoringModelMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<UpdateScoringModelFormValues>({
+      onSubmit: async (values: UpdateScoringModelFormValues, form) => {
+        try {
+          const request = mapToRequestValues(values)
+          const response = await updateScoringModel({
+            id: scoringModelData!.id,
+            ...request,
+          })
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Scoring Model updated successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              (isApiError(apiError) ? apiError.detail : undefined) ??
+                'An error occurred while updating the scoring model. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while updating the scoring model. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  useEffect(() => {
+    if (!scoringModelData) return
+    form.setFieldsValue({
+      name: scoringModelData.name,
+      description: scoringModelData.description,
+    })
+  }, [scoringModelData, form])
+
+  useEffect(() => {
+    if (error) {
+      messageApi.error(
+        (isApiError(error) ? error.detail : undefined) ??
+          'An error occurred while loading the scoring model. Please try again.',
+      )
+    }
+  }, [error, messageApi])
+
+  return (
+    <Modal
+      title="Edit Scoring Model"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="update-scoring-model-form"
+      >
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 128 }]}
+        >
+          <TextArea
+            autoSize={{ minRows: 1, maxRows: 2 }}
+            showCount
+            maxLength={128}
+          />
+        </Item>
+        <Item
+          name="description"
+          label="Description"
+          rules={[
+            { required: true, message: 'Description is required' },
+            { max: 1024 },
+          ]}
+        >
+          <TextArea
+            autoSize={{ minRows: 6, maxRows: 8 }}
+            showCount
+            maxLength={1024}
+          />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default EditScoringModelForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-model-output-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-model-output-form.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelOutputDto,
+  ScoringModelOutputRequest,
+} from '@/src/services/wayd-api'
+import { useUpdateScoringModelOutputMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Checkbox, Form, Input, Modal, Typography } from 'antd'
+import TextArea from 'antd/es/input/TextArea'
+import { useEffect } from 'react'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+const { Text } = Typography
+
+export interface EditScoringModelOutputFormProps {
+  scoringModelId: string
+  output: ScoringModelOutputDto
+  availableTokens: string[]
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface UpdateScoringModelOutputFormValues {
+  name: string
+  token: string
+  formula: string
+  isPrimary: boolean
+}
+
+const mapToRequestValues = (
+  values: UpdateScoringModelOutputFormValues,
+): ScoringModelOutputRequest => {
+  return {
+    name: values.name,
+    token: values.token,
+    formula: values.formula,
+    isPrimary: values.isPrimary ?? false,
+  } as ScoringModelOutputRequest
+}
+
+const EditScoringModelOutputForm = ({
+  scoringModelId,
+  output,
+  availableTokens,
+  onFormComplete,
+  onFormCancel,
+}: EditScoringModelOutputFormProps) => {
+  const messageApi = useMessage()
+
+  const [updateScoringModelOutput] = useUpdateScoringModelOutputMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<UpdateScoringModelOutputFormValues>({
+      onSubmit: async (values: UpdateScoringModelOutputFormValues, form) => {
+        try {
+          const request = mapToRequestValues(values)
+          const response = await updateScoringModelOutput({
+            scoringModelId,
+            outputId: output.id,
+            ...request,
+          })
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Output updated successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while updating the output. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while updating the output. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  useEffect(() => {
+    if (!output) return
+    form.setFieldsValue({
+      name: output.name,
+      token: output.token,
+      formula: output.formula,
+      isPrimary: output.isPrimary,
+    })
+  }, [output, form])
+
+  return (
+    <Modal
+      title="Edit Output"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="update-scoring-model-output-form"
+      >
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 128 }]}
+        >
+          <Input showCount maxLength={128} />
+        </Item>
+        <Item
+          label="Token"
+          name="token"
+          tooltip="The short identifier later output formulas can reference (e.g., CoD)."
+          rules={[
+            { required: true, message: 'Token is required' },
+            { max: 32 },
+            {
+              pattern: /^[A-Za-z_][A-Za-z0-9_]*$/,
+              message:
+                'Tokens must start with a letter or underscore and contain only letters, digits, or underscores.',
+            },
+          ]}
+        >
+          <Input maxLength={32} />
+        </Item>
+        <Item
+          label="Formula"
+          name="formula"
+          tooltip="An arithmetic expression over criterion tokens and earlier output tokens (e.g., (BV + TC + RR) / JS)."
+          rules={[
+            { required: true, message: 'Formula is required' },
+            { max: 1000 },
+          ]}
+          extra={
+            availableTokens.length > 0 ? (
+              <Text type="secondary">
+                Available tokens: {availableTokens.join(', ')}
+              </Text>
+            ) : undefined
+          }
+        >
+          <TextArea autoSize={{ minRows: 2, maxRows: 4 }} maxLength={1000} />
+        </Item>
+        <Item name="isPrimary" valuePropName="checked">
+          <Checkbox>Primary score (the model&apos;s ranking value)</Checkbox>
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default EditScoringModelOutputForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-scale-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-scale-form.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringScaleDto,
+  ScoringScaleRequest,
+} from '@/src/services/wayd-api'
+import { useUpdateScoringScaleMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Input, Modal } from 'antd'
+import { useEffect } from 'react'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface EditScoringScaleFormProps {
+  scoringModelId: string
+  scale: ScoringScaleDto
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface EditScoringScaleFormValues {
+  name: string
+}
+
+const EditScoringScaleForm = ({
+  scoringModelId,
+  scale,
+  onFormComplete,
+  onFormCancel,
+}: EditScoringScaleFormProps) => {
+  const messageApi = useMessage()
+
+  const [updateScoringScale] = useUpdateScoringScaleMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<EditScoringScaleFormValues>({
+      onSubmit: async (values: EditScoringScaleFormValues, form) => {
+        try {
+          const response = await updateScoringScale({
+            scoringModelId,
+            scaleId: scale.id,
+            name: values.name,
+          } as { scoringModelId: string; scaleId: string } & ScoringScaleRequest)
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Scale updated successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while updating the scale. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while updating the scale. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  useEffect(() => {
+    if (!scale) return
+    form.setFieldsValue({ name: scale.name })
+  }, [scale, form])
+
+  return (
+    <Modal
+      title="Edit Scale"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form form={form} size="small" layout="vertical" name="update-scoring-scale-form">
+        <Item
+          label="Name"
+          name="name"
+          rules={[{ required: true, message: 'Name is required' }, { max: 64 }]}
+        >
+          <Input showCount maxLength={64} />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default EditScoringScaleForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-scale-level-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/edit-scoring-scale-level-form.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringRatingLevelDto,
+  ScoringScaleLevelRequest,
+} from '@/src/services/wayd-api'
+import { useUpdateScoringScaleLevelMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
+import { Form, Input, InputNumber, Modal } from 'antd'
+import { useEffect } from 'react'
+import { useModalForm } from '@/src/hooks'
+
+const { Item } = Form
+
+export interface EditScoringScaleLevelFormProps {
+  scoringModelId: string
+  scaleId: string
+  level: ScoringRatingLevelDto
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+interface EditScoringScaleLevelFormValues {
+  label: string
+  value: number
+}
+
+const EditScoringScaleLevelForm = ({
+  scoringModelId,
+  scaleId,
+  level,
+  onFormComplete,
+  onFormCancel,
+}: EditScoringScaleLevelFormProps) => {
+  const messageApi = useMessage()
+
+  const [updateScoringScaleLevel] = useUpdateScoringScaleLevelMutation()
+
+  const { form, isOpen, isValid, isSaving, handleOk, handleCancel } =
+    useModalForm<EditScoringScaleLevelFormValues>({
+      onSubmit: async (values: EditScoringScaleLevelFormValues, form) => {
+        try {
+          const response = await updateScoringScaleLevel({
+            scoringModelId,
+            scaleId,
+            levelId: level.id,
+            label: values.label,
+            value: values.value,
+          } as {
+            scoringModelId: string
+            scaleId: string
+            levelId: string
+          } & ScoringScaleLevelRequest)
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Rating level updated successfully.')
+          return true
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          if (apiError.status === 422 && apiError.errors) {
+            const formErrors = toFormErrors(apiError.errors)
+            form.setFields(formErrors)
+            messageApi.error('Correct the validation error(s) to continue.')
+          } else {
+            messageApi.error(
+              apiError.detail ??
+                'An error occurred while updating the rating level. Please try again.',
+            )
+          }
+          return false
+        }
+      },
+      onComplete: onFormComplete,
+      onCancel: onFormCancel,
+      errorMessage:
+        'An error occurred while updating the rating level. Please try again.',
+      permission: 'Permissions.ScoringModels.Update',
+    })
+
+  useEffect(() => {
+    if (!level) return
+    form.setFieldsValue({ label: level.label, value: level.value })
+  }, [level, form])
+
+  return (
+    <Modal
+      title="Edit Rating Level"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <Form
+        form={form}
+        size="small"
+        layout="vertical"
+        name="update-scoring-scale-level-form"
+      >
+        <Item
+          label="Label"
+          name="label"
+          rules={[{ required: true, message: 'Label is required' }, { max: 64 }]}
+        >
+          <Input showCount maxLength={64} />
+        </Item>
+        <Item
+          label="Value"
+          name="value"
+          rules={[{ required: true, message: 'Value is required' }]}
+        >
+          <InputNumber style={{ width: '100%' }} />
+        </Item>
+      </Form>
+    </Modal>
+  )
+}
+
+export default EditScoringScaleLevelForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-criteria-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-criteria-list.tsx
@@ -1,0 +1,291 @@
+'use client'
+
+import { WaydGrid } from '@/src/components/common'
+import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelCriterionDto,
+  ScoringModelDetailsDto,
+} from '@/src/services/wayd-api'
+import {
+  useRemoveScoringModelCriterionMutation,
+  useReorderScoringModelCriteriaMutation,
+} from '@/src/store/features/scoring/scoring-models-api'
+import { App, Button, Space, Tag, Typography } from 'antd'
+import { ItemType } from 'antd/es/menu/interface'
+import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import { useMemo, useState } from 'react'
+import AddScoringModelCriterionForm from './add-scoring-model-criterion-form'
+import EditScoringModelCriterionForm from './edit-scoring-model-criterion-form'
+import { isApiError, type ApiError } from '@/src/utils'
+
+const { Text } = Typography
+
+export interface ScoringModelCriteriaListProps {
+  scoringModel: ScoringModelDetailsDto
+  canManage: boolean
+  loadData?: () => void
+}
+
+interface RowMenuProps {
+  criterion: ScoringModelCriterionDto
+  sortedCriteria: ScoringModelCriterionDto[]
+  onEditClicked: (criterion: ScoringModelCriterionDto) => void
+  onDeleteClicked: (criterion: ScoringModelCriterionDto) => void
+  onMoveClicked: (
+    criterion: ScoringModelCriterionDto,
+    direction: 'up' | 'down',
+  ) => void
+}
+
+const getRowMenuItems = (props: RowMenuProps): ItemType[] => {
+  if (!props.criterion) return []
+
+  const index = props.sortedCriteria.findIndex(
+    (c) => c.id === props.criterion.id,
+  )
+  const isFirst = index === 0
+  const isLast = index === props.sortedCriteria.length - 1
+
+  const items: ItemType[] = [
+    {
+      key: 'edit',
+      label: 'Edit',
+      onClick: () => props.onEditClicked(props.criterion),
+    },
+  ]
+
+  if (!isFirst) {
+    items.push({
+      key: 'move-up',
+      label: 'Move Up',
+      onClick: () => props.onMoveClicked(props.criterion, 'up'),
+    })
+  }
+
+  if (!isLast) {
+    items.push({
+      key: 'move-down',
+      label: 'Move Down',
+      onClick: () => props.onMoveClicked(props.criterion, 'down'),
+    })
+  }
+
+  items.push(
+    { key: 'divider', type: 'divider' },
+    {
+      key: 'delete',
+      label: 'Delete',
+      danger: true,
+      onClick: () => props.onDeleteClicked(props.criterion),
+    },
+  )
+
+  return items
+}
+
+const ScoringModelCriteriaList = ({
+  scoringModel,
+  canManage,
+  loadData,
+}: ScoringModelCriteriaListProps) => {
+  const messageApi = useMessage()
+  const { modal } = App.useApp()
+
+  const [openAddForm, setOpenAddForm] = useState(false)
+  const [editingCriterion, setEditingCriterion] =
+    useState<ScoringModelCriterionDto | null>(null)
+
+  const [removeCriterion] = useRemoveScoringModelCriterionMutation()
+  const [reorderCriteria] = useReorderScoringModelCriteriaMutation()
+
+  const sortedCriteria = useMemo(
+    () =>
+      !scoringModel?.criteria
+        ? []
+        : [...scoringModel.criteria].sort((a, b) => a.order - b.order),
+    [scoringModel?.criteria],
+  )
+
+  const totalWeight = useMemo(
+    () => sortedCriteria.reduce((sum, c) => sum + (c.weight ?? 0), 0),
+    [sortedCriteria],
+  )
+
+  const hasAnyWeight = useMemo(
+    () => sortedCriteria.some((c) => c.weight != null),
+    [sortedCriteria],
+  )
+
+  const columnDefs = useMemo<ColDef<ScoringModelCriterionDto>[]>(() => {
+    const handleEdit = (criterion: ScoringModelCriterionDto) => {
+      setEditingCriterion(criterion)
+    }
+
+    const handleDelete = (criterion: ScoringModelCriterionDto) => {
+      modal.confirm({
+        title: 'Are you sure you want to delete this criterion?',
+        content: `${criterion.name} (${criterion.weight}%)`,
+        okText: 'Delete',
+        okType: 'danger',
+        onOk: async () => {
+          try {
+            const response = await removeCriterion({
+              scoringModelId: scoringModel.id,
+              criterionId: criterion.id,
+            })
+            if (response.error) {
+              throw response.error
+            }
+            messageApi.success('Criterion deleted successfully.')
+          } catch (error) {
+            const apiError: ApiError = isApiError(error) ? error : {}
+            messageApi.error(
+              apiError.detail ??
+                'An unexpected error occurred while deleting the criterion.',
+            )
+            console.log(error)
+          }
+        },
+      })
+    }
+
+    const handleMove = async (
+      criterion: ScoringModelCriterionDto,
+      direction: 'up' | 'down',
+    ) => {
+      const ordered = [...sortedCriteria]
+      const index = ordered.findIndex((c) => c.id === criterion.id)
+      if (index < 0) return
+
+      const swapIndex = direction === 'up' ? index - 1 : index + 1
+      if (swapIndex < 0 || swapIndex >= ordered.length) return
+
+      ;[ordered[index], ordered[swapIndex]] = [
+        ordered[swapIndex],
+        ordered[index],
+      ]
+
+      try {
+        const response = await reorderCriteria({
+          scoringModelId: scoringModel.id,
+          orderedCriterionIds: ordered.map((c) => c.id),
+        })
+        if (response.error) {
+          throw response.error
+        }
+      } catch (error) {
+        const apiError: ApiError = isApiError(error) ? error : {}
+        messageApi.error(
+          apiError.detail ?? 'An error occurred while reordering criteria.',
+        )
+        console.error(error)
+      }
+    }
+
+    return [
+      {
+        width: 50,
+        filter: false,
+        sortable: false,
+        resizable: false,
+        hide: !canManage,
+        suppressHeaderMenuButton: true,
+        cellRenderer: (
+          params: ICellRendererParams<ScoringModelCriterionDto>,
+        ) => {
+          const menuItems = getRowMenuItems({
+            criterion: params.data!,
+            sortedCriteria,
+            onEditClicked: handleEdit,
+            onDeleteClicked: handleDelete,
+            onMoveClicked: handleMove,
+          })
+          if (menuItems.length === 0) return null
+          return RowMenuCellRenderer({ ...params, menuItems })
+        },
+      },
+      { field: 'order', headerName: 'Order', width: 90, sort: 'asc' as const },
+      { field: 'name', headerName: 'Name', width: 200 },
+      { field: 'token', headerName: 'Token', width: 110 },
+      {
+        headerName: 'Scale',
+        width: 130,
+        valueGetter: (p) => {
+          const scaleId = p.data?.scaleId
+          if (!scaleId) return 'Free entry'
+          return scoringModel.scales?.find((s) => s.id === scaleId)?.name ?? '—'
+        },
+      },
+      {
+        field: 'weight',
+        headerName: 'Weight (%)',
+        width: 120,
+        valueFormatter: (p) => (p.value != null ? `${p.value}%` : ''),
+      },
+      { field: 'description', headerName: 'Description', flex: 1 },
+    ]
+  }, [
+    canManage,
+    sortedCriteria,
+    modal,
+    removeCriterion,
+    reorderCriteria,
+    scoringModel.id,
+    scoringModel.scales,
+    messageApi,
+  ])
+
+  const weightsBalanced = totalWeight === 100
+
+  const actions = (
+    <Space>
+      {hasAnyWeight && (
+        <Text type={weightsBalanced ? 'success' : 'secondary'}>
+          Total weight: {totalWeight}%
+          {!weightsBalanced && (
+            <Tag color="default" style={{ marginLeft: 8 }}>
+              Tip: weights are typically balanced to 100%
+            </Tag>
+          )}
+        </Text>
+      )}
+      {canManage && (
+        <Button type="primary" size="small" onClick={() => setOpenAddForm(true)}>
+          Add Criterion
+        </Button>
+      )}
+    </Space>
+  )
+
+  return (
+    <>
+      <WaydGrid
+        height={300}
+        columnDefs={columnDefs}
+        rowData={sortedCriteria}
+        actions={actions}
+        loadData={loadData}
+      />
+      {openAddForm && (
+        <AddScoringModelCriterionForm
+          scoringModelId={scoringModel.id}
+          scales={scoringModel.scales ?? []}
+          onFormComplete={() => setOpenAddForm(false)}
+          onFormCancel={() => setOpenAddForm(false)}
+        />
+      )}
+      {editingCriterion && (
+        <EditScoringModelCriterionForm
+          scoringModelId={scoringModel.id}
+          scales={scoringModel.scales ?? []}
+          criterion={editingCriterion}
+          onFormComplete={() => setEditingCriterion(null)}
+          onFormCancel={() => setEditingCriterion(null)}
+        />
+      )}
+    </>
+  )
+}
+
+export default ScoringModelCriteriaList

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-details.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-details.tsx
@@ -1,0 +1,29 @@
+'use client'
+
+import { ScoringModelDetailsDto } from '@/src/services/wayd-api'
+import { Descriptions, Space } from 'antd'
+
+const { Item } = Descriptions
+
+interface ScoringModelDetailsProps {
+  scoringModel: ScoringModelDetailsDto | undefined
+}
+
+const ScoringModelDetails: React.FC<ScoringModelDetailsProps> = ({
+  scoringModel,
+}: ScoringModelDetailsProps) => {
+  if (!scoringModel) return null
+
+  return (
+    <Space orientation="vertical">
+      <Descriptions size="small">
+        <Item label="State">{scoringModel.state?.name}</Item>
+      </Descriptions>
+      <Descriptions size="small">
+        <Item label="Description">{scoringModel.description}</Item>
+      </Descriptions>
+    </Space>
+  )
+}
+
+export default ScoringModelDetails

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-outputs-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-outputs-list.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import { WaydGrid } from '@/src/components/common'
+import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelDetailsDto,
+  ScoringModelOutputDto,
+} from '@/src/services/wayd-api'
+import {
+  useRemoveScoringModelOutputMutation,
+  useReorderScoringModelOutputsMutation,
+} from '@/src/store/features/scoring/scoring-models-api'
+import { App, Button, Space, Tag } from 'antd'
+import { ItemType } from 'antd/es/menu/interface'
+import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import { useMemo, useState } from 'react'
+import AddScoringModelOutputForm from './add-scoring-model-output-form'
+import EditScoringModelOutputForm from './edit-scoring-model-output-form'
+import { isApiError, type ApiError } from '@/src/utils'
+
+export interface ScoringModelOutputsListProps {
+  scoringModel: ScoringModelDetailsDto
+  canManage: boolean
+  loadData?: () => void
+}
+
+interface RowMenuProps {
+  output: ScoringModelOutputDto
+  sortedOutputs: ScoringModelOutputDto[]
+  onEditClicked: (output: ScoringModelOutputDto) => void
+  onDeleteClicked: (output: ScoringModelOutputDto) => void
+  onMoveClicked: (output: ScoringModelOutputDto, direction: 'up' | 'down') => void
+}
+
+const getRowMenuItems = (props: RowMenuProps): ItemType[] => {
+  if (!props.output) return []
+
+  const index = props.sortedOutputs.findIndex((o) => o.id === props.output.id)
+  const isFirst = index === 0
+  const isLast = index === props.sortedOutputs.length - 1
+
+  const items: ItemType[] = [
+    {
+      key: 'edit',
+      label: 'Edit',
+      onClick: () => props.onEditClicked(props.output),
+    },
+  ]
+
+  if (!isFirst) {
+    items.push({
+      key: 'move-up',
+      label: 'Move Up',
+      onClick: () => props.onMoveClicked(props.output, 'up'),
+    })
+  }
+
+  if (!isLast) {
+    items.push({
+      key: 'move-down',
+      label: 'Move Down',
+      onClick: () => props.onMoveClicked(props.output, 'down'),
+    })
+  }
+
+  items.push(
+    { key: 'divider', type: 'divider' },
+    {
+      key: 'delete',
+      label: 'Delete',
+      danger: true,
+      onClick: () => props.onDeleteClicked(props.output),
+    },
+  )
+
+  return items
+}
+
+const ScoringModelOutputsList = ({
+  scoringModel,
+  canManage,
+  loadData,
+}: ScoringModelOutputsListProps) => {
+  const messageApi = useMessage()
+  const { modal } = App.useApp()
+
+  const [openAddForm, setOpenAddForm] = useState(false)
+  const [addInitialValues, setAddInitialValues] = useState<
+    | { name?: string; token?: string; formula?: string; isPrimary?: boolean }
+    | undefined
+  >(undefined)
+  const [editingOutput, setEditingOutput] =
+    useState<ScoringModelOutputDto | null>(null)
+
+  const [removeOutput] = useRemoveScoringModelOutputMutation()
+  const [reorderOutputs] = useReorderScoringModelOutputsMutation()
+
+  const sortedOutputs = useMemo(
+    () =>
+      !scoringModel?.outputs
+        ? []
+        : [...scoringModel.outputs].sort((a, b) => a.order - b.order),
+    [scoringModel?.outputs],
+  )
+
+  // Tokens a formula can reference: every criterion token plus every output token.
+  const availableTokens = useMemo(
+    () => [
+      ...(scoringModel?.criteria ?? []).map((c) => c.token),
+      ...(scoringModel?.outputs ?? []).map((o) => o.token),
+    ],
+    [scoringModel?.criteria, scoringModel?.outputs],
+  )
+
+  const columnDefs = useMemo<ColDef<ScoringModelOutputDto>[]>(() => {
+    const handleEdit = (output: ScoringModelOutputDto) => {
+      setEditingOutput(output)
+    }
+
+    const handleDelete = (output: ScoringModelOutputDto) => {
+      modal.confirm({
+        title: 'Are you sure you want to delete this output?',
+        content: `${output.name} = ${output.formula}`,
+        okText: 'Delete',
+        okType: 'danger',
+        onOk: async () => {
+          try {
+            const response = await removeOutput({
+              scoringModelId: scoringModel.id,
+              outputId: output.id,
+            })
+            if (response.error) {
+              throw response.error
+            }
+            messageApi.success('Output deleted successfully.')
+          } catch (error) {
+            const apiError: ApiError = isApiError(error) ? error : {}
+            messageApi.error(
+              apiError.detail ??
+                'An unexpected error occurred while deleting the output.',
+            )
+            console.log(error)
+          }
+        },
+      })
+    }
+
+    const handleMove = async (
+      output: ScoringModelOutputDto,
+      direction: 'up' | 'down',
+    ) => {
+      const ordered = [...sortedOutputs]
+      const index = ordered.findIndex((o) => o.id === output.id)
+      if (index < 0) return
+
+      const swapIndex = direction === 'up' ? index - 1 : index + 1
+      if (swapIndex < 0 || swapIndex >= ordered.length) return
+
+      ;[ordered[index], ordered[swapIndex]] = [
+        ordered[swapIndex],
+        ordered[index],
+      ]
+
+      try {
+        const response = await reorderOutputs({
+          scoringModelId: scoringModel.id,
+          orderedOutputIds: ordered.map((o) => o.id),
+        })
+        if (response.error) {
+          throw response.error
+        }
+      } catch (error) {
+        const apiError: ApiError = isApiError(error) ? error : {}
+        messageApi.error(
+          apiError.detail ?? 'An error occurred while reordering outputs.',
+        )
+        console.error(error)
+      }
+    }
+
+    return [
+      {
+        width: 50,
+        filter: false,
+        sortable: false,
+        resizable: false,
+        hide: !canManage,
+        suppressHeaderMenuButton: true,
+        cellRenderer: (params: ICellRendererParams<ScoringModelOutputDto>) => {
+          const menuItems = getRowMenuItems({
+            output: params.data!,
+            sortedOutputs,
+            onEditClicked: handleEdit,
+            onDeleteClicked: handleDelete,
+            onMoveClicked: handleMove,
+          })
+          if (menuItems.length === 0) return null
+          return RowMenuCellRenderer({ ...params, menuItems })
+        },
+      },
+      { field: 'order', headerName: 'Order', width: 90, sort: 'asc' as const },
+      { field: 'name', headerName: 'Name', width: 180 },
+      { field: 'token', headerName: 'Token', width: 110 },
+      { field: 'formula', headerName: 'Formula', flex: 1 },
+      {
+        field: 'isPrimary',
+        headerName: 'Primary',
+        width: 110,
+        cellRenderer: (params: ICellRendererParams<ScoringModelOutputDto>) =>
+          params.value ? <Tag color="blue">Primary</Tag> : null,
+      },
+    ]
+  }, [
+    canManage,
+    sortedOutputs,
+    modal,
+    removeOutput,
+    reorderOutputs,
+    scoringModel.id,
+    messageApi,
+  ])
+
+  // Build a normalized weighted-sum formula from criteria that have weights:
+  // (T1*w1 + T2*w2 + ...) / (w1 + w2 + ...). Scaffolding only — fully editable afterward.
+  const weightedScaffold = useMemo(() => {
+    const weighted = (scoringModel?.criteria ?? []).filter(
+      (c) => c.weight != null && c.weight > 0,
+    )
+    if (weighted.length < 2) return null
+
+    const totalWeight = weighted.reduce((sum, c) => sum + (c.weight ?? 0), 0)
+    const numerator = weighted
+      .map((c) => `${c.token} * ${c.weight}`)
+      .join(' + ')
+    return `(${numerator}) / ${totalWeight}`
+  }, [scoringModel?.criteria])
+
+  const openWeightedScaffold = () => {
+    setAddInitialValues({
+      name: 'Weighted Score',
+      token: 'Score',
+      formula: weightedScaffold ?? '',
+      isPrimary: true,
+    })
+    setOpenAddForm(true)
+  }
+
+  const openBlankAdd = () => {
+    setAddInitialValues(undefined)
+    setOpenAddForm(true)
+  }
+
+  const closeAddForm = () => {
+    setOpenAddForm(false)
+    setAddInitialValues(undefined)
+  }
+
+  const actions = (
+    <Space>
+      {canManage && weightedScaffold && (
+        <Button
+          size="small"
+          onClick={openWeightedScaffold}
+          title="Pre-fill a weighted-sum formula from the criteria weights. You can edit it afterward."
+        >
+          Generate Weighted Formula
+        </Button>
+      )}
+      {canManage && (
+        <Button type="primary" size="small" onClick={openBlankAdd}>
+          Add Output
+        </Button>
+      )}
+    </Space>
+  )
+
+  return (
+    <>
+      <WaydGrid
+        height={300}
+        columnDefs={columnDefs}
+        rowData={sortedOutputs}
+        actions={actions}
+        loadData={loadData}
+      />
+      {openAddForm && (
+        <AddScoringModelOutputForm
+          scoringModelId={scoringModel.id}
+          availableTokens={availableTokens}
+          initialValues={addInitialValues}
+          onFormComplete={closeAddForm}
+          onFormCancel={closeAddForm}
+        />
+      )}
+      {editingOutput && (
+        <EditScoringModelOutputForm
+          scoringModelId={scoringModel.id}
+          output={editingOutput}
+          availableTokens={availableTokens}
+          onFormComplete={() => setEditingOutput(null)}
+          onFormCancel={() => setEditingOutput(null)}
+        />
+      )}
+    </>
+  )
+}
+
+export default ScoringModelOutputsList

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-test-panel.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-test-panel.tsx
@@ -1,0 +1,193 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelDetailsDto,
+  ScoringModelEvaluationDto,
+} from '@/src/services/wayd-api'
+import { useEvaluateScoringModelMutation } from '@/src/store/features/scoring/scoring-models-api'
+import { isApiError, type ApiError } from '@/src/utils'
+import {
+  Alert,
+  Button,
+  Card,
+  Empty,
+  Form,
+  InputNumber,
+  Select,
+  Space,
+  Statistic,
+  Tag,
+  Typography,
+  theme,
+} from 'antd'
+import { useMemo, useState } from 'react'
+
+const { Text } = Typography
+
+export interface ScoringModelTestPanelProps {
+  scoringModel: ScoringModelDetailsDto
+}
+
+type CriterionValues = Record<string, number | null>
+
+const ScoringModelTestPanel = ({ scoringModel }: ScoringModelTestPanelProps) => {
+  const messageApi = useMessage()
+  const { token } = theme.useToken()
+
+  const [evaluate, { isLoading }] = useEvaluateScoringModelMutation()
+
+  const sortedCriteria = useMemo(
+    () => [...(scoringModel.criteria ?? [])].sort((a, b) => a.order - b.order),
+    [scoringModel.criteria],
+  )
+
+  const scalesById = useMemo(
+    () => new Map((scoringModel.scales ?? []).map((s) => [s.id, s])),
+    [scoringModel.scales],
+  )
+
+  const [values, setValues] = useState<CriterionValues>({})
+  const [result, setResult] = useState<ScoringModelEvaluationDto | null>(null)
+
+  const setValue = (criterionId: string, value: number | null) => {
+    setValues((prev) => ({ ...prev, [criterionId]: value }))
+    // A changed input invalidates the previously shown result.
+    setResult(null)
+  }
+
+  const allRated = sortedCriteria.every(
+    (c) => values[c.id] !== undefined && values[c.id] !== null,
+  )
+
+  const handleCalculate = async () => {
+    try {
+      const response = await evaluate({
+        scoringModelId: scoringModel.id,
+        criterionValues: sortedCriteria.map((c) => ({
+          criterionId: c.id,
+          value: values[c.id] as number,
+        })),
+      })
+      if (response.error) {
+        throw response.error
+      }
+      setResult(response.data ?? null)
+    } catch (error) {
+      const apiError: ApiError = isApiError(error) ? error : {}
+      setResult(null)
+      messageApi.error(
+        apiError.detail ??
+          'An error occurred while evaluating the scoring model. Please try again.',
+      )
+    }
+  }
+
+  if (sortedCriteria.length === 0) {
+    return (
+      <Empty description="Add criteria and outputs to test this scoring model." />
+    )
+  }
+
+  return (
+    <Space orientation="vertical" size="large" style={{ width: '100%' }}>
+      <Alert
+        type="info"
+        title="Plug in a value for each criterion to preview the output formulas. Nothing is saved."
+      />
+
+      <Card size="small" title="Criterion values">
+        <Form layout="vertical" size="small">
+          {sortedCriteria.map((criterion) => {
+            const scale = criterion.scaleId
+              ? scalesById.get(criterion.scaleId)
+              : undefined
+            const sortedLevels = scale
+              ? [...scale.levels].sort((a, b) => a.order - b.order)
+              : []
+            return (
+              <Form.Item
+                key={criterion.id}
+                label={
+                  <Space size="small">
+                    <Text strong>{criterion.name}</Text>
+                    <Tag>{criterion.token}</Tag>
+                  </Space>
+                }
+                tooltip={
+                  scale
+                    ? `Rated on the "${scale.name}" scale.`
+                    : 'Free numeric entry — no scale assigned.'
+                }
+                style={{ marginBottom: token.marginSM }}
+              >
+                {scale ? (
+                  <Select
+                    style={{ width: '100%' }}
+                    value={values[criterion.id] ?? undefined}
+                    onChange={(v) => setValue(criterion.id, v ?? null)}
+                    placeholder="Select a rating"
+                    options={sortedLevels.map((l) => ({
+                      value: l.value,
+                      label:
+                        l.label === l.value.toString()
+                          ? l.label
+                          : `${l.label} (${l.value})`,
+                    }))}
+                  />
+                ) : (
+                  <InputNumber
+                    style={{ width: '100%' }}
+                    value={values[criterion.id] ?? null}
+                    onChange={(v) => setValue(criterion.id, v)}
+                    placeholder="Enter a numeric value"
+                  />
+                )}
+              </Form.Item>
+            )
+          })}
+          <Button
+            type="primary"
+            size="small"
+            loading={isLoading}
+            disabled={!allRated}
+            onClick={handleCalculate}
+          >
+            Calculate
+          </Button>
+        </Form>
+      </Card>
+
+      {result && (
+        <Card size="small" title="Results">
+          <Space size="large" wrap>
+            {[...result.outputs]
+              .sort((a, b) => a.order - b.order)
+              .map((output) => (
+                <Statistic
+                  key={output.token}
+                  title={
+                    <Space size="small">
+                      {output.name}
+                      {output.isPrimary && (
+                        <Tag color={token.colorPrimary}>Score</Tag>
+                      )}
+                    </Space>
+                  }
+                  value={output.value}
+                  precision={2}
+                  styles={
+                    output.isPrimary
+                      ? { content: { color: token.colorPrimary } }
+                      : undefined
+                  }
+                />
+              ))}
+          </Space>
+        </Card>
+      )}
+    </Space>
+  )
+}
+
+export default ScoringModelTestPanel

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-scales-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-scales-list.tsx
@@ -1,0 +1,294 @@
+'use client'
+
+import { WaydGrid } from '@/src/components/common'
+import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  ScoringModelDetailsDto,
+  ScoringRatingLevelDto,
+  ScoringScaleDto,
+} from '@/src/services/wayd-api'
+import {
+  useRemoveScoringScaleMutation,
+  useRemoveScoringScaleLevelMutation,
+  useReorderScoringScaleLevelsMutation,
+} from '@/src/store/features/scoring/scoring-models-api'
+import { App, Button, Collapse, Empty, Space, Typography } from 'antd'
+import { ItemType } from 'antd/es/menu/interface'
+import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import { useMemo, useState } from 'react'
+import AddScoringScaleForm from './add-scoring-scale-form'
+import EditScoringScaleForm from './edit-scoring-scale-form'
+import AddScoringScaleLevelForm from './add-scoring-scale-level-form'
+import EditScoringScaleLevelForm from './edit-scoring-scale-level-form'
+import { isApiError, type ApiError } from '@/src/utils'
+
+const { Text } = Typography
+
+export interface ScoringScalesListProps {
+  scoringModel: ScoringModelDetailsDto
+  canManage: boolean
+  loadData?: () => void
+}
+
+const ScoringScalesList = ({
+  scoringModel,
+  canManage,
+  loadData,
+}: ScoringScalesListProps) => {
+  const messageApi = useMessage()
+  const { modal } = App.useApp()
+
+  const [openAddScale, setOpenAddScale] = useState(false)
+  const [editingScale, setEditingScale] = useState<ScoringScaleDto | null>(null)
+  const [addLevelScaleId, setAddLevelScaleId] = useState<string | null>(null)
+  const [editingLevel, setEditingLevel] = useState<{
+    scaleId: string
+    level: ScoringRatingLevelDto
+  } | null>(null)
+
+  const [removeScale] = useRemoveScoringScaleMutation()
+  const [removeLevel] = useRemoveScoringScaleLevelMutation()
+  const [reorderLevels] = useReorderScoringScaleLevelsMutation()
+
+  const sortedScales = useMemo(
+    () =>
+      !scoringModel?.scales
+        ? []
+        : [...scoringModel.scales].sort((a, b) => a.order - b.order),
+    [scoringModel?.scales],
+  )
+
+  const handleDeleteScale = (scale: ScoringScaleDto) => {
+    modal.confirm({
+      title: 'Delete this scale?',
+      content: scale.name,
+      okText: 'Delete',
+      okType: 'danger',
+      onOk: async () => {
+        try {
+          const response = await removeScale({
+            scoringModelId: scoringModel.id,
+            scaleId: scale.id,
+          })
+          if (response.error) {
+            throw response.error
+          }
+          messageApi.success('Scale deleted successfully.')
+        } catch (error) {
+          const apiError: ApiError = isApiError(error) ? error : {}
+          messageApi.error(
+            apiError.detail ??
+              'An unexpected error occurred while deleting the scale.',
+          )
+        }
+      },
+    })
+  }
+
+  const makeLevelColumnDefs = (
+    scale: ScoringScaleDto,
+    sortedLevels: ScoringRatingLevelDto[],
+  ): ColDef<ScoringRatingLevelDto>[] => {
+    const handleDeleteLevel = (level: ScoringRatingLevelDto) => {
+      modal.confirm({
+        title: 'Delete this rating level?',
+        content: `${level.label} (${level.value})`,
+        okText: 'Delete',
+        okType: 'danger',
+        onOk: async () => {
+          try {
+            const response = await removeLevel({
+              scoringModelId: scoringModel.id,
+              scaleId: scale.id,
+              levelId: level.id,
+            })
+            if (response.error) {
+              throw response.error
+            }
+            messageApi.success('Rating level deleted successfully.')
+          } catch (error) {
+            const apiError: ApiError = isApiError(error) ? error : {}
+            messageApi.error(
+              apiError.detail ??
+                'An unexpected error occurred while deleting the rating level.',
+            )
+          }
+        },
+      })
+    }
+
+    const handleMoveLevel = async (
+      level: ScoringRatingLevelDto,
+      direction: 'up' | 'down',
+    ) => {
+      const ordered = [...sortedLevels]
+      const index = ordered.findIndex((l) => l.id === level.id)
+      if (index < 0) return
+      const swapIndex = direction === 'up' ? index - 1 : index + 1
+      if (swapIndex < 0 || swapIndex >= ordered.length) return
+      ;[ordered[index], ordered[swapIndex]] = [ordered[swapIndex], ordered[index]]
+
+      try {
+        const response = await reorderLevels({
+          scoringModelId: scoringModel.id,
+          scaleId: scale.id,
+          orderedLevelIds: ordered.map((l) => l.id),
+        })
+        if (response.error) {
+          throw response.error
+        }
+      } catch (error) {
+        const apiError: ApiError = isApiError(error) ? error : {}
+        messageApi.error(
+          apiError.detail ??
+            'An error occurred while reordering rating levels.',
+        )
+      }
+    }
+
+    const getRowMenuItems = (
+      level: ScoringRatingLevelDto,
+    ): ItemType[] => {
+      const index = sortedLevels.findIndex((l) => l.id === level.id)
+      const items: ItemType[] = [
+        {
+          key: 'edit',
+          label: 'Edit',
+          onClick: () => setEditingLevel({ scaleId: scale.id, level }),
+        },
+      ]
+      if (index > 0) {
+        items.push({
+          key: 'move-up',
+          label: 'Move Up',
+          onClick: () => handleMoveLevel(level, 'up'),
+        })
+      }
+      if (index < sortedLevels.length - 1) {
+        items.push({
+          key: 'move-down',
+          label: 'Move Down',
+          onClick: () => handleMoveLevel(level, 'down'),
+        })
+      }
+      items.push(
+        { key: 'divider', type: 'divider' },
+        {
+          key: 'delete',
+          label: 'Delete',
+          danger: true,
+          onClick: () => handleDeleteLevel(level),
+        },
+      )
+      return items
+    }
+
+    return [
+      {
+        width: 50,
+        filter: false,
+        sortable: false,
+        resizable: false,
+        hide: !canManage,
+        suppressHeaderMenuButton: true,
+        cellRenderer: (params: ICellRendererParams<ScoringRatingLevelDto>) =>
+          RowMenuCellRenderer({
+            ...params,
+            menuItems: getRowMenuItems(params.data!),
+          }),
+      },
+      { field: 'order', headerName: 'Order', width: 90, sort: 'asc' as const },
+      { field: 'label', headerName: 'Label', width: 200 },
+      { field: 'value', headerName: 'Value', flex: 1 },
+    ]
+  }
+
+  const collapseItems = sortedScales.map((scale) => {
+    const sortedLevels = [...scale.levels].sort((a, b) => a.order - b.order)
+    return {
+      key: scale.id,
+      label: (
+        <Space>
+          <Text strong>{scale.name}</Text>
+          <Text type="secondary">
+            ({scale.levels.length} level{scale.levels.length === 1 ? '' : 's'})
+          </Text>
+        </Space>
+      ),
+      extra: canManage ? (
+        <Space onClick={(e) => e.stopPropagation()}>
+          <Button size="small" onClick={() => setAddLevelScaleId(scale.id)}>
+            Add Level
+          </Button>
+          <Button size="small" onClick={() => setEditingScale(scale)}>
+            Rename
+          </Button>
+          <Button size="small" danger onClick={() => handleDeleteScale(scale)}>
+            Delete
+          </Button>
+        </Space>
+      ) : undefined,
+      children: (
+        <WaydGrid
+          height={220}
+          columnDefs={makeLevelColumnDefs(scale, sortedLevels)}
+          rowData={sortedLevels}
+          loadData={loadData}
+        />
+      ),
+    }
+  })
+
+  return (
+    <>
+      <Space orientation="vertical" style={{ width: '100%' }}>
+        {canManage && (
+          <Button type="primary" size="small" onClick={() => setOpenAddScale(true)}>
+            Add Scale
+          </Button>
+        )}
+        {sortedScales.length === 0 ? (
+          <Empty description="No scales. Criteria without a scale are rated by free numeric entry." />
+        ) : (
+          <Collapse items={collapseItems} defaultActiveKey={sortedScales.map((s) => s.id)} />
+        )}
+      </Space>
+
+      {openAddScale && (
+        <AddScoringScaleForm
+          scoringModelId={scoringModel.id}
+          onFormComplete={() => setOpenAddScale(false)}
+          onFormCancel={() => setOpenAddScale(false)}
+        />
+      )}
+      {editingScale && (
+        <EditScoringScaleForm
+          scoringModelId={scoringModel.id}
+          scale={editingScale}
+          onFormComplete={() => setEditingScale(null)}
+          onFormCancel={() => setEditingScale(null)}
+        />
+      )}
+      {addLevelScaleId && (
+        <AddScoringScaleLevelForm
+          scoringModelId={scoringModel.id}
+          scaleId={addLevelScaleId}
+          onFormComplete={() => setAddLevelScaleId(null)}
+          onFormCancel={() => setAddLevelScaleId(null)}
+        />
+      )}
+      {editingLevel && (
+        <EditScoringScaleLevelForm
+          scoringModelId={scoringModel.id}
+          scaleId={editingLevel.scaleId}
+          level={editingLevel.level}
+          onFormComplete={() => setEditingLevel(null)}
+          onFormCancel={() => setEditingLevel(null)}
+        />
+      )}
+    </>
+  )
+}
+
+export default ScoringScalesList

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/page.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { WaydGrid, PageTitle } from '@/src/components/common'
+import useAuth from '@/src/components/contexts/auth'
+import { authorizePage } from '@/src/components/hoc'
+import { useDocumentTitle } from '@/src/hooks'
+import { ScoringModelListDto } from '@/src/services/wayd-api'
+import { useGetScoringModelsQuery } from '@/src/store/features/scoring/scoring-models-api'
+import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import { Button } from 'antd'
+import Link from 'next/link'
+import { useEffect, useMemo, useState } from 'react'
+import CreateScoringModelForm from './_components/create-scoring-model-form'
+import { useMessage } from '@/src/components/contexts/messaging'
+import { isApiError } from '@/src/utils'
+
+const ScoringModelCellRenderer = ({
+  value,
+  data,
+}: ICellRendererParams<ScoringModelListDto>) => {
+  return <Link href={`./scoring-models/${data!.key}`}>{value}</Link>
+}
+
+const ScoringModelsPage = () => {
+  useDocumentTitle('Settings - Scoring Models')
+  const [openCreateForm, setOpenCreateForm] = useState<boolean>(false)
+
+  const messageApi = useMessage()
+
+  const {
+    data: scoringModelData,
+    isLoading,
+    error,
+    refetch,
+  } = useGetScoringModelsQuery(null)
+
+  const { hasPermissionClaim } = useAuth()
+  const canCreateScoringModel = hasPermissionClaim(
+    'Permissions.ScoringModels.Create',
+  )
+  const showActions = canCreateScoringModel
+
+  useEffect(() => {
+    if (error) {
+      messageApi.error(
+        (isApiError(error) ? error.detail : undefined) ??
+          'An error occurred while loading scoring models',
+      )
+      console.error(error)
+    }
+  }, [error, messageApi])
+
+  const columnDefs = useMemo<ColDef<ScoringModelListDto>[]>(
+    () => [
+      { field: 'id', hide: true },
+      { field: 'key', width: 90 },
+      { field: 'name', cellRenderer: ScoringModelCellRenderer, sort: 'asc' },
+      { field: 'state.name', headerName: 'State', width: 100 },
+      { field: 'criterionCount', headerName: 'Criteria', width: 110 },
+      { field: 'scaleCount', headerName: 'Scales', width: 110 },
+      { field: 'outputCount', headerName: 'Outputs', width: 110 },
+    ],
+    [],
+  )
+
+  const refresh = async () => {
+    refetch()
+  }
+
+  const actions = !showActions ? null : (
+    <>
+      {canCreateScoringModel && (
+        <Button onClick={() => setOpenCreateForm(true)}>
+          Create Scoring Model
+        </Button>
+      )}
+    </>
+  )
+
+  const onCreateFormClosed = (wasCreated: boolean) => {
+    setOpenCreateForm(false)
+    if (wasCreated) {
+      refetch()
+    }
+  }
+
+  return (
+    <>
+      <PageTitle title="Scoring Models" actions={actions} />
+
+      <WaydGrid
+        height={600}
+        columnDefs={columnDefs}
+        rowData={scoringModelData}
+        loadData={refresh}
+        loading={isLoading}
+      />
+      {openCreateForm && (
+        <CreateScoringModelForm
+          onFormComplete={() => onCreateFormClosed(true)}
+          onFormCancel={() => onCreateFormClosed(false)}
+        />
+      )}
+    </>
+  )
+}
+
+const ScoringModelsPageWithAuthorization = authorizePage(
+  ScoringModelsPage,
+  'Permission',
+  'Permissions.ScoringModels.View',
+)
+
+export default ScoringModelsPageWithAuthorization
+

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
@@ -31,6 +31,7 @@ import {
   ProjectTasksClient,
   StrategicInitiativesClient,
   ProjectLifecyclesClient,
+  ScoringModelsClient,
   SprintsClient,
   EstimationScalesClient,
   PokerSessionsClient,
@@ -399,6 +400,8 @@ export const getStrategicInitiativesClient = () =>
   new StrategicInitiativesClient('', axiosClient)
 export const getProjectLifecyclesClient = () =>
   new ProjectLifecyclesClient('', axiosClient)
+export const getScoringModelsClient = () =>
+  new ScoringModelsClient('', axiosClient)
 
 // SEARCH
 export const getSearchClient = () => new SearchClient('', axiosClient)

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -27027,6 +27027,78 @@ export class ScoringModelsClient {
     }
 
     /**
+     * Evaluate (test) a scoring model against supplied criterion values.
+     */
+    evaluate(id: string, request: EvaluateScoringModelRequest, cancelToken?: CancelToken): Promise<ScoringModelEvaluationDto> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/evaluate";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processEvaluate(_response);
+        });
+    }
+
+    protected processEvaluate(response: AxiosResponse): Promise<ScoringModelEvaluationDto> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<ScoringModelEvaluationDto>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ScoringModelEvaluationDto>(null as any);
+    }
+
+    /**
      * Add a criterion to a scoring model.
      */
     addCriterion(id: string, request: ScoringModelCriterionRequest, cancelToken?: CancelToken): Promise<string> {
@@ -31713,6 +31785,30 @@ export interface UpdateScoringModelRequest {
     name: string;
     /** The description of the scoring model. */
     description: string;
+}
+
+export interface ScoringModelEvaluationDto {
+    primaryValue: number;
+    outputs: ScoringModelOutputValueDto[];
+}
+
+export interface ScoringModelOutputValueDto {
+    token: string;
+    name: string;
+    value: number;
+    isPrimary: boolean;
+    order: number;
+}
+
+/** A request to evaluate (test) a scoring model against a set of supplied criterion values, returning the resulting output values without persisting anything. */
+export interface EvaluateScoringModelRequest {
+    /** The value to plug in for each criterion, keyed by criterion id. */
+    criterionValues: CriterionValue[];
+}
+
+export interface CriterionValue {
+    criterionId: string;
+    value: number;
 }
 
 export interface ScoringModelCriterionRequest {

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -26576,6 +26576,1525 @@ export class BackgroundJobsClient {
     }
 }
 
+export class ScoringModelsClient {
+    protected instance: AxiosInstance;
+    protected baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, instance?: AxiosInstance) {
+
+        this.instance = instance || axios.create();
+
+        this.baseUrl = baseUrl ?? "";
+
+    }
+
+    /**
+     * Get a list of scoring models.
+     * @param state (optional) 
+     */
+    getScoringModels(state?: ScoringModelState | null | undefined, cancelToken?: CancelToken): Promise<ScoringModelListDto[]> {
+        let url_ = this.baseUrl + "/api/scoring-models?";
+        if (state !== undefined && state !== null)
+            url_ += "state=" + encodeURIComponent("" + state) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetScoringModels(_response);
+        });
+    }
+
+    protected processGetScoringModels(response: AxiosResponse): Promise<ScoringModelListDto[]> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<ScoringModelListDto[]>(result200);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ScoringModelListDto[]>(null as any);
+    }
+
+    /**
+     * Create a scoring model.
+     */
+    create(request: CreateScoringModelRequest, cancelToken?: CancelToken): Promise<string> {
+        let url_ = this.baseUrl + "/api/scoring-models";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processCreate(_response);
+        });
+    }
+
+    protected processCreate(response: AxiosResponse): Promise<string> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 201) {
+            const _responseText = response.data;
+            let result201: any = null;
+            let resultData201  = _responseText;
+            result201 = resultData201;
+            return Promise.resolve<string>(result201);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<string>(null as any);
+    }
+
+    /**
+     * Get scoring model details.
+     */
+    getScoringModel(idOrKey: string, cancelToken?: CancelToken): Promise<ScoringModelDetailsDto> {
+        let url_ = this.baseUrl + "/api/scoring-models/{idOrKey}";
+        if (idOrKey === undefined || idOrKey === null)
+            throw new globalThis.Error("The parameter 'idOrKey' must be defined.");
+        url_ = url_.replace("{idOrKey}", encodeURIComponent("" + idOrKey));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetScoringModel(_response);
+        });
+    }
+
+    protected processGetScoringModel(response: AxiosResponse): Promise<ScoringModelDetailsDto> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<ScoringModelDetailsDto>(result200);
+
+        } else if (status === 404) {
+            const _responseText = response.data;
+            let result404: any = null;
+            let resultData404  = _responseText;
+            result404 = resultData404;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<ScoringModelDetailsDto>(null as any);
+    }
+
+    /**
+     * Update a scoring model.
+     */
+    update(id: string, request: UpdateScoringModelRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdate(_response);
+        });
+    }
+
+    protected processUpdate(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Delete a scoring model.
+     */
+    delete(id: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDelete(_response);
+        });
+    }
+
+    protected processDelete(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Activate a scoring model.
+     */
+    activate(id: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/activate";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processActivate(_response);
+        });
+    }
+
+    protected processActivate(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Archive a scoring model.
+     */
+    archive(id: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/archive";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "POST",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processArchive(_response);
+        });
+    }
+
+    protected processArchive(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Add a criterion to a scoring model.
+     */
+    addCriterion(id: string, request: ScoringModelCriterionRequest, cancelToken?: CancelToken): Promise<string> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/criteria";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAddCriterion(_response);
+        });
+    }
+
+    protected processAddCriterion(response: AxiosResponse): Promise<string> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 201) {
+            const _responseText = response.data;
+            let result201: any = null;
+            let resultData201  = _responseText;
+            result201 = resultData201;
+            return Promise.resolve<string>(result201);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<string>(null as any);
+    }
+
+    /**
+     * Update a criterion in a scoring model.
+     */
+    updateCriterion(id: string, criterionId: string, request: ScoringModelCriterionRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/criteria/{criterionId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (criterionId === undefined || criterionId === null)
+            throw new globalThis.Error("The parameter 'criterionId' must be defined.");
+        url_ = url_.replace("{criterionId}", encodeURIComponent("" + criterionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateCriterion(_response);
+        });
+    }
+
+    protected processUpdateCriterion(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Remove a criterion from a scoring model.
+     */
+    removeCriterion(id: string, criterionId: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/criteria/{criterionId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (criterionId === undefined || criterionId === null)
+            throw new globalThis.Error("The parameter 'criterionId' must be defined.");
+        url_ = url_.replace("{criterionId}", encodeURIComponent("" + criterionId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRemoveCriterion(_response);
+        });
+    }
+
+    protected processRemoveCriterion(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Reorder criteria in a scoring model.
+     */
+    reorderCriteria(id: string, request: ReorderScoringModelCriteriaRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/criteria/reorder";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processReorderCriteria(_response);
+        });
+    }
+
+    protected processReorderCriteria(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Add a rating scale to a scoring model.
+     */
+    addScale(id: string, request: ScoringScaleRequest, cancelToken?: CancelToken): Promise<string> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAddScale(_response);
+        });
+    }
+
+    protected processAddScale(response: AxiosResponse): Promise<string> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 201) {
+            const _responseText = response.data;
+            let result201: any = null;
+            let resultData201  = _responseText;
+            result201 = resultData201;
+            return Promise.resolve<string>(result201);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<string>(null as any);
+    }
+
+    /**
+     * Rename a rating scale in a scoring model.
+     */
+    updateScale(id: string, scaleId: string, request: ScoringScaleRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/{scaleId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (scaleId === undefined || scaleId === null)
+            throw new globalThis.Error("The parameter 'scaleId' must be defined.");
+        url_ = url_.replace("{scaleId}", encodeURIComponent("" + scaleId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateScale(_response);
+        });
+    }
+
+    protected processUpdateScale(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Remove a rating scale from a scoring model.
+     */
+    removeScale(id: string, scaleId: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/{scaleId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (scaleId === undefined || scaleId === null)
+            throw new globalThis.Error("The parameter 'scaleId' must be defined.");
+        url_ = url_.replace("{scaleId}", encodeURIComponent("" + scaleId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRemoveScale(_response);
+        });
+    }
+
+    protected processRemoveScale(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Reorder rating scales in a scoring model.
+     */
+    reorderScales(id: string, request: ReorderScoringScalesRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/reorder";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processReorderScales(_response);
+        });
+    }
+
+    protected processReorderScales(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Add a rating level to a scale.
+     */
+    addScaleLevel(id: string, scaleId: string, request: ScoringScaleLevelRequest, cancelToken?: CancelToken): Promise<string> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/{scaleId}/levels";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (scaleId === undefined || scaleId === null)
+            throw new globalThis.Error("The parameter 'scaleId' must be defined.");
+        url_ = url_.replace("{scaleId}", encodeURIComponent("" + scaleId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAddScaleLevel(_response);
+        });
+    }
+
+    protected processAddScaleLevel(response: AxiosResponse): Promise<string> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 201) {
+            const _responseText = response.data;
+            let result201: any = null;
+            let resultData201  = _responseText;
+            result201 = resultData201;
+            return Promise.resolve<string>(result201);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<string>(null as any);
+    }
+
+    /**
+     * Update a rating level on a scale.
+     */
+    updateScaleLevel(id: string, scaleId: string, levelId: string, request: ScoringScaleLevelRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/{scaleId}/levels/{levelId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (scaleId === undefined || scaleId === null)
+            throw new globalThis.Error("The parameter 'scaleId' must be defined.");
+        url_ = url_.replace("{scaleId}", encodeURIComponent("" + scaleId));
+        if (levelId === undefined || levelId === null)
+            throw new globalThis.Error("The parameter 'levelId' must be defined.");
+        url_ = url_.replace("{levelId}", encodeURIComponent("" + levelId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateScaleLevel(_response);
+        });
+    }
+
+    protected processUpdateScaleLevel(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Remove a rating level from a scale.
+     */
+    removeScaleLevel(id: string, scaleId: string, levelId: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/{scaleId}/levels/{levelId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (scaleId === undefined || scaleId === null)
+            throw new globalThis.Error("The parameter 'scaleId' must be defined.");
+        url_ = url_.replace("{scaleId}", encodeURIComponent("" + scaleId));
+        if (levelId === undefined || levelId === null)
+            throw new globalThis.Error("The parameter 'levelId' must be defined.");
+        url_ = url_.replace("{levelId}", encodeURIComponent("" + levelId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRemoveScaleLevel(_response);
+        });
+    }
+
+    protected processRemoveScaleLevel(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Reorder rating levels on a scale.
+     */
+    reorderScaleLevels(id: string, scaleId: string, request: ReorderScoringScaleLevelsRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/scales/{scaleId}/levels/reorder";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (scaleId === undefined || scaleId === null)
+            throw new globalThis.Error("The parameter 'scaleId' must be defined.");
+        url_ = url_.replace("{scaleId}", encodeURIComponent("" + scaleId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processReorderScaleLevels(_response);
+        });
+    }
+
+    protected processReorderScaleLevels(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Add an output formula to a scoring model.
+     */
+    addOutput(id: string, request: ScoringModelOutputRequest, cancelToken?: CancelToken): Promise<string> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/outputs";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processAddOutput(_response);
+        });
+    }
+
+    protected processAddOutput(response: AxiosResponse): Promise<string> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 201) {
+            const _responseText = response.data;
+            let result201: any = null;
+            let resultData201  = _responseText;
+            result201 = resultData201;
+            return Promise.resolve<string>(result201);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<string>(null as any);
+    }
+
+    /**
+     * Update an output formula in a scoring model.
+     */
+    updateOutput(id: string, outputId: string, request: ScoringModelOutputRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/outputs/{outputId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (outputId === undefined || outputId === null)
+            throw new globalThis.Error("The parameter 'outputId' must be defined.");
+        url_ = url_.replace("{outputId}", encodeURIComponent("" + outputId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateOutput(_response);
+        });
+    }
+
+    protected processUpdateOutput(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Remove an output formula from a scoring model.
+     */
+    removeOutput(id: string, outputId: string, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/outputs/{outputId}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        if (outputId === undefined || outputId === null)
+            throw new globalThis.Error("The parameter 'outputId' must be defined.");
+        url_ = url_.replace("{outputId}", encodeURIComponent("" + outputId));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "DELETE",
+            url: url_,
+            headers: {
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processRemoveOutput(_response);
+        });
+    }
+
+    protected processRemoveOutput(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Reorder output formulas in a scoring model.
+     */
+    reorderOutputs(id: string, request: ReorderScoringModelOutputsRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/scoring-models/{id}/outputs/reorder";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processReorderOutputs(_response);
+        });
+    }
+
+    protected processReorderOutputs(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+}
+
 export interface ClientFeatureFlagDto {
     name: string;
     isEnabled: boolean;
@@ -30075,6 +31594,181 @@ export interface UpdateFeatureFlagRequest {
 export interface ToggleFeatureFlagRequest {
     id: number;
     isEnabled: boolean;
+}
+
+export interface ScoringModelListDto {
+    id: string;
+    key: number;
+    name: string;
+    description: string;
+    state: SimpleNavigationDto;
+    criterionCount: number;
+    scaleCount: number;
+    outputCount: number;
+}
+
+export enum ScoringModelState {
+    Proposed = "Proposed",
+    Active = "Active",
+    Archived = "Archived",
+}
+
+export interface ScoringModelDetailsDto {
+    id: string;
+    key: number;
+    name: string;
+    description: string;
+    state: SimpleNavigationDto;
+    criteria: ScoringModelCriterionDto[];
+    scales: ScoringScaleDto[];
+    outputs: ScoringModelOutputDto[];
+}
+
+export interface ScoringModelCriterionDto {
+    id: string;
+    name: string;
+    token: string;
+    description?: string | undefined;
+    weight?: number | undefined;
+    scaleId?: string | undefined;
+    order: number;
+}
+
+export interface ScoringScaleDto {
+    id: string;
+    name: string;
+    order: number;
+    levels: ScoringRatingLevelDto[];
+}
+
+export interface ScoringRatingLevelDto {
+    id: string;
+    label: string;
+    value: number;
+    order: number;
+}
+
+export interface ScoringModelOutputDto {
+    id: string;
+    name: string;
+    token: string;
+    formula: string;
+    isPrimary: boolean;
+    order: number;
+}
+
+export interface CreateScoringModelRequest {
+    /** The name of the scoring model. */
+    name: string;
+    /** The description of the scoring model. */
+    description: string;
+    /** Optional initial rating scales for the scoring model. */
+    scales?: ScaleInput[] | undefined;
+    /** Optional initial criteria (rated inputs) for the scoring model. */
+    criteria?: CriterionInput[] | undefined;
+    /** Optional initial output formulas for the scoring model. */
+    outputs?: OutputInput[] | undefined;
+}
+
+export interface ScaleInput {
+    /** The name of the scale (e.g., "Fibonacci", "Impact"). */
+    name: string;
+    /** The ordered rating levels of the scale. */
+    levels: ScaleLevelInput[];
+}
+
+export interface ScaleLevelInput {
+    /** The label for the rating level (e.g., "Very High"). */
+    label: string;
+    /** The numeric value a chosen rating contributes. */
+    value: number;
+}
+
+export interface CriterionInput {
+    /** The name of the criterion. */
+    name: string;
+    /** The token used to reference this criterion in formulas (e.g., "BV"). */
+    token: string;
+    /** An optional description of the criterion. */
+    description?: string | undefined;
+    /** An optional, non-authoritative weight (used only by the weighted-formula scaffolder). */
+    weight?: number | undefined;
+    /** The name of a scale (from Scales) this criterion is rated against, or null for free numeric entry. */
+    scaleName?: string | undefined;
+}
+
+export interface OutputInput {
+    /** The name of the output (e.g., "Cost of Delay", "WSJF"). */
+    name: string;
+    /** The token other output formulas can reference (e.g., "CoD"). */
+    token: string;
+    /** The arithmetic formula over criterion and earlier-output tokens. */
+    formula: string;
+    /** Whether this output is the model's primary score. */
+    isPrimary: boolean;
+}
+
+export interface UpdateScoringModelRequest {
+    /** The name of the scoring model. */
+    name: string;
+    /** The description of the scoring model. */
+    description: string;
+}
+
+export interface ScoringModelCriterionRequest {
+    /** The name of the criterion. */
+    name: string;
+    /** The token used to reference this criterion in output formulas (e.g., "BV"). */
+    token: string;
+    /** An optional description of the criterion. */
+    description?: string | undefined;
+    /** An optional, non-authoritative weight (used only by the weighted-formula scaffolder). */
+    weight?: number | undefined;
+    /** The optional rating scale this criterion is rated against. Null = free numeric entry. */
+    scaleId?: string | undefined;
+}
+
+export interface ReorderScoringModelCriteriaRequest {
+    /** The ordered list of criterion IDs representing the desired order. */
+    orderedCriterionIds: string[];
+}
+
+export interface ScoringScaleRequest {
+    /** The name of the scale (e.g., "Fibonacci", "Impact"). */
+    name: string;
+}
+
+export interface ReorderScoringScalesRequest {
+    /** The ordered list of scale IDs representing the desired order. */
+    orderedScaleIds: string[];
+}
+
+export interface ScoringScaleLevelRequest {
+    /** The label for the rating level (e.g., "Very High"). */
+    label: string;
+    /** The numeric value a chosen rating contributes to the criterion. */
+    value: number;
+}
+
+export interface ReorderScoringScaleLevelsRequest {
+    /** The ordered list of rating level IDs representing the desired order. */
+    orderedLevelIds: string[];
+}
+
+export interface ScoringModelOutputRequest {
+    /** The name of the output (e.g., "Cost of Delay", "WSJF"). */
+    name: string;
+    /** The token other output formulas can reference (e.g., "CoD"). */
+    token: string;
+    /** The arithmetic formula over criterion and earlier-output tokens. */
+    formula: string;
+    /** Whether this output is the model's primary score. */
+    isPrimary: boolean;
+}
+
+export interface ReorderScoringModelOutputsRequest {
+    /** The ordered list of output IDs representing the desired evaluation order. */
+    orderedOutputIds: string[];
 }
 
 export class ApiException extends Error {

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
@@ -100,6 +100,7 @@ export enum QueryTags {
   TaskPriorityOptions = 'Ppm.Project.Task.PriorityOptions',
   TaskTypeOptions = 'Ppm.Project.Task.TypeOptions',
   ProjectLifecycle = 'Ppm.ProjectLifecycle',
+  ScoringModel = 'Ppm.ScoringModel',
   ProjectPlanTree = 'Ppm.Project.PlanTree',
   StrategicInitiative = 'Ppm.StrategicInitiative',
   StrategicInitiativeKpi = 'Ppm.StrategicInitiativeKpi',

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
@@ -24,6 +24,7 @@ export enum QueryTags {
   HealthCheck = 'Common.HealthCheck',
   HealthChecksHealthReport = 'Common.HealthChecks.HealthReport',
   HealthChecksStatusOptions = 'Common.HealthChecks.StatusOptions',
+  ScoringModel = 'Common.ScoringModel',
 
   // ORGANIZATIONS
   ActiveSprint = 'Organizations.ActiveSprint',
@@ -100,7 +101,6 @@ export enum QueryTags {
   TaskPriorityOptions = 'Ppm.Project.Task.PriorityOptions',
   TaskTypeOptions = 'Ppm.Project.Task.TypeOptions',
   ProjectLifecycle = 'Ppm.ProjectLifecycle',
-  ScoringModel = 'Ppm.ScoringModel',
   ProjectPlanTree = 'Ppm.Project.PlanTree',
   StrategicInitiative = 'Ppm.StrategicInitiative',
   StrategicInitiativeKpi = 'Ppm.StrategicInitiativeKpi',

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/scoring/scoring-models-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/scoring/scoring-models-api.ts
@@ -43,6 +43,10 @@ export const scoringModelsApi = apiSlice.injectEndpoints({
         }
       },
       providesTags: (result, error, arg) => [
+        // Tag by the model's GUID id (what mutations invalidate by), plus the original arg so a
+        // caller fetching by either id or key still matches. The detail page fetches by key, while
+        // update/activate/archive invalidate by id — without the id tag those would never refetch.
+        ...(result ? [{ type: QueryTags.ScoringModel, id: result.id }] : []),
         { type: QueryTags.ScoringModel, id: arg },
       ],
     }),

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/scoring/scoring-models-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/scoring/scoring-models-api.ts
@@ -1,0 +1,446 @@
+import { getScoringModelsClient } from '@/src/services/clients'
+import { apiSlice } from '../apiSlice'
+import { QueryTags } from '../query-tags'
+import {
+  CreateScoringModelRequest,
+  ScoringModelCriterionRequest,
+  ScoringModelDetailsDto,
+  ScoringModelListDto,
+  ScoringModelOutputRequest,
+  ScoringModelState,
+  ScoringScaleLevelRequest,
+  ScoringScaleRequest,
+  UpdateScoringModelRequest,
+} from '@/src/services/wayd-api'
+
+export const scoringModelsApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getScoringModels: builder.query<
+      ScoringModelListDto[],
+      ScoringModelState | null | undefined
+    >({
+      queryFn: async (state) => {
+        try {
+          const data = await getScoringModelsClient().getScoringModels(state)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: () => [{ type: QueryTags.ScoringModel, id: 'LIST' }],
+    }),
+    getScoringModel: builder.query<ScoringModelDetailsDto, string>({
+      queryFn: async (idOrKey) => {
+        try {
+          const data = await getScoringModelsClient().getScoringModel(idOrKey)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, arg) => [
+        { type: QueryTags.ScoringModel, id: arg },
+      ],
+    }),
+    createScoringModel: builder.mutation<string, CreateScoringModelRequest>({
+      queryFn: async (request) => {
+        try {
+          const data = await getScoringModelsClient().create(request)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel, id: 'LIST' }],
+    }),
+    updateScoringModel: builder.mutation<
+      void,
+      { id: string } & UpdateScoringModelRequest
+    >({
+      queryFn: async (request) => {
+        try {
+          const data = await getScoringModelsClient().update(request.id, request)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [
+        { type: QueryTags.ScoringModel, id: 'LIST' },
+        { type: QueryTags.ScoringModel, id: arg.id },
+      ],
+    }),
+    deleteScoringModel: builder.mutation<void, string>({
+      queryFn: async (id) => {
+        try {
+          const data = await getScoringModelsClient().delete(id)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel, id: 'LIST' }],
+    }),
+    activateScoringModel: builder.mutation<void, string>({
+      queryFn: async (id) => {
+        try {
+          const data = await getScoringModelsClient().activate(id)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [
+        { type: QueryTags.ScoringModel, id: 'LIST' },
+        { type: QueryTags.ScoringModel, id: arg },
+      ],
+    }),
+    archiveScoringModel: builder.mutation<void, string>({
+      queryFn: async (id) => {
+        try {
+          const data = await getScoringModelsClient().archive(id)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, arg) => [
+        { type: QueryTags.ScoringModel, id: 'LIST' },
+        { type: QueryTags.ScoringModel, id: arg },
+      ],
+    }),
+    addScoringModelCriterion: builder.mutation<
+      string,
+      { scoringModelId: string } & ScoringModelCriterionRequest
+    >({
+      queryFn: async ({ scoringModelId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().addCriterion(
+            scoringModelId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    updateScoringModelCriterion: builder.mutation<
+      void,
+      { scoringModelId: string; criterionId: string } & ScoringModelCriterionRequest
+    >({
+      queryFn: async ({ scoringModelId, criterionId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().updateCriterion(
+            scoringModelId,
+            criterionId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    removeScoringModelCriterion: builder.mutation<
+      void,
+      { scoringModelId: string; criterionId: string }
+    >({
+      queryFn: async ({ scoringModelId, criterionId }) => {
+        try {
+          const data = await getScoringModelsClient().removeCriterion(
+            scoringModelId,
+            criterionId,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    reorderScoringModelCriteria: builder.mutation<
+      void,
+      { scoringModelId: string; orderedCriterionIds: string[] }
+    >({
+      queryFn: async ({ scoringModelId, orderedCriterionIds }) => {
+        try {
+          const data = await getScoringModelsClient().reorderCriteria(
+            scoringModelId,
+            { orderedCriterionIds },
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    addScoringScale: builder.mutation<
+      string,
+      { scoringModelId: string } & ScoringScaleRequest
+    >({
+      queryFn: async ({ scoringModelId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().addScale(
+            scoringModelId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    updateScoringScale: builder.mutation<
+      void,
+      { scoringModelId: string; scaleId: string } & ScoringScaleRequest
+    >({
+      queryFn: async ({ scoringModelId, scaleId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().updateScale(
+            scoringModelId,
+            scaleId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    removeScoringScale: builder.mutation<
+      void,
+      { scoringModelId: string; scaleId: string }
+    >({
+      queryFn: async ({ scoringModelId, scaleId }) => {
+        try {
+          const data = await getScoringModelsClient().removeScale(
+            scoringModelId,
+            scaleId,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    reorderScoringScales: builder.mutation<
+      void,
+      { scoringModelId: string; orderedScaleIds: string[] }
+    >({
+      queryFn: async ({ scoringModelId, orderedScaleIds }) => {
+        try {
+          const data = await getScoringModelsClient().reorderScales(
+            scoringModelId,
+            { orderedScaleIds },
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    addScoringScaleLevel: builder.mutation<
+      string,
+      { scoringModelId: string; scaleId: string } & ScoringScaleLevelRequest
+    >({
+      queryFn: async ({ scoringModelId, scaleId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().addScaleLevel(
+            scoringModelId,
+            scaleId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    updateScoringScaleLevel: builder.mutation<
+      void,
+      {
+        scoringModelId: string
+        scaleId: string
+        levelId: string
+      } & ScoringScaleLevelRequest
+    >({
+      queryFn: async ({ scoringModelId, scaleId, levelId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().updateScaleLevel(
+            scoringModelId,
+            scaleId,
+            levelId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    removeScoringScaleLevel: builder.mutation<
+      void,
+      { scoringModelId: string; scaleId: string; levelId: string }
+    >({
+      queryFn: async ({ scoringModelId, scaleId, levelId }) => {
+        try {
+          const data = await getScoringModelsClient().removeScaleLevel(
+            scoringModelId,
+            scaleId,
+            levelId,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    reorderScoringScaleLevels: builder.mutation<
+      void,
+      { scoringModelId: string; scaleId: string; orderedLevelIds: string[] }
+    >({
+      queryFn: async ({ scoringModelId, scaleId, orderedLevelIds }) => {
+        try {
+          const data = await getScoringModelsClient().reorderScaleLevels(
+            scoringModelId,
+            scaleId,
+            { orderedLevelIds },
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    addScoringModelOutput: builder.mutation<
+      string,
+      { scoringModelId: string } & ScoringModelOutputRequest
+    >({
+      queryFn: async ({ scoringModelId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().addOutput(
+            scoringModelId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    updateScoringModelOutput: builder.mutation<
+      void,
+      { scoringModelId: string; outputId: string } & ScoringModelOutputRequest
+    >({
+      queryFn: async ({ scoringModelId, outputId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().updateOutput(
+            scoringModelId,
+            outputId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    removeScoringModelOutput: builder.mutation<
+      void,
+      { scoringModelId: string; outputId: string }
+    >({
+      queryFn: async ({ scoringModelId, outputId }) => {
+        try {
+          const data = await getScoringModelsClient().removeOutput(
+            scoringModelId,
+            outputId,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+    reorderScoringModelOutputs: builder.mutation<
+      void,
+      { scoringModelId: string; orderedOutputIds: string[] }
+    >({
+      queryFn: async ({ scoringModelId, orderedOutputIds }) => {
+        try {
+          const data = await getScoringModelsClient().reorderOutputs(
+            scoringModelId,
+            { orderedOutputIds },
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
+    }),
+  }),
+})
+
+export const {
+  useGetScoringModelsQuery,
+  useGetScoringModelQuery,
+  useCreateScoringModelMutation,
+  useUpdateScoringModelMutation,
+  useDeleteScoringModelMutation,
+  useActivateScoringModelMutation,
+  useArchiveScoringModelMutation,
+  useAddScoringModelCriterionMutation,
+  useUpdateScoringModelCriterionMutation,
+  useRemoveScoringModelCriterionMutation,
+  useReorderScoringModelCriteriaMutation,
+  useAddScoringScaleMutation,
+  useUpdateScoringScaleMutation,
+  useRemoveScoringScaleMutation,
+  useReorderScoringScalesMutation,
+  useAddScoringScaleLevelMutation,
+  useUpdateScoringScaleLevelMutation,
+  useRemoveScoringScaleLevelMutation,
+  useReorderScoringScaleLevelsMutation,
+  useAddScoringModelOutputMutation,
+  useUpdateScoringModelOutputMutation,
+  useRemoveScoringModelOutputMutation,
+  useReorderScoringModelOutputsMutation,
+} = scoringModelsApi

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/scoring/scoring-models-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/scoring/scoring-models-api.ts
@@ -3,8 +3,10 @@ import { apiSlice } from '../apiSlice'
 import { QueryTags } from '../query-tags'
 import {
   CreateScoringModelRequest,
+  EvaluateScoringModelRequest,
   ScoringModelCriterionRequest,
   ScoringModelDetailsDto,
+  ScoringModelEvaluationDto,
   ScoringModelListDto,
   ScoringModelOutputRequest,
   ScoringModelState,
@@ -416,6 +418,23 @@ export const scoringModelsApi = apiSlice.injectEndpoints({
       },
       invalidatesTags: () => [{ type: QueryTags.ScoringModel }],
     }),
+    evaluateScoringModel: builder.mutation<
+      ScoringModelEvaluationDto,
+      { scoringModelId: string } & EvaluateScoringModelRequest
+    >({
+      queryFn: async ({ scoringModelId, ...request }) => {
+        try {
+          const data = await getScoringModelsClient().evaluate(
+            scoringModelId,
+            request,
+          )
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+    }),
   }),
 })
 
@@ -443,4 +462,5 @@ export const {
   useUpdateScoringModelOutputMutation,
   useRemoveScoringModelOutputMutation,
   useReorderScoringModelOutputsMutation,
+  useEvaluateScoringModelMutation,
 } = scoringModelsApi

--- a/docs/contributing/testing.mdx
+++ b/docs/contributing/testing.mdx
@@ -31,16 +31,67 @@ Test projects: `\{ProjectName\}.Tests`
 
 Test classes and methods should clearly describe the scenario being tested.
 
-## Fake Data
+## Test Structure
 
-Domain fakers are located in `Wayd.Tests.Shared`. Use Bogus to generate realistic test data:
+These conventions keep the suite consistent and easy to scan. New tests should follow them.
+
+### One class per system-under-test, named after the file
+
+Each test class targets a single system-under-test (SUT), and the class name matches its file name. Do **not** merge tests for several SUTs (e.g. multiple command handlers) into one class — give each handler its own `\{Handler\}Tests.cs` containing a class of the same name.
+
+### Arrange / Act / Assert comments
+
+Every test method marks the three phases with `// Arrange`, `// Act`, and `// Assert` comments so the flow reads at a glance. When the setup needs context, append a note to the marker:
 
 ```csharp
-var faker = new WorkItemFaker();
-var workItem = faker.Generate();
+[Fact]
+public async Task Handle_ShouldFail_WhenModelIsActive()
+{
+    // Arrange — an active model cannot be deleted; the handler's guard should reject it
+    // and leave the row in place.
+    var model = _faker.AsActiveWsjf();
+    _dbContext.ScoringModels.Add(model);
+    var command = new DeleteScoringModelCommand(model.Id);
+
+    // Act
+    var result = await CreateHandler().Handle(command, TestContext.Current.CancellationToken);
+
+    // Assert
+    result.IsFailure.Should().BeTrue();
+    _dbContext.SaveChangesCallCount.Should().Be(0);
+}
 ```
 
-Fake DbContext implementations are available for each application area for integration-style tests.
+### Cancellation tokens
+
+Pass `TestContext.Current.CancellationToken` to **every** method that accepts a `CancellationToken` — both the handler's `Handle(...)` call and any EF assertion queries (`SingleAsync(...)`, `AnyAsync(...)`, etc.). This is the dominant convention across the suite and clears the `xUnit1051` analyzer warning. Avoid `CancellationToken.None`.
+
+## Fake Data
+
+Domain fakers generate realistic test data with Bogus. They live in **each model's own test project**, under a `Data/` folder — not in `Wayd.Tests.Shared`. Only the `PrivateConstructorFaker<T>` base class lives in `Wayd.Tests.Shared`.
+
+```csharp
+var faker = new ScoringModelFaker();
+var model = faker.Generate();
+```
+
+### Faker conventions
+
+- **Per-property `With\{Property\}` builder extensions**, not a single `WithData(...)` with optional parameters. Each extension sets one `RuleFor` and returns the faker for chaining.
+- **Composition helpers** that build child collections through the aggregate's own methods (so invariants and ordering hold) are encouraged — e.g. `AsProposedWith(scales, criteria, outputs)`.
+- **Encapsulate shared fixtures as faker extensions**, not a separate `\{Thing\}TestData` holder class. When several test classes need the same realistic entity, add a convenience extension that builds the canonical fixture (e.g. `AsProposedWsjf()` / `AsActiveWsjf()` on `ScoringModelFaker`) and call it from each test. Keep small one-off fixtures inline.
+
+### Fake DbContext
+
+Fake `DbContext` implementations are available for each application area (e.g. `FakeWaydDbContext`), backing each `DbSet` with an in-memory list so handlers can be tested without a database. They track `SaveChangesCallCount`, which assertions use to verify a handler saved (or didn't) as expected. Combine with `NullLogger<T>.Instance` for the handler's logger.
+
+```csharp
+private readonly FakeWaydDbContext _dbContext = new();
+private readonly ScoringModelFaker _faker = new();
+
+private DeleteScoringModelCommandHandler CreateHandler() =>
+    new(_dbContext, NullLogger<DeleteScoringModelCommandHandler>.Instance);
+```
 
 ## Running Tests
 

--- a/docs/user-guide/settings/index.mdx
+++ b/docs/user-guide/settings/index.mdx
@@ -177,6 +177,10 @@ Managing roles:
 
 **Project Lifecycles** define the template of phases that projects go through. See [Project Portfolio Management](../ppm/index.mdx) for details.
 
+## Scoring Models
+
+**Scoring Models** define formula-driven ways to score and rank work consistently — for example, prioritizing a backlog by WSJF. Each model combines rated **criteria** with named **output formulas**, designating one as the primary score, and includes a **Test** tab for previewing results without saving. See [Scoring Models](./scoring-models.mdx) for the full guide. Configured in **Settings → Scoring → Scoring Models**.
+
 ## Integrations
 
 Wayd integrates with external systems to synchronize data. Integrations are configured through **Connections**.

--- a/docs/user-guide/settings/scoring-models.mdx
+++ b/docs/user-guide/settings/scoring-models.mdx
@@ -1,0 +1,106 @@
+---
+title: Scoring Models
+description: Define formula-driven scoring models to rate and rank work consistently across Wayd.
+sidebar_position: 2
+audience: [user, agent]
+---
+
+# Scoring Models
+
+A **scoring model** defines how items are scored and ranked — for example, prioritizing a backlog by [WSJF](#worked-example-wsjf) (Weighted Shortest Job First). Each model is a set of **rated criteria** combined by one or more **output formulas**, with one formula designated as the primary **score**.
+
+Scoring models are managed under **Settings → Scoring → Scoring Models** and require the `Permissions.ScoringModels.*` permissions to view and manage.
+
+## How a model is built
+
+A scoring model is assembled from four kinds of building blocks, each on its own tab of the model detail page.
+
+### Criteria
+
+**Criteria** are the inputs a person rates. Each criterion has:
+
+- **Name** — what is being assessed (e.g. *Business Value*).
+- **Token** — a short symbol (e.g. `BV`) used to reference the criterion in formulas. Tokens must be unique within the model.
+- **Description** — optional guidance for whoever does the rating.
+- **Rating scale** — *optional*. When a criterion references a [scale](#rating-scales), raters pick from that scale's defined levels. With no scale, the criterion accepts free numeric entry.
+- **Weight** — *optional*. A weight can be recorded for reference and is used by the [Weighted Sum helper](#the-weighted-sum-helper), but it is **not authoritative**: the formulas are the single source of truth for how the score is calculated.
+
+### Rating scales
+
+**Rating scales** standardize qualitative judgments into numbers. A model owns any number of named scales, and each scale holds an ordered list of **levels**, where each level pairs a **Label** with a numeric **Value**.
+
+For example, a "Relative (Fibonacci)" scale might define the levels `1, 2, 3, 5, 8, 13, 20`, while an "Impact" scale might map `Very High = 5` down to `Very Low = 1`. Assigning the same scale to several criteria keeps their inputs comparable.
+
+Scales are reusable across criteria and optional per criterion — use them where standardizing input matters, and leave a criterion scale-free where a raw number is more natural (e.g. *Job Size* in raw points).
+
+### Outputs (formulas)
+
+**Outputs** are the named formulas that turn rated inputs into results. Each output has:
+
+- **Name** — a human-readable label (e.g. *Cost of Delay*).
+- **Token** — referenced by later formulas (e.g. `CoD`).
+- **Formula** — an arithmetic expression over criterion tokens and **earlier** output tokens.
+- **Is Primary** — exactly one output is the primary one; its value is *the* score for the model.
+
+Outputs are evaluated **in order**, so a later formula can build on an earlier one. This lets you express multi-step models — for example, summing several criteria into an intermediate value and then dividing by another criterion.
+
+Formulas support standard arithmetic (`+`, `-`, `*`, `/`, parentheses) over decimal values. A formula that divides by zero, references an unknown token, or is otherwise malformed produces an error rather than a score.
+
+### The Weighted Sum helper
+
+"Weighted sum" is **not** a separate model type — it is a convenience for getting started. The helper generates a single primary output whose formula is the **normalized** weighted sum of your criteria, using the weights you entered:
+
+```
+(BV*w1 + TC*w2 + ...) / (w1 + w2 + ...)
+```
+
+Because the formula divides by the actual sum of the weights, the weights only need to be *relative* — weights of `30 / 30 / 40` rank identically to `3 / 3 / 4`. The UI shows a running **Total: X%** for guidance but never blocks you on it. After generating the formula you can edit it freely like any other output.
+
+## Worked example: WSJF
+
+Wayd seeds a starter **WSJF** model (in the Proposed state) on first run when no scoring models exist yet. It illustrates the building blocks working together:
+
+- **Scale:** *Relative (Fibonacci)* — `1, 2, 3, 5, 8, 13, 20`.
+- **Criteria** (all rated on the Fibonacci scale):
+  - Business Value (`BV`)
+  - Time Criticality (`TC`)
+  - Risk Reduction / Opportunity Enablement (`RR`)
+  - Job Size (`JS`)
+- **Outputs:**
+  - *Cost of Delay* (`CoD`) = `BV + TC + RR` — a secondary output.
+  - *WSJF* (`WSJF`) = `CoD / JS` — the **primary** score.
+
+Because `WSJF` references `CoD`, the *Cost of Delay* output must be ordered before it. The highest WSJF score is the most economically valuable item to deliver next.
+
+## Testing a model
+
+The **Test** tab lets you preview the output formulas against sample inputs **without saving anything** — useful for sanity-checking a model before activating it, or for understanding how a change to a formula affects the score.
+
+1. Open a scoring model and select the **Test** tab.
+2. Enter a value for each criterion. Criteria with a rating scale offer a dropdown of that scale's levels; criteria without one accept a raw number.
+3. Once every criterion has a value, click **Calculate**.
+4. The results show **every** output value (not just the primary), with the primary output tagged as the **Score**.
+
+Editing any input clears the previously shown result, so the displayed numbers always reflect the current inputs. The test panel never persists data — it is purely a preview.
+
+:::note
+Testing requires only the View permission. You can preview a model in any state, including a published one, without affecting any real scores.
+:::
+
+## Model states
+
+A scoring model moves through a simple lifecycle:
+
+| State | Editable? | Meaning |
+|-------|-----------|---------|
+| **Proposed** | Yes | Being designed. Criteria, scales, and outputs can be added, edited, reordered, and removed. |
+| **Active** | No | Published and locked. The definition is frozen so that scores and rankings stay stable. |
+| **Archived** | No | Retired from use. |
+
+**State actions** are available from the **Actions** menu on the model detail page:
+
+- **Activate** — move a Proposed model to Active. Once active, the model is locked: its criteria, scales, and outputs can no longer be changed (this protects the stability of any rankings built on it).
+- **Archive** — retire an Active model.
+- **Delete** — only available while a model is Proposed.
+
+Because activation freezes the definition, use the [Test tab](#testing-a-model) to validate the model thoroughly while it is still Proposed.


### PR DESCRIPTION
## Add Scoring Models

Introduces **Scoring Models** — admin-defined, formula-driven models for scoring and ranking work (e.g. prioritizing a backlog by WSJF). A scoring model combines user-rated **criteria** with named **output formulas**, designating one output as the primary **score**. Formulas are evaluated with NCalc (safe, arithmetic-only), so the scoring method is fully configurable rather than hard-coded.

The feature lives in the **Common** domain (it's cross-cutting, not PPM-specific), with tables in the `App` schema.

### What's included

**Domain** (`Wayd.Common.Domain/Scoring`)
- `ScoringModel` aggregate with a `Proposed → Active → Archived` lifecycle. Proposed models are editable; activation freezes the definition so rankings stay stable.
- **Criteria** (token + optional weight + optional rating scale), reusable named **rating scales** with ordered levels, and ordered **output formulas** that can reference criterion tokens *and* earlier outputs (so WSJF can reference Cost of Delay).
- `ScoringFormulaEvaluator` (NCalc-backed) and `ScoringToken` validation; division-by-zero, unknown-token, and malformed formulas surface as `Result` failures.
- "Weighted sum" is not a separate type — it's a normalized-formula convenience generated from entered weights (Jira-style soft weighting).

**Application** (CQRS / MediatR)
- Full command/query set: create/update/delete/activate/archive the model, plus add/update/remove/reorder for criteria, scales, scale levels, and outputs.
- `EvaluateScoringModelQuery` — previews all output values against supplied criterion values **without persisting**, backing the test panel.
- DTOs, validators, and Mapster projections.

**Infrastructure**
- EF Core entity configuration, `AddScoringModels` migration (`App` schema), and `IWaydDbContext` wiring.
- `ScoringModelSeeder` seeds a starter **WSJF** model (Proposed) on first run when none exist.

**API** (`ScoringModelsController`)
- REST endpoints for the full model + child CRUD, state transitions, and `POST /{id}/evaluate`. Gated by `Permissions.ScoringModels.*` under the Application permission category.

**Frontend** (`settings/scoring/scoring-models`)
- List + detail pages with tabs for Details, Criteria, Rating Scales, Outputs, and **Test**. The Test panel plugs sample values into each criterion and previews every output (primary tagged as the score). RTK Query API slice + generated NSwag client. Settings menu entry added.

**Documentation**
- New user guide: `docs/user-guide/settings/scoring-models.mdx` (building blocks, WSJF worked example, testing, lifecycle), linked from the settings overview.

**Testing**
- Domain tests for the aggregate (lifecycle, formula evaluation, ordering) and handler-level tests for the command handlers (persistence, not-found guards, domain-failure passthrough, save behavior).
- Per-model fakers in `Wayd.Common.Domain.Tests/Data/` with `AsProposedWsjf()` / `AsActiveWsjf()` convenience builders.
- Updated `docs/contributing/testing.mdx` and `CLAUDE.md` with the project's test conventions (one class per SUT, AAA comments, faker placement/builders, `TestContext.Current.CancellationToken`).

### Notes for reviewers
- The large `specification.json` diff is regenerated OpenAPI output (drives the NSwag client) — no need to review by hand.
- The migration has only shipped to local dev so far.
