### PR TITLE
Feature/identity management config

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/CreateOidcProviderCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/CreateOidcProviderCommand.cs
@@ -23,7 +23,7 @@ public sealed record CreateOidcProviderCommand(
     int ClockSkewSeconds,
     bool IsEnabled,
     bool AllowAutoRegistration,
-    bool RequireEmployeeRecord,
+    bool? RequireEmployeeRecord,
     string? DefaultRoleId) : ICommand<OidcProviderDto>;
 
 public sealed class CreateOidcProviderCommandValidator : CustomValidator<CreateOidcProviderCommand>

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/CreateOidcProviderCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/CreateOidcProviderCommand.cs
@@ -1,4 +1,5 @@
 using Wayd.Common.Application.Identity.OidcProviders.Dtos;
+using Wayd.Common.Application.Identity.Roles;
 using Wayd.Common.Application.Persistence;
 using Wayd.Common.Domain.Identity;
 
@@ -20,15 +21,20 @@ public sealed record CreateOidcProviderCommand(
     IReadOnlyList<string> Scopes,
     IReadOnlyList<string>? AllowedTenantIds,
     int ClockSkewSeconds,
-    bool IsEnabled) : ICommand<OidcProviderDto>;
+    bool IsEnabled,
+    bool AllowAutoRegistration,
+    bool RequireEmployeeRecord,
+    string? DefaultRoleId) : ICommand<OidcProviderDto>;
 
 public sealed class CreateOidcProviderCommandValidator : CustomValidator<CreateOidcProviderCommand>
 {
     private readonly IWaydDbContext _dbContext;
+    private readonly IRoleService _roleService;
 
-    public CreateOidcProviderCommandValidator(IWaydDbContext dbContext)
+    public CreateOidcProviderCommandValidator(IWaydDbContext dbContext, IRoleService roleService)
     {
         _dbContext = dbContext;
+        _roleService = roleService;
         RuleLevelCascadeMode = CascadeMode.Stop;
 
         // Field-level shape — domain entity also enforces these, but failing
@@ -58,6 +64,22 @@ public sealed class CreateOidcProviderCommandValidator : CustomValidator<CreateO
         RuleFor(x => x.Name)
             .Must(n => !string.Equals(n?.Trim(), "Wayd", StringComparison.OrdinalIgnoreCase))
             .WithMessage("'Wayd' is a reserved provider name.");
+
+        // When auto-registration is enabled a default role is required and must
+        // reference an existing role. Validated here so it's a clean 400 rather than
+        // the entity throwing at construction time. When disabled the role is ignored.
+        RuleFor(x => x.DefaultRoleId)
+            .NotEmpty().WithMessage("A default role is required when auto-registration is enabled.")
+            .DependentRules(() =>
+                RuleFor(x => x.DefaultRoleId)
+                    .MustAsync(BeAnExistingRole)
+                    .WithMessage("The selected default role does not exist."))
+            .When(x => x.AllowAutoRegistration);
+    }
+
+    private async Task<bool> BeAnExistingRole(string? roleId, CancellationToken cancellationToken)
+    {
+        return await _roleService.GetById(roleId!.Trim(), cancellationToken) is not null;
     }
 
     private static bool BeHttpsAbsoluteUrl(string? value)
@@ -101,7 +123,11 @@ internal sealed class CreateOidcProviderCommandHandler(
                 allowedTenantIds: request.AllowedTenantIds,
                 clockSkewSeconds: request.ClockSkewSeconds,
                 isEnabled: request.IsEnabled,
-                timestamp: _dateTimeProvider.Now);
+                timestamp: _dateTimeProvider.Now,
+                registrationPolicy: RegistrationPolicy.FromFlat(
+                    request.AllowAutoRegistration,
+                    request.RequireEmployeeRecord,
+                    request.DefaultRoleId));
 
             if (result.IsFailure)
             {
@@ -142,5 +168,10 @@ internal sealed class CreateOidcProviderCommandHandler(
         AllowedTenantIds = p.AllowedTenantIds,
         ClockSkewSeconds = p.ClockSkewSeconds,
         IsEnabled = p.IsEnabled,
+        AllowAutoRegistration = p.RegistrationPolicy.AllowAutoRegistration,
+        // Flatten the gated value for the admin form; when auto-registration is
+        // off the gate has no stored value, so surface its default for display.
+        RequireEmployeeRecord = p.RegistrationPolicy.RequireEmployeeRecord ?? true,
+        DefaultRoleId = p.RegistrationPolicy.DefaultRoleId,
     };
 }

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/UpdateOidcProviderCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/UpdateOidcProviderCommand.cs
@@ -1,4 +1,6 @@
-﻿using Wayd.Common.Application.Persistence;
+﻿using Wayd.Common.Application.Identity.Roles;
+using Wayd.Common.Application.Persistence;
+using Wayd.Common.Domain.Identity;
 
 namespace Wayd.Common.Application.Identity.OidcProviders.Commands;
 
@@ -17,12 +19,18 @@ public sealed record UpdateOidcProviderCommand(
     IReadOnlyList<string> Scopes,
     IReadOnlyList<string>? AllowedTenantIds,
     int ClockSkewSeconds,
-    bool IsEnabled) : ICommand;
+    bool IsEnabled,
+    bool AllowAutoRegistration,
+    bool RequireEmployeeRecord,
+    string? DefaultRoleId) : ICommand;
 
 public sealed class UpdateOidcProviderCommandValidator : CustomValidator<UpdateOidcProviderCommand>
 {
-    public UpdateOidcProviderCommandValidator()
+    private readonly IRoleService _roleService;
+
+    public UpdateOidcProviderCommandValidator(IRoleService roleService)
     {
+        _roleService = roleService;
         RuleLevelCascadeMode = CascadeMode.Stop;
 
         RuleFor(x => x.Id).NotEmpty();
@@ -36,6 +44,16 @@ public sealed class UpdateOidcProviderCommandValidator : CustomValidator<UpdateO
         // need to read the persisted ProviderType to know which branch applies,
         // and FluentValidation can't easily fetch the row here without coupling
         // to IWaydDbContext just for one MustAsync.
+
+        // When auto-registration is enabled a default role is required and must
+        // reference an existing role; when disabled it's ignored.
+        RuleFor(x => x.DefaultRoleId)
+            .NotEmpty().WithMessage("A default role is required when auto-registration is enabled.")
+            .DependentRules(() =>
+                RuleFor(x => x.DefaultRoleId)
+                    .MustAsync(BeAnExistingRole)
+                    .WithMessage("The selected default role does not exist."))
+            .When(x => x.AllowAutoRegistration);
     }
 
     private static bool BeHttpsAbsoluteUrl(string? value)
@@ -43,6 +61,11 @@ public sealed class UpdateOidcProviderCommandValidator : CustomValidator<UpdateO
         return !string.IsNullOrWhiteSpace(value)
             && Uri.TryCreate(value, UriKind.Absolute, out var uri)
             && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private async Task<bool> BeAnExistingRole(string? roleId, CancellationToken cancellationToken)
+    {
+        return await _roleService.GetById(roleId!.Trim(), cancellationToken) is not null;
     }
 }
 
@@ -79,7 +102,11 @@ internal sealed class UpdateOidcProviderCommandHandler(
                 allowedTenantIds: request.AllowedTenantIds,
                 clockSkewSeconds: request.ClockSkewSeconds,
                 isEnabled: request.IsEnabled,
-                timestamp: _dateTimeProvider.Now);
+                timestamp: _dateTimeProvider.Now,
+                registrationPolicy: RegistrationPolicy.FromFlat(
+                    request.AllowAutoRegistration,
+                    request.RequireEmployeeRecord,
+                    request.DefaultRoleId));
 
             if (updateResult.IsFailure)
             {

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/UpdateOidcProviderCommand.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Commands/UpdateOidcProviderCommand.cs
@@ -21,7 +21,7 @@ public sealed record UpdateOidcProviderCommand(
     int ClockSkewSeconds,
     bool IsEnabled,
     bool AllowAutoRegistration,
-    bool RequireEmployeeRecord,
+    bool? RequireEmployeeRecord,
     string? DefaultRoleId) : ICommand;
 
 public sealed class UpdateOidcProviderCommandValidator : CustomValidator<UpdateOidcProviderCommand>

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Dtos/OidcProviderDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Dtos/OidcProviderDto.cs
@@ -1,51 +1,36 @@
-namespace Wayd.Common.Application.Identity.OidcProviders.Dtos;
+﻿namespace Wayd.Common.Application.Identity.OidcProviders.Dtos;
 
 /// <summary>
 /// Admin-facing detail DTO. Includes every editable field plus audit metadata.
 /// </summary>
 public sealed record OidcProviderDto
 {
-    public Guid Id { get; init; }
-    public string Name { get; init; } = null!;
-    public string DisplayName { get; init; } = null!;
-    public string ProviderType { get; init; } = null!;
-    public string Authority { get; init; } = null!;
-    public string ClientId { get; init; } = null!;
-    public string Audience { get; init; } = null!;
-    public IReadOnlyList<string> Scopes { get; init; } = [];
-    public IReadOnlyList<string>? AllowedTenantIds { get; init; }
-    public int ClockSkewSeconds { get; init; }
-    public bool IsEnabled { get; init; }
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required string DisplayName { get; set; }
+    public required string ProviderType { get; set; }
+    public required string Authority { get; set; }
+    public required string ClientId { get; set; }
+    public required string Audience { get; set; }
+    public IReadOnlyList<string> Scopes { get; set; } = [];
+    public IReadOnlyList<string>? AllowedTenantIds { get; set; }
+    public int ClockSkewSeconds { get; set; }
+    public bool IsEnabled { get; set; }
 
     /// <summary>
     /// Whether first-time sign-ins through this provider auto-create an account.
     /// </summary>
-    public bool AllowAutoRegistration { get; init; }
+    public bool AllowAutoRegistration { get; set; }
 
     /// <summary>
     /// Whether auto-registration is restricted to users with a matching employee
     /// record. Only meaningful when <see cref="AllowAutoRegistration"/> is true.
     /// </summary>
-    public bool RequireEmployeeRecord { get; init; }
+    public bool? RequireEmployeeRecord { get; set; }
 
     /// <summary>
-    /// Role id assigned to auto-created users; null means the built-in Basic role.
-    /// The admin UI resolves the display name from its roles list.
+    /// Role id assigned to auto-created users. Null when auto-registration is
+    /// disabled (a default role is required whenever it's enabled).
     /// </summary>
-    public string? DefaultRoleId { get; init; }
-}
-
-/// <summary>
-/// Compact list row. Same fields as the detail DTO; kept as a separate type so
-/// the API contract is explicit and the listing endpoint stays stable if the
-/// detail shape grows fields later.
-/// </summary>
-public sealed record OidcProviderListItemDto
-{
-    public Guid Id { get; init; }
-    public string Name { get; init; } = null!;
-    public string DisplayName { get; init; } = null!;
-    public string ProviderType { get; init; } = null!;
-    public string Authority { get; init; } = null!;
-    public bool IsEnabled { get; init; }
+    public string? DefaultRoleId { get; set; }
 }

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Dtos/OidcProviderDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Dtos/OidcProviderDto.cs
@@ -16,6 +16,23 @@ public sealed record OidcProviderDto
     public IReadOnlyList<string>? AllowedTenantIds { get; init; }
     public int ClockSkewSeconds { get; init; }
     public bool IsEnabled { get; init; }
+
+    /// <summary>
+    /// Whether first-time sign-ins through this provider auto-create an account.
+    /// </summary>
+    public bool AllowAutoRegistration { get; init; }
+
+    /// <summary>
+    /// Whether auto-registration is restricted to users with a matching employee
+    /// record. Only meaningful when <see cref="AllowAutoRegistration"/> is true.
+    /// </summary>
+    public bool RequireEmployeeRecord { get; init; }
+
+    /// <summary>
+    /// Role id assigned to auto-created users; null means the built-in Basic role.
+    /// The admin UI resolves the display name from its roles list.
+    /// </summary>
+    public string? DefaultRoleId { get; init; }
 }
 
 /// <summary>

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Dtos/OidcProviderListItemDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Dtos/OidcProviderListItemDto.cs
@@ -1,0 +1,17 @@
+﻿namespace Wayd.Common.Application.Identity.OidcProviders.Dtos;
+
+
+/// <summary>
+/// Compact list row. Same fields as the detail DTO; kept as a separate type so
+/// the API contract is explicit and the listing endpoint stays stable if the
+/// detail shape grows fields later.
+/// </summary>
+public sealed record OidcProviderListItemDto
+{
+    public Guid Id { get; set; }
+    public required string Name { get; set; }
+    public required string DisplayName { get; set; }
+    public required string ProviderType { get; set; }
+    public required string Authority { get; set; }
+    public bool IsEnabled { get; set; }
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Queries/GetOidcProviderQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/OidcProviders/Queries/GetOidcProviderQuery.cs
@@ -35,6 +35,11 @@ internal sealed class GetOidcProviderQueryHandler(IWaydDbContext dbContext)
                 AllowedTenantIds = p.AllowedTenantIds,
                 ClockSkewSeconds = p.ClockSkewSeconds,
                 IsEnabled = p.IsEnabled,
+                AllowAutoRegistration = p.RegistrationPolicy.AllowAutoRegistration,
+                // Dependent settings are NULL on a disabled policy; surface the safe
+                // default (employee gate on) so the form shows it when re-enabling.
+                RequireEmployeeRecord = p.RegistrationPolicy.RequireEmployeeRecord ?? true,
+                DefaultRoleId = p.RegistrationPolicy.DefaultRoleId,
             })
             .SingleOrDefaultAsync(cancellationToken);
     }

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/Roles/IOidcProviderDefaultRoleChecker.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/Roles/IOidcProviderDefaultRoleChecker.cs
@@ -1,0 +1,13 @@
+using Wayd.Common.Application.Interfaces;
+
+namespace Wayd.Common.Application.Identity.Roles;
+
+/// <summary>
+/// Reports how many OIDC providers pin a given role as their auto-registration
+/// default. Used by role deletion to block removing a role that's still referenced
+/// — mirroring the database FK guarantee with a friendly, pre-emptive error.
+/// </summary>
+public interface IOidcProviderDefaultRoleChecker : ITransientService
+{
+    Task<int> CountProvidersUsingRole(string roleId, CancellationToken cancellationToken);
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Identity/OidcProvider.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Identity/OidcProvider.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using CSharpFunctionalExtensions;
 using Wayd.Common.Domain.Data;
 using NodaTime;
@@ -46,7 +46,8 @@ public sealed class OidcProvider : BaseAuditableEntity
         IReadOnlyList<string> scopes,
         IReadOnlyList<string>? allowedTenantIds,
         int clockSkewSeconds,
-        bool isEnabled)
+        bool isEnabled,
+        RegistrationPolicy registrationPolicy)
     {
         Name = name;
         DisplayName = displayName;
@@ -58,6 +59,7 @@ public sealed class OidcProvider : BaseAuditableEntity
         AllowedTenantIds = allowedTenantIds;
         ClockSkewSeconds = clockSkewSeconds;
         IsEnabled = isEnabled;
+        RegistrationPolicy = registrationPolicy;
     }
 
     /// <summary>
@@ -137,9 +139,31 @@ public sealed class OidcProvider : BaseAuditableEntity
     public bool IsEnabled { get; private set; }
 
     /// <summary>
+    /// Just-in-time provisioning policy: whether first-time sign-ins auto-create an
+    /// account and, if so, under what employee-record gate and default role. The
+    /// dependent settings are only readable while auto-registration is enabled — see
+    /// <see cref="Identity.RegistrationPolicy"/>. Never <c>null</c>; a brand-new or
+    /// reset provider carries a disabled policy.
+    /// </summary>
+    public RegistrationPolicy RegistrationPolicy { get; private set; } = RegistrationPolicy.Disabled();
+
+    /// <summary>
     /// Creates a new OIDC provider configuration. Validates the type-specific
     /// invariants up front (e.g. Entra requires at least one tenant ID).
     /// </summary>
+    /// <param name="name">The name of the provider.</param>
+    /// <param name="displayName">The display name of the provider.</param>
+    /// <param name="providerType">The type of the provider.</param>
+    /// <param name="authority">The authority URL of the provider.</param>
+    /// <param name="clientId">The client ID of the provider.</param>
+    /// <param name="audience">The audience of the provider.</param>
+    /// <param name="scopes">The scopes of the provider.</param>
+    /// <param name="allowedTenantIds">The allowed tenant IDs of the provider.</param>
+    /// <param name="clockSkewSeconds">The clock skew in seconds.</param>
+    /// <param name="isEnabled">Whether the provider is enabled.</param>
+    /// <param name="timestamp">The timestamp of the creation.</param>
+    /// <param name="registrationPolicy">The registration policy of the provider. Optional; if not provided, defaults to disabled.</param>
+    /// <returns>A result indicating success or failure.</returns>
     public static Result<OidcProvider> Create(
         string name,
         string displayName,
@@ -151,7 +175,8 @@ public sealed class OidcProvider : BaseAuditableEntity
         IReadOnlyList<string>? allowedTenantIds,
         int clockSkewSeconds,
         bool isEnabled,
-        Instant timestamp)
+        Instant timestamp,
+        RegistrationPolicy? registrationPolicy = null)
     {
         try
         {
@@ -171,7 +196,8 @@ public sealed class OidcProvider : BaseAuditableEntity
                 scopes ?? [],
                 NormalizeAllowedTenantIds(allowedTenantIds),
                 clockSkewSeconds,
-                isEnabled);
+                isEnabled,
+                registrationPolicy ?? RegistrationPolicy.Disabled());
 
             provider.AddDomainEvent(EntityCreatedEvent.WithEntity(provider, timestamp));
 
@@ -190,6 +216,17 @@ public sealed class OidcProvider : BaseAuditableEntity
     /// path applies to existing identities. Mutating either would orphan or
     /// silently re-route those rows.
     /// </summary>
+    /// <param name="displayName">The display name of the provider.</param>
+    /// <param name="authority">The authority URL of the provider.</param>
+    /// <param name="clientId">The client ID of the provider.</param>
+    /// <param name="audience">The audience of the provider.</param>
+    /// <param name="scopes">The scopes of the provider.</param>
+    /// <param name="allowedTenantIds">The allowed tenant IDs of the provider.</param>
+    /// <param name="clockSkewSeconds">The clock skew in seconds.</param>
+    /// <param name="isEnabled">Whether the provider is enabled.</param>
+    /// <param name="timestamp">The timestamp of the update.</param>
+    /// <param name="registrationPolicy">The registration policy of the provider. Optional; if not provided, defaults to disabled.</param>
+    /// <returns>A result indicating success or failure.</returns>
     public Result Update(
         string displayName,
         string authority,
@@ -199,7 +236,8 @@ public sealed class OidcProvider : BaseAuditableEntity
         IReadOnlyList<string>? allowedTenantIds,
         int clockSkewSeconds,
         bool isEnabled,
-        Instant timestamp)
+        Instant timestamp,
+        RegistrationPolicy? registrationPolicy = null)
     {
         try
         {
@@ -217,6 +255,7 @@ public sealed class OidcProvider : BaseAuditableEntity
             AllowedTenantIds = NormalizeAllowedTenantIds(allowedTenantIds);
             ClockSkewSeconds = clockSkewSeconds;
             IsEnabled = isEnabled;
+            RegistrationPolicy = registrationPolicy ?? RegistrationPolicy.Disabled();
 
             AddDomainEvent(EntityUpdatedEvent.WithEntity(this, timestamp));
 

--- a/Wayd.Common/src/Wayd.Common.Domain/Identity/RegistrationPolicy.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Identity/RegistrationPolicy.cs
@@ -1,0 +1,114 @@
+using Ardalis.GuardClauses;
+
+namespace Wayd.Common.Domain.Identity;
+
+/// <summary>
+/// The just-in-time provisioning policy for an <see cref="OidcProvider"/>, modeled
+/// as a discriminated shape: either auto-registration is <b>disabled</b> (no other
+/// setting is meaningful), or it is <b>enabled</b> with an employee-record gate and
+/// a required default role.
+/// </summary>
+/// <remarks>
+/// The dependent settings (<see cref="RequireEmployeeRecord"/>,
+/// <see cref="DefaultRoleId"/>) are nullable and are non-null <i>exactly</i> while
+/// <see cref="AllowAutoRegistration"/> is <c>true</c>. The constructor validates and
+/// <b>rejects</b> any contradictory combination rather than silently coercing it —
+/// a disabled policy with a dependent value, or an enabled policy missing its gate or
+/// role, throws. The illegal state is unrepresentable, and a caller mistake surfaces
+/// immediately instead of being papered over.
+///
+/// Owned by <see cref="OidcProvider"/> and flattened by EF into the provider's own
+/// table (see the entity configuration). EF materializes via the parameterless ctor
+/// and writes the columns directly, bypassing this validation; that is safe because
+/// the DB only ever holds values that were written through the validating path.
+/// <see cref="AllowAutoRegistration"/> is always a non-null column, which keeps EF
+/// from reading the owned instance back as <c>null</c> when the dependent columns are.
+/// </remarks>
+public sealed class RegistrationPolicy
+{
+    // EF materializes via this parameterless ctor and sets the column values
+    // directly — see the remarks on why that's safe.
+    private RegistrationPolicy() { }
+
+    // The single chokepoint for object state. Validates the invariant and throws on
+    // any contradiction; it does not normalize bad input into a legal state.
+    private RegistrationPolicy(bool allowAutoRegistration, bool? requireEmployeeRecord, string? defaultRoleId)
+    {
+        if (allowAutoRegistration)
+        {
+            if (requireEmployeeRecord is null)
+            {
+                throw new ArgumentNullException(nameof(requireEmployeeRecord),
+                    "An enabled registration policy must specify the employee-record gate.");
+            }
+
+            // The default role is required when enabled — there is no implicit
+            // fallback. Trimming is cosmetic input cleaning; a blank id is a missing
+            // role and is rejected.
+            DefaultRoleId = Guard.Against.NullOrWhiteSpace(defaultRoleId, nameof(defaultRoleId),
+                "An enabled registration policy must specify a default role.").Trim();
+            RequireEmployeeRecord = requireEmployeeRecord;
+        }
+        else
+        {
+            // A disabled policy carries no dependent settings; supplying one is a
+            // caller error, not something to quietly discard.
+            if (requireEmployeeRecord is not null)
+            {
+                throw new ArgumentException(
+                    "A disabled registration policy cannot specify an employee-record gate.",
+                    nameof(requireEmployeeRecord));
+            }
+
+            if (defaultRoleId is not null)
+            {
+                throw new ArgumentException(
+                    "A disabled registration policy cannot specify a default role.",
+                    nameof(defaultRoleId));
+            }
+        }
+
+        AllowAutoRegistration = allowAutoRegistration;
+    }
+
+    /// <summary>
+    /// Master switch. When <c>false</c>, an unknown user signing in for the first
+    /// time is rejected and an admin must pre-create the account.
+    /// </summary>
+    public bool AllowAutoRegistration { get; private set; }
+
+    /// <summary>
+    /// Whether auto-registration is gated to users with a matching employee record.
+    /// <c>null</c> exactly when auto-registration is disabled — the setting has no
+    /// meaning then.
+    /// </summary>
+    public bool? RequireEmployeeRecord { get; private set; }
+
+    /// <summary>
+    /// The role id assigned to auto-created users. Always present within an enabled
+    /// policy (it is required); <c>null</c> exactly when auto-registration is disabled.
+    /// </summary>
+    public string? DefaultRoleId { get; private set; }
+
+    /// <summary>Auto-registration off. No user is provisioned on first sign-in.</summary>
+    public static RegistrationPolicy Disabled() => new(false, null, null);
+
+    /// <summary>
+    /// Auto-registration on. Both the employee-record gate and the default role id
+    /// are required; the role id is trimmed and rejected if blank.
+    /// </summary>
+    public static RegistrationPolicy Enabled(bool requireEmployeeRecord, string defaultRoleId) =>
+        new(allowAutoRegistration: true, requireEmployeeRecord, defaultRoleId);
+
+    /// <summary>
+    /// Builds a policy from the flat fields that arrive at the entity boundary
+    /// (commands). This is the one place the loose external shape is translated into
+    /// the strict domain shape: when auto-registration is off the dependent inputs are
+    /// irrelevant and dropped; when on they are required and validated by the ctor.
+    /// </summary>
+    public static RegistrationPolicy FromFlat(bool allowAutoRegistration, bool requireEmployeeRecord, string? defaultRoleId) =>
+        allowAutoRegistration
+            ? Enabled(requireEmployeeRecord, Guard.Against.NullOrWhiteSpace(defaultRoleId, nameof(defaultRoleId),
+                "A default role is required when auto-registration is enabled."))
+            : Disabled();
+}

--- a/Wayd.Common/src/Wayd.Common.Domain/Identity/RegistrationPolicy.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Identity/RegistrationPolicy.cs
@@ -105,10 +105,15 @@ public sealed class RegistrationPolicy
     /// (commands). This is the one place the loose external shape is translated into
     /// the strict domain shape: when auto-registration is off the dependent inputs are
     /// irrelevant and dropped; when on they are required and validated by the ctor.
+    /// The employee-record gate is nullable on the way in — null is only legal when
+    /// auto-registration is disabled, and is rejected when enabled.
     /// </summary>
-    public static RegistrationPolicy FromFlat(bool allowAutoRegistration, bool requireEmployeeRecord, string? defaultRoleId) =>
+    public static RegistrationPolicy FromFlat(bool allowAutoRegistration, bool? requireEmployeeRecord, string? defaultRoleId) =>
         allowAutoRegistration
-            ? Enabled(requireEmployeeRecord, Guard.Against.NullOrWhiteSpace(defaultRoleId, nameof(defaultRoleId),
-                "A default role is required when auto-registration is enabled."))
+            ? Enabled(
+                Guard.Against.Null(requireEmployeeRecord, nameof(requireEmployeeRecord),
+                    "The employee-record gate is required when auto-registration is enabled."),
+                Guard.Against.NullOrWhiteSpace(defaultRoleId, nameof(defaultRoleId),
+                    "A default role is required when auto-registration is enabled."))
             : Disabled();
 }

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Identity/OidcProviders/CreateOidcProviderCommandValidatorTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Identity/OidcProviders/CreateOidcProviderCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FluentValidation.TestHelper;
 using Wayd.Common.Application.Identity.OidcProviders.Commands;
+using Wayd.Common.Application.Identity.Roles;
 using Wayd.Common.Application.Tests.Infrastructure;
 using Wayd.Common.Domain.Identity;
 
@@ -13,13 +14,21 @@ namespace Wayd.Common.Application.Tests.Sut.Identity.OidcProviders;
 /// </summary>
 public class CreateOidcProviderCommandValidatorTests
 {
+    private const string ExistingRoleId = "role-existing";
+
     private readonly FakeWaydDbContext _dbContext;
+    private readonly Mock<IRoleService> _roleService;
     private readonly CreateOidcProviderCommandValidator _sut;
 
     public CreateOidcProviderCommandValidatorTests()
     {
         _dbContext = new FakeWaydDbContext();
-        _sut = new CreateOidcProviderCommandValidator(_dbContext);
+        _roleService = new Mock<IRoleService>();
+        // Default: the configured default role exists. Tests that need a missing
+        // role override this per-case.
+        _roleService.Setup(s => s.GetById(ExistingRoleId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RoleDto { Id = ExistingRoleId, Name = "Existing" });
+        _sut = new CreateOidcProviderCommandValidator(_dbContext, _roleService.Object);
     }
 
     private static CreateOidcProviderCommand ValidEntraCommand() => new(
@@ -32,7 +41,10 @@ public class CreateOidcProviderCommandValidatorTests
         Scopes: new[] { "openid", "profile" },
         AllowedTenantIds: new[] { "11111111-1111-1111-1111-111111111111" },
         ClockSkewSeconds: 60,
-        IsEnabled: true);
+        IsEnabled: true,
+        AllowAutoRegistration: true,
+        RequireEmployeeRecord: true,
+        DefaultRoleId: ExistingRoleId);
 
     private static CreateOidcProviderCommand ValidGenericCommand() => new(
         Name: "Acme-Google",
@@ -44,7 +56,10 @@ public class CreateOidcProviderCommandValidatorTests
         Scopes: new[] { "openid", "profile" },
         AllowedTenantIds: null,
         ClockSkewSeconds: 60,
-        IsEnabled: true);
+        IsEnabled: true,
+        AllowAutoRegistration: true,
+        RequireEmployeeRecord: true,
+        DefaultRoleId: ExistingRoleId);
 
     [Fact]
     public async Task Validate_WithValidEntraCommand_PassesAllRules()
@@ -131,6 +146,45 @@ public class CreateOidcProviderCommandValidatorTests
         var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
         result.ShouldHaveValidationErrorFor(x => x.Name)
             .WithErrorMessage("'Wayd' is a reserved provider name.");
+    }
+
+    // --- Default role ---
+
+    [Fact]
+    public async Task Validate_WithNullDefaultRoleId_WhenAutoRegistrationOn_FailsRoleRule()
+    {
+        // A default role is required when auto-registration is enabled.
+        var command = ValidEntraCommand() with { DefaultRoleId = null };
+        var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        result.ShouldHaveValidationErrorFor(x => x.DefaultRoleId)
+            .WithErrorMessage("A default role is required when auto-registration is enabled.");
+    }
+
+    [Fact]
+    public async Task Validate_WithNullDefaultRoleId_WhenAutoRegistrationOff_PassesRoleRule()
+    {
+        // When auto-registration is off the role is irrelevant and not validated.
+        var command = ValidEntraCommand() with { AllowAutoRegistration = false, DefaultRoleId = null };
+        var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        result.ShouldNotHaveValidationErrorFor(x => x.DefaultRoleId);
+    }
+
+    [Fact]
+    public async Task Validate_WithExistingDefaultRoleId_PassesRoleRule()
+    {
+        var command = ValidEntraCommand() with { DefaultRoleId = ExistingRoleId };
+        var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        result.ShouldNotHaveValidationErrorFor(x => x.DefaultRoleId);
+    }
+
+    [Fact]
+    public async Task Validate_WithUnknownDefaultRoleId_FailsRoleRule()
+    {
+        // GetById returns null for an unknown id (the default Mock behavior).
+        var command = ValidEntraCommand() with { DefaultRoleId = "does-not-exist" };
+        var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        result.ShouldHaveValidationErrorFor(x => x.DefaultRoleId)
+            .WithErrorMessage("The selected default role does not exist.");
     }
 
     // --- Field-level shape ---

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Identity/OidcProviders/UpdateOidcProviderCommandValidatorTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Identity/OidcProviders/UpdateOidcProviderCommandValidatorTests.cs
@@ -1,5 +1,6 @@
 using FluentValidation.TestHelper;
 using Wayd.Common.Application.Identity.OidcProviders.Commands;
+using Wayd.Common.Application.Identity.Roles;
 
 namespace Wayd.Common.Application.Tests.Sut.Identity.OidcProviders;
 
@@ -11,7 +12,18 @@ namespace Wayd.Common.Application.Tests.Sut.Identity.OidcProviders;
 /// </summary>
 public class UpdateOidcProviderCommandValidatorTests
 {
-    private readonly UpdateOidcProviderCommandValidator _sut = new();
+    private const string ExistingRoleId = "role-existing";
+
+    private readonly Mock<IRoleService> _roleService;
+    private readonly UpdateOidcProviderCommandValidator _sut;
+
+    public UpdateOidcProviderCommandValidatorTests()
+    {
+        _roleService = new Mock<IRoleService>();
+        _roleService.Setup(s => s.GetById(ExistingRoleId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RoleDto { Id = ExistingRoleId, Name = "Existing" });
+        _sut = new UpdateOidcProviderCommandValidator(_roleService.Object);
+    }
 
     private static UpdateOidcProviderCommand ValidCommand() => new(
         Id: Guid.NewGuid(),
@@ -22,7 +34,10 @@ public class UpdateOidcProviderCommandValidatorTests
         Scopes: new[] { "openid", "profile" },
         AllowedTenantIds: new[] { "11111111-1111-1111-1111-111111111111" },
         ClockSkewSeconds: 60,
-        IsEnabled: true);
+        IsEnabled: true,
+        AllowAutoRegistration: true,
+        RequireEmployeeRecord: true,
+        DefaultRoleId: ExistingRoleId);
 
     [Fact]
     public async Task Validate_WithValidCommand_PassesAllRules()
@@ -77,5 +92,22 @@ public class UpdateOidcProviderCommandValidatorTests
         var command = ValidCommand() with { ClockSkewSeconds = clockSkew };
         var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
         result.ShouldHaveValidationErrorFor(x => x.ClockSkewSeconds);
+    }
+
+    [Fact]
+    public async Task Validate_WithExistingDefaultRoleId_PassesRoleRule()
+    {
+        var command = ValidCommand() with { DefaultRoleId = ExistingRoleId };
+        var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        result.ShouldNotHaveValidationErrorFor(x => x.DefaultRoleId);
+    }
+
+    [Fact]
+    public async Task Validate_WithUnknownDefaultRoleId_FailsRoleRule()
+    {
+        var command = ValidCommand() with { DefaultRoleId = "does-not-exist" };
+        var result = await _sut.TestValidateAsync(command, cancellationToken: TestContext.Current.CancellationToken);
+        result.ShouldHaveValidationErrorFor(x => x.DefaultRoleId)
+            .WithErrorMessage("The selected default role does not exist.");
     }
 }

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Identity/OidcProviderTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Identity/OidcProviderTests.cs
@@ -1,6 +1,7 @@
 using CSharpFunctionalExtensions;
 using Wayd.Common.Domain.Events;
 using Wayd.Common.Domain.Identity;
+using Wayd.Tests.Shared.Data;
 
 namespace Wayd.Common.Domain.Tests.Sut.Identity;
 
@@ -225,7 +226,7 @@ public sealed class OidcProviderTests
     [Fact]
     public void Update_WithValidFields_ChangesMutableFieldsOnly()
     {
-        var provider = CreateEntra().Value;
+        var provider = EntraFixture().Generate();
         provider.ClearDomainEvents();
 
         var result = provider.Update(
@@ -264,7 +265,7 @@ public sealed class OidcProviderTests
     {
         // Same Authority invariant as Create. Update could otherwise downgrade
         // a previously-secure provider config.
-        var provider = CreateEntra().Value;
+        var provider = EntraFixture().Generate();
 
         var result = provider.Update(
             displayName: ValidDisplayName,
@@ -286,7 +287,7 @@ public sealed class OidcProviderTests
     {
         // The Entra tenant-allowlist invariant must hold across Updates too.
         // Without this an admin could disable the multi-tenant gate post-create.
-        var provider = CreateEntra().Value;
+        var provider = EntraFixture().Generate();
 
         var result = provider.Update(
             displayName: ValidDisplayName,
@@ -340,7 +341,7 @@ public sealed class OidcProviderTests
     [Fact]
     public void SetEnabled_FromEnabledToDisabled_AddsUpdateEvent()
     {
-        var provider = CreateEntra(isEnabled: true).Value;
+        var provider = EntraFixture().AsEnabled().Generate();
         provider.ClearDomainEvents();
 
         var result = provider.SetEnabled(false, Timestamp);
@@ -356,7 +357,7 @@ public sealed class OidcProviderTests
         // Idempotent: re-applying the current state shouldn't generate an
         // audit event. Saves event-handler work for admins clicking the toggle
         // twice.
-        var provider = CreateEntra(isEnabled: true).Value;
+        var provider = EntraFixture().AsEnabled().Generate();
         provider.ClearDomainEvents();
 
         var result = provider.SetEnabled(true, Timestamp);
@@ -366,8 +367,127 @@ public sealed class OidcProviderTests
         provider.DomainEvents.Should().BeEmpty();
     }
 
+    // --- Registration policy ---
+
+    [Fact]
+    public void Create_WithoutPolicyArgs_DefaultsToAutoRegistrationOff()
+    {
+        // Secure by default: omitting the policy args creates a provider with
+        // auto-registration disabled. The dependent settings have no value in that
+        // state — the nullable projections read null.
+        var provider = EntraFixture().Generate();
+
+        provider.RegistrationPolicy.AllowAutoRegistration.Should().BeFalse();
+        provider.RegistrationPolicy.RequireEmployeeRecord.Should().BeNull();
+        provider.RegistrationPolicy.DefaultRoleId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithAutoRegistrationOn_PersistsDependentFields()
+    {
+        var result = OidcProvider.Create(
+            name: ValidName,
+            displayName: ValidDisplayName,
+            providerType: OidcProviderType.MicrosoftEntraId,
+            authority: ValidEntraAuthority,
+            clientId: ValidClientId,
+            audience: ValidAudience,
+            scopes: ValidScopes,
+            allowedTenantIds: ValidAllowedTenants,
+            clockSkewSeconds: 60,
+            isEnabled: true,
+            timestamp: Timestamp,
+            registrationPolicy: RegistrationPolicy.Enabled(requireEmployeeRecord: false, defaultRoleId: "role-123"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RegistrationPolicy.AllowAutoRegistration.Should().BeTrue();
+        result.Value.RegistrationPolicy.RequireEmployeeRecord.Should().BeFalse();
+        result.Value.RegistrationPolicy.DefaultRoleId.Should().Be("role-123");
+    }
+
+    [Fact]
+    public void Create_WithAutoRegistrationOff_IgnoresDependentFields()
+    {
+        // The invariant: when auto-registration is off, the dependent settings
+        // can't carry a value — FromFlat discards loosened inputs, so the stored
+        // policy projections read null regardless of what the caller passed.
+        var result = OidcProvider.Create(
+            name: ValidName,
+            displayName: ValidDisplayName,
+            providerType: OidcProviderType.MicrosoftEntraId,
+            authority: ValidEntraAuthority,
+            clientId: ValidClientId,
+            audience: ValidAudience,
+            scopes: ValidScopes,
+            allowedTenantIds: ValidAllowedTenants,
+            clockSkewSeconds: 60,
+            isEnabled: true,
+            timestamp: Timestamp,
+            registrationPolicy: RegistrationPolicy.FromFlat(
+                allowAutoRegistration: false, requireEmployeeRecord: false, defaultRoleId: "role-123"));
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.RegistrationPolicy.AllowAutoRegistration.Should().BeFalse();
+        result.Value.RegistrationPolicy.RequireEmployeeRecord.Should().BeNull();
+        result.Value.RegistrationPolicy.DefaultRoleId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Update_WithAutoRegistrationOn_ChangesDependentFields()
+    {
+        var provider = EntraFixture().Generate();
+
+        var result = provider.Update(
+            displayName: ValidDisplayName,
+            authority: ValidEntraAuthority,
+            clientId: ValidClientId,
+            audience: ValidAudience,
+            scopes: ValidScopes,
+            allowedTenantIds: ValidAllowedTenants,
+            clockSkewSeconds: 60,
+            isEnabled: true,
+            timestamp: Timestamp,
+            registrationPolicy: RegistrationPolicy.Enabled(requireEmployeeRecord: false, defaultRoleId: " role-xyz "));
+
+        result.IsSuccess.Should().BeTrue();
+        provider.RegistrationPolicy.AllowAutoRegistration.Should().BeTrue();
+        provider.RegistrationPolicy.RequireEmployeeRecord.Should().BeFalse();
+        provider.RegistrationPolicy.DefaultRoleId.Should().Be("role-xyz");
+    }
+
+    [Fact]
+    public void Update_TurningAutoRegistrationOff_ClearsDependentFields()
+    {
+        // Start from an auto-registering provider with a custom role, then disable
+        // auto-registration. The dependent fields must not survive — a later
+        // re-enable shouldn't silently inherit the old loosened posture.
+        var provider = EntraFixture()
+            .WithAutoRegistration(requireEmployeeRecord: false, defaultRoleId: "role-abc")
+            .Generate();
+
+        var result = provider.Update(
+            displayName: ValidDisplayName,
+            authority: ValidEntraAuthority,
+            clientId: ValidClientId,
+            audience: ValidAudience,
+            scopes: ValidScopes,
+            allowedTenantIds: ValidAllowedTenants,
+            clockSkewSeconds: 60,
+            isEnabled: true,
+            timestamp: Timestamp,
+            registrationPolicy: RegistrationPolicy.Disabled());
+
+        result.IsSuccess.Should().BeTrue();
+        provider.RegistrationPolicy.AllowAutoRegistration.Should().BeFalse();
+        provider.RegistrationPolicy.RequireEmployeeRecord.Should().BeNull();
+        provider.RegistrationPolicy.DefaultRoleId.Should().BeNull();
+    }
+
     // --- Helpers ---
 
+    // CreateEntra exercises the Create factory directly — it is the system under
+    // test for the validation cases above, so it must NOT go through the faker
+    // (which bypasses Create via field binding and would test nothing).
     private static Result<OidcProvider> CreateEntra(
         string name = ValidName,
         string authority = ValidEntraAuthority,
@@ -388,4 +508,19 @@ public sealed class OidcProviderTests
             isEnabled: isEnabled,
             timestamp: Timestamp);
     }
+
+    // A valid Entra provider built via the faker, for tests that need a starting
+    // fixture to act on (Update/SetEnabled) rather than testing Create itself.
+    // Name/authority/etc. are pinned to the same constants the Create-based tests
+    // use so assertions that check those values stay stable.
+    private static OidcProviderFaker EntraFixture() =>
+        new OidcProviderFaker()
+            .WithName(ValidName)
+            .WithDisplayName(ValidDisplayName)
+            .AsMicrosoftEntraId(ValidTenantId)
+            .WithAuthority(ValidEntraAuthority)
+            .WithClientId(ValidClientId)
+            .WithAudience(ValidAudience)
+            .WithScopes(ValidScopes)
+            .WithClockSkewSeconds(60);
 }

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Identity/RegistrationPolicyTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Identity/RegistrationPolicyTests.cs
@@ -1,0 +1,93 @@
+using Wayd.Common.Domain.Identity;
+
+namespace Wayd.Common.Domain.Tests.Sut.Identity;
+
+/// <summary>
+/// Pins the discriminated-shape invariant on <see cref="RegistrationPolicy"/>: the
+/// employee-gate and default-role settings are only observable while
+/// auto-registration is enabled, so an illegal "disabled but configured" state is
+/// unrepresentable rather than merely discouraged. The invariant is enforced by the
+/// constructor (the single chokepoint for state), so the FromFlat cases below — which
+/// forward raw inputs straight to it — exercise that enforcement, not a factory's.
+/// </summary>
+public sealed class RegistrationPolicyTests
+{
+    [Fact]
+    public void Disabled_HasNoDependentValues()
+    {
+        // Arrange / Act
+        var policy = RegistrationPolicy.Disabled();
+
+        // Assert
+        policy.AllowAutoRegistration.Should().BeFalse();
+        policy.RequireEmployeeRecord.Should().BeNull();
+        policy.DefaultRoleId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Enabled_ExposesDependentValues()
+    {
+        // Arrange / Act
+        var policy = RegistrationPolicy.Enabled(requireEmployeeRecord: false, defaultRoleId: "role-1");
+
+        // Assert
+        policy.AllowAutoRegistration.Should().BeTrue();
+        policy.RequireEmployeeRecord.Should().BeFalse();
+        policy.DefaultRoleId.Should().Be("role-1");
+    }
+
+    [Fact]
+    public void Enabled_TrimsRoleId()
+    {
+        // Arrange / Act — trimming is cosmetic input cleaning, still allowed.
+        var policy = RegistrationPolicy.Enabled(requireEmployeeRecord: true, defaultRoleId: "  role-2  ");
+
+        // Assert
+        policy.DefaultRoleId.Should().Be("role-2");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Enabled_RejectsMissingRole(string? defaultRoleId)
+    {
+        // Arrange / Act — the default role is required when enabled; a blank or
+        // missing id is a caller error, not something to coerce to null.
+        var act = () => RegistrationPolicy.Enabled(requireEmployeeRecord: true, defaultRoleId: defaultRoleId!);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    public void FromFlat_WithAutoRegistrationOff_DiscardsDependentInputs()
+    {
+        // Arrange / Act — even though loosened inputs are supplied, a disabled
+        // policy must not surface them.
+        var policy = RegistrationPolicy.FromFlat(
+            allowAutoRegistration: false,
+            requireEmployeeRecord: false,
+            defaultRoleId: "role-3");
+
+        // Assert
+        policy.AllowAutoRegistration.Should().BeFalse();
+        policy.RequireEmployeeRecord.Should().BeNull();
+        policy.DefaultRoleId.Should().BeNull();
+    }
+
+    [Fact]
+    public void FromFlat_WithAutoRegistrationOn_KeepsDependentInputs()
+    {
+        // Arrange / Act
+        var policy = RegistrationPolicy.FromFlat(
+            allowAutoRegistration: true,
+            requireEmployeeRecord: false,
+            defaultRoleId: "role-4");
+
+        // Assert
+        policy.AllowAutoRegistration.Should().BeTrue();
+        policy.RequireEmployeeRecord.Should().BeFalse();
+        policy.DefaultRoleId.Should().Be("role-4");
+    }
+}

--- a/Wayd.Common/tests/Wayd.Tests.Shared/Data/OidcProviderFaker.cs
+++ b/Wayd.Common/tests/Wayd.Tests.Shared/Data/OidcProviderFaker.cs
@@ -1,0 +1,137 @@
+using Wayd.Common.Domain.Identity;
+
+namespace Wayd.Tests.Shared.Data;
+
+/// <summary>
+/// Produces valid <see cref="OidcProvider"/> instances for tests. Defaults to a
+/// GenericOidc provider (no tenant allowlist required) with auto-registration
+/// disabled — the secure default. Use the <c>As*</c>/<c>With*</c> extensions to
+/// shape it (e.g. <see cref="OidcProviderFakerExtensions.AsMicrosoftEntraId"/> or
+/// <see cref="OidcProviderFakerExtensions.WithAutoRegistration"/>).
+/// </summary>
+public sealed class OidcProviderFaker : PrivateConstructorFaker<OidcProvider>
+{
+    public OidcProviderFaker()
+    {
+        RuleFor(x => x.Id, f => f.Random.Guid());
+        RuleFor(x => x.Name, f => f.Internet.DomainWord().ToLowerInvariant() + "-oidc");
+        RuleFor(x => x.DisplayName, f => $"{f.Company.CompanyName()} SSO");
+        RuleFor(x => x.ProviderType, OidcProviderType.GenericOidc);
+        RuleFor(x => x.Authority, f => $"https://{f.Internet.DomainName()}");
+        RuleFor(x => x.ClientId, f => f.Random.Guid().ToString());
+        RuleFor(x => x.Audience, f => f.Random.Guid().ToString());
+        RuleFor(x => x.Scopes, _ => new[] { "openid", "profile", "email" });
+        // GenericOidc ignores the tenant allowlist; AsMicrosoftEntraId() supplies one.
+        RuleFor(x => x.AllowedTenantIds, (IReadOnlyList<string>?)null);
+        RuleFor(x => x.ClockSkewSeconds, 60);
+        RuleFor(x => x.IsEnabled, true);
+        // Secure by default, mirroring the entity's own default.
+        RuleFor(x => x.RegistrationPolicy, _ => RegistrationPolicy.Disabled());
+    }
+}
+
+public static class OidcProviderFakerExtensions
+{
+    public static OidcProviderFaker WithId(this OidcProviderFaker faker, Guid id)
+    {
+        faker.RuleFor(x => x.Id, id);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithName(this OidcProviderFaker faker, string name)
+    {
+        faker.RuleFor(x => x.Name, name);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithDisplayName(this OidcProviderFaker faker, string displayName)
+    {
+        faker.RuleFor(x => x.DisplayName, displayName);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithAuthority(this OidcProviderFaker faker, string authority)
+    {
+        faker.RuleFor(x => x.Authority, authority);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithClientId(this OidcProviderFaker faker, string clientId)
+    {
+        faker.RuleFor(x => x.ClientId, clientId);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithAudience(this OidcProviderFaker faker, string audience)
+    {
+        faker.RuleFor(x => x.Audience, audience);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithScopes(this OidcProviderFaker faker, params string[] scopes)
+    {
+        faker.RuleFor(x => x.Scopes, scopes);
+        return faker;
+    }
+
+    public static OidcProviderFaker WithClockSkewSeconds(this OidcProviderFaker faker, int clockSkewSeconds)
+    {
+        faker.RuleFor(x => x.ClockSkewSeconds, clockSkewSeconds);
+        return faker;
+    }
+
+    /// <summary>Turns this into a Microsoft Entra ID provider with a tenant allowlist (required for that type).</summary>
+    public static OidcProviderFaker AsMicrosoftEntraId(this OidcProviderFaker faker, params string[] allowedTenantIds)
+    {
+        faker.RuleFor(x => x.ProviderType, OidcProviderType.MicrosoftEntraId);
+        faker.RuleFor(
+            x => x.AllowedTenantIds,
+            f => (IReadOnlyList<string>)(allowedTenantIds.Length > 0
+                ? allowedTenantIds
+                : new[] { f.Random.Guid().ToString() }));
+        return faker;
+    }
+
+    /// <summary>Turns this into a GenericOidc provider (no tenant allowlist).</summary>
+    public static OidcProviderFaker AsGenericOidc(this OidcProviderFaker faker)
+    {
+        faker.RuleFor(x => x.ProviderType, OidcProviderType.GenericOidc);
+        faker.RuleFor(x => x.AllowedTenantIds, (IReadOnlyList<string>?)null);
+        return faker;
+    }
+
+    public static OidcProviderFaker AsEnabled(this OidcProviderFaker faker)
+    {
+        faker.RuleFor(x => x.IsEnabled, true);
+        return faker;
+    }
+
+    public static OidcProviderFaker AsDisabled(this OidcProviderFaker faker)
+    {
+        faker.RuleFor(x => x.IsEnabled, false);
+        return faker;
+    }
+
+    /// <summary>
+    /// Enables auto-registration with an employee-record gate and a required default
+    /// role. A role id is generated when none is supplied, since an enabled policy
+    /// must always name one.
+    /// </summary>
+    public static OidcProviderFaker WithAutoRegistration(
+        this OidcProviderFaker faker,
+        bool requireEmployeeRecord = true,
+        string? defaultRoleId = null)
+    {
+        faker.RuleFor(
+            x => x.RegistrationPolicy,
+            f => RegistrationPolicy.Enabled(requireEmployeeRecord, defaultRoleId ?? f.Random.Guid().ToString()));
+        return faker;
+    }
+
+    /// <summary>Disables auto-registration (the secure default).</summary>
+    public static OidcProviderFaker WithoutAutoRegistration(this OidcProviderFaker faker)
+    {
+        faker.RuleFor(x => x.RegistrationPolicy, _ => RegistrationPolicy.Disabled());
+        return faker;
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260613144618_AddOidcProviderRegistrationPolicy.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260613144618_AddOidcProviderRegistrationPolicy.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260613144618_AddOidcProviderRegistrationPolicy")]
+    partial class AddOidcProviderRegistrationPolicy
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260613144618_AddOidcProviderRegistrationPolicy.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260613144618_AddOidcProviderRegistrationPolicy.cs
@@ -1,0 +1,81 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddOidcProviderRegistrationPolicy : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "AllowAutoRegistration",
+                schema: "Identity",
+                table: "OidcProviders",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "DefaultRoleId",
+                schema: "Identity",
+                table: "OidcProviders",
+                type: "nvarchar(450)",
+                maxLength: 450,
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "RequireEmployeeRecord",
+                schema: "Identity",
+                table: "OidcProviders",
+                type: "bit",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OidcProviders_DefaultRoleId",
+                schema: "Identity",
+                table: "OidcProviders",
+                column: "DefaultRoleId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_OidcProviders_Roles_DefaultRoleId",
+                schema: "Identity",
+                table: "OidcProviders",
+                column: "DefaultRoleId",
+                principalSchema: "Identity",
+                principalTable: "Roles",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_OidcProviders_Roles_DefaultRoleId",
+                schema: "Identity",
+                table: "OidcProviders");
+
+            migrationBuilder.DropIndex(
+                name: "IX_OidcProviders_DefaultRoleId",
+                schema: "Identity",
+                table: "OidcProviders");
+
+            migrationBuilder.DropColumn(
+                name: "AllowAutoRegistration",
+                schema: "Identity",
+                table: "OidcProviders");
+
+            migrationBuilder.DropColumn(
+                name: "DefaultRoleId",
+                schema: "Identity",
+                table: "OidcProviders");
+
+            migrationBuilder.DropColumn(
+                name: "RequireEmployeeRecord",
+                schema: "Identity",
+                table: "OidcProviders");
+        }
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/OidcProviderDefaultRoleChecker.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/OidcProviderDefaultRoleChecker.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Wayd.Infrastructure.Identity;
+
+internal sealed class OidcProviderDefaultRoleChecker(WaydDbContext db) : IOidcProviderDefaultRoleChecker
+{
+    private readonly WaydDbContext _db = db;
+
+    public async Task<int> CountProvidersUsingRole(string roleId, CancellationToken cancellationToken)
+    {
+        // A role can only be pinned by an enabled policy (a disabled one stores NULL),
+        // so matching on DefaultRoleId directly counts exactly the providers the FK
+        // would block this role's deletion for.
+        return await _db.OidcProviders
+            .CountAsync(p => p.RegistrationPolicy.DefaultRoleId == roleId, cancellationToken);
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/RoleService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/RoleService.cs
@@ -3,6 +3,7 @@ using FluentValidation.Results;
 using Mapster;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Wayd.Infrastructure.Identity;
 
@@ -10,16 +11,20 @@ internal class RoleService(
     RoleManager<ApplicationRole> roleManager,
     UserManager<ApplicationUser> userManager,
     WaydDbContext db,
+    IOidcProviderDefaultRoleChecker defaultRoleChecker,
     ICurrentUser currentUser,
     IEventPublisher events,
-    IDateTimeProvider dateTimeProvider) : IRoleService
+    IDateTimeProvider dateTimeProvider,
+    ILogger<RoleService> logger) : IRoleService
 {
     private readonly RoleManager<ApplicationRole> _roleManager = roleManager;
     private readonly UserManager<ApplicationUser> _userManager = userManager;
     private readonly WaydDbContext _db = db;
+    private readonly IOidcProviderDefaultRoleChecker _defaultRoleChecker = defaultRoleChecker;
     private readonly ICurrentUser _currentUser = currentUser;
     private readonly IEventPublisher _events = events;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
+    private readonly ILogger<RoleService> _logger = logger;
 
     public async Task<List<RoleListDto>> GetList(CancellationToken cancellationToken)
         => await _roleManager.Roles.ProjectToType<RoleListDto>().ToListAsync(cancellationToken);
@@ -44,6 +49,7 @@ internal class RoleService(
         var role = await GetById(roleId, cancellationToken);
         if (role == null)
         {
+            _logger.LogDebug("Role {RoleId} not found when loading permissions.", roleId);
             return null;
         }
 
@@ -59,12 +65,16 @@ internal class RoleService(
     {
         if (string.IsNullOrEmpty(request.Id))
         {
+            _logger.LogInformation("Role create requested for {RoleName} by user {UserId}.", request.Name, _currentUser.GetUserId());
+
             // Create a new role.
             var role = new ApplicationRole(request.Name, request.Description);
             var result = await _roleManager.CreateAsync(role);
 
             if (!result.Succeeded)
             {
+                _logger.LogWarning("Role create failed for {RoleName}: {Errors}",
+                    request.Name, string.Join("; ", result.Errors.Select(e => e.Description)));
                 HandleValidationErrors(result);
 
                 throw new InternalServerException("Register role failed");
@@ -72,17 +82,26 @@ internal class RoleService(
 
             await _events.PublishAsync(new ApplicationRoleCreatedEvent(role.Id, role.Name!, _dateTimeProvider.Now));
 
+            _logger.LogInformation("Role {RoleName} ({RoleId}) created by user {UserId}.", role.Name, role.Id, _currentUser.GetUserId());
+
             return role.Id;
         }
         else
         {
+            _logger.LogInformation("Role update requested for {RoleId} by user {UserId}.", request.Id, _currentUser.GetUserId());
+
             // Update an existing role.
             var role = await _roleManager.FindByIdAsync(request.Id);
 
-            _ = role ?? throw new NotFoundException("Role Not Found");
+            if (role is null)
+            {
+                _logger.LogWarning("Role update failed: role {RoleId} not found.", request.Id);
+                throw new NotFoundException("Role Not Found");
+            }
 
             if (ApplicationRoles.IsDefault(role.Name!))
             {
+                _logger.LogWarning("Role update denied: {RoleName} ({RoleId}) is a built-in system role.", role.Name, role.Id);
                 throw new ConflictException(string.Format("Not allowed to modify {0} Role.", role.Name));
             }
 
@@ -91,6 +110,8 @@ internal class RoleService(
 
             if (!result.Succeeded)
             {
+                _logger.LogWarning("Role update failed for {RoleId}: {Errors}",
+                    role.Id, string.Join("; ", result.Errors.Select(e => e.Description)));
                 HandleValidationErrors(result);
 
                 throw new InternalServerException("Update role failed");
@@ -98,16 +119,26 @@ internal class RoleService(
 
             await _events.PublishAsync(new ApplicationRoleUpdatedEvent(role.Id, role.Name!, _dateTimeProvider.Now));
 
+            _logger.LogInformation("Role {RoleName} ({RoleId}) updated by user {UserId}.", role.Name, role.Id, _currentUser.GetUserId());
+
             return role.Id;
         }
     }
 
     public async Task<Result> UpdatePermissions(UpdateRolePermissionsCommand request, CancellationToken cancellationToken)
     {
+        _logger.LogInformation("Role permissions update requested for {RoleId} by user {UserId}.", request.RoleId, _currentUser.GetUserId());
+
         var role = await _roleManager.FindByIdAsync(request.RoleId);
-        _ = role ?? throw new NotFoundException("Role Not Found");
+        if (role is null)
+        {
+            _logger.LogWarning("Role permissions update failed: role {RoleId} not found.", request.RoleId);
+            throw new NotFoundException("Role Not Found");
+        }
+
         if (role.Name == ApplicationRoles.Admin)
         {
+            _logger.LogWarning("Role permissions update denied: {RoleName} ({RoleId}) permissions are not modifiable.", role.Name, role.Id);
             return Result.Failure("Not allowed to modify Permissions for this Role.");
         }
 
@@ -120,16 +151,22 @@ internal class RoleService(
         var currentClaims = await _roleManager.GetClaimsAsync(role);
 
         // Remove permissions that were previously selected
+        var removed = 0;
         foreach (var claim in currentClaims.Where(c => !request.Permissions.Any(p => p == c.Value)))
         {
             var removeResult = await _roleManager.RemoveClaimAsync(role, claim);
             if (!removeResult.Succeeded)
             {
+                _logger.LogWarning("Role permissions update failed removing claim {Permission} from {RoleId}: {Errors}",
+                    claim.Value, role.Id, string.Join("; ", removeResult.Errors.Select(e => e.Description)));
                 return Result.Failure("Update permissions failed.");
             }
+
+            removed++;
         }
 
         // Add all permissions that were not previously selected
+        var added = 0;
         foreach (string permission in request.Permissions.Where(c => !currentClaims.Any(p => p.Value == c)))
         {
             if (!string.IsNullOrEmpty(permission))
@@ -142,33 +179,63 @@ internal class RoleService(
                     CreatedBy = _currentUser.GetUserId()
                 });
                 await _db.SaveChangesAsync(cancellationToken);
+                added++;
             }
         }
 
         await _events.PublishAsync(new ApplicationRoleUpdatedEvent(role.Id, role.Name!, _dateTimeProvider.Now, true));
+
+        _logger.LogInformation("Role {RoleName} ({RoleId}) permissions updated by user {UserId}: {Added} added, {Removed} removed.",
+            role.Name, role.Id, _currentUser.GetUserId(), added, removed);
 
         return Result.Success();
     }
 
     public async Task<string> Delete(string id)
     {
+        _logger.LogInformation("Role delete requested for {RoleId} by user {UserId}.", id, _currentUser.GetUserId());
+
         var role = await _roleManager.FindByIdAsync(id);
 
-        _ = role ?? throw new NotFoundException("Role Not Found");
+        if (role is null)
+        {
+            _logger.LogWarning("Role delete failed: role {RoleId} not found.", id);
+            throw new NotFoundException("Role Not Found");
+        }
 
         if (ApplicationRoles.IsDefault(role.Name!))
         {
+            _logger.LogWarning("Role delete denied: {RoleName} ({RoleId}) is a built-in system role.", role.Name, role.Id);
             throw new ConflictException(string.Format("Not allowed to delete the {0} Role.", role.Name));
         }
 
-        if ((await _userManager.GetUsersInRoleAsync(role.Name!)).Count > 0)
+        var usersInRole = (await _userManager.GetUsersInRoleAsync(role.Name!)).Count;
+        if (usersInRole > 0)
         {
+            _logger.LogWarning("Role delete denied: {RoleName} ({RoleId}) is assigned to {UserCount} user(s).",
+                role.Name, role.Id, usersInRole);
             throw new ConflictException(string.Format("Not allowed to delete the {0} Role as it is currently assigned to users.", role.Name));
+        }
+
+        // Mirror the user-assignment guard for providers that pin this role as
+        // their auto-registration default. The DB FK (ON DELETE NO ACTION) is the
+        // hard backstop; this check turns the raw constraint violation into a
+        // clear, actionable error before we touch the database.
+        var dependentProviders = await _defaultRoleChecker.CountProvidersUsingRole(role.Id, CancellationToken.None);
+        if (dependentProviders > 0)
+        {
+            _logger.LogWarning("Role delete denied: {RoleName} ({RoleId}) is the default registration role for {ProviderCount} identity provider(s).",
+                role.Name, role.Id, dependentProviders);
+            throw new ConflictException(string.Format(
+                "Not allowed to delete the {0} Role as it is the default registration role for {1} identity provider(s).",
+                role.Name, dependentProviders));
         }
 
         await _roleManager.DeleteAsync(role);
 
         await _events.PublishAsync(new ApplicationRoleDeletedEvent(role.Id, role.Name!, _dateTimeProvider.Now));
+
+        _logger.LogInformation("Role {RoleName} ({RoleId}) deleted by user {UserId}.", role.Name, role.Id, _currentUser.GetUserId());
 
         return string.Format("Role {0} Deleted.", role.Name);
     }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -50,12 +50,19 @@ internal partial class UserService
 
         var isFirstUser = !await _userManager.Users.AnyAsync();
 
+        // The Entra provider's UserIdentity.Provider key is the well-known constant,
+        // which is also its OidcProvider.Name. Load its registration policy so the
+        // create path can honor the admin's auto-registration / employee-record /
+        // default-role settings. First-user bootstrap ignores the policy entirely
+        // (see below) — a fresh install must always be able to create its admin.
+        var policy = await ResolveRegistrationPolicy(LoginProviders.MicrosoftEntraId);
+
         var user = await ResolveUserByEntraIdentityAsync(tenantId, objectId, upn)
-            ?? await CreateOrUpdateFromPrincipalAsync(principal, isFirstUser);
+            ?? await CreateOrUpdateFromPrincipalAsync(principal, isFirstUser, policy);
 
         if (isFirstUser)
         {
-            await _userManager.AddToRoleAsync(user, "Admin");
+            await _userManager.AddToRoleAsync(user, ApplicationRoles.Admin);
             await _events.PublishAsync(new ApplicationUserUpdatedEvent(user.Id, _dateTimeProvider.Now, true));
         }
         else
@@ -63,12 +70,49 @@ internal partial class UserService
             var roles = await _userManager.GetRolesAsync(user);
             if (roles is null || !roles.Any())
             {
-                await _userManager.AddToRoleAsync(user, "Basic");
+                await _userManager.AddToRoleAsync(user, await ResolveDefaultRoleName(policy));
                 await _events.PublishAsync(new ApplicationUserUpdatedEvent(user.Id, _dateTimeProvider.Now, true));
             }
         }
 
         return (user.Id, user.EmployeeId?.ToString());
+    }
+
+    /// <summary>
+    /// Resolves the provider's <see cref="RegistrationPolicy"/> from the registry.
+    /// A missing row is treated as a disabled policy: the token was already
+    /// validated against a configured provider, so a cache miss here is effectively
+    /// impossible, and denying is the safe default if it ever occurs.
+    /// </summary>
+    private async Task<RegistrationPolicy> ResolveRegistrationPolicy(string providerName)
+    {
+        var provider = await _oidcProviderRegistry.GetByName(providerName, CancellationToken.None);
+        return provider?.RegistrationPolicy ?? RegistrationPolicy.Disabled();
+    }
+
+    /// <summary>
+    /// Resolves the role name to assign to an auto-created user. An enabled policy
+    /// always names a role (it's required), so this looks it up directly. The FK on
+    /// <c>DefaultRoleId</c> means the role can't normally be deleted while referenced;
+    /// the "role missing" branch is a defensive backstop (e.g. a raw SQL delete) —
+    /// a sign-in must never hard-fail on a dangling reference, so it falls back to
+    /// <see cref="ApplicationRoles.Basic"/>.
+    /// </summary>
+    private async Task<string> ResolveDefaultRoleName(RegistrationPolicy policy)
+    {
+        var roleId = policy.DefaultRoleId
+            ?? throw new InvalidOperationException("Enabled registration policy is missing its default role.");
+
+        var role = await _roleManager.FindByIdAsync(roleId);
+        if (role?.Name is null)
+        {
+            _logger.LogWarning(
+                "Default role {RoleId} configured for auto-registration no longer exists; falling back to {FallbackRole}.",
+                roleId, ApplicationRoles.Basic);
+            return ApplicationRoles.Basic;
+        }
+
+        return role.Name;
     }
 
     private async Task<ApplicationUser?> ResolveUserByEntraIdentityAsync(string tenantId, string objectId, string? upn)
@@ -350,7 +394,7 @@ internal partial class UserService
         return candidate;
     }
 
-    private async Task<ApplicationUser> CreateOrUpdateFromPrincipalAsync(ClaimsPrincipal principal, bool isFirstUser)
+    private async Task<ApplicationUser> CreateOrUpdateFromPrincipalAsync(ClaimsPrincipal principal, bool isFirstUser, RegistrationPolicy policy)
     {
         string principalObjectId = principal.GetObjectId() ?? throw new InternalServerException("Principal ObjectId is missing or null.");
 
@@ -394,9 +438,22 @@ internal partial class UserService
         }
         else
         {
+            // The first-ever user bootstraps the system and bypasses all policy
+            // gates — a fresh install must always be able to create its admin even
+            // with auto-registration disabled or no employee records seeded yet.
+            if (!isFirstUser && !policy.AllowAutoRegistration)
+            {
+                _logger.LogWarning("Registration denied for user {Username} (Email: {Email}). Auto-registration is disabled for this provider.",
+                    username, email);
+                throw new ForbiddenException("Registration is disabled for this identity provider. Contact an administrator.");
+            }
+
             var employeeId = await GetEmployeeIdByEmail(email);
 
-            if (!employeeId.HasValue && !isFirstUser)
+            // RequireEmployeeRecord is null only on a disabled policy, which the
+            // gate above already rejected for non-first users — so `== true` here
+            // safely means "auto-reg on and the employee gate is set".
+            if (!employeeId.HasValue && !isFirstUser && policy.RequireEmployeeRecord == true)
             {
                 _logger.LogWarning("Registration denied for user {Username} (Email: {Email}). No matching employee record found.",
                     username, email);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/IdentityConfiguration.cs
@@ -237,6 +237,33 @@ public class OidcProviderConfig : IEntityTypeConfiguration<OidcProvider>
         builder.Property(p => p.IsEnabled)
             .IsRequired()
             .HasDefaultValue(false);
+
+        builder.OwnsOne(p => p.RegistrationPolicy, policy =>
+        {
+            policy.Property(rp => rp.AllowAutoRegistration)
+                .HasColumnName("AllowAutoRegistration")
+                .IsRequired()
+                .HasDefaultValue(false);
+
+            policy.Property(rp => rp.RequireEmployeeRecord)
+                .HasColumnName("RequireEmployeeRecord");
+
+            policy.Property(rp => rp.DefaultRoleId)
+                .HasColumnName("DefaultRoleId")
+                .HasMaxLength(450);
+
+            // Real FK to the role, with NO ACTION on delete: a role that's pinned as
+            // a provider's auto-registration default cannot be deleted until the
+            // provider is repointed. This is the hard guarantee that the stored
+            // DefaultRoleId can never dangle; RoleService.Delete surfaces the same
+            // rule as a friendly ConflictException before the constraint fires.
+            policy.HasOne<ApplicationRole>()
+                .WithMany()
+                .HasForeignKey(rp => rp.DefaultRoleId)
+                .OnDelete(DeleteBehavior.NoAction);
+        });
+
+        builder.Navigation(p => p.RegistrationPolicy).IsRequired();
     }
 }
 

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Local/TokenServiceTests.cs
@@ -14,6 +14,7 @@ using Wayd.Infrastructure.Auth.Local;
 using Wayd.Infrastructure.Auth.Oidc;
 using Wayd.Infrastructure.Identity;
 using Wayd.Tests.Shared;
+using Wayd.Tests.Shared.Data;
 
 namespace Wayd.Infrastructure.Tests.Sut.Auth.Local;
 
@@ -777,18 +778,15 @@ public class TokenServiceTests
         // via the explicit field list (BeEquivalentTo treats extras as a failure
         // when the expected shape doesn't include them — but here we just check
         // each known field is right).
-        var entra = OidcProvider.Create(
-            name: LoginProviders.MicrosoftEntraId,
-            displayName: "Microsoft Entra ID",
-            providerType: OidcProviderType.MicrosoftEntraId,
-            authority: "https://login.microsoftonline.com/common/v2.0",
-            clientId: "test-client-id",
-            audience: "api://test",
-            scopes: new[] { "openid", "profile" },
-            allowedTenantIds: new[] { "11111111-1111-1111-1111-111111111111" },
-            clockSkewSeconds: 60,
-            isEnabled: true,
-            timestamp: NodaTime.SystemClock.Instance.GetCurrentInstant()).Value;
+        // Pin the fields the assertions below check; the faker fills the rest.
+        var entra = new OidcProviderFaker()
+            .WithName(LoginProviders.MicrosoftEntraId)
+            .WithDisplayName("Microsoft Entra ID")
+            .AsMicrosoftEntraId("11111111-1111-1111-1111-111111111111")
+            .WithAuthority("https://login.microsoftonline.com/common/v2.0")
+            .WithClientId("test-client-id")
+            .WithScopes("openid", "profile")
+            .Generate();
 
         _mockOidcProviderRegistry
             .Setup(r => r.GetEnabled(It.IsAny<CancellationToken>()))

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Oidc/OidcTokenValidatorTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Auth/Oidc/OidcTokenValidatorTests.cs
@@ -10,6 +10,7 @@ using Wayd.Common.Application.Exceptions;
 using Wayd.Common.Application.Identity.OidcProviders;
 using Wayd.Common.Domain.Identity;
 using Wayd.Infrastructure.Auth.Oidc;
+using Wayd.Tests.Shared.Data;
 
 namespace Wayd.Infrastructure.Tests.Sut.Auth.Oidc;
 
@@ -429,39 +430,40 @@ public class OidcTokenValidatorTests
         // common happy-path case. Tests that want a different list pass it in.
         allowedTenantIds ??= new[] { AllowedTenantId };
 
-        var result = OidcProvider.Create(
-            name: EntraProviderName,
-            displayName: "Microsoft Entra ID",
-            providerType: OidcProviderType.MicrosoftEntraId,
-            authority: EntraAuthority,
-            clientId: "test-client-id",
-            audience: TestAudience,
-            scopes: new[] { "openid", "profile" },
-            allowedTenantIds: allowedTenantIds,
-            clockSkewSeconds: 60,
-            isEnabled: isEnabled,
-            timestamp: SystemClock.Instance.GetCurrentInstant());
-        result.IsSuccess.Should().BeTrue();
-        return result.Value;
+        // The validator pins on authority/audience/client-id, so set them explicitly
+        // rather than taking the faker's randomized values.
+        var faker = new OidcProviderFaker()
+            .WithName(EntraProviderName)
+            .WithDisplayName("Microsoft Entra ID")
+            .AsMicrosoftEntraId([.. allowedTenantIds])
+            .WithAuthority(EntraAuthority)
+            .WithClientId("test-client-id")
+            .WithAudience(TestAudience);
+
+        return (isEnabled ? faker.AsEnabled() : faker.AsDisabled()).Generate();
     }
 
     private static OidcProvider CreateGenericProvider(
         IReadOnlyList<string>? allowedTenantIds = null)
     {
-        var result = OidcProvider.Create(
-            name: GenericProviderName,
-            displayName: "Acme Google",
-            providerType: OidcProviderType.GenericOidc,
-            authority: GenericAuthority,
-            clientId: "test-client-id",
-            audience: TestAudience,
-            scopes: new[] { "openid", "profile" },
-            allowedTenantIds: allowedTenantIds,
-            clockSkewSeconds: 60,
-            isEnabled: true,
-            timestamp: SystemClock.Instance.GetCurrentInstant());
-        result.IsSuccess.Should().BeTrue();
-        return result.Value;
+        var provider = new OidcProviderFaker()
+            .WithName(GenericProviderName)
+            .WithDisplayName("Acme Google")
+            .AsGenericOidc()
+            .WithAuthority(GenericAuthority)
+            .WithClientId("test-client-id")
+            .WithAudience(TestAudience)
+            .Generate();
+
+        // GenericOidc ignores the tenant allowlist, but a couple of tests assert the
+        // validator does too — honor an explicitly supplied list via field binding.
+        if (allowedTenantIds is not null)
+        {
+            typeof(OidcProvider).GetProperty(nameof(OidcProvider.AllowedTenantIds))!
+                .SetValue(provider, allowedTenantIds);
+        }
+
+        return provider;
     }
 
     /// <summary>

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/OidcProviderDefaultRoleCheckerRegistrationTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/OidcProviderDefaultRoleCheckerRegistrationTests.cs
@@ -1,0 +1,29 @@
+using Wayd.Common.Application.Identity.Roles;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Infrastructure.Identity;
+
+namespace Wayd.Infrastructure.Tests.Sut.Identity;
+
+/// <summary>
+/// The DI container auto-registers <see cref="ITransientService"/> implementations
+/// by their first interface (see Common.ConfigureServices.AddServices). This pins
+/// that <see cref="OidcProviderDefaultRoleChecker"/> resolves to its specific
+/// contract rather than the bare marker — a wiring guarantee that ordinary unit
+/// tests (which inject the mock directly) wouldn't catch.
+/// </summary>
+public sealed class OidcProviderDefaultRoleCheckerRegistrationTests
+{
+    [Fact]
+    public void Implementation_ResolvesToItsSpecificContract_NotTheMarker()
+    {
+        // Arrange
+        var type = typeof(OidcProviderDefaultRoleChecker);
+
+        // Act — mirrors the scanner's selection: the first declared interface.
+        var registeredAgainst = type.GetInterfaces().FirstOrDefault();
+
+        // Assert
+        registeredAgainst.Should().Be<IOidcProviderDefaultRoleChecker>();
+        typeof(IOidcProviderDefaultRoleChecker).Should().BeAssignableTo<ITransientService>();
+    }
+}

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/RoleServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/RoleServiceTests.cs
@@ -1,8 +1,10 @@
 ﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
 using Wayd.Common.Application.Events;
 using Wayd.Common.Application.Exceptions;
 using Wayd.Common.Application.Identity.Roles;
 using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Persistence;
 using Wayd.Common.Domain.Authorization;
 using Wayd.Common.Domain.Identity;
 using Wayd.Infrastructure.Identity;
@@ -15,8 +17,10 @@ public class RoleServiceTests
 {
     private readonly Mock<RoleManager<ApplicationRole>> _mockRoleManager;
     private readonly Mock<UserManager<ApplicationUser>> _mockUserManager;
+    private readonly Mock<IOidcProviderDefaultRoleChecker> _mockDefaultRoleChecker;
     private readonly Mock<IEventPublisher> _mockEvents;
     private readonly Mock<ICurrentUser> _mockCurrentUser;
+    private readonly Mock<ILogger<RoleService>> _mockLogger;
     private readonly TestingDateTimeProvider _dateTimeProvider;
 
     public RoleServiceTests()
@@ -29,8 +33,10 @@ public class RoleServiceTests
         _mockUserManager = new Mock<UserManager<ApplicationUser>>(
             userStore.Object, null!, null!, null!, null!, null!, null!, null!, null!);
 
+        _mockDefaultRoleChecker = new Mock<IOidcProviderDefaultRoleChecker>();
         _mockEvents = new Mock<IEventPublisher>();
         _mockCurrentUser = new Mock<ICurrentUser>();
+        _mockLogger = new Mock<ILogger<RoleService>>();
         _dateTimeProvider = new TestingDateTimeProvider(DateTime.UtcNow);
     }
 
@@ -40,9 +46,11 @@ public class RoleServiceTests
             _mockRoleManager.Object,
             _mockUserManager.Object,
             null!, // WaydDbContext - not used by Create/Delete methods
+            _mockDefaultRoleChecker.Object,
             _mockCurrentUser.Object,
             _mockEvents.Object,
-            _dateTimeProvider);
+            _dateTimeProvider,
+            _mockLogger.Object);
     }
 
     #region CreateOrUpdate - Create
@@ -177,10 +185,13 @@ public class RoleServiceTests
     public async Task Delete_ShouldDeleteRole_WhenRoleExistsAndIsNotDefault()
     {
         // Arrange
-        var role = new ApplicationRole("CustomRole", "A custom role");
+        var role = new ApplicationRole("CustomRole", "A custom role") { Id = "role-1" };
         _mockRoleManager.Setup(x => x.FindByIdAsync("role-1")).ReturnsAsync(role);
         _mockUserManager.Setup(x => x.GetUsersInRoleAsync("CustomRole")).ReturnsAsync([]);
         _mockRoleManager.Setup(x => x.DeleteAsync(role)).ReturnsAsync(IdentityResult.Success);
+        // No provider references this role as its default.
+        _mockDefaultRoleChecker.Setup(x => x.CountProvidersUsingRole("role-1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
 
         var sut = CreateSut();
 
@@ -191,6 +202,27 @@ public class RoleServiceTests
         result.Should().Contain("CustomRole").And.Contain("Deleted");
         _mockRoleManager.Verify(x => x.DeleteAsync(role), Times.Once);
         _mockEvents.Verify(x => x.PublishAsync(It.IsAny<ApplicationRoleDeletedEvent>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_ShouldThrowConflict_WhenRoleIsAProviderDefault()
+    {
+        // Arrange — a provider pins this role as its auto-registration default.
+        var role = new ApplicationRole("ProjectManager") { Id = "role-pm" };
+        _mockRoleManager.Setup(x => x.FindByIdAsync("role-pm")).ReturnsAsync(role);
+        _mockUserManager.Setup(x => x.GetUsersInRoleAsync("ProjectManager")).ReturnsAsync([]);
+        _mockDefaultRoleChecker.Setup(x => x.CountProvidersUsingRole("role-pm", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(2);
+
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.Delete("role-pm");
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*default registration role*identity provider*");
+        _mockRoleManager.Verify(x => x.DeleteAsync(It.IsAny<ApplicationRole>()), Times.Never);
     }
 
     [Fact]

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
@@ -14,6 +14,7 @@ using Wayd.Common.Domain.Authorization;
 using Wayd.Common.Domain.Identity;
 using Wayd.Infrastructure.Identity;
 using Wayd.Tests.Shared;
+using Wayd.Tests.Shared.Data;
 using NotFoundException = Wayd.Common.Application.Exceptions.NotFoundException;
 
 namespace Wayd.Infrastructure.Tests.Sut.Identity;
@@ -1233,6 +1234,189 @@ public class UserServiceTests
         _mockUserIdentityStore.Verify(s => s.DeactivateAllActive(
             user.Id, It.IsAny<NodaTime.Instant>(), UserIdentityUnlinkReasons.TenantMigration, It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    #endregion
+
+    #region GetOrCreateFromPrincipalAsync — registration policy
+
+    // A principal carrying every claim the create path reads: object/tenant id for
+    // identity resolution, UPN as email, name for the username, and given/surname
+    // which the entity guards against being blank.
+    private static ClaimsPrincipal CreateNewUserPrincipal(
+        string objectId, string tenantId, string upn, string displayName = "New User")
+    {
+        var claims = new List<Claim>
+        {
+            new(Microsoft.Identity.Web.ClaimConstants.ObjectId, objectId),
+            new(Microsoft.Identity.Web.ClaimConstants.TenantId, tenantId),
+            new(ClaimTypes.Upn, upn),
+            new("name", displayName),
+            new(ClaimTypes.GivenName, "New"),
+            new(ClaimTypes.Surname, "User"),
+        };
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
+    }
+
+    private static OidcProvider CreateEntraProviderWithPolicy(
+        bool allowAutoRegistration = true,
+        bool requireEmployeeRecord = true,
+        string? defaultRoleId = null)
+    {
+        // Name must be the well-known Entra key — the registry lookup in
+        // GetOrCreateFromPrincipalAsync resolves the policy by it.
+        var faker = new OidcProviderFaker()
+            .WithName(LoginProviders.MicrosoftEntraId)
+            .AsMicrosoftEntraId("tenant-1");
+
+        faker = allowAutoRegistration
+            ? faker.WithAutoRegistration(requireEmployeeRecord, defaultRoleId)
+            : faker.WithoutAutoRegistration();
+
+        return faker.Generate();
+    }
+
+    // Arranges the registry to return the given provider for the Entra key, an
+    // empty (non-first-user) user set, no existing user/identity match, and a
+    // successful create. The employee lookup defaults to "no match" unless overridden.
+    private void ArrangeNewUserCreatePath(OidcProvider provider, Guid? employeeId = null)
+    {
+        _mockOidcProviderRegistry
+            .Setup(r => r.GetByName(LoginProviders.MicrosoftEntraId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(provider);
+
+        // A single existing user makes isFirstUser false without matching the new
+        // principal (different username/email), so we exercise real policy rather
+        // than the first-user bootstrap exemption.
+        var existing = CreateUser(id: "existing", userName: "someone-else", loginProvider: LoginProviders.MicrosoftEntraId);
+        existing.NormalizedUserName = "SOMEONE-ELSE";
+        existing.NormalizedEmail = "SOMEONE-ELSE@EXAMPLE.COM";
+        _mockUserManager.Setup(x => x.Users).Returns(new[] { existing }.AsQueryable().BuildMockDbSet().Object);
+
+        _mockUserIdentityStore.Setup(s => s.FindActive(LoginProviders.MicrosoftEntraId, It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserIdentity?)null);
+        _mockUserIdentityStore.Setup(s => s.FindActiveByNullTenant(LoginProviders.MicrosoftEntraId, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<UserIdentity>());
+        _mockUserIdentityStore.Setup(s => s.ExistsActive(It.IsAny<string>(), LoginProviders.MicrosoftEntraId))
+            .ReturnsAsync(false);
+
+        _mockUserManager.Setup(x => x.FindByNameAsync(It.IsAny<string>())).ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(x => x.FindByEmailAsync(It.IsAny<string>())).ReturnsAsync((ApplicationUser?)null);
+        _mockUserManager.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>())).ReturnsAsync(IdentityResult.Success);
+        _mockUserManager.Setup(x => x.GetRolesAsync(It.IsAny<ApplicationUser>())).ReturnsAsync([]);
+        _mockUserManager.Setup(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), It.IsAny<string>())).ReturnsAsync(IdentityResult.Success);
+
+        _mockSender.Setup(s => s.Send(It.IsAny<Wayd.Common.Application.Employees.Queries.GetEmployeeByEmailQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(employeeId);
+    }
+
+    [Fact]
+    public async Task GetOrCreateFromPrincipalAsync_ShouldDenyRegistration_WhenAutoRegistrationDisabled()
+    {
+        // Arrange
+        var provider = CreateEntraProviderWithPolicy(allowAutoRegistration: false);
+        ArrangeNewUserCreatePath(provider, employeeId: Guid.NewGuid());
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetOrCreateFromPrincipalAsync(
+            CreateNewUserPrincipal("oid-1", "tenant-1", "newuser@acme.example"));
+
+        // Assert
+        await act.Should().ThrowAsync<ForbiddenException>().WithMessage("*disabled for this identity provider*");
+        _mockUserManager.Verify(x => x.CreateAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrCreateFromPrincipalAsync_ShouldDenyRegistration_WhenEmployeeRequiredButNoMatch()
+    {
+        // Arrange
+        var provider = CreateEntraProviderWithPolicy(allowAutoRegistration: true, requireEmployeeRecord: true);
+        ArrangeNewUserCreatePath(provider, employeeId: null);
+        var sut = CreateSut();
+
+        // Act
+        var act = () => sut.GetOrCreateFromPrincipalAsync(
+            CreateNewUserPrincipal("oid-2", "tenant-1", "newuser@acme.example"));
+
+        // Assert
+        await act.Should().ThrowAsync<ForbiddenException>().WithMessage("*restricted to users with an employee record*");
+        _mockUserManager.Verify(x => x.CreateAsync(It.IsAny<ApplicationUser>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrCreateFromPrincipalAsync_ShouldCreateUser_WhenEmployeeRequiredAndMatches()
+    {
+        // Arrange
+        var employeeId = Guid.NewGuid();
+        var provider = CreateEntraProviderWithPolicy(allowAutoRegistration: true, requireEmployeeRecord: true);
+        ArrangeNewUserCreatePath(provider, employeeId: employeeId);
+        var sut = CreateSut();
+
+        // Act
+        var (resolvedId, resolvedEmployeeId) = await sut.GetOrCreateFromPrincipalAsync(
+            CreateNewUserPrincipal("oid-3", "tenant-1", "newuser@acme.example"));
+
+        // Assert
+        resolvedId.Should().NotBeNullOrWhiteSpace();
+        resolvedEmployeeId.Should().Be(employeeId.ToString());
+        _mockUserManager.Verify(x => x.CreateAsync(It.Is<ApplicationUser>(u => u.EmployeeId == employeeId)), Times.Once);
+        _mockUserManager.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), ApplicationRoles.Basic), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrCreateFromPrincipalAsync_ShouldCreateUser_WhenEmployeeNotRequiredAndNoEmployeeMatch()
+    {
+        // Arrange — the loosened posture: anyone who authenticates gets an account.
+        var provider = CreateEntraProviderWithPolicy(allowAutoRegistration: true, requireEmployeeRecord: false);
+        ArrangeNewUserCreatePath(provider, employeeId: null);
+        var sut = CreateSut();
+
+        // Act
+        var (resolvedId, _) = await sut.GetOrCreateFromPrincipalAsync(
+            CreateNewUserPrincipal("oid-4", "tenant-1", "outsider@acme.example"));
+
+        // Assert
+        resolvedId.Should().NotBeNullOrWhiteSpace();
+        _mockUserManager.Verify(x => x.CreateAsync(It.Is<ApplicationUser>(u => u.EmployeeId == null)), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetOrCreateFromPrincipalAsync_ShouldAssignConfiguredDefaultRole_WhenPolicyNamesRole()
+    {
+        // Arrange
+        const string roleId = "role-guid-pm";
+        const string roleName = "ProjectManager";
+        var provider = CreateEntraProviderWithPolicy(requireEmployeeRecord: false, defaultRoleId: roleId);
+        ArrangeNewUserCreatePath(provider, employeeId: null);
+        _mockRoleManager.Setup(x => x.FindByIdAsync(roleId))
+            .ReturnsAsync(new ApplicationRole(roleName) { Id = roleId });
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetOrCreateFromPrincipalAsync(CreateNewUserPrincipal("oid-5", "tenant-1", "pm@acme.example"));
+
+        // Assert
+        _mockUserManager.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), roleName), Times.Once);
+        _mockUserManager.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), ApplicationRoles.Basic), Times.Never);
+    }
+
+    [Fact]
+    public async Task GetOrCreateFromPrincipalAsync_ShouldFallBackToBasic_WhenConfiguredDefaultRoleDeleted()
+    {
+        // Arrange — a stale default-role reference must not block sign-in.
+        const string roleId = "role-guid-deleted";
+        var provider = CreateEntraProviderWithPolicy(requireEmployeeRecord: false, defaultRoleId: roleId);
+        ArrangeNewUserCreatePath(provider, employeeId: null);
+        _mockRoleManager.Setup(x => x.FindByIdAsync(roleId)).ReturnsAsync((ApplicationRole?)null);
+        var sut = CreateSut();
+
+        // Act
+        await sut.GetOrCreateFromPrincipalAsync(CreateNewUserPrincipal("oid-6", "tenant-1", "user@acme.example"));
+
+        // Assert
+        _mockUserManager.Verify(x => x.AddToRoleAsync(It.IsAny<ApplicationUser>(), ApplicationRoles.Basic), Times.Once);
     }
 
     #endregion

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/OidcProvidersController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/OidcProvidersController.cs
@@ -58,7 +58,10 @@ public class OidcProvidersController(ISender sender) : ControllerBase
             request.Scopes,
             request.AllowedTenantIds,
             request.ClockSkewSeconds,
-            request.IsEnabled);
+            request.IsEnabled,
+            request.AllowAutoRegistration,
+            request.RequireEmployeeRecord,
+            request.DefaultRoleId);
 
         var result = await _sender.Send(command, cancellationToken);
 
@@ -86,7 +89,10 @@ public class OidcProvidersController(ISender sender) : ControllerBase
             request.Scopes,
             request.AllowedTenantIds,
             request.ClockSkewSeconds,
-            request.IsEnabled);
+            request.IsEnabled,
+            request.AllowAutoRegistration,
+            request.RequireEmployeeRecord,
+            request.DefaultRoleId);
 
         var result = await _sender.Send(command, cancellationToken);
 

--- a/Wayd.Web/src/Wayd.Web.Api/Models/UserManagement/OidcProviders/OidcProviderRequests.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/UserManagement/OidcProviders/OidcProviderRequests.cs
@@ -12,7 +12,12 @@ public sealed record CreateOidcProviderRequest(
     IReadOnlyList<string> Scopes,
     IReadOnlyList<string>? AllowedTenantIds,
     int ClockSkewSeconds,
-    bool IsEnabled);
+    bool IsEnabled,
+    // Defaults preserve the historical behavior (auto-register employee-matched
+    // users into Basic) for callers that omit the registration-policy fields.
+    bool AllowAutoRegistration = true,
+    bool RequireEmployeeRecord = true,
+    string? DefaultRoleId = null);
 
 public sealed record UpdateOidcProviderRequest(
     Guid Id,
@@ -23,4 +28,7 @@ public sealed record UpdateOidcProviderRequest(
     IReadOnlyList<string> Scopes,
     IReadOnlyList<string>? AllowedTenantIds,
     int ClockSkewSeconds,
-    bool IsEnabled);
+    bool IsEnabled,
+    bool AllowAutoRegistration = true,
+    bool RequireEmployeeRecord = true,
+    string? DefaultRoleId = null);

--- a/Wayd.Web/src/Wayd.Web.Api/Models/UserManagement/OidcProviders/OidcProviderRequests.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/UserManagement/OidcProviders/OidcProviderRequests.cs
@@ -1,34 +1,172 @@
-using Wayd.Common.Domain.Identity;
+﻿using Wayd.Common.Domain.Identity;
 
 namespace Wayd.Web.Api.Models.UserManagement.OidcProviders;
 
-public sealed record CreateOidcProviderRequest(
-    string Name,
-    string DisplayName,
-    OidcProviderType ProviderType,
-    string Authority,
-    string ClientId,
-    string Audience,
-    IReadOnlyList<string> Scopes,
-    IReadOnlyList<string>? AllowedTenantIds,
-    int ClockSkewSeconds,
-    bool IsEnabled,
-    // Defaults preserve the historical behavior (auto-register employee-matched
-    // users into Basic) for callers that omit the registration-policy fields.
-    bool AllowAutoRegistration = true,
-    bool RequireEmployeeRecord = true,
-    string? DefaultRoleId = null);
+public sealed record CreateOidcProviderRequest : IOidcRegistrationPolicyRequest
+{
+    public required string Name { get; set; }
+    public required string DisplayName { get; set; }
+    public OidcProviderType ProviderType { get; set; }
+    public required string Authority { get; set; }
+    public required string ClientId { get; set; }
+    public required string Audience { get; set; }
+    public IReadOnlyList<string> Scopes { get; set; } = [];
+    public IReadOnlyList<string>? AllowedTenantIds { get; set; }
+    public int ClockSkewSeconds { get; set; }
+    public bool IsEnabled { get; set; }
 
-public sealed record UpdateOidcProviderRequest(
-    Guid Id,
-    string DisplayName,
-    string Authority,
-    string ClientId,
-    string Audience,
-    IReadOnlyList<string> Scopes,
-    IReadOnlyList<string>? AllowedTenantIds,
-    int ClockSkewSeconds,
-    bool IsEnabled,
-    bool AllowAutoRegistration = true,
-    bool RequireEmployeeRecord = true,
-    string? DefaultRoleId = null);
+    // Registration policy is a required part of the contract — callers state it
+    // explicitly rather than inheriting a default. The dependent fields are only
+    // meaningful when AllowAutoRegistration is true: RequireEmployeeRecord is the
+    // gate (null when disabled) and DefaultRoleId is required when enabled.
+    public bool AllowAutoRegistration { get; set; }
+    public bool? RequireEmployeeRecord { get; set; }
+    public string? DefaultRoleId { get; set; }
+}
+
+public sealed record UpdateOidcProviderRequest : IOidcRegistrationPolicyRequest
+{
+    public Guid Id { get; set; }
+    public required string DisplayName { get; set; }
+    public required string Authority { get; set; }
+    public required string ClientId { get; set; }
+    public required string Audience { get; set; }
+    public IReadOnlyList<string> Scopes { get; set; } = [];
+    public IReadOnlyList<string>? AllowedTenantIds { get; set; }
+    public int ClockSkewSeconds { get; set; }
+    public bool IsEnabled { get; set; }
+
+    // See CreateOidcProviderRequest — the registration policy is required and
+    // RequireEmployeeRecord is null exactly when auto-registration is disabled.
+    public bool AllowAutoRegistration { get; set; }
+    public bool? RequireEmployeeRecord { get; set; }
+    public string? DefaultRoleId { get; set; }
+}
+
+public static class OidcProviderRequestMessages
+{
+    public const string EmployeeGateRequired =
+        "RequireEmployeeRecord is required when auto-registration is enabled.";
+    public const string EmployeeGateForbidden =
+        "RequireEmployeeRecord must be omitted when auto-registration is disabled.";
+    public const string DefaultRoleRequired =
+        "A default role is required when auto-registration is enabled.";
+    public const string DefaultRoleForbidden =
+        "A default role must be omitted when auto-registration is disabled.";
+    public const string AuthorityHttps = "Authority must be an absolute HTTPS URL.";
+
+    public static bool BeHttpsAbsoluteUrl(string? value) =>
+        !string.IsNullOrWhiteSpace(value)
+        && Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Structural validation for the create request — guarantees a well-formed shape
+/// at the API boundary. The command validator in the MediatR pipeline still owns
+/// the checks that need services (default-role existence, name uniqueness).
+/// </summary>
+/// <remarks>
+/// The registration-policy invariant is expressed with model-level <c>Must</c>
+/// predicates rather than property-level <c>NotNull</c>/<c>NotEmpty</c> rules.
+/// The FluentValidation → NSwag schema bridge translates the latter into schema
+/// <c>required</c> + non-nullable, which would force the generated TS client to
+/// type the nullable <c>RequireEmployeeRecord</c>/<c>DefaultRoleId</c> as required
+/// (the conditional <c>When</c> is invisible to the schema). Model-level predicates
+/// validate identically at runtime without leaking into the schema.
+/// </remarks>
+public sealed class CreateOidcProviderRequestValidator : CustomValidator<CreateOidcProviderRequest>
+{
+    public CreateOidcProviderRequestValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(50);
+        RuleFor(x => x.DisplayName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Authority).NotEmpty().MaximumLength(500)
+            .Must(OidcProviderRequestMessages.BeHttpsAbsoluteUrl)
+            .WithMessage(OidcProviderRequestMessages.AuthorityHttps);
+        RuleFor(x => x.ClientId).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Audience).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.ClockSkewSeconds).InclusiveBetween(0, 600);
+
+        // Entra requires at least one allowed tenant — without it every login is
+        // rejected at runtime.
+        RuleFor(x => x.AllowedTenantIds)
+            .Must(ids => ids != null && ids.Any(t => !string.IsNullOrWhiteSpace(t)))
+            .When(x => x.ProviderType == OidcProviderType.MicrosoftEntraId)
+            .WithMessage("Microsoft Entra ID providers require at least one AllowedTenantId.");
+
+        OidcProviderRequestRules.AddRegistrationPolicyRules(this);
+    }
+}
+
+/// <summary>
+/// Structural validation for the update request. Mirrors the create rules minus
+/// the immutable Name/ProviderType fields; the command validator owns the
+/// service-backed checks. See <see cref="CreateOidcProviderRequestValidator"/>
+/// for why the registration-policy rules are model-level predicates.
+/// </summary>
+public sealed class UpdateOidcProviderRequestValidator : CustomValidator<UpdateOidcProviderRequest>
+{
+    public UpdateOidcProviderRequestValidator()
+    {
+        RuleFor(x => x.Id).NotEmpty();
+        RuleFor(x => x.DisplayName).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Authority).NotEmpty().MaximumLength(500)
+            .Must(OidcProviderRequestMessages.BeHttpsAbsoluteUrl)
+            .WithMessage(OidcProviderRequestMessages.AuthorityHttps);
+        RuleFor(x => x.ClientId).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Audience).NotEmpty().MaximumLength(500);
+        RuleFor(x => x.ClockSkewSeconds).InclusiveBetween(0, 600);
+
+        OidcProviderRequestRules.AddRegistrationPolicyRules(this);
+    }
+}
+
+/// <summary>
+/// Shared registration-policy rules for the create/update request validators.
+/// Both requests expose the same flat policy fields, so the discriminated-shape
+/// invariant is identical. The rules target the model (not the nullable
+/// properties directly) so the FluentValidation → NSwag schema bridge leaves
+/// <c>RequireEmployeeRecord</c>/<c>DefaultRoleId</c> nullable and optional.
+/// </summary>
+internal static class OidcProviderRequestRules
+{
+    public static void AddRegistrationPolicyRules<T>(AbstractValidator<T> validator)
+        where T : IOidcRegistrationPolicyRequest
+    {
+        // Enabled: the employee-record gate must be supplied and a default role is
+        // required. Disabled: both dependent fields must be omitted — sending them
+        // is a contradiction the domain would reject, so fail fast with a 400.
+        validator.RuleFor(x => x)
+            .Must(x => x.RequireEmployeeRecord is not null)
+            .When(x => x.AllowAutoRegistration)
+            .WithName(nameof(IOidcRegistrationPolicyRequest.RequireEmployeeRecord))
+            .WithMessage(OidcProviderRequestMessages.EmployeeGateRequired);
+        validator.RuleFor(x => x)
+            .Must(x => x.RequireEmployeeRecord is null)
+            .When(x => !x.AllowAutoRegistration)
+            .WithName(nameof(IOidcRegistrationPolicyRequest.RequireEmployeeRecord))
+            .WithMessage(OidcProviderRequestMessages.EmployeeGateForbidden);
+        validator.RuleFor(x => x)
+            .Must(x => !string.IsNullOrWhiteSpace(x.DefaultRoleId))
+            .When(x => x.AllowAutoRegistration)
+            .WithName(nameof(IOidcRegistrationPolicyRequest.DefaultRoleId))
+            .WithMessage(OidcProviderRequestMessages.DefaultRoleRequired);
+        validator.RuleFor(x => x)
+            .Must(x => string.IsNullOrWhiteSpace(x.DefaultRoleId))
+            .When(x => !x.AllowAutoRegistration)
+            .WithName(nameof(IOidcRegistrationPolicyRequest.DefaultRoleId))
+            .WithMessage(OidcProviderRequestMessages.DefaultRoleForbidden);
+    }
+}
+
+/// <summary>
+/// The flat registration-policy fields shared by the create and update requests.
+/// Lets one set of cross-field rules validate both request types.
+/// </summary>
+internal interface IOidcRegistrationPolicyRequest
+{
+    bool AllowAutoRegistration { get; }
+    bool? RequireEmployeeRecord { get; }
+    string? DefaultRoleId { get; }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -24702,7 +24702,9 @@
           "audience",
           "scopes",
           "clockSkewSeconds",
-          "isEnabled"
+          "isEnabled",
+          "allowAutoRegistration",
+          "requireEmployeeRecord"
         ],
         "properties": {
           "id": {
@@ -24748,6 +24750,16 @@
           },
           "isEnabled": {
             "type": "boolean"
+          },
+          "allowAutoRegistration": {
+            "type": "boolean"
+          },
+          "requireEmployeeRecord": {
+            "type": "boolean"
+          },
+          "defaultRoleId": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -24763,7 +24775,9 @@
           "audience",
           "scopes",
           "clockSkewSeconds",
-          "isEnabled"
+          "isEnabled",
+          "allowAutoRegistration",
+          "requireEmployeeRecord"
         ],
         "properties": {
           "name": {
@@ -24803,6 +24817,16 @@
           },
           "isEnabled": {
             "type": "boolean"
+          },
+          "allowAutoRegistration": {
+            "type": "boolean"
+          },
+          "requireEmployeeRecord": {
+            "type": "boolean"
+          },
+          "defaultRoleId": {
+            "type": "string",
+            "nullable": true
           }
         }
       },
@@ -24829,7 +24853,9 @@
           "audience",
           "scopes",
           "clockSkewSeconds",
-          "isEnabled"
+          "isEnabled",
+          "allowAutoRegistration",
+          "requireEmployeeRecord"
         ],
         "properties": {
           "id": {
@@ -24869,6 +24895,16 @@
           },
           "isEnabled": {
             "type": "boolean"
+          },
+          "allowAutoRegistration": {
+            "type": "boolean"
+          },
+          "requireEmployeeRecord": {
+            "type": "boolean"
+          },
+          "defaultRoleId": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -24658,11 +24658,11 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "id",
           "name",
           "displayName",
           "providerType",
           "authority",
+          "id",
           "isEnabled"
         ],
         "properties": {
@@ -24693,18 +24693,17 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "id",
           "name",
           "displayName",
           "providerType",
           "authority",
           "clientId",
           "audience",
+          "id",
           "scopes",
           "clockSkewSeconds",
           "isEnabled",
-          "allowAutoRegistration",
-          "requireEmployeeRecord"
+          "allowAutoRegistration"
         ],
         "properties": {
           "id": {
@@ -24755,7 +24754,8 @@
             "type": "boolean"
           },
           "requireEmployeeRecord": {
-            "type": "boolean"
+            "type": "boolean",
+            "nullable": true
           },
           "defaultRoleId": {
             "type": "string",
@@ -24769,34 +24769,48 @@
         "required": [
           "name",
           "displayName",
-          "providerType",
           "authority",
           "clientId",
           "audience",
+          "providerType",
           "scopes",
           "clockSkewSeconds",
           "isEnabled",
-          "allowAutoRegistration",
-          "requireEmployeeRecord"
+          "allowAutoRegistration"
         ],
         "properties": {
           "name": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 50,
+            "minLength": 1,
+            "nullable": false
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "nullable": false
           },
           "providerType": {
             "$ref": "#/components/schemas/OidcProviderType"
           },
           "authority": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "nullable": false
           },
           "clientId": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "nullable": false
           },
           "audience": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "nullable": false
           },
           "scopes": {
             "type": "array",
@@ -24813,7 +24827,9 @@
           },
           "clockSkewSeconds": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "maximum": 600.0,
+            "minimum": 0.0
           },
           "isEnabled": {
             "type": "boolean"
@@ -24822,7 +24838,8 @@
             "type": "boolean"
           },
           "requireEmployeeRecord": {
-            "type": "boolean"
+            "type": "boolean",
+            "nullable": true
           },
           "defaultRoleId": {
             "type": "string",
@@ -24846,35 +24863,47 @@
         "type": "object",
         "additionalProperties": false,
         "required": [
-          "id",
           "displayName",
           "authority",
           "clientId",
           "audience",
+          "id",
           "scopes",
           "clockSkewSeconds",
           "isEnabled",
-          "allowAutoRegistration",
-          "requireEmployeeRecord"
+          "allowAutoRegistration"
         ],
         "properties": {
           "id": {
             "type": "string",
             "format": "guid",
+            "minLength": 1,
             "nullable": false,
             "example": "00000000-0000-0000-0000-000000000000"
           },
           "displayName": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 1,
+            "nullable": false
           },
           "authority": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "nullable": false
           },
           "clientId": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 200,
+            "minLength": 1,
+            "nullable": false
           },
           "audience": {
-            "type": "string"
+            "type": "string",
+            "maxLength": 500,
+            "minLength": 1,
+            "nullable": false
           },
           "scopes": {
             "type": "array",
@@ -24891,7 +24920,9 @@
           },
           "clockSkewSeconds": {
             "type": "integer",
-            "format": "int32"
+            "format": "int32",
+            "maximum": 600.0,
+            "minimum": 0.0
           },
           "isEnabled": {
             "type": "boolean"
@@ -24900,7 +24931,8 @@
             "type": "boolean"
           },
           "requireEmployeeRecord": {
-            "type": "boolean"
+            "type": "boolean",
+            "nullable": true
           },
           "defaultRoleId": {
             "type": "string",

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/[id]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/[id]/page.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { PageActions } from '@/src/components/common'
+import PageTitle from '@/src/components/common/page-title'
+import BasicBreadcrumb from '@/src/components/common/basic-breadcrumb'
+import { authorizePage } from '@/src/components/hoc'
+import useAuth from '@/src/components/contexts/auth'
+import { useDocumentTitle } from '@/src/hooks'
+import { useGetOidcProviderQuery } from '@/src/store/features/user-management/oidc-providers-api'
+import { ItemType } from 'antd/es/menu/interface'
+import { Card, MenuProps, Skeleton, Tag } from 'antd'
+import { notFound, useRouter } from 'next/navigation'
+import { use, useEffect, useState } from 'react'
+import {
+  DeleteOidcProviderForm,
+  EditOidcProviderForm,
+  OidcProviderDetails,
+} from '../_components'
+
+const OidcProviderDetailsPage = (props: {
+  params: Promise<{ id: string }>
+}) => {
+  const { id } = use(props.params)
+  const router = useRouter()
+
+  const [openEditForm, setOpenEditForm] = useState(false)
+  const [openDeleteForm, setOpenDeleteForm] = useState(false)
+
+  const { data: provider, isLoading, error } = useGetOidcProviderQuery(id)
+
+  const { hasPermissionClaim } = useAuth()
+  const canUpdate = hasPermissionClaim('Permissions.OidcProviders.Update')
+  const canDelete = hasPermissionClaim('Permissions.OidcProviders.Delete')
+
+  const title = provider
+    ? `${provider.displayName} - Identity Provider`
+    : 'Identity Provider'
+  useDocumentTitle(title)
+
+  useEffect(() => {
+    error && console.error(error)
+  }, [error])
+
+  const actionsMenuItems: MenuProps['items'] = (() => {
+    if (!provider) return []
+    const items: ItemType[] = []
+    if (canUpdate) {
+      items.push({
+        key: 'edit',
+        label: 'Edit',
+        onClick: () => setOpenEditForm(true),
+      })
+    }
+    if (canDelete) {
+      items.push({
+        key: 'delete',
+        label: 'Delete',
+        danger: true,
+        onClick: () => setOpenDeleteForm(true),
+      })
+    }
+    return items
+  })()
+
+  if (isLoading) {
+    return (
+      <Card style={{ width: '100%' }}>
+        <Skeleton active />
+      </Card>
+    )
+  }
+
+  if (!provider) {
+    return notFound()
+  }
+
+  return (
+    <>
+      <BasicBreadcrumb
+        items={[
+          { title: 'Settings' },
+          { title: 'Identity Providers', href: './' },
+          { title: 'Details' },
+        ]}
+      />
+      <PageTitle
+        title={provider.displayName}
+        subtitle="Identity Provider"
+        tags={
+          provider.isEnabled ? (
+            <Tag color="success">Enabled</Tag>
+          ) : (
+            <Tag color="default">Disabled</Tag>
+          )
+        }
+        actions={<PageActions actionItems={actionsMenuItems} />}
+      />
+      <Card style={{ width: '100%' }}>
+        <OidcProviderDetails provider={provider} />
+      </Card>
+
+      {openEditForm && (
+        <EditOidcProviderForm
+          providerId={provider.id}
+          onFormComplete={() => setOpenEditForm(false)}
+          onFormCancel={() => setOpenEditForm(false)}
+        />
+      )}
+      {openDeleteForm && (
+        <DeleteOidcProviderForm
+          provider={provider}
+          onFormComplete={() => {
+            setOpenDeleteForm(false)
+            router.push('/settings/auth/providers')
+          }}
+          onFormCancel={() => setOpenDeleteForm(false)}
+        />
+      )}
+    </>
+  )
+}
+
+const OidcProviderDetailsPageWithAuthorization = authorizePage(
+  OidcProviderDetailsPage,
+  'Permission',
+  'Permissions.OidcProviders.View',
+)
+
+export default OidcProviderDetailsPageWithAuthorization

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/create-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/create-oidc-provider-form.tsx
@@ -292,7 +292,7 @@ const CreateOidcProviderForm = ({
                     type="warning"
                     showIcon
                     style={{ marginBottom: 16 }}
-                    message="Anyone who can authenticate through this provider will be granted an account."
+                    title="Anyone who can authenticate through this provider will be granted an account."
                   />
                 )
               }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/create-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/create-oidc-provider-form.tsx
@@ -6,9 +6,19 @@ import {
   OidcProviderType,
 } from '@/src/services/wayd-api'
 import { useCreateOidcProviderMutation } from '@/src/store/features/user-management/oidc-providers-api'
+import { useGetRolesQuery } from '@/src/store/features/user-management/roles-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
 import { useModalForm } from '@/src/hooks'
-import { Form, Input, InputNumber, Modal, Select, Switch } from 'antd'
+import {
+  Alert,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Select,
+  Switch,
+  Typography,
+} from 'antd'
 import { useState } from 'react'
 import TagInput from './tag-input'
 
@@ -30,6 +40,9 @@ interface CreateOidcProviderFormValues {
   allowedTenantIds?: string[]
   clockSkewSeconds: number
   isEnabled: boolean
+  allowAutoRegistration: boolean
+  requireEmployeeRecord: boolean
+  defaultRoleId?: string
 }
 
 const CreateOidcProviderForm = ({
@@ -37,6 +50,7 @@ const CreateOidcProviderForm = ({
   onFormCancel,
 }: CreateOidcProviderFormProps) => {
   const messageApi = useMessage()
+  const { data: roles } = useGetRolesQuery()
   const [createOidcProvider] = useCreateOidcProviderMutation()
   const [providerType, setProviderType] = useState<OidcProviderType>(
     OidcProviderType.GenericOidc,
@@ -60,6 +74,13 @@ const CreateOidcProviderForm = ({
                 : undefined,
             clockSkewSeconds: values.clockSkewSeconds ?? 60,
             isEnabled: values.isEnabled ?? true,
+            allowAutoRegistration: values.allowAutoRegistration ?? true,
+            requireEmployeeRecord: values.allowAutoRegistration
+              ? (values.requireEmployeeRecord ?? true)
+              : true,
+            defaultRoleId: values.allowAutoRegistration
+              ? (values.defaultRoleId ?? undefined)
+              : undefined,
           }
           const response = await createOidcProvider(request)
           if (response.error) throw response.error
@@ -84,6 +105,8 @@ const CreateOidcProviderForm = ({
       permission: 'Permissions.OidcProviders.Create',
     })
 
+  const allowAutoRegistration = Form.useWatch('allowAutoRegistration', form)
+
   return (
     <Modal
       title="Create Identity Provider"
@@ -107,6 +130,8 @@ const CreateOidcProviderForm = ({
           scopes: ['openid', 'profile', 'email'],
           clockSkewSeconds: 60,
           isEnabled: true,
+          allowAutoRegistration: false,
+          requireEmployeeRecord: true,
         }}
       >
         <Item
@@ -235,6 +260,60 @@ const CreateOidcProviderForm = ({
         >
           <Switch />
         </Item>
+
+        <Typography.Title level={5} style={{ marginTop: 8 }}>
+          Registration
+        </Typography.Title>
+
+        <Item
+          label="Allow automatic user registration"
+          name="allowAutoRegistration"
+          valuePropName="checked"
+          tooltip="When on, a user signing in through this provider for the first time has an account created automatically. When off, unknown users are rejected and an admin must create their account first."
+        >
+          <Switch />
+        </Item>
+
+        {allowAutoRegistration && (
+          <>
+            <Item
+              label="Require matching employee record"
+              name="requireEmployeeRecord"
+              valuePropName="checked"
+              tooltip="When on, only users whose email matches an existing employee can self-register."
+            >
+              <Switch />
+            </Item>
+
+            <Item noStyle shouldUpdate>
+              {({ getFieldValue }) =>
+                getFieldValue('requireEmployeeRecord') ? null : (
+                  <Alert
+                    type="warning"
+                    showIcon
+                    style={{ marginBottom: 16 }}
+                    message="Anyone who can authenticate through this provider will be granted an account."
+                  />
+                )
+              }
+            </Item>
+
+            <Item
+              label="Default role for new users"
+              name="defaultRoleId"
+              rules={[{ required: true, message: 'A default role is required' }]}
+              tooltip="Role assigned to users created automatically through this provider."
+            >
+              <Select
+                placeholder="Select a role"
+                options={(roles ?? []).map((r) => ({
+                  value: r.id,
+                  label: r.name,
+                }))}
+              />
+            </Item>
+          </>
+        )}
       </Form>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/create-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/create-oidc-provider-form.tsx
@@ -74,10 +74,12 @@ const CreateOidcProviderForm = ({
                 : undefined,
             clockSkewSeconds: values.clockSkewSeconds ?? 60,
             isEnabled: values.isEnabled ?? true,
-            allowAutoRegistration: values.allowAutoRegistration ?? true,
+            allowAutoRegistration: values.allowAutoRegistration ?? false,
+            // The dependent fields are only valid when auto-registration is on;
+            // when off they must be omitted (the request validator rejects them).
             requireEmployeeRecord: values.allowAutoRegistration
               ? (values.requireEmployeeRecord ?? true)
-              : true,
+              : undefined,
             defaultRoleId: values.allowAutoRegistration
               ? (values.defaultRoleId ?? undefined)
               : undefined,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/delete-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/delete-oidc-provider-form.tsx
@@ -104,7 +104,7 @@ const DeleteOidcProviderForm = ({
         <Alert
           type="warning"
           showIcon
-          message="This cannot be completed if any users have an active identity bound to this provider. Rebind those users first."
+          title="This cannot be completed if any users have an active identity bound to this provider. Rebind those users first."
         />
       </Flex>
     </Modal>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/edit-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/edit-oidc-provider-form.tsx
@@ -9,9 +9,19 @@ import {
   useGetOidcProviderQuery,
   useUpdateOidcProviderMutation,
 } from '@/src/store/features/user-management/oidc-providers-api'
+import { useGetRolesQuery } from '@/src/store/features/user-management/roles-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
 import { useModalForm } from '@/src/hooks'
-import { Form, Input, InputNumber, Modal, Switch, Typography } from 'antd'
+import {
+  Alert,
+  Form,
+  Input,
+  InputNumber,
+  Modal,
+  Select,
+  Switch,
+  Typography,
+} from 'antd'
 import { useEffect } from 'react'
 import TagInput from './tag-input'
 
@@ -33,6 +43,9 @@ interface EditOidcProviderFormValues {
   allowedTenantIds?: string[]
   clockSkewSeconds: number
   isEnabled: boolean
+  allowAutoRegistration: boolean
+  requireEmployeeRecord: boolean
+  defaultRoleId?: string
 }
 
 const EditOidcProviderForm = ({
@@ -43,6 +56,7 @@ const EditOidcProviderForm = ({
   const messageApi = useMessage()
   const { data: providerData, isLoading: providerLoading } =
     useGetOidcProviderQuery(providerId)
+  const { data: roles } = useGetRolesQuery()
   const [updateOidcProvider] = useUpdateOidcProviderMutation()
 
   const isMicrosoftEntraId =
@@ -64,6 +78,16 @@ const EditOidcProviderForm = ({
               : undefined,
             clockSkewSeconds: values.clockSkewSeconds ?? 60,
             isEnabled: values.isEnabled ?? true,
+            allowAutoRegistration: values.allowAutoRegistration ?? true,
+            // When auto-registration is off, the gating fields are irrelevant —
+            // send conservative values so a later re-enable doesn't inherit a
+            // stale loosened posture.
+            requireEmployeeRecord: values.allowAutoRegistration
+              ? (values.requireEmployeeRecord ?? true)
+              : true,
+            defaultRoleId: values.allowAutoRegistration
+              ? (values.defaultRoleId ?? undefined)
+              : undefined,
           }
           const response = await updateOidcProvider(request)
           if (response.error) throw response.error
@@ -88,6 +112,8 @@ const EditOidcProviderForm = ({
       permission: 'Permissions.OidcProviders.Update',
     })
 
+  const allowAutoRegistration = Form.useWatch('allowAutoRegistration', form)
+
   useEffect(() => {
     if (!providerData) return
     form.setFieldsValue({
@@ -99,6 +125,9 @@ const EditOidcProviderForm = ({
       allowedTenantIds: [...(providerData.allowedTenantIds ?? [])],
       clockSkewSeconds: providerData.clockSkewSeconds,
       isEnabled: providerData.isEnabled,
+      allowAutoRegistration: providerData.allowAutoRegistration,
+      requireEmployeeRecord: providerData.requireEmployeeRecord,
+      defaultRoleId: providerData.defaultRoleId ?? undefined,
     })
   }, [providerData, form])
 
@@ -226,6 +255,60 @@ const EditOidcProviderForm = ({
         >
           <Switch />
         </Item>
+
+        <Typography.Title level={5} style={{ marginTop: 8 }}>
+          Registration
+        </Typography.Title>
+
+        <Item
+          label="Allow automatic user registration"
+          name="allowAutoRegistration"
+          valuePropName="checked"
+          tooltip="When on, a user signing in through this provider for the first time has an account created automatically. When off, unknown users are rejected and an admin must create their account first."
+        >
+          <Switch />
+        </Item>
+
+        {allowAutoRegistration && (
+          <>
+            <Item
+              label="Require matching employee record"
+              name="requireEmployeeRecord"
+              valuePropName="checked"
+              tooltip="When on, only users whose email matches an existing employee can self-register."
+            >
+              <Switch />
+            </Item>
+
+            <Item noStyle shouldUpdate>
+              {({ getFieldValue }) =>
+                getFieldValue('requireEmployeeRecord') ? null : (
+                  <Alert
+                    type="warning"
+                    showIcon
+                    style={{ marginBottom: 16 }}
+                    message="Anyone who can authenticate through this provider will be granted an account."
+                  />
+                )
+              }
+            </Item>
+
+            <Item
+              label="Default role for new users"
+              name="defaultRoleId"
+              rules={[{ required: true, message: 'A default role is required' }]}
+              tooltip="Role assigned to users created automatically through this provider."
+            >
+              <Select
+                placeholder="Select a role"
+                options={(roles ?? []).map((r) => ({
+                  value: r.id,
+                  label: r.name,
+                }))}
+              />
+            </Item>
+          </>
+        )}
       </Form>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/edit-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/edit-oidc-provider-form.tsx
@@ -78,13 +78,13 @@ const EditOidcProviderForm = ({
               : undefined,
             clockSkewSeconds: values.clockSkewSeconds ?? 60,
             isEnabled: values.isEnabled ?? true,
-            allowAutoRegistration: values.allowAutoRegistration ?? true,
-            // When auto-registration is off, the gating fields are irrelevant —
-            // send conservative values so a later re-enable doesn't inherit a
-            // stale loosened posture.
+            allowAutoRegistration: values.allowAutoRegistration ?? false,
+            // When auto-registration is off the dependent fields must be omitted —
+            // the request validator rejects them, and the domain treats the policy
+            // as a discriminated shape (no dependent values while disabled).
             requireEmployeeRecord: values.allowAutoRegistration
               ? (values.requireEmployeeRecord ?? true)
-              : true,
+              : undefined,
             defaultRoleId: values.allowAutoRegistration
               ? (values.defaultRoleId ?? undefined)
               : undefined,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/edit-oidc-provider-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/edit-oidc-provider-form.tsx
@@ -287,7 +287,7 @@ const EditOidcProviderForm = ({
                     type="warning"
                     showIcon
                     style={{ marginBottom: 16 }}
-                    message="Anyone who can authenticate through this provider will be granted an account."
+                    title="Anyone who can authenticate through this provider will be granted an account."
                   />
                 )
               }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/index.ts
@@ -1,3 +1,4 @@
 export { default as CreateOidcProviderForm } from './create-oidc-provider-form'
 export { default as EditOidcProviderForm } from './edit-oidc-provider-form'
 export { default as DeleteOidcProviderForm } from './delete-oidc-provider-form'
+export { default as OidcProviderDetails } from './oidc-provider-details'

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/oidc-provider-details.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/oidc-provider-details.tsx
@@ -1,0 +1,197 @@
+'use client'
+
+import { OidcProviderDto, OidcProviderType } from '@/src/services/wayd-api'
+import { useTestOidcProviderDiscoveryMutation } from '@/src/store/features/user-management/oidc-providers-api'
+import { useGetRolesQuery } from '@/src/store/features/user-management/roles-api'
+import {
+  CheckCircleOutlined,
+  CloseCircleOutlined,
+  LoadingOutlined,
+} from '@ant-design/icons'
+import {
+  Alert,
+  Button,
+  Card,
+  Col,
+  Descriptions,
+  Flex,
+  Row,
+  Space,
+  Typography,
+} from 'antd'
+import { useState } from 'react'
+
+const { Item } = Descriptions
+const { Text } = Typography
+
+const providerTypeLabel = (type: string) => {
+  if (type === OidcProviderType.MicrosoftEntraId) return 'Microsoft Entra ID'
+  if (type === OidcProviderType.GenericOidc) return 'Generic OIDC'
+  return type
+}
+
+interface DiscoveryState {
+  status: 'idle' | 'loading' | 'success' | 'error'
+  issuer?: string
+  jwksKeyCount?: number
+  error?: string
+}
+
+const DiscoveryTest = ({ providerId }: { providerId: string }) => {
+  const [state, setState] = useState<DiscoveryState>({ status: 'idle' })
+  const [testDiscovery] = useTestOidcProviderDiscoveryMutation()
+
+  const handleTest = async () => {
+    setState({ status: 'loading' })
+    try {
+      const response = await testDiscovery(providerId)
+      if (response.error) throw response.error
+      const result = response.data!
+      if (result.success) {
+        setState({
+          status: 'success',
+          issuer: result.issuer,
+          jwksKeyCount: result.jwksKeyCount,
+        })
+      } else {
+        setState({ status: 'error', error: result.error })
+      }
+    } catch {
+      setState({ status: 'error', error: 'Request failed' })
+    }
+  }
+
+  return (
+    <Card size="small" title="Discovery">
+      <Flex vertical gap="small" align="flex-start">
+        <Button
+          size="small"
+          onClick={handleTest}
+          loading={state.status === 'loading'}
+        >
+          Test discovery
+        </Button>
+        {state.status === 'success' && (
+          <Space size={4}>
+            <CheckCircleOutlined
+              style={{ color: 'var(--ant-color-success)' }}
+            />
+            <Text style={{ color: 'var(--ant-color-success)' }}>
+              Reachable — issuer {state.issuer}, {state.jwksKeyCount} signing
+              key(s)
+            </Text>
+          </Space>
+        )}
+        {state.status === 'error' && (
+          <Space size={4}>
+            <CloseCircleOutlined style={{ color: 'var(--ant-color-error)' }} />
+            <Text style={{ color: 'var(--ant-color-error)' }}>
+              {state.error ?? 'Discovery failed'}
+            </Text>
+          </Space>
+        )}
+        {state.status === 'loading' && (
+          <Space size={4}>
+            <LoadingOutlined style={{ color: 'var(--ant-color-primary)' }} />
+            <Text type="secondary">Testing the discovery endpoint…</Text>
+          </Space>
+        )}
+      </Flex>
+    </Card>
+  )
+}
+
+interface OidcProviderDetailsProps {
+  provider: OidcProviderDto
+}
+
+const OidcProviderDetails = ({ provider }: OidcProviderDetailsProps) => {
+  const { data: roles } = useGetRolesQuery()
+
+  const isMicrosoftEntraId =
+    provider.providerType === OidcProviderType.MicrosoftEntraId
+
+  const defaultRoleName = provider.defaultRoleId
+    ? (roles?.find((r) => r.id === provider.defaultRoleId)?.name ??
+      provider.defaultRoleId)
+    : null
+
+  return (
+    <Flex vertical gap="middle">
+      {!provider.isEnabled && (
+        <Alert
+          type="warning"
+          showIcon
+          title="This provider is disabled."
+          description="Disabled providers are hidden from the login page and reject token exchange attempts."
+        />
+      )}
+
+      <Row gutter={[16, 16]}>
+        <Col xs={24} lg={14}>
+          <Descriptions column={1} size="small">
+            <Item label="Name">{provider.name}</Item>
+            <Item label="Display Name">{provider.displayName}</Item>
+            <Item label="Type">
+              {providerTypeLabel(provider.providerType)}
+            </Item>
+            <Item label="Authority">
+              <Text copyable>{provider.authority}</Text>
+            </Item>
+            <Item label="Client ID">
+              <Text copyable>{provider.clientId}</Text>
+            </Item>
+            <Item label="Audience">
+              <Text copyable>{provider.audience}</Text>
+            </Item>
+            <Item label="Scopes">
+              <ul style={{ margin: 0, paddingInlineStart: 20 }}>
+                {(provider.scopes ?? []).map((scope) => (
+                  <li key={scope}>{scope}</li>
+                ))}
+              </ul>
+            </Item>
+            {isMicrosoftEntraId && (
+              <Item label="Allowed Tenant IDs">
+                <ul style={{ margin: 0, paddingInlineStart: 20 }}>
+                  {(provider.allowedTenantIds ?? []).map((tenantId) => (
+                    <li key={tenantId}>{tenantId}</li>
+                  ))}
+                </ul>
+              </Item>
+            )}
+            <Item label="Clock Skew">
+              {provider.clockSkewSeconds} seconds
+            </Item>
+          </Descriptions>
+        </Col>
+
+        <Col xs={24} lg={10}>
+          <Flex vertical gap="middle">
+            <DiscoveryTest providerId={provider.id} />
+
+            <Card size="small" title="Registration Policy">
+              <Descriptions column={1} size="small">
+                <Item label="Automatic user registration">
+                  {provider.allowAutoRegistration ? 'Allowed' : 'Disabled'}
+                </Item>
+                {provider.allowAutoRegistration && (
+                  <>
+                    <Item label="Require matching employee record">
+                      {provider.requireEmployeeRecord ? 'Yes' : 'No'}
+                    </Item>
+                    <Item label="Default role for new users">
+                      {defaultRoleName}
+                    </Item>
+                  </>
+                )}
+              </Descriptions>
+            </Card>
+          </Flex>
+        </Col>
+      </Row>
+    </Flex>
+  )
+}
+
+export default OidcProviderDetails

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/page.tsx
@@ -20,6 +20,7 @@ import {
 import { ColDef, ICellRendererParams } from 'ag-grid-community'
 import { Button, Space, Tag, Tooltip, Typography } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
+import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import {
   CreateOidcProviderForm,
@@ -205,7 +206,19 @@ const OidcProvidersPage = () => {
         },
       },
       { field: 'id', hide: true },
-      { field: 'name', headerName: 'Name', flex: 1 },
+      {
+        field: 'name',
+        headerName: 'Name',
+        flex: 1,
+        cellRenderer: (params: ICellRendererParams<OidcProviderListItemDto>) => {
+          if (!params.data) return null
+          return (
+            <Link href={`/settings/auth/providers/${params.data.id}`}>
+              {params.data.name}
+            </Link>
+          )
+        },
+      },
       { field: 'displayName', headerName: 'Display Name', flex: 1 },
       {
         field: 'providerType',

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -28843,7 +28843,7 @@ export interface OidcProviderDto {
     clockSkewSeconds: number;
     isEnabled: boolean;
     allowAutoRegistration: boolean;
-    requireEmployeeRecord: boolean;
+    requireEmployeeRecord?: boolean | undefined;
     defaultRoleId?: string | undefined;
 }
 
@@ -28859,7 +28859,7 @@ export interface CreateOidcProviderRequest {
     clockSkewSeconds: number;
     isEnabled: boolean;
     allowAutoRegistration: boolean;
-    requireEmployeeRecord: boolean;
+    requireEmployeeRecord?: boolean | undefined;
     defaultRoleId?: string | undefined;
 }
 
@@ -28879,7 +28879,7 @@ export interface UpdateOidcProviderRequest {
     clockSkewSeconds: number;
     isEnabled: boolean;
     allowAutoRegistration: boolean;
-    requireEmployeeRecord: boolean;
+    requireEmployeeRecord?: boolean | undefined;
     defaultRoleId?: string | undefined;
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -28842,6 +28842,9 @@ export interface OidcProviderDto {
     allowedTenantIds?: string[] | undefined;
     clockSkewSeconds: number;
     isEnabled: boolean;
+    allowAutoRegistration: boolean;
+    requireEmployeeRecord: boolean;
+    defaultRoleId?: string | undefined;
 }
 
 export interface CreateOidcProviderRequest {
@@ -28855,6 +28858,9 @@ export interface CreateOidcProviderRequest {
     allowedTenantIds?: string[] | undefined;
     clockSkewSeconds: number;
     isEnabled: boolean;
+    allowAutoRegistration: boolean;
+    requireEmployeeRecord: boolean;
+    defaultRoleId?: string | undefined;
 }
 
 export enum OidcProviderType {
@@ -28872,6 +28878,9 @@ export interface UpdateOidcProviderRequest {
     allowedTenantIds?: string[] | undefined;
     clockSkewSeconds: number;
     isEnabled: boolean;
+    allowAutoRegistration: boolean;
+    requireEmployeeRecord: boolean;
+    defaultRoleId?: string | undefined;
 }
 
 export interface DeleteOidcProviderResult {

--- a/Wayd.Web/tests/Wayd.Web.Api.Tests/Sut/Models/UserManagement/OidcProviders/OidcProviderRequestValidatorTests.cs
+++ b/Wayd.Web/tests/Wayd.Web.Api.Tests/Sut/Models/UserManagement/OidcProviders/OidcProviderRequestValidatorTests.cs
@@ -1,0 +1,188 @@
+using FluentValidation.TestHelper;
+using Wayd.Common.Domain.Identity;
+using Wayd.Web.Api.Models.UserManagement.OidcProviders;
+
+namespace Wayd.Web.Api.Tests.Sut.Models.UserManagement.OidcProviders;
+
+public sealed class OidcProviderRequestValidatorTests
+{
+    private readonly CreateOidcProviderRequestValidator _createValidator = new();
+    private readonly UpdateOidcProviderRequestValidator _updateValidator = new();
+
+    private static CreateOidcProviderRequest ValidCreateRequest() => new()
+    {
+        Name = "acme-oidc",
+        DisplayName = "Acme OIDC",
+        ProviderType = OidcProviderType.GenericOidc,
+        Authority = "https://login.example.com/v2.0",
+        ClientId = "client-123",
+        Audience = "api://client-123",
+        Scopes = ["openid", "profile"],
+        AllowedTenantIds = null,
+        ClockSkewSeconds = 60,
+        IsEnabled = true,
+        AllowAutoRegistration = false,
+        RequireEmployeeRecord = null,
+        DefaultRoleId = null,
+    };
+
+    private static UpdateOidcProviderRequest ValidUpdateRequest() => new()
+    {
+        Id = Guid.NewGuid(),
+        DisplayName = "Acme OIDC",
+        Authority = "https://login.example.com/v2.0",
+        ClientId = "client-123",
+        Audience = "api://client-123",
+        Scopes = ["openid", "profile"],
+        AllowedTenantIds = null,
+        ClockSkewSeconds = 60,
+        IsEnabled = true,
+        AllowAutoRegistration = false,
+        RequireEmployeeRecord = null,
+        DefaultRoleId = null,
+    };
+
+    [Fact]
+    public void Create_DisabledRegistration_WithNoDependentFields_Passes()
+    {
+        // Arrange
+        var request = ValidCreateRequest();
+
+        // Act
+        var result = _createValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.RequireEmployeeRecord);
+        result.ShouldNotHaveValidationErrorFor(x => x.DefaultRoleId);
+    }
+
+    [Fact]
+    public void Create_EnabledRegistration_WithGateAndRole_Passes()
+    {
+        // Arrange
+        var request = ValidCreateRequest() with
+        {
+            AllowAutoRegistration = true,
+            RequireEmployeeRecord = true,
+            DefaultRoleId = "role-1",
+        };
+
+        // Act
+        var result = _createValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.RequireEmployeeRecord);
+        result.ShouldNotHaveValidationErrorFor(x => x.DefaultRoleId);
+    }
+
+    [Fact]
+    public void Create_EnabledRegistration_MissingGate_FailsRequireEmployeeRecord()
+    {
+        // Arrange
+        var request = ValidCreateRequest() with
+        {
+            AllowAutoRegistration = true,
+            RequireEmployeeRecord = null,
+            DefaultRoleId = "role-1",
+        };
+
+        // Act
+        var result = _createValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(nameof(CreateOidcProviderRequest.RequireEmployeeRecord))
+            .WithErrorMessage(OidcProviderRequestMessages.EmployeeGateRequired);
+    }
+
+    [Fact]
+    public void Create_EnabledRegistration_MissingRole_FailsDefaultRoleId()
+    {
+        // Arrange
+        var request = ValidCreateRequest() with
+        {
+            AllowAutoRegistration = true,
+            RequireEmployeeRecord = true,
+            DefaultRoleId = null,
+        };
+
+        // Act
+        var result = _createValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(nameof(CreateOidcProviderRequest.DefaultRoleId))
+            .WithErrorMessage(OidcProviderRequestMessages.DefaultRoleRequired);
+    }
+
+    [Fact]
+    public void Create_DisabledRegistration_WithGate_FailsRequireEmployeeRecord()
+    {
+        // Arrange
+        var request = ValidCreateRequest() with
+        {
+            AllowAutoRegistration = false,
+            RequireEmployeeRecord = true,
+        };
+
+        // Act
+        var result = _createValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(nameof(CreateOidcProviderRequest.RequireEmployeeRecord))
+            .WithErrorMessage(OidcProviderRequestMessages.EmployeeGateForbidden);
+    }
+
+    [Fact]
+    public void Create_DisabledRegistration_WithRole_FailsDefaultRoleId()
+    {
+        // Arrange
+        var request = ValidCreateRequest() with
+        {
+            AllowAutoRegistration = false,
+            DefaultRoleId = "role-1",
+        };
+
+        // Act
+        var result = _createValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(nameof(CreateOidcProviderRequest.DefaultRoleId))
+            .WithErrorMessage(OidcProviderRequestMessages.DefaultRoleForbidden);
+    }
+
+    [Fact]
+    public void Update_EnabledRegistration_MissingGate_FailsRequireEmployeeRecord()
+    {
+        // Arrange
+        var request = ValidUpdateRequest() with
+        {
+            AllowAutoRegistration = true,
+            RequireEmployeeRecord = null,
+            DefaultRoleId = "role-1",
+        };
+
+        // Act
+        var result = _updateValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(nameof(UpdateOidcProviderRequest.RequireEmployeeRecord))
+            .WithErrorMessage(OidcProviderRequestMessages.EmployeeGateRequired);
+    }
+
+    [Fact]
+    public void Update_DisabledRegistration_WithRole_FailsDefaultRoleId()
+    {
+        // Arrange
+        var request = ValidUpdateRequest() with
+        {
+            AllowAutoRegistration = false,
+            DefaultRoleId = "role-1",
+        };
+
+        // Act
+        var result = _updateValidator.TestValidate(request);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(nameof(UpdateOidcProviderRequest.DefaultRoleId))
+            .WithErrorMessage(OidcProviderRequestMessages.DefaultRoleForbidden);
+    }
+}

--- a/docs/ai/domain-glossary.mdx
+++ b/docs/ai/domain-glossary.mdx
@@ -118,6 +118,20 @@ This glossary defines the key terms and concepts used throughout Wayd. It is des
 | **Strategy** | The approach for achieving the vision. States: Draft → Active → Completed → Archived. Independent of visions. |
 | **Strategic Theme** | A high-level organizational priority guiding investment decisions. States: Proposed → Active → Archived. Only Proposed deletable. Cross-domain: tags Projects, Programs, Strategic Initiatives in PPM. |
 
+## Identity & Access
+
+| Term | Definition |
+|------|-----------|
+| **Identity Provider (OIDC Provider)** | A configured single sign-on source (Microsoft Entra ID or a generic OIDC issuer), stored as a row in `Identity.OidcProviders`. The database is the sole source of truth; providers are managed via Settings → Identity Providers. |
+| **UserIdentity** | The link between an `ApplicationUser` and a login provider, keyed by `(Provider, ProviderTenantId, ProviderSubject)`. At most one active row per user; every authentication path resolves through this table. |
+| **Role** | A named permission group assigned to users. Two system roles (`Admin`, `Basic`) are seeded and protected; admins can create custom roles. |
+| **Auto-Registration (JIT Provisioning)** | Creating a Wayd account automatically the first time an unknown user signs in through an identity provider. Governed by a per-provider registration policy; **off by default** (secure by default). |
+| **Registration Policy** | The per-provider settings that govern auto-registration: `AllowAutoRegistration` (master switch), `RequireEmployeeRecord` (employee-match gate), and `DefaultRoleId` (role for new users). Modeled as a `RegistrationPolicy` value object whose dependent fields are only meaningful while auto-registration is enabled. |
+| **Employee-Record Gate** | The `RequireEmployeeRecord` policy: when on, auto-registration is restricted to users whose email matches an existing `Employee`. Turning it off grants accounts to anyone who can authenticate through the provider. |
+| **Default Role** | The role assigned to auto-registered users for a provider (`DefaultRoleId`); required when auto-registration is enabled (no implicit fallback). Protected by a foreign key — a role pinned as a default cannot be deleted until the provider is repointed. |
+| **First-User Bootstrap** | The first user to sign in to an empty deployment is always created and made `Admin`, bypassing the registration policy so a fresh install cannot lock itself out. |
+| **Identity Migration** | Admin-staged moves that preserve `ApplicationUser.Id`: Entra tenant migration, cross-provider migration (OIDC→OIDC or Wayd→OIDC), and immediate OIDC→local conversion. |
+
 ## Cross-Cutting Concepts
 
 | Term | Definition |

--- a/docs/contributing/configuration.mdx
+++ b/docs/contributing/configuration.mdx
@@ -46,6 +46,9 @@ The database is the single source of truth for identity providers — there is n
 | `AllowedTenantIds` | **Entra only.** Empty/null rejected at the entity level. Tokens whose `tid` (or issuer-derived tenant) is not in this list are rejected. Ignored for `GenericOidc`. |
 | `ClockSkewSeconds` | Tolerance for expiry/not-before checks. Defaults to 60; range `[0, 600]`. |
 | `IsEnabled` | Disabled providers are hidden from the login page; exchange attempts against them return 401. |
+| `AllowAutoRegistration` | Master switch for just-in-time user provisioning. Defaults to **`false`** (secure by default). When off, an unknown user signing in is rejected and must be pre-created by an admin. See [User provisioning](#user-provisioning-auto-registration). |
+| `RequireEmployeeRecord` | When auto-registration is on, gates it to users whose email matches an existing employee. `true` (the safer default) lets only known employees self-register; `false` grants an account to anyone who can authenticate. Ignored when `AllowAutoRegistration` is off. |
+| `DefaultRoleId` | Role assigned to users auto-created through this provider. **Required** when `AllowAutoRegistration` is on (no implicit fallback). Protected by a FK: a role pinned here cannot be deleted until the provider is repointed. Null/ignored when `AllowAutoRegistration` is off. |
 
 **Adding a Microsoft Entra ID provider.** From **Settings → Identity Providers**, choose **Add provider → Microsoft Entra ID** and fill in:
 
@@ -244,6 +247,28 @@ Provider-specific logic is confined to *how the incoming credential is validated
 
 `ApplicationUser.LoginProvider` is retained as a "primary provider" indicator (it mirrors the active `UserIdentity.Provider`) so code that needs a cheap provider check doesn't have to join.
 
+### User provisioning (auto-registration)
+
+When a sign-in resolves no active `UserIdentity` (and no pending migration applies), the exchange reaches the **create-new-user** path. Whether a user is actually created there is governed by a per-provider **registration policy** stored on the `OidcProvider` row: `AllowAutoRegistration`, `RequireEmployeeRecord`, and `DefaultRoleId`. The policy is read from the provider via the registry on every first-time sign-in.
+
+**Decision flow for a new (unresolved) user:**
+
+```text
+new user signing in via provider P
+├─ first user ever?  ──────────────► create, assign Admin   (bootstrap — ignores policy)
+├─ P.AllowAutoRegistration == false ─► reject (403)          "Registration is disabled for this identity provider"
+├─ P.RequireEmployeeRecord == true
+│    and no matching employee ───────► reject (403)          "Registration is restricted to users with an employee record"
+└─ otherwise ───────────────────────► create, assign P.DefaultRoleId  (required when enabled)
+```
+
+- **Secure by default.** `AllowAutoRegistration` defaults to `false`. A freshly configured provider does **not** auto-provision until an admin opts in — including providers that predate this setting (the migration backfills existing rows to `false`, so they stop auto-registering on upgrade until re-enabled).
+- **First-user bootstrap is exempt.** The very first user to sign in to an empty deployment is always created and made `Admin`, regardless of policy — a fresh install can never lock itself out. (Self-hosted first-run uses the bootstrap-token flow instead; see [First-Run Setup](./first-run-setup.mdx).)
+- **Employee-record gate.** Historically registration was restricted to users whose email matched an `Employee` record. That gate is now `RequireEmployeeRecord`, defaulting to `true`. Turning it off is a deliberate loosening: anyone who can authenticate through the provider gets an account.
+- **Default role.** Auto-created users are assigned `DefaultRoleId` (any role — system or custom). It is **required** when auto-registration is enabled — there is no implicit fallback; an enabled policy always names a role. The reference is protected by a foreign key with `NO ACTION` on delete, so a role that's pinned as a provider's default cannot be deleted until the provider is repointed; `RoleService` surfaces this as a clear conflict before the constraint fires. As a runtime backstop, if the referenced role is somehow missing (e.g. a raw SQL delete), sign-in falls back to `Basic` rather than failing.
+
+The policy is enforced in `UserService.CreateOrUpdateFromPrincipalAsync`. Generic-OIDC providers do not yet provision new users at all (unknown users are rejected); the policy is currently actionable on the Entra path.
+
 ### Identity migration
 
 Wayd supports three admin-initiated identity migration workflows. In all three cases the `ApplicationUser.Id` is preserved, so all downstream FKs (permissions, work items, audit) remain intact.
@@ -252,7 +277,7 @@ Wayd supports three admin-initiated identity migration workflows. In all three c
 
 When an org moves users from one Entra tenant to another, an admin stages the migration per user. The rebind completes automatically when the user next signs in from the new tenant.
 
-`PendingMigrationTenantId` is set on `ApplicationUser` to the target Entra tenant GUID. During Entra token exchange, `UserService.ResolveUserByEntraIdentity` tries lookups in order: `FindActive(provider, tid, sub)` → null-tid upgrade (one-time tenant population for backfilled rows) → **pending-migration rebind** → fall through to create-new-user. The rebind path matches a user by `PendingMigrationTenantId == token.tid` AND `LoginProvider == MicrosoftEntraId` AND (`NormalizedUserName == token.upn` OR `NormalizedEmail == token.upn`). On match, inside one transaction:
+`PendingMigrationTenantId` is set on `ApplicationUser` to the target Entra tenant GUID. During Entra token exchange, `UserService.ResolveUserByEntraIdentity` tries lookups in order: `FindActive(provider, tid, sub)` → null-tid upgrade (one-time tenant population for backfilled rows) → **pending-migration rebind** → fall through to create-new-user (subject to the [registration policy](#user-provisioning-auto-registration)). The rebind path matches a user by `PendingMigrationTenantId == token.tid` AND `LoginProvider == MicrosoftEntraId` AND (`NormalizedUserName == token.upn` OR `NormalizedEmail == token.upn`). On match, inside one transaction:
 
 1. Deactivate all active identity rows (`UnlinkReason = TenantMigration`).
 2. Insert a new active row with `(MicrosoftEntraId, token.tid, token.sub)`.

--- a/docs/contributing/entra-app-registration.mdx
+++ b/docs/contributing/entra-app-registration.mdx
@@ -221,6 +221,10 @@ If `aud` has `api://` in it but the provider's `Audience` is a bare GUID, the AP
 
 **User from a new Entra tenant gets rejected.** Add their tenant ID to `AllowedTenantIds`. The tenant's admin also needs to admin-consent the `access_as_user` permission (see Step 2) — otherwise users see Microsoft's consent prompt on first sign-in, and individual users may not be allowed to consent depending on the tenant's policies.
 
+**`403 Registration is disabled for this identity provider`.** The token validated fine, but the provider's `AllowAutoRegistration` is off (the default) and this user has no existing account. Either enable auto-registration on the provider or pre-create the user. See [User provisioning](./configuration.mdx#user-provisioning-auto-registration).
+
+**`403 Registration is restricted to users with an employee record`.** Auto-registration is on, but the provider's `RequireEmployeeRecord` is on and no `Employee` matches the user's email. Add a matching employee (e.g. via People Sync), turn off the employee-record requirement on the provider, or pre-create the user.
+
 **People sync / Graph calls fail with 401.** The Entra connection's client secret has expired, was never set, or is wrong. Edit the connection in **Settings → Connections** and re-enter the secret. This is independent of the token-exchange flow — login still works, only Graph-backed people sync breaks. See [Create a client secret](#create-a-client-secret-only-if-you-want-the-entra-people-sync-connector).
 
 ## References

--- a/docs/user-guide/settings/index.mdx
+++ b/docs/user-guide/settings/index.mdx
@@ -88,6 +88,31 @@ Converts an OIDC user to a local (password-based) account **immediately** — no
 - The user's `UserId`, permissions, and all other records are preserved — only the authentication method changes.
 - The temporary password must meet the deployment's password policy (minimum 8 characters).
 
+### Identity Providers
+
+Single sign-on providers are configured in **Settings → Identity Providers** (available once the `IdentityProviders` feature flag is enabled). Beyond the connection details — issuer, client ID, audience, scopes, and (for Microsoft Entra ID) the allowed tenants — each provider carries a **registration policy** that controls whether and how new users are created when someone signs in for the first time.
+
+**Registration policy fields:**
+
+- **Allow automatic user registration** — The master switch. **Off by default.** When off, a person who authenticates successfully but has no Wayd account yet is turned away, and an administrator must create their account first. When on, a matching account is created automatically on first sign-in (subject to the options below).
+- **Require matching employee record** — Shown only when auto-registration is on; defaults to on. While on, only people whose email matches an existing employee can self-register. Turning it off is a deliberate loosening — **anyone** who can authenticate through this provider will be granted an account — so the form shows a warning when you do.
+- **Default role for new users** — Shown only when auto-registration is on, where it is **required**. The role assigned to accounts created through this provider — pick any role, system or custom. There is no implicit fallback; you must choose one explicitly.
+
+**What happens on first sign-in:**
+
+| Auto-registration | Employee record | Result |
+|---|---|---|
+| Off | — | Sign-in rejected; an admin must pre-create the account. |
+| On | Required, no match | Sign-in rejected ("restricted to users with an employee record"). |
+| On | Required, match found | Account created, assigned the default role. |
+| On | Not required | Account created for anyone who authenticates, assigned the default role. |
+
+**Things to know:**
+
+- **The first user is special.** The very first person to sign in to a brand-new deployment always becomes an administrator, regardless of policy — this can't lock you out of an empty system.
+- **Upgrades are secure by default.** Existing providers have auto-registration turned **off** after upgrading to this version; re-enable it deliberately per provider.
+- **A role in use can't be deleted.** If a role is set as a provider's default, attempting to delete it is blocked with a clear message until you repoint the provider to a different role.
+
 ### Roles
 
 Roles define permission groups. Users are assigned to roles to control access to features, pages, and actions throughout the application.


### PR DESCRIPTION
## Summary

Adds an OIDC identity-provider **registration policy** (controlling whether and how users are auto-provisioned on first sign-in) and a new **provider details page** in Settings → Identity Providers. Together these give admins explicit, secure-by-default control over self-registration and a place to inspect a provider's full configuration.

## Registration policy

A new `RegistrationPolicy` value object on `OidcProvider` governs first-sign-in provisioning, exposed through three fields:

- **`AllowAutoRegistration`** — when off, unknown users are rejected and an admin must create the account first. **Off by default.**
- **`RequireEmployeeRecord`** — when on, only users whose email matches an existing employee may self-register. **On by default.**
- **`DefaultRoleId`** — role assigned to auto-created users.

The value object enforces strict invariants: the dependent fields (`RequireEmployeeRecord`, `DefaultRoleId`) can only be set when auto-registration is enabled, so a disabled policy can't carry a stale loosened posture. Roles referenced as a provider's default role are protected from deletion.

**Secure-by-default:** new providers start with auto-registration off and employee-record required. **Existing providers have auto-registration disabled on upgrade** — no behavior change without an explicit admin opt-in.

## Provider details page

New route `/settings/auth/providers/{id}`:

- Two-column layout — provider configuration (name, type, authority, client ID, audience, scopes, allowed tenant IDs, clock skew) on the left; **Discovery** test and **Registration Policy** cards on the right.
- Inline **Test discovery** button that exercises the provider's OIDC discovery endpoint and reports issuer + signing-key count.
- Enabled/Disabled status shown as a tag in the page header; a warning banner when the provider is disabled.
- Edit / Delete actions reuse the existing modal forms; delete returns to the list.
- Provider names in the list grid now link to the details page.
- Gated on `Permissions.OidcProviders.View`, with Edit/Delete gated on their respective claims.

Also fixes a deprecated antd `Alert` `message` → `title` prop warning in the create/edit/delete provider forms.

## Changes

- **Domain:** `RegistrationPolicy` value object; `OidcProvider` persists it with a disabled default; factory/update methods validate it.
- **Application:** create/update commands + validators; `OidcProviderDto` and `GetOidcProviderQuery` expose the policy; `IOidcProviderDefaultRoleChecker` blocks deletion of in-use default roles.
- **Infrastructure:** EF migration `AddOidcProviderRegistrationPolicy`; `UserService` enforces the policy during auto-provisioning; `RoleService` honors the default-role deletion guard.
- **API:** `OidcProvidersController` / request contracts + OpenAPI spec updated.
- **Frontend:** details page + component, list-page link, regenerated NSwag client, form updates.
- **Docs:** configuration, domain glossary, settings user guide, and Entra app-registration docs.

## Testing

- New/extended unit tests: `RegistrationPolicyTests`, `OidcProviderTests`, create/update command validator tests, `UserServiceTests`, `RoleServiceTests`, `OidcProviderDefaultRoleCheckerRegistrationTests`, token validator/service tests, plus `OidcProviderFaker`.
- Frontend typecheck (`tsc --noEmit`) and lint pass on all changed files.

## Migration / upgrade notes

- Applies EF migration `AddOidcProviderRegistrationPolicy` on startup.
- Existing OIDC providers are migrated with **auto-registration disabled**; re-enable per provider via Settings → Identity Providers if self-registration is desired.
