### PR TITLE
Feature/create new timeline component

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Domain/FeatureManagement/FeatureFlags.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/FeatureManagement/FeatureFlags.cs
@@ -9,16 +9,22 @@ public static class FeatureFlags
 {
     public static readonly FeatureFlagDefinition PlanningPoker = new(Names.PlanningPoker, "Planning Poker", "Controls visibility of the Planning Poker feature.");
 
+    public static readonly FeatureFlagDefinition NewTimelineUi = new(Names.NewTimelineUi, "Use New Timeline UI", "Renders roadmaps (and later objectives/PPM) with the new in-house timeline component instead of the legacy vis-timeline.", DefaultEnabled: true);
+
     /// <summary>
     /// Compile-time constant names for use in attributes (e.g., [FeatureGate]).
     /// </summary>
     public static class Names
     {
         public const string PlanningPoker = "planning-poker";
+        public const string NewTimelineUi = "new-timeline-ui";
     }
 }
 
 /// <summary>
 /// Represents a feature flag definition to be seeded.
+/// <paramref name="DefaultEnabled"/> sets the initial state when the seeder first
+/// creates the flag (admins can toggle it afterward; the seeder never overwrites
+/// an existing flag).
 /// </summary>
-public sealed record FeatureFlagDefinition(string Name, string DisplayName, string? Description);
+public sealed record FeatureFlagDefinition(string Name, string DisplayName, string? Description, bool DefaultEnabled = false);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Initialization/FeatureFlagSeeder.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Initialization/FeatureFlagSeeder.cs
@@ -24,7 +24,7 @@ public class FeatureFlagSeeder : ICustomSeeder
             if (existingNamesSet.Contains(definition.Name))
                 continue;
 
-            var result = FeatureFlag.Create(definition.Name, definition.DisplayName, definition.Description, false, isSystem: true);
+            var result = FeatureFlag.Create(definition.Name, definition.DisplayName, definition.Description, definition.DefaultEnabled, isSystem: true);
             if (result.IsSuccess)
             {
                 dbContext.FeatureFlags.Add(result.Value);

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
@@ -1,0 +1,244 @@
+'use client'
+
+// roadmap-timeline-v2.tsx — adapter that feeds roadmap data into the new
+// in-house WaydTimeline2 component. Rendered in place of the legacy vis-timeline
+// (roadmaps-timeline.tsx) when the "new-timeline-ui" feature flag is enabled;
+// RoadmapViewManager picks between the two. Maps the roadmap item tree to the
+// component's TimelineItem/TimelineGroup shape (epoch-ms bounds).
+//
+// activity  -> kind 'range'      (and a GROUP, so its children can nest)
+// milestone -> kind 'milestone'
+// timebox   -> kind 'background' (chart-wide band for now)
+
+import { FC, ReactNode, useState } from 'react'
+import dayjs from 'dayjs'
+import {
+  RoadmapActivityListDto,
+  RoadmapDetailsDto,
+  RoadmapItemListDto,
+  RoadmapMilestoneListDto,
+  RoadmapTimeboxListDto,
+} from '@/src/services/wayd-api'
+import { WaydTimeline2 } from '@/src/components/common/timeline2'
+import type {
+  TimelineItem,
+  TimelineGroup,
+  ItemDateChange,
+} from '@/src/components/common/timeline2'
+import { useUpdateRoadmapItemDatesMutation } from '@/src/store/features/planning/roadmaps-api'
+import { useMessage } from '@/src/components/contexts/messaging'
+import { isApiError, type ApiError } from '@/src/utils'
+
+export interface RoadmapTimelineV2Props {
+  roadmap: RoadmapDetailsDto
+  roadmapItems: RoadmapItemListDto[]
+  isRoadmapItemsLoading: boolean
+  refreshRoadmapItems: () => void
+  viewSelector?: ReactNode
+  openRoadmapItemDrawer: (itemId: string) => void
+  isRoadmapManager: boolean
+}
+
+enum RoadmapItemType {
+  Activity = 'activity',
+  Milestone = 'milestone',
+  Timebox = 'timebox',
+}
+
+const ms = (d: unknown) => dayjs(d as string).valueOf()
+
+interface RoadmapPayload {
+  dto: RoadmapItemListDto
+  color?: string
+  openDrawer: (id: string) => void
+}
+
+// Walk the roadmap item tree -> flat TimelineItems + Groups for WaydTimeline2.
+// EVERY activity is emitted as BOTH a group (potential left-column row) AND a
+// range item assigned to its own group. The drill level (resolved inside
+// WaydTimeline2) then decides which activities stay groups vs. demote to bars in
+// an ancestor row — so the adapter just exposes the full tree, no level logic.
+// Synthetic group for the roadmap-root band — holds root-level timeboxes /
+// milestones (attached to the roadmap itself, not an activity), like the legacy
+// timeline's blank first row.
+const ROOT_GROUP_ID = '__roadmap_root__'
+
+function mapRoadmap(
+  items: RoadmapItemListDto[],
+  openDrawer: (id: string) => void,
+): { items: TimelineItem<RoadmapPayload>[]; groups: TimelineGroup[] } {
+  const out: TimelineItem<RoadmapPayload>[] = []
+  const groups: TimelineGroup[] = []
+  let hasRootDecoration = false
+
+  // `treeLevel` is 1-based: top-level activities = 1, their children = 2, etc.
+  // (matches the legacy timeline's treeLevel). Milestones/timeboxes take their
+  // parent activity's level + 1. A root-level decoration (depth 1, no parent
+  // activity) is assigned to the synthetic root group so it gets a top band.
+  const walk = (
+    list: RoadmapItemListDto[],
+    order: number,
+    treeLevel: number,
+  ) => {
+    list.forEach((item, index) => {
+      const id = String(item.id)
+      const parentId = item.parent?.id ? String(item.parent.id) : undefined
+      // Decorations (timebox/milestone) at the top level have no parent
+      // ACTIVITY group — route them to the synthetic root band.
+      const isActivity = item.$type === RoadmapItemType.Activity
+      const decorationGroupId =
+        !isActivity && treeLevel === 1 ? ROOT_GROUP_ID : parentId
+      if (!isActivity && treeLevel === 1) hasRootDecoration = true
+      const payload: RoadmapPayload = {
+        dto: item,
+        color: item.color,
+        openDrawer,
+      }
+
+      switch (item.$type) {
+        case RoadmapItemType.Activity: {
+          const a = item as RoadmapActivityListDto
+          // Activity = a group (with its real parent for hierarchy) AND a range
+          // item in that group. The drill level decides which role it plays.
+          groups.push({
+            id,
+            parentId,
+            treeLevel,
+            label: a.name,
+            order: a.order ?? order + index,
+          })
+          out.push({
+            id,
+            kind: 'range',
+            label: a.name,
+            color: a.color,
+            start: ms(a.start),
+            end: ms(a.end),
+            groupId: id,
+            treeLevel,
+            order: a.order ?? order + index,
+            data: payload,
+          })
+          if (a.children?.length) walk(a.children, 0, treeLevel + 1)
+          break
+        }
+        case RoadmapItemType.Milestone: {
+          const m = item as RoadmapMilestoneListDto
+          out.push({
+            id,
+            kind: 'milestone',
+            label: m.name,
+            color: m.color,
+            start: ms(m.date),
+            end: ms(m.date),
+            groupId: decorationGroupId,
+            treeLevel,
+            order: order + index,
+            data: payload,
+          })
+          break
+        }
+        case RoadmapItemType.Timebox: {
+          const t = item as RoadmapTimeboxListDto
+          out.push({
+            id,
+            kind: 'background',
+            label: t.name,
+            color: t.color,
+            start: ms(t.start),
+            end: ms(t.end),
+            groupId: decorationGroupId,
+            treeLevel,
+            order: order + index,
+            data: payload,
+          })
+          break
+        }
+      }
+    })
+  }
+
+  walk(items, 0, 1)
+
+  // Prepend the synthetic root band group (blank label, sorts first) when there
+  // are root-level decorations to host. treeLevel 0 keeps it always visible.
+  if (hasRootDecoration) {
+    groups.unshift({
+      id: ROOT_GROUP_ID,
+      treeLevel: 0,
+      label: '',
+      order: -Infinity,
+    })
+  }
+
+  return { items: out, groups }
+}
+
+const RoadmapTimelineV2: FC<RoadmapTimelineV2Props> = (props) => {
+  const messageApi = useMessage()
+  const [updateRoadmapItemDates] = useUpdateRoadmapItemDatesMutation()
+  const [updatingId, setUpdatingId] = useState<string | null>(null)
+
+  const { items, groups } = mapRoadmap(
+    props.roadmapItems,
+    props.openRoadmapItemDrawer,
+  )
+
+  const windowStart = ms(props.roadmap.start)
+  const windowEnd = ms(props.roadmap.end)
+
+  const onItemDateChange = async (change: ItemDateChange) => {
+    const source = items.find((i) => i.id === change.id)
+    const dto = source?.data?.dto
+    if (!dto) return
+
+    setUpdatingId(change.id)
+    try {
+      const response = await updateRoadmapItemDates({
+        $type: dto.$type,
+        roadmapId: dto.roadmapId,
+        itemId: change.id,
+        start: dayjs(change.start).format('YYYY-MM-DD') as unknown as Date,
+        end: dayjs(change.end).format('YYYY-MM-DD') as unknown as Date,
+      })
+      if ('error' in response && response.error) throw response.error
+    } catch (error) {
+      const apiError: ApiError = isApiError(error) ? error : {}
+      messageApi.error(
+        apiError.detail ??
+          'An error occurred while updating the roadmap item. Please try again.',
+      )
+    } finally {
+      setUpdatingId(null)
+    }
+  }
+
+  return (
+    <WaydTimeline2<RoadmapPayload>
+      variant="timeline"
+      items={items}
+      groups={groups}
+      windowStart={windowStart}
+      windowEnd={windowEnd}
+      // Roadmaps hard-bound the timeline to the roadmap's own dates (matching the
+      // legacy timeline's min/max == start/end): the axis spans exactly the
+      // roadmap window and you can't pan/zoom outside it.
+      minDate={windowStart}
+      maxDate={windowEnd}
+      storageKey={`roadmap-${props.roadmap.id}`}
+      onRefresh={props.refreshRoadmapItems}
+      height={650}
+      isLoading={props.isRoadmapItemsLoading || updatingId !== null}
+      editable={props.isRoadmapManager}
+      allowFullScreen
+      allowSaveAsImage
+      saveImageFileName={props.roadmap.name}
+      // The view selector (Timeline/List) renders inside the toolbar, like WaydGrid.
+      toolbarRightSlot={props.viewSelector}
+      onItemDateChange={onItemDateChange}
+      onItemClick={(item) => item.data?.openDrawer(item.id)}
+    />
+  )
+}
+
+export default RoadmapTimelineV2

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-view-manager.tsx
@@ -6,9 +6,18 @@ import Segmented, { SegmentedLabeledOption } from 'antd/es/segmented'
 import { memo, useState } from 'react'
 import dynamic from 'next/dynamic'
 import { Spin } from 'antd'
+import { useFeatureFlag } from '@/src/hooks'
+import { useMessage } from '@/src/components/contexts/messaging'
 import RoadmapItemsGrid from './roadmap-items-grid'
 
+// Legacy (vis-timeline) and new (in-house WaydTimeline2) roadmap timelines.
+// Which one renders is gated by the "new-timeline-ui" feature flag below.
 const RoadmapsTimeline = dynamic(() => import('./roadmaps-timeline'), {
+  ssr: false,
+  loading: () => <Spin />,
+})
+
+const RoadmapTimelineV2 = dynamic(() => import('./roadmap-timeline-v2'), {
   ssr: false,
   loading: () => <Spin />,
 })
@@ -24,6 +33,12 @@ interface RoadmapViewManagerProps {
 
 const RoadmapViewManager = (props: RoadmapViewManagerProps) => {
   const [currentView, setCurrentView] = useState<string | number>('Timeline')
+
+  const messageApi = useMessage()
+  // Default-on flag (see FeatureFlags.cs). While flags load we keep the new UI
+  // to avoid a flash of the legacy timeline on the happy path.
+  const { isEnabled: useNewTimeline, isLoading: isFlagLoading } =
+    useFeatureFlag('new-timeline-ui')
 
   const viewSelectorOptions: SegmentedLabeledOption[] = [
     {
@@ -44,19 +59,39 @@ const RoadmapViewManager = (props: RoadmapViewManagerProps) => {
     />
   )
 
+  // The new timeline's Refresh button has no other visible signal when data
+  // already exists (the chart looks identical after refetching unchanged data),
+  // so confirm the action here. We await the refetch so the toast lands after it
+  // settles. Failures surface through the query's own error state, not a throw.
+  const refreshTimelineWithFeedback = async () => {
+    await Promise.resolve(props.refreshRoadmapItems())
+    messageApi.success('Timeline refreshed.')
+  }
+
   return (
     <>
-      {currentView === 'Timeline' && (
-        <RoadmapsTimeline
-          roadmap={props.roadmap}
-          roadmapItems={props.roadmapItems}
-          isRoadmapItemsLoading={props.isRoadmapItemsLoading}
-          refreshRoadmapItems={props.refreshRoadmapItems}
-          viewSelector={viewSelector}
-          openRoadmapItemDrawer={props.openRoadmapItemDrawer}
-          isRoadmapManager={props.canUpdateRoadmap}
-        />
-      )}
+      {currentView === 'Timeline' &&
+        (isFlagLoading || useNewTimeline ? (
+          <RoadmapTimelineV2
+            roadmap={props.roadmap}
+            roadmapItems={props.roadmapItems}
+            isRoadmapItemsLoading={props.isRoadmapItemsLoading}
+            refreshRoadmapItems={refreshTimelineWithFeedback}
+            viewSelector={viewSelector}
+            openRoadmapItemDrawer={props.openRoadmapItemDrawer}
+            isRoadmapManager={props.canUpdateRoadmap}
+          />
+        ) : (
+          <RoadmapsTimeline
+            roadmap={props.roadmap}
+            roadmapItems={props.roadmapItems}
+            isRoadmapItemsLoading={props.isRoadmapItemsLoading}
+            refreshRoadmapItems={props.refreshRoadmapItems}
+            viewSelector={viewSelector}
+            openRoadmapItemDrawer={props.openRoadmapItemDrawer}
+            isRoadmapManager={props.canUpdateRoadmap}
+          />
+        ))}
       {currentView === 'List' && (
         <RoadmapItemsGrid
           roadmapItemsData={props.roadmapItems}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-view-manager.tsx
@@ -64,7 +64,7 @@ const RoadmapViewManager = (props: RoadmapViewManagerProps) => {
   // so confirm the action here. We await the refetch so the toast lands after it
   // settles. Failures surface through the query's own error state, not a throw.
   const refreshTimelineWithFeedback = async () => {
-    await Promise.resolve(props.refreshRoadmapItems())
+    await props.refreshRoadmapItems()
     messageApi.success('Timeline refreshed.')
   }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/color.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/color.ts
@@ -1,0 +1,25 @@
+// timeline2/core/color.ts
+// Tiny contrast helper: choose readable text color for a given bar background.
+// Pure, no deps. Matches the luminance approach the legacy timeline used.
+
+/** Relative luminance (0..1) of a #rrggbb / #rgb hex color; 1 for unknown. */
+export function luminance(hex: string): number {
+  let h = hex.trim().replace('#', '')
+  if (h.length === 3) {
+    h = h
+      .split('')
+      .map((c) => c + c)
+      .join('')
+  }
+  if (h.length !== 6) return 1
+  const r = parseInt(h.slice(0, 2), 16) / 255
+  const g = parseInt(h.slice(2, 4), 16) / 255
+  const b = parseInt(h.slice(4, 6), 16) / 255
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/** Black for light backgrounds, white for dark — readable bar text. */
+export function contrastText(backgroundHex: string | undefined): string {
+  if (!backgroundHex) return '#ffffff'
+  return luminance(backgroundHex) > 0.6 ? '#1f1f1f' : '#ffffff'
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/depth.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/depth.test.ts
@@ -1,0 +1,150 @@
+import { groupDepths, maxGroupDepth, resolveLevel } from './depth'
+import type { TimelineGroup, TimelineItem } from './types'
+
+const g = (
+  id: string,
+  treeLevel: number,
+  parentId?: string,
+): TimelineGroup => ({ id, parentId, treeLevel })
+
+// Tree (1-based treeLevel): a(1) -> a1(2) -> a1a(3) ; b(1, no children)
+const groups: TimelineGroup[] = [
+  g('a', 1),
+  g('a1', 2, 'a'),
+  g('a1a', 3, 'a1'),
+  g('b', 1),
+]
+
+// Each activity is a range item assigned to its own group, carrying treeLevel.
+const item = (id: string, groupId: string, treeLevel: number): TimelineItem => ({
+  id,
+  kind: 'range',
+  start: 0,
+  end: 1,
+  groupId,
+  treeLevel,
+})
+const items: TimelineItem[] = [
+  item('ia', 'a', 1),
+  item('ia1', 'a1', 2),
+  item('ia1a', 'a1a', 3),
+  item('ib', 'b', 1),
+  // A milestone (decoration) under a1 → treeLevel = a1's level + 1 = 3.
+  { id: 'm', kind: 'milestone', start: 0, end: 0, groupId: 'a1', treeLevel: 3 },
+]
+
+describe('groupDepths', () => {
+  it('computes 0-based depth from the parent chain', () => {
+    // Arrange / Act
+    const d = groupDepths(groups)
+    // Assert
+    expect(d.get('a')).toBe(0)
+    expect(d.get('a1')).toBe(1)
+    expect(d.get('a1a')).toBe(2)
+    expect(d.get('b')).toBe(0)
+  })
+
+  it('treats a missing parent as a root', () => {
+    // Arrange — parent id not in the set.
+    const orphan = [g('x', 1, 'ghost')]
+    // Act / Assert
+    expect(groupDepths(orphan).get('x')).toBe(0)
+  })
+})
+
+describe('maxGroupDepth', () => {
+  it('returns the deepest level', () => {
+    // Arrange / Act / Assert
+    expect(maxGroupDepth(groups)).toBe(2)
+  })
+
+  it('is 0 for a flat set', () => {
+    // Arrange / Act / Assert
+    expect(maxGroupDepth([g('a', 1), g('b', 1)])).toBe(0)
+  })
+})
+
+describe('resolveLevel', () => {
+  it('level 1 → no groups; only treeLevel-1 activity bars, flat', () => {
+    // Arrange / Act
+    const out = resolveLevel(items, groups, 1)
+    // Assert — no groups; bars are the level-1 activities (ia, ib), flat.
+    expect(out.groups).toHaveLength(0)
+    const ids = out.items.map((i) => i.id).sort()
+    expect(ids).toEqual(['ia', 'ib'])
+    expect(out.items.every((i) => i.groupId === undefined)).toBe(true)
+  })
+
+  it('level 2 → level-1 activities are groups; level-2 items are bars', () => {
+    // Arrange / Act
+    const out = resolveLevel(items, groups, 2)
+    // Assert — groups: a, b (treeLevel 1). NOT a1 (that's a bar now).
+    expect(out.groups.map((x) => x.id).sort()).toEqual(['a', 'b'])
+    const ids = out.items.map((i) => i.id).sort()
+    // Bars: ia1 (level-2 activity). NOT ia/ib (they're groups now), NOT ia1a
+    // (level 3, hidden), NOT m (decoration level 3 > 2, hidden).
+    expect(ids).toEqual(['ia1'])
+    // ia1 sits under its surviving parent group 'a'.
+    expect(out.items[0].groupId).toBe('a')
+  })
+
+  it('level 3 → level-1,2 activities are groups; level-3 items + decorations are bars', () => {
+    // Arrange / Act
+    const out = resolveLevel(items, groups, 3)
+    // Assert — groups: a, a1, b (treeLevel < 3).
+    expect(out.groups.map((x) => x.id).sort()).toEqual(['a', 'a1', 'b'])
+    const ids = out.items.map((i) => i.id).sort()
+    // Bars: ia1a (level-3 activity) + m (level-3 milestone). a1a not a group.
+    expect(ids).toEqual(['ia1a', 'm'])
+    const byId = new Map(out.items.map((i) => [i.id, i]))
+    expect(byId.get('ia1a')?.groupId).toBe('a1') // under surviving parent
+    expect(byId.get('m')?.groupId).toBe('a1')
+  })
+
+  it('a level-1 activity (no children) is a BAR at level 1, hidden at level 2', () => {
+    // Arrange — 'b' has no children. Act/Assert.
+    const l1 = resolveLevel(items, groups, 1)
+    expect(l1.items.some((i) => i.id === 'ib')).toBe(true) // bar at level 1
+    const l2 = resolveLevel(items, groups, 2)
+    // At level 2, b becomes a group; its own bar 'ib' is NOT shown (no level-2
+    // child to render) — b is just an (empty) group row.
+    expect(l2.groups.some((x) => x.id === 'b')).toBe(true)
+    expect(l2.items.some((i) => i.id === 'ib')).toBe(false)
+  })
+
+  it('decorations show whenever treeLevel <= level (never become groups)', () => {
+    // Arrange — milestone m at treeLevel 3.
+    // Act / Assert — hidden at level 2, shown at level 3.
+    expect(resolveLevel(items, groups, 2).items.some((i) => i.id === 'm')).toBe(false)
+    expect(resolveLevel(items, groups, 3).items.some((i) => i.id === 'm')).toBe(true)
+  })
+
+  it('clamps level below 1 up to 1', () => {
+    // Arrange / Act / Assert
+    expect(resolveLevel(items, groups, 0).groups).toHaveLength(0)
+  })
+
+  it('excludes a treeLevel-0 root band at level 1 (its decoration goes ungrouped)', () => {
+    // Arrange — synthetic root band group + a root-level background under it.
+    const root: TimelineGroup = { id: 'root', treeLevel: 0, label: '' }
+    const rootBg: TimelineItem = {
+      id: 'tb',
+      kind: 'background',
+      start: 0,
+      end: 1,
+      groupId: 'root',
+      treeLevel: 1,
+    }
+    const g2 = [root, ...groups]
+    const i2 = [...items, rootBg]
+    // Act — level 1: nothing is a group (flat); root bg falls through ungrouped.
+    const l1 = resolveLevel(i2, g2, 1)
+    // Assert
+    expect(l1.groups).toHaveLength(0)
+    expect(l1.items.find((i) => i.id === 'tb')?.groupId).toBeUndefined()
+    // Level 2: root band survives as a group; bg scopes to it.
+    const l2 = resolveLevel(i2, g2, 2)
+    expect(l2.groups.some((x) => x.id === 'root')).toBe(true)
+    expect(l2.items.find((i) => i.id === 'tb')?.groupId).toBe('root')
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/depth.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/depth.ts
@@ -56,8 +56,9 @@ export function resolveLevel<T, G>(
   level: number,
 ): { items: TimelineItem<T>[]; groups: TimelineGroup<G>[] } {
   const byId = new Map(groups.map((g) => [g.id, g]))
+  const depths = groupDepths(groups)
   const groupLevel = (g: TimelineGroup<G>) =>
-    g.treeLevel ?? (groupDepths(groups).get(g.id) ?? 0) + 1
+    g.treeLevel ?? (depths.get(g.id) ?? 0) + 1
 
   // Deepest level present (consider both groups and items).
   let maxLevel = 1

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/depth.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/depth.ts
@@ -1,0 +1,96 @@
+// timeline2/core/depth.ts
+// Drill-through level helpers (pure). A "drill level" is a global expand depth:
+// groups at depth < level stay expanded; groups at depth >= level are collapsed
+// (their descendants fold onto their lane). Level 1 = only top-level groups
+// expanded; higher = drill deeper. This drives the toolbar -/+ controls while
+// the layout still consumes plain per-group `collapsed` flags.
+
+import type { TimelineGroup, TimelineItem } from './types'
+
+/** Depth (0-based) of each group in the parent tree. */
+export function groupDepths(groups: TimelineGroup[]): Map<string, number> {
+  const byId = new Map(groups.map((g) => [g.id, g]))
+  const cache = new Map<string, number>()
+
+  const depthOf = (id: string): number => {
+    const cached = cache.get(id)
+    if (cached != null) return cached
+    const g = byId.get(id)
+    const d = g?.parentId && byId.has(g.parentId) ? depthOf(g.parentId) + 1 : 0
+    cache.set(id, d)
+    return d
+  }
+
+  for (const g of groups) depthOf(g.id)
+  return cache
+}
+
+/** Maximum group depth (0-based). 0 when there are no nested groups. */
+export function maxGroupDepth(groups: TimelineGroup[]): number {
+  let max = 0
+  for (const d of groupDepths(groups).values()) max = Math.max(max, d)
+  return max
+}
+
+/**
+ * Resolve a drill `level` into exactly what renders, mirroring the legacy
+ * roadmap timeline's filter. Item/group `treeLevel` is 1-based here (top tier
+ * = 1), matching the legacy `treeLevel`. Rules at level L:
+ *
+ *  - GROUPS: nodes (kind 'range') with `treeLevel < L` become group rows.
+ *  - BARS: range items with `treeLevel === L` render in the chart. A node that
+ *    is a group (treeLevel < L) does NOT also render its own bar.
+ *  - DECORATIONS (milestone/background): render whenever `treeLevel <= L`
+ *    (they never become groups — they always show under their nearest group).
+ *  - Anything with `treeLevel > L` is hidden.
+ *
+ * Each surviving bar/decoration is assigned to its nearest ancestor group that
+ * survives (treeLevel < L), or undefined (flat) when none do — e.g. at level 1
+ * there are no groups, so level-1 bars render flat.
+ *
+ * `level` is clamped to [1, maxLevel] where maxLevel = deepest treeLevel.
+ */
+export function resolveLevel<T, G>(
+  items: TimelineItem<T>[],
+  groups: TimelineGroup<G>[],
+  level: number,
+): { items: TimelineItem<T>[]; groups: TimelineGroup<G>[] } {
+  const byId = new Map(groups.map((g) => [g.id, g]))
+  const groupLevel = (g: TimelineGroup<G>) =>
+    g.treeLevel ?? (groupDepths(groups).get(g.id) ?? 0) + 1
+
+  // Deepest level present (consider both groups and items).
+  let maxLevel = 1
+  for (const g of groups) maxLevel = Math.max(maxLevel, groupLevel(g))
+  for (const i of items) maxLevel = Math.max(maxLevel, i.treeLevel ?? 1)
+  const L = Math.max(1, Math.min(level, maxLevel))
+
+  // Groups that survive at this level: treeLevel < L. At level 1 NOTHING is a
+  // group (flat chart) — even a treeLevel-0 synthetic root band — so all items
+  // (incl. root timeboxes) fall through to the full-height/ungrouped area.
+  const survivingGroups = L <= 1 ? [] : groups.filter((g) => groupLevel(g) < L)
+  const survivesId = new Set(survivingGroups.map((g) => g.id))
+
+  // Nearest surviving ancestor group for an arbitrary group id.
+  const nearestSurviving = (id: string | undefined): string | undefined => {
+    let cur = id
+    while (cur) {
+      if (survivesId.has(cur)) return cur
+      cur = byId.get(cur)?.parentId
+    }
+    return undefined
+  }
+
+  const visibleItems: TimelineItem<T>[] = []
+  for (const item of items) {
+    const lvl = item.treeLevel ?? 1
+    const isDecoration = item.kind !== 'range'
+    // Bars: range items exactly at L. Decorations: at or above L. Hide deeper.
+    const visible = isDecoration ? lvl <= L : lvl === L
+    if (!visible) continue
+    const target = nearestSurviving(item.groupId)
+    visibleItems.push(target === item.groupId ? item : { ...item, groupId: target })
+  }
+
+  return { items: visibleItems, groups: survivingGroups }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.test.ts
@@ -1,0 +1,180 @@
+import {
+  itemBox,
+  backgroundBox,
+  isHorizontallyVisible,
+  growRowsForLabels,
+} from './geometry'
+import { createTimeScale } from './scale'
+import type { ResolvedRow, TimelineItem } from './types'
+
+const DAY = 86_400_000
+const day = (n: number) => n * DAY
+
+// Scale: 10 days mapped onto 1000px => 100px/day.
+const scale = createTimeScale(day(0), day(10), 1000)
+const config = { laneHeight: 40, lanePadding: 4 }
+
+const row = (top: number): ResolvedRow => ({
+  groupId: 'g',
+  top,
+  height: 80,
+  laneCount: 2,
+  items: [],
+  depth: 0,
+})
+
+describe('itemBox', () => {
+  it('maps a range item to left/width via the scale', () => {
+    // Arrange — days 2..5 on lane 0 of a row at top 0.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(2), end: day(5) }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, config)
+    // Assert — 100px/day: left 200, width 300.
+    expect(box.left).toBeCloseTo(200)
+    expect(box.width).toBeCloseTo(300)
+  })
+
+  it('offsets top by lane index and lane padding', () => {
+    // Arrange — lane 1 in a row at top 100.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(0), end: day(1) }
+    // Act
+    const box = itemBox(item, 1, row(100), scale, config)
+    // Assert — top = 100 + 1*40 + 4; height = 40 - 2*4.
+    expect(box.top).toBe(144)
+    expect(box.height).toBe(32)
+  })
+
+  it('enforces a minimum width for zero-duration ranges', () => {
+    // Arrange — start === end.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(3), end: day(3) }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, config)
+    // Assert
+    expect(box.width).toBeGreaterThanOrEqual(4)
+  })
+
+  it('clamps a range that extends past the domain end to the right edge', () => {
+    // Arrange — starts at day 8 but ends at day 20, beyond the 10-day domain.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(8), end: day(20) }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, config)
+    // Assert — left 800, clamped right edge at 1000 → width 200 (not 1200).
+    expect(box.left).toBeCloseTo(800)
+    expect(box.width).toBeCloseTo(200)
+  })
+
+  it('clamps a range that starts before the domain to the left edge', () => {
+    // Arrange — starts at day -5, ends at day 2.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(-5), end: day(2) }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, config)
+    // Assert — left clamped to 0, right at 200 → width 200.
+    expect(box.left).toBeCloseTo(0)
+    expect(box.width).toBeCloseTo(200)
+  })
+
+  it('gives zero width to a range entirely outside the domain', () => {
+    // Arrange — days 12..15, fully past the 10-day domain.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(12), end: day(15) }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, config)
+    // Assert — nothing to show; no min-width sliver at the edge.
+    expect(box.width).toBe(0)
+  })
+
+  it('places a milestone at its start with zero width', () => {
+    // Arrange
+    const item: TimelineItem = { id: 'm', kind: 'milestone', start: day(4), end: day(4) }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, config)
+    // Assert
+    expect(box.left).toBeCloseTo(400)
+    expect(box.width).toBe(0)
+  })
+})
+
+describe('backgroundBox', () => {
+  it('spans a row when a row is given', () => {
+    // Arrange
+    const bg: TimelineItem = { id: 'bg', kind: 'background', start: day(1), end: day(4) }
+    // Act
+    const box = backgroundBox(bg, row(50), scale)
+    // Assert — left 100, width 300, full row height/top.
+    expect(box.left).toBeCloseTo(100)
+    expect(box.width).toBeCloseTo(300)
+    expect(box.top).toBe(50)
+    expect(box.height).toBe(80)
+  })
+
+  it('spans full chart height when no row is given', () => {
+    // Arrange
+    const bg: TimelineItem = { id: 'bg', kind: 'background', start: day(0), end: day(2) }
+    // Act
+    const box = backgroundBox(bg, null, scale, 500)
+    // Assert
+    expect(box.top).toBe(0)
+    expect(box.height).toBe(500)
+  })
+})
+
+describe('isHorizontallyVisible', () => {
+  it('is true when the box overlaps the viewport', () => {
+    // Arrange / Act / Assert
+    expect(isHorizontallyVisible({ left: 100, top: 0, width: 50, height: 10 }, 1000)).toBe(true)
+  })
+
+  it('is false when the box is entirely left of the viewport', () => {
+    // Arrange / Act / Assert
+    expect(isHorizontallyVisible({ left: -200, top: 0, width: 50, height: 10 }, 1000)).toBe(false)
+  })
+
+  it('is false when the box is entirely right of the viewport', () => {
+    // Arrange / Act / Assert
+    expect(isHorizontallyVisible({ left: 1200, top: 0, width: 50, height: 10 }, 1000)).toBe(false)
+  })
+})
+
+describe('growRowsForLabels', () => {
+  const mkRow = (groupId: string, top: number, height: number): ResolvedRow => ({
+    groupId,
+    top,
+    height,
+    laneCount: 1,
+    items: [],
+    depth: 0,
+  })
+
+  it('returns the same rows reference when nothing needs growing', () => {
+    // Arrange — labels shorter than row heights.
+    const rows = [mkRow('a', 0, 40), mkRow('b', 40, 40)]
+    const heights = new Map([['a', 30], ['b', 20]])
+    // Act
+    const out = growRowsForLabels(rows, heights)
+    // Assert
+    expect(out.rows).toBe(rows)
+    expect(out.totalHeight).toBe(80)
+  })
+
+  it('grows a row whose label is taller and restacks following rows', () => {
+    // Arrange — 'a' label needs 60px (row is 40).
+    const rows = [mkRow('a', 0, 40), mkRow('b', 40, 40)]
+    const heights = new Map([['a', 60]])
+    // Act
+    const out = growRowsForLabels(rows, heights)
+    // Assert — 'a' grows to 60; 'b' shifts down to top 60.
+    expect(out.rows[0].height).toBe(60)
+    expect(out.rows[1].top).toBe(60)
+    expect(out.totalHeight).toBe(100)
+  })
+
+  it('ignores rows without a groupId', () => {
+    // Arrange
+    const ungrouped: ResolvedRow = {
+      top: 0, height: 40, laneCount: 1, items: [], depth: 0,
+    }
+    // Act
+    const out = growRowsForLabels([ungrouped], new Map([['x', 99]]))
+    // Assert — unchanged.
+    expect(out.rows[0].height).toBe(40)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.ts
@@ -1,0 +1,122 @@
+// timeline2/core/geometry.ts
+// Pure pixel-box computation: given a TimeScale, a resolved row, and lane sizing,
+// produce absolute {left, top, width, height} boxes for items and backgrounds.
+// No React, no DOM. Consumed by the render layer.
+
+import type { ResolvedRow, TimelineItem } from './types'
+import type { TimeScale } from './scale'
+
+export interface Box {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+export interface ItemBox extends Box {
+  item: TimelineItem
+}
+
+/** Minimum rendered width so zero/short-duration ranges stay clickable. */
+const MIN_RANGE_WIDTH = 4
+/** Milestone diamonds are square; sized to the lane height at render time. */
+
+export interface GeometryConfig {
+  laneHeight: number
+  /** Inset within a lane so bars don't touch lane edges, px. */
+  lanePadding: number
+}
+
+/**
+ * Box for a single item placed at `lane` within `row`.
+ * Range: spans [start,end) in x. Milestone: zero-duration, centered on start
+ * (the render layer draws a diamond of `height` width around left).
+ */
+export function itemBox(
+  item: TimelineItem,
+  lane: number,
+  row: ResolvedRow,
+  scale: TimeScale,
+  config: GeometryConfig,
+): ItemBox {
+  // Offset bars below any reserved headroom (e.g. a timebox label band).
+  const top =
+    row.top + (row.topInset ?? 0) + lane * config.laneHeight + config.lanePadding
+  const height = config.laneHeight - config.lanePadding * 2
+
+  if (item.kind === 'milestone') {
+    const center = Math.max(0, Math.min(scale.width, scale.toX(item.start)))
+    return { item, left: center, top, width: 0, height }
+  }
+
+  // Clamp the bar to the rendered domain [0, scale.width]. Items can extend past
+  // the hard bounds (min/max); we cut them at the edge rather than let them
+  // overflow the canvas into a gridline-less, scrollable void (legacy behavior).
+  const rawX1 = scale.toX(item.start)
+  const rawX2 = scale.toX(item.end)
+  const x1 = Math.max(0, Math.min(scale.width, rawX1))
+  const x2 = Math.max(0, Math.min(scale.width, rawX2))
+  // Does the (unclamped) item overlap the visible domain at all? A point item
+  // (start === end) counts as intersecting when it sits within [0, width].
+  const intersects = rawX2 >= 0 && rawX1 <= scale.width
+  // Outside the domain → zero width (nothing to show). Inside → keep the
+  // min-width floor so short/zero-duration ranges remain visible/clickable.
+  const width = intersects ? Math.max(MIN_RANGE_WIDTH, x2 - x1) : 0
+  return { item, left: x1, top, width, height }
+}
+
+/**
+ * Box for a background region spanning a row (or the whole chart body when
+ * `fullHeight` is given). Backgrounds ignore lanes — they sit behind items.
+ */
+export function backgroundBox(
+  item: TimelineItem,
+  row: ResolvedRow | null,
+  scale: TimeScale,
+  fullHeight?: number,
+): Box {
+  // Clamp to the rendered domain so a timebox extending past the bounds is cut
+  // at the edge (same as item bars), never overflowing the canvas.
+  const x1 = Math.max(0, Math.min(scale.width, scale.toX(item.start)))
+  const x2 = Math.max(0, Math.min(scale.width, scale.toX(item.end)))
+  const width = Math.max(0, x2 - x1)
+  if (row) {
+    return { left: x1, top: row.top, width, height: row.height }
+  }
+  return { left: x1, top: 0, width, height: fullHeight ?? 0 }
+}
+
+/** Clamp a box's horizontal span to the visible [0,width] viewport (for culling). */
+export function isHorizontallyVisible(
+  box: Box,
+  viewportWidth: number,
+): boolean {
+  return box.left + box.width >= 0 && box.left <= viewportWidth
+}
+
+/**
+ * Grow rows whose group label (measured in the rendered column) is taller than
+ * the lane-based height, then re-stack so tops stay contiguous. Pure: takes
+ * measured label heights (keyed by row identity — rowKey, falling back to
+ * groupId) and returns adjusted rows + new total height. When no row needs
+ * growing, returns the input rows unchanged (same reference) so callers can skip
+ * a re-render.
+ */
+export function growRowsForLabels(
+  rows: ResolvedRow[],
+  labelHeights: Map<string, number>,
+): { rows: ResolvedRow[]; totalHeight: number } {
+  let changed = false
+  let top = 0
+  const adjusted = rows.map((row) => {
+    const measureKey = row.rowKey ?? row.groupId
+    const labelH = measureKey ? labelHeights.get(measureKey) ?? 0 : 0
+    const height = Math.max(row.height, labelH)
+    const next =
+      height !== row.height || top !== row.top ? { ...row, top, height } : row
+    if (next !== row) changed = true
+    top += height
+    return next
+  })
+  return changed ? { rows: adjusted, totalHeight: top } : { rows, totalHeight: top }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/interaction.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/interaction.test.ts
@@ -1,0 +1,144 @@
+// Core math needs REAL dayjs (the global jest.setup mock only stubs `.format`).
+jest.unmock('dayjs')
+import { applyDrag, progressFromX, snapToDay } from './interaction'
+import dayjs from 'dayjs'
+
+const DAY = 86_400_000
+const day = (n: number) => dayjs('2026-01-01').startOf('day').add(n, 'day').valueOf()
+
+// 100px per day => pxPerMs.
+const pxPerMs = 100 / DAY
+
+const item = (startDay: number, endDay: number) => ({
+  start: day(startDay),
+  end: day(endDay),
+  kind: 'range' as const,
+})
+
+describe('snapToDay', () => {
+  it('snaps a mid-day timestamp to the start of that day', () => {
+    // Arrange
+    const midday = dayjs('2026-03-10').startOf('day').add(13, 'hour').valueOf()
+    // Act
+    const snapped = snapToDay(midday)
+    // Assert
+    expect(snapped).toBe(dayjs('2026-03-10').startOf('day').valueOf())
+  })
+})
+
+describe('applyDrag — move', () => {
+  it('shifts both ends by the dragged days, preserving duration', () => {
+    // Arrange — drag +200px = +2 days.
+    const ctx = { mode: 'move' as const, item: item(0, 3), pxPerMs, deltaPx: 200 }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert
+    expect(r.start).toBe(day(2))
+    expect(r.end).toBe(day(5))
+  })
+
+  it('snaps a fractional-day drag to the nearest day boundary', () => {
+    // Arrange — +150px = +1.5 days; snaps start to a day boundary.
+    const ctx = { mode: 'move' as const, item: item(0, 3), pxPerMs, deltaPx: 150 }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert — start lands on a clean day start.
+    expect(r.start).toBe(dayjs(r.start).startOf('day').valueOf())
+    expect(r.end - r.start).toBe(3 * DAY)
+  })
+
+  it('clamps move to max without changing duration', () => {
+    // Arrange — large positive drag, max at day 4; item is 3 days long.
+    const ctx = {
+      mode: 'move' as const,
+      item: item(0, 3),
+      pxPerMs,
+      deltaPx: 100000,
+      max: day(4),
+    }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert — end pinned at max, duration kept.
+    expect(r.end).toBe(day(4))
+    expect(r.end - r.start).toBe(3 * DAY)
+  })
+})
+
+describe('applyDrag — resize', () => {
+  it('moves only the start on resize-start', () => {
+    // Arrange — drag start -100px = -1 day.
+    const ctx = {
+      mode: 'resize-start' as const,
+      item: item(2, 6),
+      pxPerMs,
+      deltaPx: -100,
+    }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert
+    expect(r.start).toBe(day(1))
+    expect(r.end).toBe(day(6))
+  })
+
+  it('does not let start cross end (min one-day span)', () => {
+    // Arrange — drag start far right, past the end.
+    const ctx = {
+      mode: 'resize-start' as const,
+      item: item(2, 4),
+      pxPerMs,
+      deltaPx: 100000,
+    }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert
+    expect(r.start).toBe(r.end - DAY)
+  })
+
+  it('moves only the end on resize-end', () => {
+    // Arrange — drag end +200px = +2 days.
+    const ctx = {
+      mode: 'resize-end' as const,
+      item: item(0, 3),
+      pxPerMs,
+      deltaPx: 200,
+    }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert
+    expect(r.start).toBe(day(0))
+    expect(r.end).toBe(day(5))
+  })
+
+  it('does not let end cross start (min one-day span)', () => {
+    // Arrange — drag end far left, before the start.
+    const ctx = {
+      mode: 'resize-end' as const,
+      item: item(2, 6),
+      pxPerMs,
+      deltaPx: -100000,
+    }
+    // Act
+    const r = applyDrag(ctx)
+    // Assert
+    expect(r.end).toBe(r.start + DAY)
+  })
+})
+
+describe('progressFromX', () => {
+  it('maps pointer position across the bar to 0..100', () => {
+    // Arrange — bar at left=100, width=200; pointer at the midpoint.
+    // Act / Assert
+    expect(progressFromX(200, 100, 200)).toBe(50)
+  })
+
+  it('clamps below 0 and above 100', () => {
+    // Arrange / Act / Assert
+    expect(progressFromX(50, 100, 200)).toBe(0)
+    expect(progressFromX(400, 100, 200)).toBe(100)
+  })
+
+  it('returns 0 for a zero-width bar', () => {
+    // Arrange / Act / Assert
+    expect(progressFromX(100, 100, 0)).toBe(0)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/interaction.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/interaction.ts
@@ -1,0 +1,94 @@
+// timeline2/core/interaction.ts
+// Pure drag math: translate a horizontal pixel delta into a date change, with
+// day-snapping and domain clamping. No DOM, no React — the testable core of
+// move / resize-start / resize-end (FR-5). The hook (useBarDrag) handles pointer
+// plumbing and calls these.
+
+import dayjs from 'dayjs'
+import type { TimelineItem } from './types'
+
+export type DragMode = 'move' | 'resize-start' | 'resize-end'
+
+const DAY = 86_400_000
+
+/** Snap an epoch-ms value to the start of its UTC-agnostic local day. */
+export function snapToDay(ms: number): number {
+  return dayjs(ms).startOf('day').valueOf()
+}
+
+export interface DragContext {
+  mode: DragMode
+  /** The item being dragged (original, unmodified bounds). */
+  item: Pick<TimelineItem, 'start' | 'end' | 'kind'>
+  /** Pixels per millisecond, from the active scale. */
+  pxPerMs: number
+  /** Horizontal pixel delta since drag start. */
+  deltaPx: number
+  /** Optional hard bounds (epoch ms) the result is clamped to. */
+  min?: number
+  max?: number
+  /** Snap result to day boundaries (default true). */
+  snap?: boolean
+}
+
+export interface DragResult {
+  start: number
+  end: number
+}
+
+/**
+ * Compute the new [start,end] for a drag. Pure.
+ *  - move:         shift both ends by the delta.
+ *  - resize-start: move start only; never past end (min 1 day span).
+ *  - resize-end:   move end only; never before start (min 1 day span).
+ * Day-snaps (unless disabled) and clamps to [min,max] if given.
+ */
+export function applyDrag(ctx: DragContext): DragResult {
+  const { mode, item, pxPerMs, deltaPx, min, max, snap = true } = ctx
+  const deltaMs = pxPerMs > 0 ? deltaPx / pxPerMs : 0
+  const maybeSnap = (ms: number) => (snap ? snapToDay(ms) : ms)
+  const clamp = (ms: number) => {
+    let v = ms
+    if (min != null && v < min) v = min
+    if (max != null && v > max) v = max
+    return v
+  }
+
+  let start = item.start
+  let end = item.end
+
+  if (mode === 'move') {
+    start = clamp(maybeSnap(item.start + deltaMs))
+    // Preserve duration on move.
+    const duration = item.end - item.start
+    end = start + duration
+    if (max != null && end > max) {
+      end = max
+      start = end - duration
+    }
+  } else if (mode === 'resize-start') {
+    start = clamp(maybeSnap(item.start + deltaMs))
+    // Keep at least a one-day span.
+    if (start > end - DAY) start = end - DAY
+  } else {
+    // resize-end
+    end = clamp(maybeSnap(item.end + deltaMs))
+    if (end < start + DAY) end = start + DAY
+  }
+
+  return { start, end }
+}
+
+/**
+ * Convert a horizontal pixel position within a bar into a progress percent
+ * (0..100), given the bar's left edge and pixel width. Pure.
+ */
+export function progressFromX(
+  pointerX: number,
+  barLeft: number,
+  barWidth: number,
+): number {
+  if (barWidth <= 0) return 0
+  const ratio = (pointerX - barLeft) / barWidth
+  return Math.round(Math.max(0, Math.min(1, ratio)) * 100)
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.test.ts
@@ -1,0 +1,139 @@
+import { packLanes } from './packing'
+import type { TimelineItem } from './types'
+
+// Day in ms, for readable fixtures.
+const DAY = 86_400_000
+const day = (n: number) => n * DAY
+
+const range = (
+  id: string,
+  startDay: number,
+  endDay: number,
+  extra: Partial<TimelineItem> = {},
+): TimelineItem => ({
+  id,
+  kind: 'range',
+  start: day(startDay),
+  end: day(endDay),
+  ...extra,
+})
+
+describe('packLanes', () => {
+  it('returns no lanes for an empty set', () => {
+    // Arrange
+    const items: TimelineItem[] = []
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(0)
+    expect(result.lanes.size).toBe(0)
+  })
+
+  it('places non-overlapping items on a single lane', () => {
+    // Arrange
+    const items = [range('a', 0, 2), range('b', 3, 5), range('c', 6, 8)]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(1)
+    expect(result.lanes.get('a')).toBe(0)
+    expect(result.lanes.get('b')).toBe(0)
+    expect(result.lanes.get('c')).toBe(0)
+  })
+
+  it('treats touching intervals (a.end === b.start) as non-overlapping', () => {
+    // Arrange — half-open [start, end): b starts exactly when a ends.
+    const items = [range('a', 0, 3), range('b', 3, 6)]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(1)
+    expect(result.lanes.get('a')).toBe(0)
+    expect(result.lanes.get('b')).toBe(0)
+  })
+
+  it('pushes overlapping items onto separate lanes', () => {
+    // Arrange
+    const items = [range('a', 0, 5), range('b', 2, 7)]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(2)
+    expect(result.lanes.get('a')).toBe(0)
+    expect(result.lanes.get('b')).toBe(1)
+  })
+
+  it('uses the minimum number of lanes for a stack of overlaps', () => {
+    // Arrange — three mutually overlapping items need three lanes.
+    const items = [range('a', 0, 10), range('b', 1, 11), range('c', 2, 12)]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(3)
+  })
+
+  it('reuses a freed lane when an earlier item has ended', () => {
+    // Arrange — a (0-2) and c (3-5) can share lane 0; b (0-5) needs lane 1.
+    const items = [range('a', 0, 2), range('b', 0, 5), range('c', 3, 5)]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(2)
+    expect(result.lanes.get('a')).toBe(0)
+    expect(result.lanes.get('b')).toBe(1)
+    expect(result.lanes.get('c')).toBe(0)
+  })
+
+  it('is deterministic regardless of input order', () => {
+    // Arrange
+    const forward = [range('a', 0, 5), range('b', 2, 7), range('c', 6, 9)]
+    const reversed = [...forward].reverse()
+    // Act
+    const r1 = packLanes(forward)
+    const r2 = packLanes(reversed)
+    // Assert
+    expect(r2.laneCount).toBe(r1.laneCount)
+    expect(r2.lanes.get('a')).toBe(r1.lanes.get('a'))
+    expect(r2.lanes.get('b')).toBe(r1.lanes.get('b'))
+    expect(r2.lanes.get('c')).toBe(r1.lanes.get('c'))
+  })
+
+  it('breaks ties on equal start by `order` then id', () => {
+    // Arrange — same start; order decides which takes lane 0.
+    const items = [
+      range('late', 0, 5, { order: 2 }),
+      range('early', 0, 5, { order: 1 }),
+    ]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.lanes.get('early')).toBe(0)
+    expect(result.lanes.get('late')).toBe(1)
+  })
+
+  it('packs milestones as instants (zero-width), allowing tight sharing', () => {
+    // Arrange — a range ending at day 3 and a milestone at day 3 share a lane.
+    const items: TimelineItem[] = [
+      range('r', 0, 3),
+      { id: 'm', kind: 'milestone', start: day(3), end: day(3) },
+    ]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.laneCount).toBe(1)
+    expect(result.lanes.get('m')).toBe(0)
+  })
+
+  it('excludes background items from packing', () => {
+    // Arrange
+    const items: TimelineItem[] = [
+      range('a', 0, 5),
+      { id: 'bg', kind: 'background', start: day(0), end: day(10) },
+    ]
+    // Act
+    const result = packLanes(items)
+    // Assert
+    expect(result.lanes.has('bg')).toBe(false)
+    expect(result.laneCount).toBe(1)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.ts
@@ -1,0 +1,60 @@
+// timeline2/core/packing.ts
+// HAND-ROLLED interval lane-packing (decision D-2): assign non-overlapping
+// items to the fewest horizontal lanes — the defining timeline behavior.
+// Pure function, the primary unit-test target (NFR-7).
+
+import type { PackResult, TimelineItem } from './types'
+
+/**
+ * Greedy interval-scheduling lane assignment.
+ *
+ * Items are sorted by (start, then `order`, then id) for determinism, then each
+ * item is placed in the first lane whose last item ends at or before this item's
+ * start. If none fits, a new lane is opened. This yields the minimum number of
+ * lanes for a set of intervals (classic greedy interval-graph colouring).
+ *
+ * Two items "overlap" when one starts strictly before the other ends. Touching
+ * intervals (a.end === b.start) do NOT overlap and may share a lane — matching
+ * the half-open [start, end) convention in TimelineItem.
+ *
+ * Background items are excluded — they are not lane-packed (they render behind).
+ */
+export function packLanes(items: TimelineItem[]): PackResult {
+  const packable = items.filter((i) => i.kind !== 'background')
+
+  const sorted = [...packable].sort((a, b) => {
+    if (a.start !== b.start) return a.start - b.start
+    const ao = a.order ?? 0
+    const bo = b.order ?? 0
+    if (ao !== bo) return ao - bo
+    return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+  })
+
+  const lanes = new Map<string, number>()
+  // laneEnds[i] = exclusive end (epoch ms) of the last item placed in lane i.
+  const laneEnds: number[] = []
+
+  for (const item of sorted) {
+    // Milestones occupy an instant; treat end as start so they pack tightly.
+    const itemEnd = item.kind === 'milestone' ? item.start : item.end
+
+    let placed = -1
+    for (let lane = 0; lane < laneEnds.length; lane += 1) {
+      if (laneEnds[lane] <= item.start) {
+        placed = lane
+        break
+      }
+    }
+
+    if (placed === -1) {
+      placed = laneEnds.length
+      laneEnds.push(itemEnd)
+    } else {
+      laneEnds[placed] = itemEnd
+    }
+
+    lanes.set(item.id, placed)
+  }
+
+  return { lanes, laneCount: laneEnds.length }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.test.ts
@@ -1,0 +1,131 @@
+// scale.ticks() uses REAL dayjs (.startOf/.add); the global mock only stubs format.
+jest.unmock('dayjs')
+import { createTimeScale } from './scale'
+import dayjs from 'dayjs'
+
+const DAY = 86_400_000
+const start = dayjs('2026-01-01').startOf('day').valueOf()
+
+describe('createTimeScale — mapping', () => {
+  it('maps domain start to x=0 and end to x=width', () => {
+    // Arrange
+    const scale = createTimeScale(start, start + 10 * DAY, 1000)
+    // Act / Assert
+    expect(scale.toX(start)).toBeCloseTo(0)
+    expect(scale.toX(start + 10 * DAY)).toBeCloseTo(1000)
+  })
+
+  it('round-trips toX/toMs', () => {
+    // Arrange
+    const scale = createTimeScale(start, start + 10 * DAY, 1000)
+    const ms = start + 4 * DAY
+    // Act / Assert
+    expect(scale.toMs(scale.toX(ms))).toBeCloseTo(ms)
+  })
+
+  it('guards a zero/negative width without producing NaN', () => {
+    // Arrange
+    const scale = createTimeScale(start, start + DAY, 0)
+    // Act / Assert
+    expect(Number.isFinite(scale.toX(start))).toBe(true)
+  })
+
+  it('guards an inverted/degenerate domain', () => {
+    // Arrange — end <= start.
+    const scale = createTimeScale(start, start, 500)
+    // Act / Assert
+    expect(scale.domain[1]).toBeGreaterThan(scale.domain[0])
+  })
+})
+
+describe('createTimeScale — ticks', () => {
+  it('returns calendar-aligned ticks within the domain', () => {
+    // Arrange — 10-day window, ~10 ticks => daily.
+    const scale = createTimeScale(start, start + 10 * DAY, 1000)
+    // Act
+    const ticks = scale.ticks(10)
+    // Assert — all within domain, ascending, day-aligned.
+    expect(ticks.length).toBeGreaterThan(0)
+    expect(ticks[0]).toBeGreaterThanOrEqual(start)
+    expect(ticks[ticks.length - 1]).toBeLessThanOrEqual(start + 10 * DAY)
+    for (let i = 1; i < ticks.length; i += 1) {
+      expect(ticks[i]).toBeGreaterThan(ticks[i - 1])
+    }
+    ticks.forEach((t) => expect(t).toBe(dayjs(t).startOf('day').valueOf()))
+  })
+
+  it('uses coarser steps for a long domain', () => {
+    // Arrange — ~2 year window.
+    const scale = createTimeScale(start, start + 730 * DAY, 1000)
+    // Act
+    const ticks = scale.ticks(10)
+    // Assert — spacing is much larger than a day (monthly/quarterly/yearly).
+    const gap = ticks[1] - ticks[0]
+    expect(gap).toBeGreaterThan(20 * DAY)
+  })
+
+  it('never loops unboundedly for a tiny tick count', () => {
+    // Arrange
+    const scale = createTimeScale(start, start + 365 * DAY, 1000)
+    // Act
+    const ticks = scale.ticks(1)
+    // Assert
+    expect(ticks.length).toBeLessThan(1000)
+  })
+})
+
+describe('createTimeScale — tiers', () => {
+  it('builds month-over-week tiers for a multi-month span', () => {
+    // Arrange — ~4 month window (Sep–Dec).
+    const scale = createTimeScale(start, start + 120 * DAY, 1200)
+    // Act
+    const { upper, lower } = scale.tiers()
+    // Assert — upper tier is months; lower has more cells than upper.
+    expect(upper.length).toBeGreaterThanOrEqual(4)
+    expect(lower.length).toBeGreaterThan(upper.length)
+    expect(/\w+ \d{4}/.test(upper[0].label)).toBe(true) // e.g. "January 2026"
+  })
+
+  it('builds year-over-month tiers for a multi-year span', () => {
+    // Arrange — ~2 year window.
+    const scale = createTimeScale(start, start + 730 * DAY, 1200)
+    // Act
+    const { upper, lower } = scale.tiers()
+    // Assert — upper tier labels are 4-digit years.
+    expect(upper.every((s) => /^\d{4}$/.test(s.label))).toBe(true)
+    expect(lower.length).toBeGreaterThan(upper.length)
+  })
+
+  it('builds month-over-day tiers when zoomed in (high pixel density)', () => {
+    // Arrange — same 4-month domain, but a very wide chart (zoomed in) so each
+    // day renders >= 25px. Tiers should switch to day-level lower labels.
+    const scale = createTimeScale(start, start + 120 * DAY, 120 * 30)
+    // Act
+    const { upper, lower } = scale.tiers()
+    // Assert — upper is months; lower is per-day (one cell per day, ~120).
+    expect(/\w+ \d{4}/.test(upper[0].label)).toBe(true)
+    expect(lower.length).toBeGreaterThanOrEqual(110)
+  })
+
+  it('drives tier granularity by zoom (pixel density), not domain span alone', () => {
+    // Arrange — identical domain span, two different widths (zoom levels).
+    const zoomedOut = createTimeScale(start, start + 120 * DAY, 200)
+    const zoomedIn = createTimeScale(start, start + 120 * DAY, 120 * 30)
+    // Act
+    const out = zoomedOut.tiers()
+    const inn = zoomedIn.tiers()
+    // Assert — zoomed out is coarser (fewer lower cells) than zoomed in.
+    expect(inn.lower.length).toBeGreaterThan(out.lower.length)
+  })
+
+  it('clamps the first and last segments to the domain', () => {
+    // Arrange — start mid-month so the first month cell is partial.
+    const midMonth = dayjs('2026-01-10').startOf('day').valueOf()
+    const scale = createTimeScale(midMonth, midMonth + 90 * DAY, 1000)
+    // Act
+    const { upper } = scale.tiers()
+    // Assert — first segment starts at the domain start, not the month start.
+    expect(upper[0].startMs).toBe(midMonth)
+    expect(upper[upper.length - 1].endMs).toBe(midMonth + 90 * DAY)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.ts
@@ -1,0 +1,174 @@
+// timeline2/core/scale.ts
+// Date<->pixel mapping + calendar-aware tick generation. Pure, no DOM/React.
+//
+// Originally planned on d3-scale (decision D-2), but d3's ESM-only packaging
+// fights next/jest's transform pipeline (next/jest forces node_modules to be
+// ignored unless transpilePackages is honored, which proved unreliable here).
+// The mapping for a single contiguous time domain is just linear interpolation,
+// and calendar-aware tick stepping is a few lines on dayjs (the repo's standard
+// date lib, already a dependency). So we own this small, well-bounded math
+// instead — same spirit as hand-rolling packing. See timeline-replacement spec.
+
+import dayjs, { type Dayjs } from 'dayjs'
+
+export interface TimeScale {
+  /** epoch ms -> pixel x within [0, width]. */
+  toX: (ms: number) => number
+  /** pixel x -> epoch ms. */
+  toMs: (x: number) => number
+  /** Width of the pixel range. */
+  width: number
+  /** Pixels per millisecond (constant for a linear domain). */
+  pxPerMs: number
+  /** Visible domain as epoch ms [start, end]. */
+  domain: [number, number]
+  /** Generate ~`count` calendar-aligned ticks as epoch ms. */
+  ticks: (count?: number) => number[]
+  /** Two-tier header segments (upper = month/year, lower = week/day), span-aware. */
+  tiers: () => { upper: ScaleSegment[]; lower: ScaleSegment[] }
+}
+
+/** A labeled header cell spanning [startMs, endMs). */
+export interface ScaleSegment {
+  startMs: number
+  endMs: number
+  label: string
+}
+
+type TickUnit = 'hour' | 'day' | 'week' | 'month' | 'year'
+
+// Candidate step sizes, smallest -> largest, with approximate span in ms used
+// only to pick a sensible granularity for the requested tick count.
+const HOUR = 3_600_000
+const DAY = 86_400_000
+const TICK_STEPS: Array<{ unit: TickUnit; step: number; approxMs: number }> = [
+  { unit: 'hour', step: 1, approxMs: HOUR },
+  { unit: 'hour', step: 3, approxMs: 3 * HOUR },
+  { unit: 'hour', step: 6, approxMs: 6 * HOUR },
+  { unit: 'hour', step: 12, approxMs: 12 * HOUR },
+  { unit: 'day', step: 1, approxMs: DAY },
+  { unit: 'day', step: 2, approxMs: 2 * DAY },
+  { unit: 'week', step: 1, approxMs: 7 * DAY },
+  { unit: 'week', step: 2, approxMs: 14 * DAY },
+  { unit: 'month', step: 1, approxMs: 30 * DAY },
+  { unit: 'month', step: 3, approxMs: 91 * DAY },
+  { unit: 'year', step: 1, approxMs: 365 * DAY },
+]
+
+/** Snap a dayjs value DOWN to the start of the given unit. */
+function floorTo(d: Dayjs, unit: TickUnit): Dayjs {
+  // dayjs treats 'week' via startOf('week'); others map directly.
+  return d.startOf(unit === 'week' ? 'week' : unit)
+}
+
+/** Advance a dayjs value by step units. */
+function addStep(d: Dayjs, unit: TickUnit, step: number): Dayjs {
+  return d.add(step, unit)
+}
+
+/**
+ * Build labeled segments for `unit` across [startMs, endMs], clamped to the
+ * domain so the first/last cells don't overflow. `fmt` formats each cell.
+ */
+function segmentsFor(
+  startMs: number,
+  endMs: number,
+  unit: TickUnit,
+  fmt: (d: Dayjs) => string,
+): ScaleSegment[] {
+  const out: ScaleSegment[] = []
+  let cursor = floorTo(dayjs(startMs), unit)
+  let guard = 0
+  while (cursor.valueOf() < endMs && guard < 2000) {
+    const next = addStep(cursor, unit, 1)
+    out.push({
+      startMs: Math.max(cursor.valueOf(), startMs),
+      endMs: Math.min(next.valueOf(), endMs),
+      label: fmt(cursor),
+    })
+    cursor = next
+    guard += 1
+  }
+  return out
+}
+
+export function createTimeScale(
+  startMs: number,
+  endMs: number,
+  width: number,
+): TimeScale {
+  // Guard degenerate inputs so we never produce NaN/Infinity downstream.
+  const safeWidth = Number.isFinite(width) && width > 0 ? width : 1
+  const safeEnd = endMs > startMs ? endMs : startMs + 1
+  const span = safeEnd - startMs
+  const pxPerMs = safeWidth / span
+
+  return {
+    width: safeWidth,
+    pxPerMs,
+    domain: [startMs, safeEnd],
+    toX: (ms) => (ms - startMs) * pxPerMs,
+    toMs: (x) => startMs + x / pxPerMs,
+    ticks: (count = 10) => {
+      const target = Math.max(1, count)
+      const desiredMs = span / target
+
+      // Pick the smallest step whose span is >= the desired spacing.
+      let chosen = TICK_STEPS[TICK_STEPS.length - 1]
+      for (const candidate of TICK_STEPS) {
+        if (candidate.approxMs >= desiredMs) {
+          chosen = candidate
+          break
+        }
+      }
+
+      const out: number[] = []
+      // Start at the first aligned boundary at or after the domain start.
+      let cursor = floorTo(dayjs(startMs), chosen.unit)
+      if (cursor.valueOf() < startMs) {
+        cursor = addStep(cursor, chosen.unit, chosen.step)
+      }
+      // Guard against pathological loops.
+      let guard = 0
+      while (cursor.valueOf() <= safeEnd && guard < 1000) {
+        out.push(cursor.valueOf())
+        cursor = addStep(cursor, chosen.unit, chosen.step)
+        guard += 1
+      }
+      return out
+    },
+    tiers: () => {
+      // Pick tier granularities by PIXEL DENSITY (how wide one day renders), not
+      // the total domain span — so granularity gets FINER as the user zooms in
+      // (more px per day) and coarser as they zoom out, matching vis-timeline.
+      //  wide day  (zoomed in):  month over day   (every day number)
+      //  mid       :             month over week
+      //  narrow    (zoomed out): year over month
+      const pxPerDay = pxPerMs * DAY
+      let upperUnit: TickUnit
+      let lowerUnit: TickUnit
+      let upperFmt: (d: Dayjs) => string
+      let lowerFmt: (d: Dayjs) => string
+      if (pxPerDay >= 25) {
+        upperUnit = 'month'
+        lowerUnit = 'day'
+        upperFmt = (d) => d.format('MMMM YYYY')
+        lowerFmt = (d) => d.format('D')
+      } else if (pxPerDay >= 6) {
+        upperUnit = 'month'
+        lowerUnit = 'week'
+        upperFmt = (d) => d.format('MMMM YYYY')
+        lowerFmt = (d) => d.format('D')
+      } else {
+        upperUnit = 'year'
+        lowerUnit = 'month'
+        upperFmt = (d) => d.format('YYYY')
+        lowerFmt = (d) => d.format('MMM')
+      }
+      return {
+        upper: segmentsFor(startMs, safeEnd, upperUnit, upperFmt),
+        lower: segmentsFor(startMs, safeEnd, lowerUnit, lowerFmt),
+      }
+    },
+  }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/types.ts
@@ -1,0 +1,102 @@
+// timeline2/core/types.ts
+// Shared, variant-agnostic domain types for WaydTimeline2.
+// These describe DATA and GEOMETRY only — no React, no app/domain coupling.
+// See docs/contributing/specs/custom-timeline-requirements.md.
+
+/** The two layout variants. Only the layout strategy branches on this. */
+export type TimelineVariant = 'timeline' | 'gantt'
+
+/** Kind of item drawn on the chart. */
+export type ItemKind = 'range' | 'milestone' | 'background'
+
+/**
+ * A single chart item, normalized to epoch-millisecond bounds so all core math
+ * is plain number arithmetic (no Date/string/dayjs ambiguity — that conversion
+ * happens at the adapter boundary, not in core).
+ */
+export interface TimelineItem<T = unknown> {
+  id: string
+  kind: ItemKind
+  /** Inclusive start, epoch ms. */
+  start: number
+  /** Exclusive end, epoch ms. For milestones, equals `start`. */
+  end: number
+  /** Display label shown on the bar (first-class; default renderer uses it). */
+  label?: string
+  /** Bar background color (any CSS color). Text contrast is auto-derived. */
+  color?: string
+  /** Group this item belongs to; undefined = ungrouped. */
+  groupId?: string
+  /**
+   * Tree depth of this item (0-based). Drives the timeline drill level: at
+   * level N, item-kind nodes at this exact level render as bars; shallower
+   * group-kind nodes become group rows. Set by the adapter for hierarchical
+   * data; omitted = flat (depth 0).
+   */
+  treeLevel?: number
+  /** Optional deterministic ordering hint (lower = earlier in packing/placement). */
+  order?: number
+  /** Progress 0..100, if the item supports a progress handle. */
+  progress?: number
+  /** Opaque payload the render layer / consumer carries through (DTO, etc.). */
+  data?: T
+}
+
+/** A group (row header / lane container). May nest via `parentId`. */
+export interface TimelineGroup<T = unknown> {
+  id: string
+  parentId?: string
+  /** Tree depth of this group (0-based). Set by the adapter; defaults to the
+   *  computed parent-chain depth when omitted. */
+  treeLevel?: number
+  /** Display label shown in the left group column. */
+  label?: string
+  /** Collapsed groups pack descendants onto the parent lane (timeline variant). */
+  collapsed?: boolean
+  order?: number
+  data?: T
+}
+
+/**
+ * Result of lane-packing within a single group (or the ungrouped set):
+ * each item assigned a 0-based lane index; `laneCount` = lanes needed.
+ */
+export interface PackResult {
+  /** itemId -> lane index (0-based). */
+  lanes: Map<string, number>
+  /** Number of lanes used (max laneIndex + 1; 0 if no items). */
+  laneCount: number
+}
+
+/**
+ * A resolved, renderable row produced by a layout strategy. The render layer
+ * consumes these without knowing which variant produced them.
+ */
+export interface ResolvedRow {
+  /**
+   * Stable, unique identity for this row, used as the React key and for
+   * label-measurement lookup. In the timeline variant a row IS a group, so this
+   * is the group id; in the gantt variant a row is a single record, so it's the
+   * item id (groups can hold many item-rows, which would otherwise collide).
+   * Falls back to a positional id when neither exists (ungrouped packed row).
+   */
+  rowKey?: string
+  /** Group id this row represents, or a synthetic id for ungrouped/packed rows. */
+  groupId?: string
+  /** Vertical offset of the row, px from the top of the chart body. */
+  top: number
+  /** Row height, px (group height = laneCount * laneHeight, min one lane). */
+  height: number
+  /** Number of stacked lanes within this row. */
+  laneCount: number
+  /** Items placed in this row, with their lane index. */
+  items: Array<{ item: TimelineItem; lane: number }>
+  /** Nesting depth for indenting group labels (0 = top level). */
+  depth: number
+  /**
+   * Vertical headroom reserved at the top of the row, px — used so a row-scoped
+   * background (timebox) shows its label band above the packed item bars. Item
+   * lanes are offset down by this amount.
+   */
+  topInset?: number
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/virtualization.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/virtualization.test.ts
@@ -1,0 +1,79 @@
+import { getVisibleRange, getTotalHeight, type RowBounds } from './virtualization'
+
+// 10 rows, 50px tall each, stacked from top: tops 0,50,100,...,450.
+const rows: RowBounds[] = Array.from({ length: 10 }, (_, i) => ({
+  top: i * 50,
+  height: 50,
+}))
+
+describe('getVisibleRange', () => {
+  it('returns an empty range for no rows', () => {
+    // Arrange / Act
+    const result = getVisibleRange([], 0, 200)
+    // Assert
+    expect(result.endIndex).toBe(-1)
+  })
+
+  it('returns an empty range for a zero-height viewport', () => {
+    // Arrange / Act
+    const result = getVisibleRange(rows, 0, 0)
+    // Assert
+    expect(result.endIndex).toBe(-1)
+  })
+
+  it('includes only intersecting rows when overscan is 0', () => {
+    // Arrange — viewport [100,200) covers rows 2 and 3.
+    // Act
+    const result = getVisibleRange(rows, 100, 100, 0)
+    // Assert
+    expect(result.startIndex).toBe(2)
+    expect(result.endIndex).toBe(3)
+  })
+
+  it('applies overscan on both sides, clamped to bounds', () => {
+    // Arrange — viewport covers rows 2-3; overscan 2 -> rows 0..5.
+    // Act
+    const result = getVisibleRange(rows, 100, 100, 2)
+    // Assert
+    expect(result.startIndex).toBe(0)
+    expect(result.endIndex).toBe(5)
+  })
+
+  it('clamps to the last row at the bottom of the list', () => {
+    // Arrange — scrolled to the very bottom.
+    // Act
+    const result = getVisibleRange(rows, 400, 100, 0)
+    // Assert
+    expect(result.startIndex).toBe(8)
+    expect(result.endIndex).toBe(9)
+  })
+
+  it('treats negative scrollTop as zero', () => {
+    // Arrange / Act
+    const result = getVisibleRange(rows, -50, 100, 0)
+    // Assert
+    expect(result.startIndex).toBe(0)
+    expect(result.endIndex).toBe(1)
+  })
+
+  it('counts a partially-visible row as visible', () => {
+    // Arrange — viewport [25,75) clips row 0 (0-50) and row 1 (50-100).
+    // Act
+    const result = getVisibleRange(rows, 25, 50, 0)
+    // Assert
+    expect(result.startIndex).toBe(0)
+    expect(result.endIndex).toBe(1)
+  })
+})
+
+describe('getTotalHeight', () => {
+  it('is zero for no rows', () => {
+    // Arrange / Act / Assert
+    expect(getTotalHeight([])).toBe(0)
+  })
+
+  it('is the bottom edge of the last row', () => {
+    // Arrange / Act / Assert — last row top 450 + height 50.
+    expect(getTotalHeight(rows)).toBe(500)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/virtualization.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/virtualization.ts
@@ -1,0 +1,71 @@
+// timeline2/core/virtualization.ts
+// Visible-row windowing (NFR-3, REQUIRED). Pure function: given rows laid out
+// with top/height, a scroll offset, and a viewport height, return the index
+// range of rows that intersect the viewport (plus overscan). Variant-agnostic —
+// runs below the layout strategy, on already-resolved rows.
+
+export interface RowBounds {
+  top: number
+  height: number
+}
+
+export interface VisibleRange {
+  /** First visible row index (inclusive). */
+  startIndex: number
+  /** Last visible row index (inclusive). -1 when nothing is visible. */
+  endIndex: number
+}
+
+/**
+ * Compute which rows intersect the viewport [scrollTop, scrollTop+viewportH].
+ *
+ * Rows must be sorted by `top` ascending and be non-overlapping (as produced by
+ * a layout strategy). `overscan` adds N extra rows on each side to avoid blank
+ * flashes while scrolling.
+ */
+export function getVisibleRange(
+  rows: RowBounds[],
+  scrollTop: number,
+  viewportHeight: number,
+  overscan = 3,
+): VisibleRange {
+  if (rows.length === 0 || viewportHeight <= 0) {
+    return { startIndex: 0, endIndex: -1 }
+  }
+
+  const top = Math.max(0, scrollTop)
+  const bottom = top + viewportHeight
+
+  let startIndex = -1
+  let endIndex = -1
+
+  for (let i = 0; i < rows.length; i += 1) {
+    const rowTop = rows[i].top
+    const rowBottom = rowTop + rows[i].height
+    // Intersects the viewport if it ends after the top and starts before bottom.
+    if (rowBottom > top && rowTop < bottom) {
+      if (startIndex === -1) startIndex = i
+      endIndex = i
+    } else if (startIndex !== -1 && rowTop >= bottom) {
+      // Rows are sorted; once we pass the viewport bottom we can stop.
+      break
+    }
+  }
+
+  if (startIndex === -1) {
+    // Nothing intersects (e.g. scrolled into a gap past the end).
+    return { startIndex: 0, endIndex: -1 }
+  }
+
+  return {
+    startIndex: Math.max(0, startIndex - overscan),
+    endIndex: Math.min(rows.length - 1, endIndex + overscan),
+  }
+}
+
+/** Total scrollable height = bottom of the last row (0 when empty). */
+export function getTotalHeight(rows: RowBounds[]): number {
+  if (rows.length === 0) return 0
+  const last = rows[rows.length - 1]
+  return last.top + last.height
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.test.ts
@@ -1,0 +1,131 @@
+import { clampZoom, maxZoom, anchoredScrollLeft } from './zoom'
+
+describe('clampZoom', () => {
+  it('returns the value when within bounds', () => {
+    // Arrange
+    const bounds = { min: 1, max: 10 }
+    // Act
+    const result = clampZoom(3, bounds)
+    // Assert
+    expect(result).toBe(3)
+  })
+
+  it('clamps below min up to min', () => {
+    // Arrange
+    const bounds = { min: 1, max: 10 }
+    // Act
+    const result = clampZoom(0.2, bounds)
+    // Assert
+    expect(result).toBe(1)
+  })
+
+  it('clamps above max down to max', () => {
+    // Arrange
+    const bounds = { min: 1, max: 10 }
+    // Act
+    const result = clampZoom(99, bounds)
+    // Assert
+    expect(result).toBe(10)
+  })
+
+  it('falls back to min for non-finite input', () => {
+    // Arrange
+    const bounds = { min: 1, max: 10 }
+    // Act
+    const result = clampZoom(NaN, bounds)
+    // Assert
+    expect(result).toBe(1)
+  })
+})
+
+describe('maxZoom', () => {
+  it('caps zoom so the viewport spans at least zoomMin', () => {
+    // Arrange: base fits a 100-day domain into a 1000px viewport; zoomMin = 1 day.
+    const day = 86_400_000
+    const domainMs = 100 * day
+    const baseWidth = 1000
+    const viewportWidth = 1000
+    // Act
+    const result = maxZoom(baseWidth, viewportWidth, domainMs, day)
+    // Assert: at the cap, viewportMs === zoomMin.
+    //   f = viewportWidth * domainMs / (zoomMin * baseWidth) = 100.
+    expect(result).toBeCloseTo(100, 5)
+  })
+
+  it('never returns less than 1 (cannot zoom out past the window)', () => {
+    // Arrange: a domain smaller than zoomMin would otherwise give a cap < 1.
+    const day = 86_400_000
+    // Act
+    const result = maxZoom(1000, 1000, day / 2, day)
+    // Assert
+    expect(result).toBe(1)
+  })
+
+  it('returns 1 for degenerate inputs', () => {
+    // Arrange / Act / Assert
+    expect(maxZoom(0, 1000, 86_400_000, 86_400_000)).toBe(1)
+    expect(maxZoom(1000, 0, 86_400_000, 86_400_000)).toBe(1)
+    expect(maxZoom(1000, 1000, 86_400_000, 0)).toBe(1)
+  })
+})
+
+describe('anchoredScrollLeft', () => {
+  it('keeps the time under the anchor fixed when zooming in', () => {
+    // Arrange: anchor at viewport x=200, currently scrolled 100px into a 1000px
+    // chart. The content point under the anchor is 300px (30% of the width).
+    // Double the width to 2000px; that point is now at 600px, so to keep it under
+    // x=200 the scrollLeft must be 400.
+    // Act
+    const result = anchoredScrollLeft({
+      oldWidth: 1000,
+      newWidth: 2000,
+      oldScrollLeft: 100,
+      anchorX: 200,
+      viewportWidth: 500,
+    })
+    // Assert
+    expect(result).toBe(400)
+  })
+
+  it('clamps to 0 when the anchored scroll would go negative', () => {
+    // Arrange: zooming out near the start.
+    // Act
+    const result = anchoredScrollLeft({
+      oldWidth: 2000,
+      newWidth: 1000,
+      oldScrollLeft: 50,
+      anchorX: 100,
+      viewportWidth: 500,
+    })
+    // Assert: contentX=150 → scaled=75 → 75-100=-25 → clamped to 0.
+    expect(result).toBe(0)
+  })
+
+  it('clamps to the maximum scrollable extent', () => {
+    // Arrange: a huge anchored target beyond the scrollable range.
+    // Act
+    const result = anchoredScrollLeft({
+      oldWidth: 1000,
+      newWidth: 2000,
+      oldScrollLeft: 900,
+      anchorX: 400,
+      viewportWidth: 500,
+    })
+    // Assert: maxScroll = newWidth - viewportWidth = 1500; the computed value is
+    //   contentX=1300 → scaled=2600 → 2600-400=2200 → clamped to 1500.
+    expect(result).toBe(1500)
+  })
+
+  it('returns 0 for a degenerate old width', () => {
+    // Arrange / Act
+    const result = anchoredScrollLeft({
+      oldWidth: 0,
+      newWidth: 2000,
+      oldScrollLeft: 0,
+      anchorX: 100,
+      viewportWidth: 500,
+    })
+    // Assert
+    expect(result).toBe(0)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.ts
@@ -1,0 +1,66 @@
+// timeline2/core/zoom.ts
+// Hand-rolled pan/zoom transform (decision D-2). Pure math, no DOM/React.
+//
+// The chart's horizontal extent is `baseWidth * zoom` pixels mapping the full
+// time domain. Panning is native horizontal scroll (scrollLeft); this module
+// owns ZOOM: clamping the factor and recomputing scrollLeft so a chosen anchor
+// point (cursor or viewport centre) stays fixed under the time axis as we zoom.
+
+/** Bounds for the zoom factor (multiplier over the base, fit-to-window width). */
+export interface ZoomBounds {
+  /** Smallest factor — fully zoomed out. Usually 1 (base = fit the window). */
+  min: number
+  /** Largest factor — fully zoomed in (derived from zoomMin; see maxZoom). */
+  max: number
+}
+
+/** Clamp a zoom factor into [min, max]. */
+export function clampZoom(zoom: number, bounds: ZoomBounds): number {
+  if (!Number.isFinite(zoom)) return bounds.min
+  return Math.min(bounds.max, Math.max(bounds.min, zoom))
+}
+
+/**
+ * Largest allowed zoom factor so the viewport still spans at least `zoomMinMs`
+ * of time (vis-timeline's `zoomMin`, e.g. 1 day). Below the base factor (zoomed
+ * further out than the window) is never allowed, so the result is >= 1.
+ *
+ *   At factor f, chartWidth = baseWidth * f, pxPerMs = chartWidth / domainMs,
+ *   viewportMs = viewportWidth / pxPerMs = viewportWidth * domainMs / chartWidth.
+ *   Require viewportMs >= zoomMinMs  =>  f <= viewportWidth * domainMs /
+ *                                              (zoomMinMs * baseWidth).
+ */
+export function maxZoom(
+  baseWidth: number,
+  viewportWidth: number,
+  domainMs: number,
+  zoomMinMs: number,
+): number {
+  if (baseWidth <= 0 || zoomMinMs <= 0 || viewportWidth <= 0) return 1
+  const cap = (viewportWidth * domainMs) / (zoomMinMs * baseWidth)
+  return Math.max(1, cap)
+}
+
+/**
+ * New scrollLeft that keeps the time currently under `anchorX` (viewport-local
+ * px, i.e. distance from the viewport's left edge) fixed after zooming.
+ *
+ * The content offset under the anchor is `scrollLeft + anchorX`. As widths scale
+ * from `oldWidth` to `newWidth`, that offset scales by `newWidth / oldWidth`;
+ * subtract the anchor to get the new scrollLeft. Clamped to a valid range.
+ */
+export function anchoredScrollLeft(params: {
+  oldWidth: number
+  newWidth: number
+  oldScrollLeft: number
+  anchorX: number
+  viewportWidth: number
+}): number {
+  const { oldWidth, newWidth, oldScrollLeft, anchorX, viewportWidth } = params
+  if (oldWidth <= 0) return 0
+  const contentX = oldScrollLeft + anchorX
+  const scaled = (contentX * newWidth) / oldWidth
+  const next = scaled - anchorX
+  const maxScroll = Math.max(0, newWidth - viewportWidth)
+  return Math.min(maxScroll, Math.max(0, next))
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/index.ts
@@ -1,0 +1,14 @@
+// timeline2 — public surface. Parallel to the legacy `timeline/` (WaydTimeline)
+// during migration; consumers import WaydTimeline2 directly per page.
+
+export { WaydTimeline2, default } from './wayd-timeline2'
+export type {
+  WaydTimeline2Props,
+  ItemRenderProps,
+  GroupRenderProps,
+  ItemDateChange,
+  ItemProgressChange,
+  TimelineItem,
+  TimelineGroup,
+  TimelineVariant,
+} from './types'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/gantt-layout.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/gantt-layout.test.ts
@@ -1,0 +1,95 @@
+import { ganttLayout } from './gantt-layout'
+import { getLayoutStrategy } from './index'
+import { DEFAULT_LAYOUT_CONFIG } from './layout-strategy'
+import type { TimelineGroup, TimelineItem } from '../core/types'
+
+const DAY = 86_400_000
+const day = (n: number) => n * DAY
+const { laneHeight, rowPadding } = DEFAULT_LAYOUT_CONFIG
+const oneRow = laneHeight + rowPadding
+
+const range = (
+  id: string,
+  startDay: number,
+  endDay: number,
+  extra: Partial<TimelineItem> = {},
+): TimelineItem => ({ id, kind: 'range', start: day(startDay), end: day(endDay), ...extra })
+
+const group = (id: string, extra: Partial<TimelineGroup> = {}): TimelineGroup => ({
+  id,
+  ...extra,
+})
+
+describe('ganttLayout', () => {
+  it('gives one single-lane row per item, even when they overlap', () => {
+    // Arrange — overlapping items would pack in timeline, but Gantt never packs.
+    const items = [range('a', 0, 5), range('b', 2, 7)]
+    // Act
+    const out = ganttLayout({ items })
+    // Assert
+    expect(out.rows).toHaveLength(2)
+    expect(out.rows.every((r) => r.laneCount === 1)).toBe(true)
+    expect(out.rows[0].top).toBe(0)
+    expect(out.rows[1].top).toBe(oneRow)
+    expect(out.totalHeight).toBe(2 * oneRow)
+  })
+
+  it('orders items by order then start then id', () => {
+    // Arrange
+    const items = [
+      range('late', 0, 1, { order: 2 }),
+      range('early', 5, 6, { order: 1 }),
+    ]
+    // Act
+    const out = ganttLayout({ items })
+    // Assert
+    expect(out.rows.map((r) => r.items[0].item.id)).toEqual(['early', 'late'])
+  })
+
+  it('gives each item-row a unique rowKey even within one group', () => {
+    // Arrange — two items in the SAME group would collide if rows keyed on
+    // groupId; rowKey must be the item id so React keys / measurement IDs differ.
+    const groups = [group('g1')]
+    const items = [
+      range('a', 0, 1, { groupId: 'g1' }),
+      range('b', 2, 3, { groupId: 'g1' }),
+    ]
+    // Act
+    const out = ganttLayout({ items, groups })
+    // Assert — both rows share a groupId but have distinct, item-based rowKeys.
+    expect(out.rows.map((r) => r.groupId)).toEqual(['g1', 'g1'])
+    expect(out.rows.map((r) => r.rowKey)).toEqual(['a', 'b'])
+    expect(new Set(out.rows.map((r) => r.rowKey)).size).toBe(out.rows.length)
+  })
+
+  it('walks the group tree, indenting child items by depth', () => {
+    // Arrange — parent group g1 with child g1a; one item each.
+    const groups = [group('g1'), group('g1a', { parentId: 'g1' })]
+    const items = [
+      range('c', 0, 1, { groupId: 'g1a' }),
+      range('p', 0, 1, { groupId: 'g1' }),
+    ]
+    // Act
+    const out = ganttLayout({ items, groups })
+    // Assert — parent item first (depth 0), then child item (depth 1).
+    expect(out.rows.map((r) => r.items[0].item.id)).toEqual(['p', 'c'])
+    expect(out.rows[0].depth).toBe(0)
+    expect(out.rows[1].depth).toBe(1)
+  })
+})
+
+describe('getLayoutStrategy', () => {
+  it('returns the gantt strategy for variant "gantt"', () => {
+    // Arrange / Act / Assert
+    expect(getLayoutStrategy('gantt')).toBe(ganttLayout)
+  })
+
+  it('returns a strategy that does not pack for gantt', () => {
+    // Arrange — overlapping items.
+    const strategy = getLayoutStrategy('gantt')
+    // Act
+    const out = strategy({ items: [range('a', 0, 5), range('b', 1, 6)] })
+    // Assert — one row each, not packed.
+    expect(out.rows).toHaveLength(2)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/gantt-layout.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/gantt-layout.ts
@@ -1,0 +1,107 @@
+// timeline2/layout/gantt-layout.ts
+// Gantt variant: ONE row per record, no lane-packing. Groups render as tree
+// rows (children are their own rows, indented by depth). Minimal v1 — dependency
+// arrows and the multi-column grid-left panel are deferred, additive layers
+// (spec non-goal) and are NOT handled here.
+
+import type { ResolvedRow, TimelineItem } from '../core/types'
+import {
+  type LayoutInput,
+  type LayoutOutput,
+  resolveConfig,
+} from './layout-strategy'
+
+/** One item => one single-lane row. */
+function itemRow(
+  item: TimelineItem,
+  depth: number,
+  top: number,
+  laneHeight: number,
+  rowPadding: number,
+): ResolvedRow {
+  return {
+    // One row per record → identity is the item id (groups hold many item-rows).
+    rowKey: item.id,
+    groupId: item.groupId,
+    depth,
+    top,
+    laneCount: 1,
+    height: laneHeight + rowPadding,
+    items: [{ item, lane: 0 }],
+  }
+}
+
+const itemSort = (a: TimelineItem, b: TimelineItem) => {
+  const oa = a.order ?? 0
+  const ob = b.order ?? 0
+  if (oa !== ob) return oa - ob
+  if (a.start !== b.start) return a.start - b.start
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0
+}
+
+export function ganttLayout(input: LayoutInput): LayoutOutput {
+  const { laneHeight, rowPadding } = resolveConfig(input.config)
+  const { items, groups } = input
+
+  const rows: ResolvedRow[] = []
+  let top = 0
+  const push = (item: TimelineItem, depth: number) => {
+    const row = itemRow(item, depth, top, laneHeight, rowPadding)
+    rows.push(row)
+    top += row.height
+  }
+
+  // ── Ungrouped: each item is its own row, ordered ──────────────────────────
+  if (!groups || groups.length === 0) {
+    for (const item of [...items].sort(itemSort)) push(item, 0)
+    return { rows, totalHeight: top }
+  }
+
+  // ── Grouped: walk the group tree; emit a row per item under each group ─────
+  const childIds = new Map<string, string[]>()
+  const depthOf = new Map<string, number>()
+  const roots: string[] = []
+  for (const g of groups) {
+    if (g.parentId && groups.some((x) => x.id === g.parentId)) {
+      const list = childIds.get(g.parentId)
+      if (list) list.push(g.id)
+      else childIds.set(g.parentId, [g.id])
+    } else {
+      roots.push(g.id)
+    }
+  }
+  const byId = new Map(groups.map((g) => [g.id, g]))
+  const setDepth = (id: string, depth: number) => {
+    depthOf.set(id, depth)
+    for (const c of childIds.get(id) ?? []) setDepth(c, depth + 1)
+  }
+  roots.forEach((id) => setDepth(id, 0))
+
+  const orderGroups = (ids: string[]) =>
+    [...ids].sort((a, b) => {
+      const ga = byId.get(a)!
+      const gb = byId.get(b)!
+      const oa = ga.order ?? 0
+      const ob = gb.order ?? 0
+      if (oa !== ob) return oa - ob
+      return ga.id < gb.id ? -1 : ga.id > gb.id ? 1 : 0
+    })
+
+  const directItems = new Map<string, TimelineItem[]>()
+  for (const item of items) {
+    if (item.groupId == null) continue
+    const list = directItems.get(item.groupId)
+    if (list) list.push(item)
+    else directItems.set(item.groupId, [item])
+  }
+
+  const emit = (id: string) => {
+    const depth = depthOf.get(id) ?? 0
+    const groupItems = (directItems.get(id) ?? []).sort(itemSort)
+    for (const item of groupItems) push(item, depth)
+    for (const childId of orderGroups(childIds.get(id) ?? [])) emit(childId)
+  }
+  for (const id of orderGroups(roots)) emit(id)
+
+  return { rows, totalHeight: top }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/index.ts
@@ -1,0 +1,15 @@
+// timeline2/layout — the variant seam. Pick a strategy by variant.
+
+import type { TimelineVariant } from '../core/types'
+import type { LayoutStrategy } from './layout-strategy'
+import { timelineLayout } from './timeline-layout'
+import { ganttLayout } from './gantt-layout'
+
+export * from './layout-strategy'
+export { timelineLayout } from './timeline-layout'
+export { ganttLayout } from './gantt-layout'
+
+/** Resolve the layout strategy for a variant. */
+export function getLayoutStrategy(variant: TimelineVariant): LayoutStrategy {
+  return variant === 'gantt' ? ganttLayout : timelineLayout
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/layout-strategy.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/layout-strategy.ts
@@ -1,0 +1,54 @@
+// timeline2/layout/layout-strategy.ts
+// The ONLY variant-aware seam (per spec architecture). A layout strategy turns
+// items + groups into ResolvedRow[] (top/height/lanes). Everything downstream
+// (render, virtualization, interaction) is variant-agnostic and consumes rows.
+
+import type { ResolvedRow, TimelineGroup, TimelineItem } from '../core/types'
+
+/** Vertical sizing knobs shared by all strategies. */
+export interface LayoutConfig {
+  /** Height of a single lane within a row, px. */
+  laneHeight: number
+  /** Vertical padding added to each row (top+bottom combined), px. */
+  rowPadding: number
+}
+
+export const DEFAULT_LAYOUT_CONFIG: LayoutConfig = {
+  laneHeight: 32,
+  rowPadding: 8,
+}
+
+export interface LayoutInput<TItem = unknown, TGroup = unknown> {
+  items: TimelineItem<TItem>[]
+  /** Omitted/empty => ungrouped: a single packed row of all items. */
+  groups?: TimelineGroup<TGroup>[]
+  /**
+   * Group ids that have a row-scoped background (timebox). Those rows reserve a
+   * lane of headroom at the top so the timebox label is readable above the bars.
+   */
+  backgroundGroupIds?: Set<string>
+  /**
+   * True when there are chart-wide (ungrouped) backgrounds — e.g. at drill
+   * level 1 the root timeboxes span the flat chart, so the single ungrouped row
+   * reserves top headroom for their labels above the bars.
+   */
+  hasChartBackground?: boolean
+  config?: Partial<LayoutConfig>
+}
+
+export interface LayoutOutput {
+  rows: ResolvedRow[]
+  /** Total stacked height of all rows, px. */
+  totalHeight: number
+}
+
+/**
+ * A pure layout strategy. `timeline` packs lanes + collapses to lane; `gantt`
+ * gives one row per record. Both produce the same ResolvedRow[] contract.
+ */
+export type LayoutStrategy = (input: LayoutInput) => LayoutOutput
+
+/** Merge partial config over defaults. */
+export function resolveConfig(config?: Partial<LayoutConfig>): LayoutConfig {
+  return { ...DEFAULT_LAYOUT_CONFIG, ...config }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.test.ts
@@ -1,0 +1,159 @@
+import { timelineLayout } from './timeline-layout'
+import { DEFAULT_LAYOUT_CONFIG } from './layout-strategy'
+import type { TimelineGroup, TimelineItem } from '../core/types'
+
+const DAY = 86_400_000
+const day = (n: number) => n * DAY
+const { laneHeight, rowPadding } = DEFAULT_LAYOUT_CONFIG
+const oneLane = laneHeight + rowPadding
+
+const range = (
+  id: string,
+  startDay: number,
+  endDay: number,
+  extra: Partial<TimelineItem> = {},
+): TimelineItem => ({ id, kind: 'range', start: day(startDay), end: day(endDay), ...extra })
+
+const group = (id: string, extra: Partial<TimelineGroup> = {}): TimelineGroup => ({
+  id,
+  ...extra,
+})
+
+describe('timelineLayout', () => {
+  it('returns nothing for empty input', () => {
+    // Arrange / Act
+    const out = timelineLayout({ items: [] })
+    // Assert
+    expect(out.rows).toEqual([])
+    expect(out.totalHeight).toBe(0)
+  })
+
+  it('packs all ungrouped items into a single row', () => {
+    // Arrange — two non-overlapping items pack onto one lane.
+    const items = [range('a', 0, 2), range('b', 3, 5)]
+    // Act
+    const out = timelineLayout({ items })
+    // Assert
+    expect(out.rows).toHaveLength(1)
+    expect(out.rows[0].laneCount).toBe(1)
+    expect(out.rows[0].groupId).toBeUndefined()
+    expect(out.totalHeight).toBe(oneLane)
+  })
+
+  it('sizes an ungrouped row by its lane count', () => {
+    // Arrange — two overlapping items => two lanes.
+    const items = [range('a', 0, 5), range('b', 2, 7)]
+    // Act
+    const out = timelineLayout({ items })
+    // Assert
+    expect(out.rows[0].laneCount).toBe(2)
+    expect(out.rows[0].height).toBe(2 * laneHeight + rowPadding)
+  })
+
+  it('emits one row per group and stacks them top-to-bottom', () => {
+    // Arrange
+    const groups = [group('g1', { order: 1 }), group('g2', { order: 2 })]
+    const items = [
+      range('a', 0, 2, { groupId: 'g1' }),
+      range('b', 0, 2, { groupId: 'g2' }),
+    ]
+    // Act
+    const out = timelineLayout({ items, groups })
+    // Assert
+    expect(out.rows.map((r) => r.groupId)).toEqual(['g1', 'g2'])
+    expect(out.rows[0].top).toBe(0)
+    expect(out.rows[1].top).toBe(out.rows[0].height)
+  })
+
+  it('orders sibling groups by order then id', () => {
+    // Arrange — declared out of order; expect order-sorted output.
+    const groups = [group('b', { order: 2 }), group('a', { order: 1 })]
+    const items = [
+      range('x', 0, 1, { groupId: 'a' }),
+      range('y', 0, 1, { groupId: 'b' }),
+    ]
+    // Act
+    const out = timelineLayout({ items, groups })
+    // Assert
+    expect(out.rows.map((r) => r.groupId)).toEqual(['a', 'b'])
+  })
+
+  it('indents nested groups by depth and shows children as their own rows when expanded', () => {
+    // Arrange — parent g1 with child g1a, both expanded (default).
+    const groups = [group('g1'), group('g1a', { parentId: 'g1' })]
+    const items = [
+      range('p', 0, 2, { groupId: 'g1' }),
+      range('c', 0, 2, { groupId: 'g1a' }),
+    ]
+    // Act
+    const out = timelineLayout({ items, groups })
+    // Assert
+    expect(out.rows.map((r) => r.groupId)).toEqual(['g1', 'g1a'])
+    expect(out.rows.find((r) => r.groupId === 'g1')!.depth).toBe(0)
+    expect(out.rows.find((r) => r.groupId === 'g1a')!.depth).toBe(1)
+  })
+
+  it('collapses children onto the parent lane (collapse-to-lane)', () => {
+    // Arrange — g1 collapsed; its child g1a's items fold up into g1's row.
+    // Parent item p (0-2) and child item c (3-5) don't overlap => 1 lane.
+    const groups = [group('g1', { collapsed: true }), group('g1a', { parentId: 'g1' })]
+    const items = [
+      range('p', 0, 2, { groupId: 'g1' }),
+      range('c', 3, 5, { groupId: 'g1a' }),
+    ]
+    // Act
+    const out = timelineLayout({ items, groups })
+    // Assert — only the parent row exists; it holds BOTH items.
+    expect(out.rows).toHaveLength(1)
+    expect(out.rows[0].groupId).toBe('g1')
+    const ids = out.rows[0].items.map((i) => i.item.id).sort()
+    expect(ids).toEqual(['c', 'p'])
+    expect(out.rows[0].laneCount).toBe(1)
+  })
+
+  it('packs collapsed descendants into multiple lanes when they overlap', () => {
+    // Arrange — collapsed parent; parent + child items overlap => 2 lanes.
+    const groups = [group('g1', { collapsed: true }), group('g1a', { parentId: 'g1' })]
+    const items = [
+      range('p', 0, 5, { groupId: 'g1' }),
+      range('c', 2, 7, { groupId: 'g1a' }),
+    ]
+    // Act
+    const out = timelineLayout({ items, groups })
+    // Assert
+    expect(out.rows).toHaveLength(1)
+    expect(out.rows[0].laneCount).toBe(2)
+  })
+
+  it('folds the entire subtree when collapsing a grandparent', () => {
+    // Arrange — g1 > g1a > g1aa, all items; g1 collapsed.
+    const groups = [
+      group('g1', { collapsed: true }),
+      group('g1a', { parentId: 'g1' }),
+      group('g1aa', { parentId: 'g1a' }),
+    ]
+    const items = [
+      range('p', 0, 1, { groupId: 'g1' }),
+      range('c', 2, 3, { groupId: 'g1a' }),
+      range('gc', 4, 5, { groupId: 'g1aa' }),
+    ]
+    // Act
+    const out = timelineLayout({ items, groups })
+    // Assert
+    expect(out.rows).toHaveLength(1)
+    expect(out.rows[0].items.map((i) => i.item.id).sort()).toEqual(['c', 'gc', 'p'])
+  })
+
+  it('assigns each placed item a lane index', () => {
+    // Arrange — overlapping items in one ungrouped row.
+    const items = [range('a', 0, 5), range('b', 2, 7)]
+    // Act
+    const out = timelineLayout({ items })
+    // Assert
+    const lanes = out.rows[0].items
+      .slice()
+      .sort((x, y) => (x.item.id < y.item.id ? -1 : 1))
+      .map((i) => i.lane)
+    expect(lanes).toEqual([0, 1])
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.ts
@@ -1,0 +1,156 @@
+// timeline2/layout/timeline-layout.ts
+// Timeline variant: lane-packing + collapse-to-lane. Pure function.
+//
+//  - Ungrouped: one packed row containing all items.
+//  - Grouped: groups form a tree (parentId). Each VISIBLE group becomes a row.
+//    A group's row contains its own direct items PLUS — when the group is
+//    collapsed — all items of its hidden descendants, packed together onto that
+//    one row's lanes (collapse-to-lane). Expanded groups show descendants as
+//    their own rows.
+
+import { packLanes } from '../core/packing'
+import type { ResolvedRow, TimelineGroup, TimelineItem } from '../core/types'
+import {
+  type LayoutInput,
+  type LayoutOutput,
+  resolveConfig,
+} from './layout-strategy'
+
+interface GroupNode {
+  group: TimelineGroup
+  depth: number
+  childIds: string[]
+}
+
+/** Build a packed ResolvedRow from a set of items at a given top/depth/groupId.
+ *  `topInset` reserves headroom (px) above the bars for a timebox label. */
+function buildRow(
+  items: TimelineItem[],
+  groupId: string | undefined,
+  depth: number,
+  top: number,
+  laneHeight: number,
+  rowPadding: number,
+  topInset = 0,
+): ResolvedRow {
+  const packed = packLanes(items)
+  const placed = items.map((item) => ({
+    item,
+    lane: packed.lanes.get(item.id) ?? 0,
+  }))
+  // Bar area: one lane per packed lane. A normal row needs at least one lane to
+  // be visible; but when `topInset` already provides content (a timebox label
+  // band), an item-less row doesn't need an extra empty lane.
+  const minLanes = topInset > 0 ? 0 : 1
+  const barArea = Math.max(minLanes, packed.laneCount) * laneHeight
+  return {
+    // A timeline row IS a group, so its identity is the group id.
+    rowKey: groupId,
+    groupId,
+    depth,
+    top,
+    laneCount: packed.laneCount,
+    height: topInset + barArea + rowPadding,
+    items: placed,
+    topInset: topInset || undefined,
+  }
+}
+
+export function timelineLayout(input: LayoutInput): LayoutOutput {
+  const { laneHeight, rowPadding } = resolveConfig(input.config)
+  const { items, groups } = input
+  const bgGroupIds = input.backgroundGroupIds ?? new Set<string>()
+  // Headroom reserved at the top of a row that has a timebox, for its label.
+  const insetFor = (id: string) => (bgGroupIds.has(id) ? laneHeight : 0)
+
+  // ── Ungrouped: a single packed row of everything ──────────────────────────
+  if (!groups || groups.length === 0) {
+    if (items.length === 0) return { rows: [], totalHeight: 0 }
+    // Chart-wide timeboxes (e.g. level-1 root timeboxes) reserve top headroom
+    // for their labels above the bars.
+    const inset = input.hasChartBackground ? laneHeight : 0
+    const row = buildRow(items, undefined, 0, 0, laneHeight, rowPadding, inset)
+    return { rows: [row], totalHeight: row.height }
+  }
+
+  // ── Index groups, items, and parent/child relationships ───────────────────
+  const nodes = new Map<string, GroupNode>()
+  for (const group of groups) {
+    nodes.set(group.id, { group, depth: 0, childIds: [] })
+  }
+  const roots: string[] = []
+  for (const group of groups) {
+    const parent = group.parentId ? nodes.get(group.parentId) : undefined
+    if (parent) parent.childIds.push(group.id)
+    else roots.push(group.id)
+  }
+  // Compute depth top-down so child indenting is correct.
+  const setDepth = (id: string, depth: number) => {
+    const node = nodes.get(id)
+    if (!node) return
+    node.depth = depth
+    for (const childId of node.childIds) setDepth(childId, depth + 1)
+  }
+  roots.forEach((id) => setDepth(id, 0))
+
+  // Items bucketed by their direct group.
+  const directItems = new Map<string, TimelineItem[]>()
+  for (const item of items) {
+    if (item.groupId == null) continue
+    const bucket = directItems.get(item.groupId)
+    if (bucket) bucket.push(item)
+    else directItems.set(item.groupId, [item])
+  }
+
+  /** All items of a group and its entire subtree (for collapse-to-lane). */
+  const subtreeItems = (id: string): TimelineItem[] => {
+    const node = nodes.get(id)
+    if (!node) return []
+    const own = directItems.get(id) ?? []
+    const fromChildren = node.childIds.flatMap((childId) => subtreeItems(childId))
+    return [...own, ...fromChildren]
+  }
+
+  // Stable ordering for sibling groups: by `order`, then id.
+  const orderSiblings = (ids: string[]) =>
+    [...ids].sort((a, b) => {
+      const ga = nodes.get(a)!.group
+      const gb = nodes.get(b)!.group
+      const oa = ga.order ?? 0
+      const ob = gb.order ?? 0
+      if (oa !== ob) return oa - ob
+      return ga.id < gb.id ? -1 : ga.id > gb.id ? 1 : 0
+    })
+
+  // ── Walk the tree depth-first, emitting a row per visible group ────────────
+  const rows: ResolvedRow[] = []
+  let top = 0
+
+  const emit = (id: string) => {
+    const node = nodes.get(id)
+    if (!node) return
+    const collapsed = node.group.collapsed === true
+
+    // Collapsed => fold the whole subtree onto this row; expanded => direct only.
+    const rowItems = collapsed ? subtreeItems(id) : directItems.get(id) ?? []
+    const row = buildRow(
+      rowItems,
+      id,
+      node.depth,
+      top,
+      laneHeight,
+      rowPadding,
+      insetFor(id),
+    )
+    rows.push(row)
+    top += row.height
+
+    if (!collapsed) {
+      for (const childId of orderSiblings(node.childIds)) emit(childId)
+    }
+  }
+
+  for (const id of orderSiblings(roots)) emit(id)
+
+  return { rows, totalHeight: top }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/axis.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/axis.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+// timeline2/render/axis.tsx — two-tier timescale header (upper: month/year,
+// lower: week/day), span-aware via scale.tiers(). Segments are positioned and
+// sized in pixels from the scale.
+
+import { FC } from 'react'
+import type { TimeScale } from '../core/scale'
+import styles from './timeline.module.css'
+
+export interface AxisProps {
+  scale: TimeScale
+  height: number
+}
+
+export const Axis: FC<AxisProps> = ({ scale, height }) => {
+  const { upper, lower } = scale.tiers()
+  const tierHeight = height / 2
+
+  return (
+    <div className={styles.axis} style={{ height, width: scale.width }}>
+      <div className={styles.axisTier} style={{ height: tierHeight }}>
+        {upper.map((seg) => {
+          const left = scale.toX(seg.startMs)
+          const width = scale.toX(seg.endMs) - left
+          return (
+            <div
+              key={`u-${seg.startMs}`}
+              className={styles.axisCell}
+              style={{ left, width }}
+              title={seg.label}
+            >
+              <span className={styles.axisCellLabel}>{seg.label}</span>
+            </div>
+          )
+        })}
+      </div>
+      <div
+        className={styles.axisTier}
+        style={{ height: tierHeight, top: tierHeight }}
+      >
+        {lower.map((seg) => {
+          const left = scale.toX(seg.startMs)
+          const width = scale.toX(seg.endMs) - left
+          return (
+            <div
+              key={`l-${seg.startMs}`}
+              className={styles.axisCell}
+              style={{ left, width }}
+            >
+              <span className={styles.axisCellLabel}>{seg.label}</span>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/capture-timeline.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/capture-timeline.ts
@@ -1,0 +1,80 @@
+// timeline2/render/capture-timeline.ts
+// Save-as-image. We capture the CURRENT horizontal viewport (no off-screen time)
+// but the FULL vertical extent (all rows, as if there were no vertical scroll).
+// Because we don't expand horizontally, the Splitter/flex layout stays valid, so
+// we capture the chart container as ONE element and only un-clip the vertical
+// scroll inside html2canvas's cloned document (onclone) — the live view never
+// reflows. No split-and-stitch needed.
+
+export interface CaptureOptions {
+  fileName: string
+  backgroundColor?: string
+  /** Full content height to capture (axis + all rows + borders), px. */
+  captureHeight: number
+  /**
+   * Live pixel width of the group-label column pane. antd's Splitter sizes its
+   * panels via JS at runtime; those widths don't survive html2canvas's clone,
+   * so the cloned group column can collapse to its min width and wrap labels.
+   * We re-pin it explicitly in the clone to match the on-screen layout.
+   */
+  groupPaneWidth?: number
+  /** Device-scale multiplier for crisp output. */
+  scale?: number
+}
+
+export async function captureTimeline(
+  root: HTMLElement,
+  options: CaptureOptions,
+) {
+  const { default: html2canvas } = await import('html2canvas')
+  const scale = options.scale ?? Math.max(window.devicePixelRatio || 1, 2)
+  const { groupPaneWidth } = options
+
+  const width = Math.ceil(root.getBoundingClientRect().width)
+  const height = Math.ceil(options.captureHeight)
+
+  const canvas = await html2canvas(root, {
+    backgroundColor: options.backgroundColor ?? null,
+    scale,
+    width,
+    height,
+    windowWidth: width,
+    windowHeight: height,
+    onclone: (_doc: Document, clonedRoot: HTMLElement) => {
+      // Un-clip vertical scrolling so all rows render; keep horizontal as-is so
+      // only the visible time window is captured. Let the container grow tall.
+      clonedRoot.style.height = `${height}px`
+      clonedRoot.querySelectorAll<HTMLElement>('*').forEach((node) => {
+        const o = getComputedStyle(node)
+        if (o.overflowY !== 'visible') node.style.overflowY = 'visible'
+      })
+
+      // Re-pin the group-label column to its live width so the clone wraps labels
+      // exactly like the on-screen view (the Splitter's JS-computed widths are
+      // lost in the clone). Pin both the pane and its Splitter.Panel ancestor.
+      if (groupPaneWidth && groupPaneWidth > 0) {
+        const pane = clonedRoot.querySelector<HTMLElement>(
+          '[data-timeline-group-pane]',
+        )
+        if (pane) {
+          const fix = (el: HTMLElement) => {
+            el.style.width = `${groupPaneWidth}px`
+            el.style.minWidth = `${groupPaneWidth}px`
+            el.style.maxWidth = `${groupPaneWidth}px`
+            el.style.flex = `0 0 ${groupPaneWidth}px`
+          }
+          fix(pane)
+          // The antd Splitter.Panel wrapper is the pane's parent.
+          if (pane.parentElement) fix(pane.parentElement)
+        }
+      }
+    },
+  })
+
+  const link = document.createElement('a')
+  link.href = canvas.toDataURL('image/png')
+  link.download = options.fileName
+  document.body.appendChild(link)
+  link.click()
+  document.body.removeChild(link)
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
@@ -1,0 +1,243 @@
+'use client'
+
+// timeline2/render/chart-canvas.tsx — the variant-agnostic chart body.
+// Consumes ResolvedRow[] (from any layout strategy) + a TimeScale and draws
+// backgrounds, rows, and item bars. Variant never reaches here. Owns the drag
+// interaction (move/resize via useBarDrag; progress via a pointer handler),
+// applying the live draft to the dragged bar and committing on release.
+
+import { FC, useCallback, useRef, useState } from 'react'
+import type { TimeScale } from '../core/scale'
+import type { ResolvedRow, TimelineItem } from '../core/types'
+import { itemBox, backgroundBox, type GeometryConfig } from '../core/geometry'
+import { progressFromX } from '../core/interaction'
+import { ItemBar } from './item-bar'
+import { useBarDrag } from './use-bar-drag'
+import { suppressNextClick } from './suppress-next-click'
+import type {
+  ItemRenderProps,
+  ItemDateChange,
+  ItemProgressChange,
+} from '../types'
+import styles from './timeline.module.css'
+
+export interface ChartCanvasProps {
+  /** Visible (virtualized) rows to render. */
+  rows: ResolvedRow[]
+  /** All rows — used to resolve row-scoped background geometry even when the
+   *  owning row is scrolled out of view. Defaults to `rows`. */
+  allRows?: ResolvedRow[]
+  /** Absolute index of the first visible row (for stable stripe alternation). */
+  rowIndexOffset?: number
+  totalHeight: number
+  scale: TimeScale
+  geometry: GeometryConfig
+  /** Chart-wide background regions (span full height). */
+  chartBackgrounds?: TimelineItem[]
+  selectedId?: string
+  editable?: boolean
+  /** Current horizontal scroll offset (px) — bar labels stick to this edge. */
+  viewportLeft?: number
+  itemRenderer?: FC<ItemRenderProps>
+  onItemClick?: (item: TimelineItem) => void
+  onItemDateChange?: (change: ItemDateChange) => void
+  onItemProgressChange?: (change: ItemProgressChange) => void
+  showCurrentTime?: boolean
+  nowMs?: number
+  /** When true, whitespace shows the grab cursor (content overflows → pannable). */
+  canPan?: boolean
+  /** Hard bounds for dragging items (epoch ms). Defaults to the full scale
+   *  domain when omitted. */
+  dragMin?: number
+  dragMax?: number
+}
+
+export const ChartCanvas: FC<ChartCanvasProps> = ({
+  rows,
+  allRows,
+  rowIndexOffset = 0,
+  totalHeight,
+  scale,
+  geometry,
+  chartBackgrounds,
+  selectedId,
+  editable,
+  viewportLeft = 0,
+  itemRenderer,
+  onItemClick,
+  onItemDateChange,
+  onItemProgressChange,
+  showCurrentTime,
+  nowMs,
+  canPan,
+  dragMin,
+  dragMax,
+}) => {
+  const tickLines = scale.ticks(10)
+  // `Date.now()` is impure; read it once on mount (a current-time line that's
+  // accurate to mount time is fine — re-render with a fresh `nowMs` prop to move
+  // it). Lazy initializer keeps render pure.
+  const [mountNow] = useState(() => Date.now())
+  const now = nowMs ?? mountNow
+  const nowVisible =
+    showCurrentTime && now >= scale.domain[0] && now <= scale.domain[1]
+
+  // Map groupId -> row, so row-scoped backgrounds can find their row geometry.
+  // Use the full row set (not just the visible slice) so a timebox whose owning
+  // row is scrolled out of view still resolves to correct geometry.
+  const rowsForLookup = allRows ?? rows
+  const rowsByGroupId = new Map(
+    rowsForLookup.filter((r) => r.groupId).map((r) => [r.groupId as string, r]),
+  )
+
+  // Move / resize drag (date change). Bounds are the EDITABLE window (dragMin/Max),
+  // not the rendered domain — the domain may be wider to fit out-of-window items.
+  const { active, start: startDrag } = useBarDrag({
+    pxPerMs: scale.pxPerMs,
+    min: dragMin ?? scale.domain[0],
+    max: dragMax ?? scale.domain[1],
+    snap: true,
+    onCommit: (change) => onItemDateChange?.(change),
+  })
+
+  // Progress drag — lighter weight, tracked on the canvas element. The pointer
+  // listeners are stored on the session ref so they can reference each other
+  // for teardown without a declaration cycle.
+  const canvasRef = useRef<HTMLDivElement>(null)
+  const [progressDraft, setProgressDraft] = useState<{
+    id: string
+    progress: number
+  } | null>(null)
+  const progressSession = useRef<{
+    item: TimelineItem
+    box: { left: number; width: number }
+    moved: boolean
+    move: (e: PointerEvent) => void
+    up: () => void
+  } | null>(null)
+
+  const beginProgressDrag = useCallback(
+    (item: TimelineItem, box: { left: number; width: number }) => {
+      const move = (e: PointerEvent) => {
+        const canvas = canvasRef.current
+        const s = progressSession.current
+        if (!canvas || !s) return
+        s.moved = true
+        const x = e.clientX - canvas.getBoundingClientRect().left
+        setProgressDraft({ id: item.id, progress: progressFromX(x, box.left, box.width) })
+      }
+      const up = () => {
+        const s = progressSession.current
+        window.removeEventListener('pointermove', s!.move)
+        window.removeEventListener('pointerup', s!.up)
+        // Dragging the progress handle ends with a synthetic click — swallow it
+        // so it doesn't open the drawer.
+        if (s?.moved) suppressNextClick()
+        progressSession.current = null
+        setProgressDraft((draft) => {
+          if (draft && draft.progress !== (item.progress ?? 0)) {
+            onItemProgressChange?.({ id: item.id, progress: draft.progress })
+          }
+          return null
+        })
+      }
+      progressSession.current = { item, box, moved: false, move, up }
+      setProgressDraft({ id: item.id, progress: item.progress ?? 0 })
+      window.addEventListener('pointermove', move)
+      window.addEventListener('pointerup', up)
+    },
+    [onItemProgressChange],
+  )
+
+  return (
+    <div
+      ref={canvasRef}
+      className={`${styles.canvas} ${canPan ? styles.canvasPannable : ''}`}
+      style={{ width: scale.width, height: totalHeight }}
+    >
+      {/* Vertical gridlines */}
+      {tickLines.map((ms) => (
+        <div key={`gl-${ms}`} className={styles.gridline} style={{ left: scale.toX(ms) }} />
+      ))}
+
+      {/* Row stripes — alternation keyed off the ABSOLUTE row index so it stays
+          stable as rows scroll in/out of the virtualized window. */}
+      {rows.map((row, i) => {
+        const rowIndex = rowIndexOffset + i
+        return (
+          <div
+            key={row.rowKey ?? row.groupId ?? `row-${rowIndex}`}
+            className={`${styles.row} ${rowIndex % 2 === 1 ? styles.rowAlt : ''}`}
+            style={{ top: row.top, height: row.height }}
+          />
+        )
+      })}
+
+      {/* Backgrounds (timeboxes): drawn AFTER row stripes so they're visible,
+          BEFORE bars so items sit on top. A row-scoped background (groupId
+          matching a row) sits behind that row; a root/ungrouped one spans the
+          full chart height. Labeled like the legacy timeline. */}
+      {chartBackgrounds?.map((bg) => {
+        const row = bg.groupId ? rowsByGroupId.get(bg.groupId) : undefined
+        const box = backgroundBox(bg, row ?? null, scale, totalHeight)
+        return (
+          <div
+            key={`bg-${bg.id}`}
+            className={styles.background}
+            style={{
+              left: box.left,
+              top: box.top,
+              width: box.width,
+              height: box.height,
+              ...(bg.color ? { backgroundColor: bg.color } : {}),
+            }}
+            title={bg.label}
+          >
+            {bg.label && <span className={styles.backgroundLabel}>{bg.label}</span>}
+          </div>
+        )
+      })}
+
+      {/* Item bars */}
+      {rows.flatMap((row) =>
+        row.items.map(({ item, lane }) => {
+          // While dragging this item, render the live draft bounds instead.
+          const dragged =
+            active?.id === item.id
+              ? { ...item, start: active.draft.start, end: active.draft.end }
+              : item
+          const withProgress =
+            progressDraft?.id === item.id
+              ? { ...dragged, progress: progressDraft.progress }
+              : dragged
+          const box = itemBox(withProgress, lane, row, scale, geometry)
+          // Push the label right so it stays visible when the bar starts before
+          // the viewport's left edge (clamped so it never leaves the bar).
+          const labelOffset = Math.max(0, Math.min(viewportLeft - box.left, box.width))
+          return (
+            <ItemBar
+              key={item.id}
+              box={box}
+              labelOffset={labelOffset}
+              selected={item.id === selectedId}
+              editable={editable}
+              itemRenderer={itemRenderer}
+              onClick={onItemClick}
+              onDragStart={startDrag}
+              onProgressDragStart={(e, dragItem) => {
+                e.preventDefault()
+                e.stopPropagation()
+                beginProgressDrag(dragItem, { left: box.left, width: box.width })
+              }}
+            />
+          )
+        }),
+      )}
+
+      {/* Current-time line */}
+      {nowVisible && (
+        <div className={styles.nowLine} style={{ left: scale.toX(now) }} />
+      )}
+    </div>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/drill-control.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/drill-control.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+// timeline2/render/drill-control.tsx — drill-through level -/+ buttons.
+// Collapse (-) reduces the expand level (fold deeper groups onto parent lanes);
+// expand (+) increases it. Lives in the toolbar's left slot. Mirrors the legacy
+// roadmap timeline's drill control.
+
+import { Button } from 'antd'
+import { MinusSquareOutlined, PlusSquareOutlined } from '@ant-design/icons'
+import WaydTooltip from '@/src/components/common/wayd-tooltip'
+
+export interface DrillControlProps {
+  level: number
+  /** Highest meaningful level (maxDepth + 1 = fully expanded). */
+  maxLevel: number
+  onChange: (level: number) => void
+}
+
+// Renders as a fragment so the toolbar's flex `gap` spaces these buttons the
+// same as every other toolbar icon (consistent with the tree-grid toolbar
+// pattern — CSS gap for layout, not antd Space).
+const DrillControl = ({ level, maxLevel, onChange }: DrillControlProps) => {
+  // Nothing to drill when there's no nesting.
+  if (maxLevel <= 1) return null
+
+  return (
+    <>
+      <WaydTooltip title="Collapse one level">
+        <Button
+          type="text"
+          shape="circle"
+          icon={<MinusSquareOutlined />}
+          disabled={level <= 1}
+          onClick={() => onChange(level - 1)}
+        />
+      </WaydTooltip>
+      <WaydTooltip title="Expand one level">
+        <Button
+          type="text"
+          shape="circle"
+          icon={<PlusSquareOutlined />}
+          disabled={level >= maxLevel}
+          onClick={() => onChange(level + 1)}
+        />
+      </WaydTooltip>
+    </>
+  )
+}
+
+export default DrillControl

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/group-column.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/group-column.tsx
@@ -1,0 +1,98 @@
+'use client'
+
+// timeline2/render/group-column.tsx — the left label column. Renders one cell
+// per resolved row, aligned to the row's top/height, indented by depth. Scrolls
+// vertically in sync with the chart body (the parent keeps them aligned).
+//
+// Labels wrap; a wrapped label can be taller than the lane-based row height, so
+// each label's natural height is measured and reported up (onMeasure) — the
+// parent grows the affected rows to fit.
+
+import { FC, useEffect, useRef } from 'react'
+import type { ResolvedRow, TimelineGroup } from '../core/types'
+import type { GroupRenderProps } from '../types'
+import styles from './timeline.module.css'
+
+export interface GroupColumnProps {
+  rows: ResolvedRow[]
+  totalHeight: number
+  width: number | string
+  /** Lookup for a row's group, by groupId. */
+  groupsById: Map<string, TimelineGroup>
+  groupRenderer?: FC<GroupRenderProps>
+  /** Reports measured label heights (incl. cell padding) keyed by groupId. */
+  onMeasure?: (heights: Map<string, number>) => void
+}
+
+const INDENT_PER_DEPTH = 14
+// Vertical padding applied by .groupCell (top + bottom), kept in sync with CSS.
+const CELL_VPAD = 8
+
+export const GroupColumn: FC<GroupColumnProps> = ({
+  rows,
+  totalHeight,
+  width,
+  groupsById,
+  groupRenderer: Renderer,
+  onMeasure,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+
+  // Measure each label's natural height after layout (and on column resize) and
+  // report the per-group cell height so the parent can grow rows to fit.
+  useEffect(() => {
+    const el = containerRef.current
+    if (!el || !onMeasure) return
+    const measure = () => {
+      const heights = new Map<string, number>()
+      el.querySelectorAll<HTMLElement>('[data-row-key]').forEach((label) => {
+        const id = label.dataset.rowKey
+        if (id) heights.set(id, Math.ceil(label.scrollHeight) + CELL_VPAD)
+      })
+      onMeasure(heights)
+    }
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [rows, onMeasure])
+
+  return (
+    <div
+      ref={containerRef}
+      className={styles.groupColumn}
+      style={{ width, height: totalHeight }}
+    >
+      {rows.map((row, rowIndex) => {
+        const group = row.groupId ? groupsById.get(row.groupId) : undefined
+        const label = group?.label ?? row.groupId ?? ''
+        return (
+          <div
+            key={row.rowKey ?? row.groupId ?? `grow-${rowIndex}`}
+            className={`${styles.groupCell} ${
+              rowIndex % 2 === 1 ? styles.rowAlt : ''
+            }`}
+            style={{ top: row.top, height: row.height }}
+            title={label}
+          >
+            <span
+              className={styles.groupLabel}
+              data-row-key={row.rowKey ?? row.groupId}
+              style={{ paddingLeft: row.depth * INDENT_PER_DEPTH }}
+            >
+              {Renderer && group ? (
+                <Renderer
+                  group={group}
+                  depth={row.depth}
+                  collapsed={group.collapsed === true}
+                />
+              ) : (
+                label
+              )}
+            </span>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+// timeline2/render/item-bar.tsx — a single range bar or milestone diamond.
+// Variant-agnostic: it just draws a box. Move/resize/progress handles are
+// layered on later (FR-5); this is the static visual + click handling.
+
+import { FC } from 'react'
+import type { ItemBox } from '../core/geometry'
+import type { DragMode } from '../core/interaction'
+import { contrastText } from '../core/color'
+import type { ItemRenderProps, TimelineItem } from '../types'
+import styles from './timeline.module.css'
+
+export interface ItemBarProps {
+  box: ItemBox
+  selected: boolean
+  editable?: boolean
+  /** Px to shift the label right so it stays visible when the bar starts before
+   *  the viewport's left edge. */
+  labelOffset?: number
+  itemRenderer?: FC<ItemRenderProps>
+  onClick?: (item: TimelineItem) => void
+  /** Begin a move/resize drag (pointer-down on bar body or a handle). */
+  onDragStart?: (
+    e: React.PointerEvent,
+    item: TimelineItem,
+    mode: DragMode,
+  ) => void
+  /** Begin a progress drag (pointer-down on the progress handle). */
+  onProgressDragStart?: (e: React.PointerEvent, item: TimelineItem) => void
+}
+
+export const ItemBar: FC<ItemBarProps> = ({
+  box,
+  selected,
+  editable,
+  labelOffset = 0,
+  itemRenderer: Renderer,
+  onClick,
+  onDragStart,
+  onProgressDragStart,
+}) => {
+  const { item, left, top, width, height } = box
+
+  if (item.kind === 'milestone') {
+    // Square rotated 45°; sized to the lane height, centered on its date.
+    // Milestones are a single instant — moved as a whole, no resize handles.
+    return (
+      <div
+        data-timeline-item
+        className={styles.milestone}
+        style={{
+          left,
+          top,
+          width: height,
+          height,
+          ...(item.color ? { backgroundColor: item.color } : {}),
+        }}
+        title={item.label}
+        onPointerDown={
+          editable && onDragStart
+            ? (e) => onDragStart(e, item, 'move')
+            : undefined
+        }
+        onClick={() => onClick?.(item)}
+      />
+    )
+  }
+
+  const hasProgress = typeof item.progress === 'number'
+  const progressX = hasProgress ? (width * (item.progress ?? 0)) / 100 : 0
+  const fontColor = contrastText(item.color)
+
+  return (
+    <div
+      data-timeline-item
+      className={`${styles.bar} ${selected ? styles.barSelected : ''} ${
+        editable ? styles.barEditable : ''
+      }`}
+      style={{
+        left,
+        top,
+        width,
+        height,
+        ...(item.color ? { backgroundColor: item.color, color: fontColor } : {}),
+      }}
+      onPointerDown={
+        editable && onDragStart
+          ? (e) => onDragStart(e, item, 'move')
+          : undefined
+      }
+      onClick={() => onClick?.(item)}
+    >
+      {/* Progress fill underlay */}
+      {hasProgress && (
+        <div className={styles.progressFill} style={{ width: progressX }} />
+      )}
+
+      <span
+        className={styles.barLabel}
+        style={labelOffset ? { marginLeft: labelOffset } : undefined}
+      >
+        {Renderer ? (
+          <Renderer
+            item={item}
+            fontColor={fontColor}
+            backgroundColor={item.color ?? 'var(--ant-color-primary)'}
+            selected={selected}
+          />
+        ) : (
+          item.label ?? item.id
+        )}
+      </span>
+
+      {editable && onDragStart && (
+        <>
+          {/* Resize handles — circles revealed on hover (CSS). */}
+          <span
+            className={`${styles.handle} ${styles.handleStart}`}
+            onPointerDown={(e) => onDragStart(e, item, 'resize-start')}
+          />
+          <span
+            className={`${styles.handle} ${styles.handleEnd}`}
+            onPointerDown={(e) => onDragStart(e, item, 'resize-end')}
+          />
+        </>
+      )}
+
+      {editable && hasProgress && onProgressDragStart && (
+        <span
+          className={styles.progressHandle}
+          style={{ left: progressX }}
+          onPointerDown={(e) => onProgressDragStart(e, item)}
+        />
+      )}
+    </div>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/suppress-next-click.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/suppress-next-click.ts
@@ -1,0 +1,15 @@
+// timeline2/render/suppress-next-click.ts
+// After a drag, the browser still fires a synthetic `click` on pointer-up.
+// Call this on drag end to swallow exactly that one click (capture phase) so it
+// doesn't trigger the item's onClick (e.g. opening a drawer).
+
+export function suppressNextClick() {
+  const onClickCapture = (ev: MouseEvent) => {
+    ev.stopPropagation()
+    ev.preventDefault()
+    window.removeEventListener('click', onClickCapture, true)
+  }
+  window.addEventListener('click', onClickCapture, true)
+  // Safety: if no click arrives (pointer released off-target), drop the listener.
+  setTimeout(() => window.removeEventListener('click', onClickCapture, true), 0)
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline-toolbar.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline-toolbar.tsx
@@ -1,0 +1,187 @@
+'use client'
+
+// timeline2/render/timeline-toolbar.tsx — the timeline's action bar, following
+// the tree-grid toolbar pattern (WaydTooltip + text/circle icon buttons +
+// leftSlot/rightSlot + dividers). leftSlot is where drill-through +/- controls
+// will live; the built-in right-side actions are save-as-image and fullscreen.
+
+import { ReactNode } from 'react'
+import { Button, Dropdown, Space, Switch, type MenuProps } from 'antd'
+import {
+  FileImageOutlined,
+  FullscreenExitOutlined,
+  FullscreenOutlined,
+  ReloadOutlined,
+  SettingOutlined,
+  UndoOutlined,
+  ZoomInOutlined,
+  ZoomOutOutlined,
+} from '@ant-design/icons'
+import WaydTooltip from '@/src/components/common/wayd-tooltip'
+import styles from './timeline.module.css'
+
+export interface TimelineToolbarProps {
+  /** Left-aligned controls (e.g. future drill-through +/- buttons). */
+  leftSlot?: ReactNode
+  /** Extra right-aligned controls, placed before the built-in actions. */
+  rightSlot?: ReactNode
+  allowZoom?: boolean
+  onZoomIn?: () => void
+  onZoomOut?: () => void
+  onResetView?: () => void
+  canZoomIn?: boolean
+  canZoomOut?: boolean
+  /** Reset View is only meaningful once zoomed/panned away from the start. */
+  canReset?: boolean
+  allowSaveAsImage?: boolean
+  onSaveAsImage?: () => void
+  allowFullScreen?: boolean
+  isFullScreen?: boolean
+  onToggleFullScreen?: () => void
+  /** Settings menu (gear) — shown when any setting is togglable. */
+  allowSettings?: boolean
+  showCurrentTime?: boolean
+  onToggleCurrentTime?: (checked: boolean) => void
+  /** Refresh action — shown (ReloadOutlined) only when provided, like WaydGrid. */
+  onRefresh?: () => void
+}
+
+const TimelineToolbar = ({
+  leftSlot,
+  rightSlot,
+  allowZoom,
+  onZoomIn,
+  onZoomOut,
+  onResetView,
+  canZoomIn = true,
+  canZoomOut = true,
+  canReset = true,
+  allowSaveAsImage,
+  onSaveAsImage,
+  allowFullScreen,
+  isFullScreen,
+  onToggleFullScreen,
+  allowSettings,
+  showCurrentTime,
+  onToggleCurrentTime,
+  onRefresh,
+}: TimelineToolbarProps) => {
+  // Settings menu: keep the dropdown open while toggling the switch (stopPropagation
+  // on the row), matching the legacy timeline's control menu behaviour.
+  const settingsItems: MenuProps['items'] = [
+    {
+      key: 'show-current-time',
+      label: (
+        <Space onClick={(e) => e.stopPropagation()}>
+          <Switch
+            size="small"
+            checked={showCurrentTime}
+            onChange={(checked) => onToggleCurrentTime?.(checked)}
+          />
+          Show Current Time
+        </Space>
+      ),
+    },
+  ]
+
+  return (
+    <div className={styles.toolbar}>
+      <div className={styles.toolbarLeft}>{leftSlot}</div>
+
+      <div className={styles.toolbarRight}>
+        {/* Built-in actions first; consumer-provided rightSlot sits on the far
+            right (after a divider), matching the WaydGrid toolbar convention. */}
+        {allowZoom && (
+          <>
+            <WaydTooltip title="Zoom out">
+              <Button
+                type="text"
+                shape="circle"
+                icon={<ZoomOutOutlined />}
+                disabled={!canZoomOut}
+                onClick={onZoomOut}
+              />
+            </WaydTooltip>
+            <WaydTooltip title="Zoom in">
+              <Button
+                type="text"
+                shape="circle"
+                icon={<ZoomInOutlined />}
+                disabled={!canZoomIn}
+                onClick={onZoomIn}
+              />
+            </WaydTooltip>
+            <WaydTooltip title="Reset view">
+              <Button
+                type="text"
+                shape="circle"
+                icon={<UndoOutlined />}
+                disabled={!canReset}
+                onClick={onResetView}
+              />
+            </WaydTooltip>
+          </>
+        )}
+        {allowZoom &&
+          (onRefresh || allowSaveAsImage || allowFullScreen || allowSettings) && (
+            <span className={styles.toolbarDivider} />
+          )}
+        {onRefresh && (
+          <WaydTooltip title="Refresh">
+            <Button
+              type="text"
+              shape="circle"
+              icon={<ReloadOutlined />}
+              onClick={onRefresh}
+            />
+          </WaydTooltip>
+        )}
+        {allowSaveAsImage && (
+          <WaydTooltip title="Save as Image">
+            <Button
+              type="text"
+              shape="circle"
+              icon={<FileImageOutlined />}
+              onClick={onSaveAsImage}
+            />
+          </WaydTooltip>
+        )}
+        {allowFullScreen && (
+          <WaydTooltip title={isFullScreen ? 'Exit Fullscreen' : 'Fullscreen'}>
+            <Button
+              type="text"
+              shape="circle"
+              icon={
+                isFullScreen ? (
+                  <FullscreenExitOutlined />
+                ) : (
+                  <FullscreenOutlined />
+                )
+              }
+              onClick={onToggleFullScreen}
+            />
+          </WaydTooltip>
+        )}
+        {allowSettings && (
+          <Dropdown
+            menu={{ items: settingsItems }}
+            trigger={['click']}
+            placement="bottomRight"
+          >
+            <WaydTooltip title="Settings">
+              <Button type="text" shape="circle" icon={<SettingOutlined />} />
+            </WaydTooltip>
+          </Dropdown>
+        )}
+        {rightSlot &&
+          (onRefresh ||
+            allowSaveAsImage ||
+            allowFullScreen ||
+            allowSettings) && <span className={styles.toolbarDivider} />}
+        {rightSlot}
+      </div>
+    </div>
+  )
+}
+
+export default TimelineToolbar

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline.module.css
@@ -1,0 +1,376 @@
+/* timeline2/render/timeline.module.css
+   Theme-token styling only (no hardcoded colors). Re-themes via CSS vars with
+   no component reinit (FR-6). */
+
+/* Outer wrapper: toolbar (above) + bordered chart container (below), like the
+   grid where the toolbar sits outside/above the data container. */
+.wrapper {
+  display: flex;
+  flex-direction: column;
+  font-size: var(--ant-font-size-sm);
+  color: var(--ant-color-text);
+}
+
+.root {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  border: 1px solid var(--ant-color-border);
+  border-radius: var(--ant-border-radius-lg);
+  background-color: var(--ant-color-bg-container);
+  overflow: hidden;
+}
+
+/* The Splitter (or the bare right pane when ungrouped) fills the root. */
+.root > :global(.ant-splitter),
+.root > .pane {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* When the browser fullscreens the wrapper, fill the screen. */
+/* "Fullscreen" = fill the browser's current viewport (a CSS overlay), matching
+   the legacy timeline. Not the native OS fullscreen (which fills the monitor). */
+.fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  height: 100vh;
+  background-color: var(--ant-color-bg-container);
+  padding: var(--ant-padding-xs);
+}
+
+.fullscreen .root {
+  border-radius: 0;
+}
+
+/* ── Toolbar (mirrors tree-grid toolbar conventions; sits ABOVE container) ── */
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ant-margin);
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
+  margin-bottom: var(--ant-margin-xs);
+}
+
+.toolbarLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--ant-margin-xxs);
+}
+
+.toolbarRight {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  /* Tight gap so icon buttons cluster; the divider separates logical groups. */
+  gap: var(--ant-margin-xxs);
+  flex-wrap: nowrap;
+  white-space: nowrap;
+}
+
+.toolbarDivider {
+  width: 1px;
+  height: 24px;
+  margin: 0 var(--ant-margin-xxs);
+  background-color: var(--ant-color-split);
+}
+
+/* ── Axis (timescale header) ───────────────────────────────────────────── */
+.axis {
+  position: relative;
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--ant-color-border);
+  background-color: var(--ant-color-bg-elevated);
+  overflow: hidden;
+}
+
+/* Two-tier header: upper (month/year) over lower (week/day). */
+.axisTier {
+  position: absolute;
+  left: 0;
+  right: 0;
+}
+
+.axisTier:first-child .axisCell {
+  border-bottom: 1px solid var(--ant-color-split);
+  font-weight: var(--ant-font-weight-strong);
+  color: var(--ant-color-text);
+}
+
+.axisCell {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  display: flex;
+  align-items: center;
+  padding-left: var(--ant-padding-xxs);
+  border-left: 1px solid var(--ant-color-split);
+  color: var(--ant-color-text-secondary);
+  font-size: var(--ant-font-size-sm);
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.axisCellLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Panes (inside the Splitter, or the right side when ungrouped) ──────── */
+/* Each pane is a vertical stack: fixed header + scroll body. */
+.pane {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-width: 0;
+}
+
+/* Corner spacer above the group column, aligned to axis height. */
+.headerCorner {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--ant-color-border);
+  background-color: var(--ant-color-bg-elevated);
+}
+
+/* Axis viewport — clips; scrolled horizontally in sync with the chart. */
+.axisViewport {
+  flex: 0 0 auto;
+  overflow: hidden;
+}
+
+/* Group label column body — vertical scroll, synced to the chart. */
+.groupBody {
+  flex: 1 1 auto;
+  /* Scrolls programmatically in sync with the chart, but its own scrollbar is
+     redundant (the chart owns the visible one) — hide the chrome, keep scroll. */
+  overflow-y: scroll;
+  overflow-x: hidden;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* legacy Edge */
+}
+
+.groupBody::-webkit-scrollbar {
+  width: 0;
+  height: 0;
+}
+
+.groupColumn {
+  position: relative;
+  background-color: var(--ant-color-bg-container);
+}
+
+.groupCell {
+  position: absolute;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  padding: var(--ant-padding-xs) var(--ant-padding-xs) var(--ant-padding-xs)
+    var(--ant-padding-sm);
+  border-bottom: 1px solid var(--ant-color-split);
+  overflow: hidden;
+}
+
+.groupLabel {
+  padding-right: var(--ant-padding-xs);
+  font-size: var(--ant-font-size-sm);
+  color: var(--ant-color-text);
+  /* Wrap long names onto multiple lines instead of truncating with an ellipsis. */
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+/* Chart scroll body — both axes; drives axis + group-column sync. */
+.chartScroll {
+  flex: 1 1 auto;
+  overflow: auto;
+}
+
+/* Inner sized to full content height so the scrollbar reflects all rows. */
+.canvas {
+  position: relative;
+}
+
+/* Whitespace is draggable to pan ONLY when the content overflows the viewport
+   (otherwise there's nowhere to pan). Bars/handles set their own cursors. */
+.canvasPannable {
+  cursor: grab;
+}
+
+.canvasPannable:active {
+  cursor: grabbing;
+}
+
+/* Vertical gridlines aligned with axis ticks, behind everything. */
+.gridline {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 1px solid var(--ant-color-split);
+  pointer-events: none;
+}
+
+/* Current-time indicator. */
+.nowLine {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 0;
+  border-left: 2px solid var(--ant-color-error);
+  pointer-events: none;
+  z-index: 3;
+}
+
+/* ── Rows & groups ─────────────────────────────────────────────────────── */
+.row {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid var(--ant-color-split);
+}
+
+.rowAlt {
+  background-color: var(--ant-color-fill-quaternary);
+}
+
+/* ── Backgrounds (behind items) ────────────────────────────────────────── */
+.background {
+  position: absolute;
+  z-index: 1;
+  pointer-events: none;
+  /* Solid, readable block (matches the legacy timebox look) — not a faint wash. */
+  background-color: var(--ant-color-fill-secondary);
+  border: 1px solid var(--ant-color-border);
+  border-radius: var(--ant-border-radius);
+  overflow: hidden;
+}
+
+.backgroundLabel {
+  display: block;
+  padding: 2px var(--ant-padding-xs);
+  font-size: var(--ant-font-size-sm);
+  line-height: var(--ant-line-height, 1.5);
+  color: var(--ant-color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Item bars ─────────────────────────────────────────────────────────── */
+.bar {
+  position: absolute;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  border-radius: var(--ant-border-radius);
+  padding: 0 var(--ant-padding-xs);
+  overflow: hidden;
+  white-space: nowrap;
+  background-color: var(--ant-color-primary);
+  color: var(--ant-color-white);
+  font-size: var(--ant-font-size-sm);
+  /* Use the theme line-height (not 1) so descenders (g, y, p) aren't clipped. */
+  line-height: var(--ant-line-height, 1.5);
+  cursor: default;
+}
+
+.barLabel {
+  position: relative;
+  z-index: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.barSelected {
+  outline: 2px solid var(--ant-color-primary-border-hover);
+  outline-offset: 1px;
+}
+
+.barEditable {
+  cursor: grab;
+}
+
+.barEditable:active {
+  cursor: grabbing;
+}
+
+/* Progress fill drawn behind the label, within the bar. */
+.progressFill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  z-index: 0;
+  background-color: var(--ant-color-primary-active);
+  border-radius: var(--ant-border-radius) 0 0 var(--ant-border-radius);
+}
+
+/* Start/end resize handles — hidden until the bar is hovered. */
+.handle {
+  position: absolute;
+  top: 50%;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background-color: var(--ant-color-bg-container);
+  border: 2px solid var(--ant-color-primary);
+  transform: translateY(-50%);
+  opacity: 0;
+  cursor: ew-resize;
+  z-index: 3;
+  transition: opacity 0.1s ease;
+}
+
+.bar:hover .handle,
+.bar:focus-within .handle {
+  opacity: 1;
+}
+
+.handleStart {
+  left: -5px;
+}
+
+.handleEnd {
+  right: -5px;
+}
+
+/* Progress drag handle — small marker at the progress boundary. */
+.progressHandle {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 6px;
+  margin-left: -3px;
+  z-index: 3;
+  cursor: ew-resize;
+  opacity: 0;
+  background-color: var(--ant-color-text-light-solid, #fff);
+  transition: opacity 0.1s ease;
+}
+
+.bar:hover .progressHandle {
+  opacity: 0.8;
+}
+
+/* Milestone diamond, centered on its date. */
+.milestone {
+  position: absolute;
+  z-index: 2;
+  background-color: var(--ant-color-warning);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+/* ── Empty / loading ───────────────────────────────────────────────────── */
+.empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--ant-padding-lg);
+  color: var(--ant-color-text-secondary);
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/use-bar-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/use-bar-drag.ts
@@ -1,0 +1,121 @@
+'use client'
+
+// timeline2/render/use-bar-drag.ts
+// Pointer-event plumbing for bar move / endpoint-resize. Tracks a live draft
+// (so the bar follows the pointer) and commits on release via onCommit. The
+// date math itself lives in core/interaction.ts (pure, tested) — this hook only
+// captures pointer geometry and drives it.
+
+import { useCallback, useRef, useState } from 'react'
+import { applyDrag, type DragMode, type DragResult } from '../core/interaction'
+import { suppressNextClick } from './suppress-next-click'
+import type { TimelineItem } from '../core/types'
+
+export interface BarDragState {
+  id: string
+  mode: DragMode
+  /** Live, in-progress bounds to render while dragging. */
+  draft: DragResult
+}
+
+export interface UseBarDragOptions {
+  pxPerMs: number
+  min?: number
+  max?: number
+  snap?: boolean
+  /** Called once on pointer-up with the final bounds (consumer persists). */
+  onCommit: (change: { id: string; start: number; end: number }) => void
+}
+
+export interface UseBarDrag {
+  /** Current drag, or null when idle. */
+  active: BarDragState | null
+  /** Begin a drag for `item` in `mode` from a pointer-down event. */
+  start: (
+    e: React.PointerEvent,
+    item: TimelineItem,
+    mode: DragMode,
+  ) => void
+}
+
+export function useBarDrag(options: UseBarDragOptions): UseBarDrag {
+  const { pxPerMs, min, max, snap, onCommit } = options
+  const [active, setActive] = useState<BarDragState | null>(null)
+
+  // Mutable drag session kept in a ref so the window listeners see fresh values
+  // without re-subscribing each render.
+  const session = useRef<{
+    item: TimelineItem
+    mode: DragMode
+    startX: number
+    moved: boolean
+    latest: DragResult
+    move: (e: PointerEvent) => void
+    up: () => void
+  } | null>(null)
+
+  // Pixels the pointer must travel before it counts as a drag (vs. a click).
+  const DRAG_THRESHOLD = 3
+
+  // The session owns its own listeners so teardown can reference them without a
+  // declaration cycle (React Compiler purity rule).
+  const start = useCallback(
+    (e: React.PointerEvent, item: TimelineItem, mode: DragMode) => {
+      // Don't let the drag also trigger selection or text selection.
+      e.preventDefault()
+      e.stopPropagation()
+
+      const startX = e.clientX
+
+      const move = (ev: PointerEvent) => {
+        const s = session.current
+        if (!s) return
+        if (!s.moved && Math.abs(ev.clientX - startX) >= DRAG_THRESHOLD) {
+          s.moved = true
+        }
+        const draft = applyDrag({
+          mode,
+          item,
+          pxPerMs,
+          deltaPx: ev.clientX - startX,
+          min,
+          max,
+          snap,
+        })
+        s.latest = draft
+        setActive({ id: item.id, mode, draft })
+      }
+
+      const up = () => {
+        const s = session.current
+        window.removeEventListener('pointermove', move)
+        window.removeEventListener('pointerup', up)
+        session.current = null
+        setActive(null)
+        if (!s) return
+        // If the pointer actually moved, this was a drag — suppress the click
+        // that would otherwise open the item drawer.
+        if (s.moved) suppressNextClick()
+        // Only commit if something actually changed.
+        if (s.latest.start !== item.start || s.latest.end !== item.end) {
+          onCommit({ id: item.id, start: s.latest.start, end: s.latest.end })
+        }
+      }
+
+      session.current = {
+        item,
+        mode,
+        startX,
+        moved: false,
+        latest: { start: item.start, end: item.end },
+        move,
+        up,
+      }
+      window.addEventListener('pointermove', move)
+      window.addEventListener('pointerup', up)
+    },
+    [pxPerMs, min, max, snap, onCommit],
+  )
+
+  return { active, start }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/types.ts
@@ -1,0 +1,114 @@
+// timeline2/types.ts
+// Public, React-facing types for WaydTimeline2 (distinct from core/types.ts,
+// which is the pure-math domain model).
+
+import type { FC, ReactNode } from 'react'
+import type {
+  TimelineGroup,
+  TimelineItem,
+  TimelineVariant,
+} from './core/types'
+
+export type { TimelineItem, TimelineGroup, TimelineVariant } from './core/types'
+
+/** Props passed to a consumer's custom bar renderer. */
+export interface ItemRenderProps<T = unknown> {
+  item: TimelineItem<T>
+  /** Resolved foreground color for text on the bar (contrast-aware). */
+  fontColor: string
+  /** Resolved background color for the bar. */
+  backgroundColor: string
+  selected: boolean
+}
+
+/** Props passed to a consumer's custom group-label renderer. */
+export interface GroupRenderProps<T = unknown> {
+  group: TimelineGroup<T>
+  depth: number
+  collapsed: boolean
+}
+
+/** A date-range change emitted by move or endpoint-resize. */
+export interface ItemDateChange {
+  id: string
+  start: number
+  end: number
+}
+
+/** A progress change emitted by the progress handle. */
+export interface ItemProgressChange {
+  id: string
+  progress: number
+}
+
+export interface WaydTimeline2Props<TItem = unknown, TGroup = unknown> {
+  variant?: TimelineVariant
+  items: TimelineItem<TItem>[]
+  groups?: TimelineGroup<TGroup>[]
+
+  /**
+   * Default visible window on load, epoch ms — the initial view the user sees.
+   * Must fall within [minDate, maxDate]. (vis-timeline's `start`/`end`.)
+   */
+  windowStart: number
+  windowEnd: number
+  /**
+   * Hard bounds for the rendered time domain AND pan/zoom limits, epoch ms.
+   * Items are clamped to this range (anything past it is clipped at the edge),
+   * and the user cannot pan/zoom outside it. Defaults to windowStart/windowEnd
+   * when omitted. (vis-timeline's `min`/`max`.)
+   */
+  minDate?: number
+  maxDate?: number
+
+  /** Sizing. */
+  height?: number
+  laneHeight?: number
+  /** Default width of the left group-label column (only shown when groups exist).
+   *  When `storageKey` is set, the user's resized width is persisted and overrides
+   *  this default on subsequent loads. */
+  groupColumnWidth?: number
+  /**
+   * Stable key identifying this timeline instance (e.g. a roadmap id). When set,
+   * per-instance UI preferences (group-column width) are persisted to
+   * localStorage under this key and restored on the next load.
+   */
+  storageKey?: string
+  /** Initial drill-through level (1 = flat, no groups; 2 = top tier as groups).
+   *  Default 2. */
+  defaultDrillLevel?: number
+
+  /** Default for the current-time indicator. When `allowToggleCurrentTime` is on,
+   *  this is the initial value of the user-togglable setting. Default true. */
+  showCurrentTime?: boolean
+  /** Show a settings menu with a "Show Current Time" toggle. Default true. */
+  allowToggleCurrentTime?: boolean
+
+  /** Toolbar chrome. */
+  allowFullScreen?: boolean
+  allowSaveAsImage?: boolean
+  /** Time-axis zoom controls (Ctrl/Cmd+wheel + toolbar +/- and Reset View).
+   *  Default true. */
+  allowZoom?: boolean
+  /** Base filename (without extension) for save-as-image. */
+  saveImageFileName?: string
+  /** Toolbar slots — left for controls (e.g. future drill +/-), right for extra actions. */
+  toolbarLeftSlot?: ReactNode
+  toolbarRightSlot?: ReactNode
+  /** Refresh action — shows a Reload toolbar button (like WaydGrid) when provided. */
+  onRefresh?: () => void
+
+  /** Custom renderers. */
+  itemRenderer?: FC<ItemRenderProps<TItem>>
+  groupRenderer?: FC<GroupRenderProps<TGroup>>
+
+  /** Interaction (omit to disable). */
+  editable?: boolean
+  onItemDateChange?: (change: ItemDateChange) => void
+  onItemProgressChange?: (change: ItemProgressChange) => void
+  onItemClick?: (item: TimelineItem<TItem>) => void
+
+  /** States. */
+  isLoading?: boolean
+  emptyMessage?: string
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react'
+import { WaydTimeline2 } from './wayd-timeline2'
+import type { TimelineItem } from './core/types'
+
+// jsdom has no ResizeObserver; the chart body's callback ref constructs one.
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver
+})
+
+// The loading/empty branches return before the chart body mounts, so the heavy
+// dependencies (Splitter layout, ResizeObserver, html2canvas) are never reached.
+
+const DAY = 86_400_000
+const windowStart = 0
+const windowEnd = 30 * DAY
+
+const item = (id: string): TimelineItem => ({
+  id,
+  kind: 'range',
+  start: 2 * DAY,
+  end: 5 * DAY,
+})
+
+describe('WaydTimeline2 — loading & empty states', () => {
+  it('renders a spinner while loading with no data', () => {
+    // Arrange / Act
+    const { container } = render(
+      <WaydTimeline2
+        items={[]}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        isLoading
+      />,
+    )
+    // Assert — antd Spin is present (so it's not a blank zero-height chart).
+    expect(container.querySelector('.ant-spin')).toBeInTheDocument()
+  })
+
+  it('renders the empty message when not loading and there are no items', () => {
+    // Arrange / Act
+    render(
+      <WaydTimeline2
+        items={[]}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        emptyMessage="Nothing here"
+      />,
+    )
+    // Assert
+    expect(screen.getByText('Nothing here')).toBeInTheDocument()
+  })
+
+  it('does not show the spinner once items are present, even while loading', () => {
+    // Arrange / Act — loading is true but data has arrived (refetch case).
+    const { container } = render(
+      <WaydTimeline2
+        items={[item('a')]}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        isLoading
+      />,
+    )
+    // Assert — the loading early-return is skipped; the chart renders instead.
+    expect(container.querySelector('.ant-spin')).not.toBeInTheDocument()
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
@@ -1,0 +1,683 @@
+'use client'
+
+// timeline2/wayd-timeline2.tsx — public component. Variant-driven; wires the
+// scale + layout strategy + render layer. Built in parallel to the existing
+// WaydTimeline (no facade swap) so pages migrate one at a time.
+//
+// Layout: an antd Splitter divides a left pane (group labels) from a right pane
+// (axis + chart). Users drag the splitter to resize the label column — no
+// separate "group width" control needed. Each pane is a vertical stack
+// [header | scroll body]; the two bodies' vertical scroll is kept in sync.
+
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
+import { Spin, Splitter } from 'antd'
+import { captureTimeline } from './render/capture-timeline'
+import { createTimeScale } from './core/scale'
+import { clampZoom, maxZoom, anchoredScrollLeft } from './core/zoom'
+import { getLayoutStrategy } from './layout'
+import { ChartCanvas, type ChartCanvasProps } from './render/chart-canvas'
+import { GroupColumn } from './render/group-column'
+import { Axis } from './render/axis'
+import TimelineToolbar from './render/timeline-toolbar'
+import DrillControl from './render/drill-control'
+import { resolveLevel, maxGroupDepth } from './core/depth'
+import { growRowsForLabels, type GeometryConfig } from './core/geometry'
+import { getVisibleRange } from './core/virtualization'
+import type { TimelineGroup } from './core/types'
+import type { WaydTimeline2Props } from './types'
+import styles from './render/timeline.module.css'
+
+const AXIS_HEIGHT = 48
+const DEFAULT_HEIGHT = 600
+const DEFAULT_LANE_HEIGHT = 28
+const DEFAULT_GROUP_COLUMN_WIDTH = 220
+const MIN_GROUP_COLUMN_WIDTH = 120
+const LANE_PADDING = 3
+const ROW_PADDING = 6
+const MIN_PX_PER_DAY = 3
+const DAY_MS = 86_400_000
+// Minimum visible time span when fully zoomed in (1 day), matching the legacy
+// timeline's `zoomMin`.
+const ZOOM_MIN_MS = DAY_MS
+// Multiplier applied per zoom-in/out step (buttons) and per wheel notch.
+const ZOOM_STEP = 1.2
+const ZOOM_WHEEL_STEP = 1.0015
+
+/** Read a persisted group-column width, or fall back to the default. Returns the
+ *  default (no read) when there's no key or storage isn't available. */
+function readPersistedWidth(key: string | null, fallback: number): number {
+  if (!key || typeof window === 'undefined') return fallback
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (raw == null) return fallback
+    const parsed = Number(JSON.parse(raw))
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+  } catch {
+    return fallback
+  }
+}
+
+export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
+  props: WaydTimeline2Props<TItem, TGroup>,
+) {
+  const {
+    variant = 'timeline',
+    items,
+    groups,
+    windowStart,
+    windowEnd,
+    minDate,
+    maxDate,
+    height = DEFAULT_HEIGHT,
+    laneHeight = DEFAULT_LANE_HEIGHT,
+    groupColumnWidth = DEFAULT_GROUP_COLUMN_WIDTH,
+    storageKey,
+    defaultDrillLevel = 2,
+    showCurrentTime: showCurrentTimeDefault = true,
+    allowToggleCurrentTime = true,
+    allowFullScreen = false,
+    allowSaveAsImage = false,
+    allowZoom = true,
+    saveImageFileName = 'timeline',
+    toolbarLeftSlot,
+    toolbarRightSlot,
+    onRefresh,
+    itemRenderer,
+    groupRenderer,
+    onItemClick,
+    editable = false,
+    onItemDateChange,
+    onItemProgressChange,
+    isLoading,
+    emptyMessage = 'No items to display',
+  } = props
+
+  const hasGroups = !!groups && groups.length > 0
+
+  // Drill-through level (1-based, matches treeLevel): at level L, activities at
+  // treeLevel L render as bars and shallower tiers become groups.
+  //  level 1 = flat (top activities are bars, no groups); level 2 = top tier as
+  //  groups + their children as bars; deeper = drill further.
+  // maxLevel = deepest activity tier (group depth is 0-based → +1 for 1-based).
+  const maxDepth = hasGroups ? maxGroupDepth(groups!) : 0
+  const maxLevel = maxDepth + 1
+  const [userLevel, setUserLevel] = useState<number | undefined>(undefined)
+  const level = Math.min(userLevel ?? defaultDrillLevel, maxLevel)
+
+  const hasDrill = hasGroups && maxLevel > 1
+  const hasToolbar =
+    allowFullScreen ||
+    allowSaveAsImage ||
+    allowZoom ||
+    hasDrill ||
+    !!onRefresh ||
+    !!toolbarLeftSlot ||
+    !!toolbarRightSlot
+
+  // wrapperRef = toolbar + chart (fullscreen target). chartRootRef = just the
+  // bordered chart container (save-as-image target, so the toolbar is excluded).
+  const wrapperRef = useRef<HTMLDivElement>(null)
+  const chartRootRef = useRef<HTMLDivElement>(null)
+  const [isFullScreen, setIsFullScreen] = useState(false)
+
+  // User-togglable current-time line (settings menu); seeded from the prop.
+  const [showCurrentTime, setShowCurrentTime] = useState(showCurrentTimeDefault)
+
+  // Group-column width. Self-persisted per instance when `storageKey` is set, so
+  // a user's splitter resize survives reloads with no consumer wiring; otherwise
+  // it's plain ephemeral state seeded from the prop default. When there's no
+  // storageKey we never touch localStorage at all (no shared/`__none__` key).
+  const widthStorageKey = storageKey
+    ? `wayd-timeline2:groupWidth:${storageKey}`
+    : null
+  const [columnWidth, setColumnWidthState] = useState(() =>
+    readPersistedWidth(widthStorageKey, groupColumnWidth),
+  )
+  // Re-read when the instance key changes without a remount (state-during-render
+  // pattern), so switching roadmaps applies the new instance's saved width.
+  const [prevWidthKey, setPrevWidthKey] = useState(widthStorageKey)
+  if (prevWidthKey !== widthStorageKey) {
+    setPrevWidthKey(widthStorageKey)
+    setColumnWidthState(readPersistedWidth(widthStorageKey, groupColumnWidth))
+  }
+  const setColumnWidth = (width: number) => {
+    setColumnWidthState(width)
+    if (widthStorageKey) {
+      try {
+        window.localStorage.setItem(widthStorageKey, JSON.stringify(width))
+      } catch {
+        // Ignore quota/availability errors — width just won't persist.
+      }
+    }
+  }
+
+  // Measured group-label heights (by groupId) → rows grow to fit wrapped labels.
+  const [labelHeights, setLabelHeights] = useState<Map<string, number>>(
+    () => new Map(),
+  )
+  const onMeasureLabels = (heights: Map<string, number>) => {
+    setLabelHeights((prev) => {
+      // Merge (don't replace): keep previously-measured heights and overlay the
+      // new readings so a partial measurement never drops a row's grown height.
+      let changed = false
+      for (const [k, v] of heights) {
+        if (prev.get(k) !== v) {
+          changed = true
+          break
+        }
+      }
+      if (!changed) return prev
+      const next = new Map(prev)
+      for (const [k, v] of heights) next.set(k, v)
+      return next
+    })
+  }
+
+  // "Fullscreen" here means fill the browser's current viewport (not the OS
+  // monitor) — a CSS fixed-position overlay, matching the legacy timeline.
+  // Native requestFullscreen would take over the whole monitor, which isn't
+  // what we want. Esc exits.
+  const toggleFullScreen = () => setIsFullScreen((v) => !v)
+
+  useEffect(() => {
+    if (!isFullScreen) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsFullScreen(false)
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [isFullScreen])
+
+  const saveImage = () => {
+    // Force every row into the DOM first (virtualization is normally on), then
+    // capture once the full-height layout has painted, and turn windowing back on.
+    setIsCapturing(true)
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const el = chartRootRef.current
+        if (!el) {
+          setIsCapturing(false)
+          return
+        }
+        const cs = getComputedStyle(el)
+        const containerBg =
+          cs.getPropertyValue('--ant-color-bg-container').trim() || undefined
+
+        // We capture the CURRENT horizontal viewport (no time scrolled off-screen)
+        // but the FULL vertical extent (all rows). Since we don't expand
+        // horizontally, the Splitter layout stays intact — so we capture `.root`
+        // as a single element (no split/stitch) and only un-clip the vertical
+        // scroll in html2canvas's cloned document. The header underline etc.
+        // render naturally because it's the real layout, just taller.
+        const fullHeight = AXIS_HEIGHT + totalHeight + 2 // +2 for top/bottom border
+
+        // The Splitter sizes its panels via JS; those widths don't survive the
+        // html2canvas clone, so capture the live group-column width and re-pin it.
+        const groupPane = el.querySelector<HTMLElement>(
+          '[data-timeline-group-pane]',
+        )
+        const groupPaneWidth = groupPane
+          ? Math.round(groupPane.getBoundingClientRect().width)
+          : undefined
+
+        captureTimeline(el, {
+          fileName: `${saveImageFileName}.png`,
+          backgroundColor: containerBg,
+          captureHeight: fullHeight,
+          groupPaneWidth,
+        }).finally(() => setIsCapturing(false))
+      })
+    })
+  }
+
+  // Measure the chart viewport width so the time scale maps onto real pixels.
+  // Use a CALLBACK ref: it fires exactly when the chart node attaches, which
+  // removes all timing ambiguity around when the (Splitter-nested) panel mounts.
+  const chartRef = useRef<HTMLDivElement | null>(null)
+  const observerRef = useRef<ResizeObserver | null>(null)
+  const scrollRafRef = useRef<number | null>(null)
+  const axisViewportRef = useRef<HTMLDivElement>(null)
+  const groupBodyRef = useRef<HTMLDivElement>(null)
+  const [viewportWidth, setViewportWidth] = useState(0)
+  const [viewportHeight, setViewportHeight] = useState(0)
+  const [scrollLeft, setScrollLeft] = useState(0)
+  const [scrollTop, setScrollTop] = useState(0)
+  // While true, virtualization is bypassed so all rows render for image capture.
+  const [isCapturing, setIsCapturing] = useState(false)
+  // Horizontal time zoom: factor over the base (fit-to-window) width. 1 = reset.
+  const [zoom, setZoom] = useState(1)
+  // scrollLeft to apply on the NEXT paint after a zoom changes chartWidth, so the
+  // anchor (cursor/centre) stays fixed. Consumed in a layout effect below.
+  const pendingScrollLeftRef = useRef<number | null>(null)
+  // Latest zoom geometry, refreshed every render so the (stable) wheel listener
+  // attached in setChartRef reads current values without a stale closure.
+  const zoomGeomRef = useRef({
+    zoom: 1,
+    baseWidth: 0,
+    chartWidth: 0,
+    bounds: { min: 1, max: 1 },
+    allowZoom: true,
+  })
+
+  // Resolve the drill level: which activities stay groups vs. demote to bars,
+  // remapping every item to its nearest surviving group. (timeline variant only;
+  // gantt keeps one row per record.) Backgrounds are split AFTER remapping so a
+  // row-scoped timebox follows its reassigned group.
+  const resolved =
+    hasGroups && variant === 'timeline'
+      ? resolveLevel(items, groups!, level)
+      : { items, groups: groups ?? [] }
+
+  // ── Horizontal time geometry (domain + zoom) ──────────────────────────────
+  // The render domain is the HARD BOUNDS [minDate, maxDate] (vis-timeline's
+  // min/max), defaulting to the view window. This is also the pan/zoom limit, so
+  // the axis matches the consumer's bounds exactly (e.g. the roadmap dates).
+  // Items extending past the bounds are clipped at the canvas edge; we do NOT
+  // widen the domain to fit them.
+  const domainStart = minDate ?? windowStart
+  const domainEnd = Math.max(domainStart + 1, maxDate ?? windowEnd)
+  const domainMs = domainEnd - domainStart
+  const spanDays = Math.max(1, domainMs / DAY_MS)
+  // Base width fits the whole domain into the viewport (or a per-day minimum).
+  // Zoom scales it up; pan is native horizontal scroll over the widened content.
+  const baseWidth = Math.max(viewportWidth, spanDays * MIN_PX_PER_DAY)
+  // Cap zoom-in so the viewport never spans less than ZOOM_MIN_MS (1 day),
+  // matching the legacy timeline's `zoomMin`.
+  const zoomMin = 1
+  const zoomMax = maxZoom(baseWidth, viewportWidth, domainMs, ZOOM_MIN_MS)
+  const effectiveZoom = clampZoom(zoom, { min: zoomMin, max: zoomMax })
+  const chartWidth = baseWidth * effectiveZoom
+
+  const wheelCleanupRef = useRef<(() => void) | null>(null)
+  const setChartRef = (el: HTMLDivElement | null) => {
+    chartRef.current = el
+    observerRef.current?.disconnect()
+    wheelCleanupRef.current?.()
+    wheelCleanupRef.current = null
+    if (!el) return
+    const measure = () => {
+      setViewportWidth(el.clientWidth)
+      setViewportHeight(el.clientHeight)
+    }
+    measure()
+    requestAnimationFrame(measure)
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    observerRef.current = observer
+
+    // Ctrl/Cmd + wheel = zoom, anchored on the cursor. Must be a NON-passive
+    // listener so we can preventDefault the browser's pinch/scroll-zoom. Plain
+    // wheel (no modifier) falls through to native horizontal/vertical scroll.
+    const onWheel = (e: WheelEvent) => {
+      const geom = zoomGeomRef.current
+      if (!geom.allowZoom) return
+      if (!e.ctrlKey && !e.metaKey) return
+      e.preventDefault()
+      const anchorX = e.clientX - el.getBoundingClientRect().left
+      // Wheel up (deltaY < 0) zooms in; scale exponentially by the scroll amount.
+      const factor = Math.pow(ZOOM_WHEEL_STEP, -e.deltaY)
+      requestZoom(geom.zoom * factor, anchorX)
+    }
+    el.addEventListener('wheel', onWheel, { passive: false })
+    wheelCleanupRef.current = () => el.removeEventListener('wheel', onWheel)
+  }
+
+  useEffect(
+    () => () => {
+      observerRef.current?.disconnect()
+      wheelCleanupRef.current?.()
+      if (scrollRafRef.current != null) cancelAnimationFrame(scrollRafRef.current)
+    },
+    [],
+  )
+
+  // After every render, publish current zoom geometry for the (stable) wheel
+  // listener and toolbar handlers to read — and, when a zoom changed chartWidth,
+  // set scrollLeft so the anchor stays fixed. useLayoutEffect runs before paint,
+  // so the user never sees an intermediate (mis-scrolled) frame. Also syncs the
+  // axis viewport (it mirrors chart scroll).
+  useLayoutEffect(() => {
+    zoomGeomRef.current = {
+      zoom: effectiveZoom,
+      baseWidth,
+      chartWidth,
+      bounds: { min: zoomMin, max: zoomMax },
+      allowZoom,
+    }
+    const pending = pendingScrollLeftRef.current
+    if (pending == null) return
+    pendingScrollLeftRef.current = null
+    const chart = chartRef.current
+    if (chart) {
+      chart.scrollLeft = pending
+      if (axisViewportRef.current) axisViewportRef.current.scrollLeft = pending
+      setScrollLeft(pending)
+    }
+  }, [effectiveZoom, baseWidth, chartWidth, zoomMin, zoomMax, allowZoom])
+
+  // Chart scroll drives: axis horizontal sync + group-column vertical sync, and
+  // a debounced scrollLeft state so bar labels can stick to the visible left
+  // edge (rAF-throttled to avoid re-rendering bars on every scroll event).
+  const onChartScroll = () => {
+    const chart = chartRef.current
+    if (!chart) return
+    if (axisViewportRef.current) {
+      axisViewportRef.current.scrollLeft = chart.scrollLeft
+    }
+    if (groupBodyRef.current) {
+      groupBodyRef.current.scrollTop = chart.scrollTop
+    }
+    if (scrollRafRef.current == null) {
+      scrollRafRef.current = requestAnimationFrame(() => {
+        scrollRafRef.current = null
+        const c = chartRef.current
+        setScrollLeft(c?.scrollLeft ?? 0)
+        setScrollTop(c?.scrollTop ?? 0)
+      })
+    }
+  }
+
+  // Group-column scroll (wheel over labels) drives the chart vertically.
+  const onGroupScroll = () => {
+    const group = groupBodyRef.current
+    if (group && chartRef.current) {
+      chartRef.current.scrollTop = group.scrollTop
+    }
+  }
+
+  // Drag-to-pan: grab empty chart space and drag to scroll horizontally (and
+  // vertically). Bars/handles/milestones stop pointer propagation (or are marked
+  // with data-timeline-item), so this only engages on whitespace — the native
+  // scrollbar still works alongside it.
+  const panSessionRef = useRef<{
+    pointerId: number
+    startX: number
+    startY: number
+    startScrollLeft: number
+    startScrollTop: number
+    moved: boolean
+  } | null>(null)
+
+  const onPanPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    // Primary button only; ignore clicks that land on an interactive item.
+    if (e.button !== 0) return
+    if ((e.target as HTMLElement).closest('[data-timeline-item]')) return
+    const chart = chartRef.current
+    if (!chart) return
+    // Nothing to pan if content fits the viewport in both axes.
+    const canScroll =
+      chart.scrollWidth > chart.clientWidth ||
+      chart.scrollHeight > chart.clientHeight
+    if (!canScroll) return
+
+    // Avoid starting a native text/element selection while dragging to pan.
+    e.preventDefault()
+
+    panSessionRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      startScrollLeft: chart.scrollLeft,
+      startScrollTop: chart.scrollTop,
+      moved: false,
+    }
+    chart.style.cursor = 'grabbing'
+
+    const move = (ev: PointerEvent) => {
+      const s = panSessionRef.current
+      const c = chartRef.current
+      if (!s || !c) return
+      const dx = ev.clientX - s.startX
+      const dy = ev.clientY - s.startY
+      if (!s.moved && Math.abs(dx) + Math.abs(dy) >= 3) s.moved = true
+      // Dragging right reveals content to the left → scrollLeft decreases.
+      c.scrollLeft = s.startScrollLeft - dx
+      c.scrollTop = s.startScrollTop - dy
+    }
+    const up = () => {
+      const c = chartRef.current
+      if (c) c.style.cursor = ''
+      panSessionRef.current = null
+      window.removeEventListener('pointermove', move)
+      window.removeEventListener('pointerup', up)
+    }
+    window.addEventListener('pointermove', move)
+    window.addEventListener('pointerup', up)
+  }
+
+  // Apply a new zoom factor, keeping the time under `anchorX` (viewport-local px)
+  // fixed. Reads current geometry from the ref so it's safe to call from both the
+  // wheel listener and the toolbar buttons. Stages the post-paint scrollLeft.
+  const requestZoom = (nextZoomRaw: number, anchorX: number) => {
+    const geom = zoomGeomRef.current
+    const next = clampZoom(nextZoomRaw, geom.bounds)
+    if (next === geom.zoom) return
+    const newWidth = geom.baseWidth * next
+    pendingScrollLeftRef.current = anchoredScrollLeft({
+      oldWidth: geom.chartWidth,
+      newWidth,
+      oldScrollLeft: chartRef.current?.scrollLeft ?? 0,
+      anchorX,
+      viewportWidth: chartRef.current?.clientWidth ?? 0,
+    })
+    setZoom(next)
+  }
+
+  // Zoom in/out by a fixed step, anchored on the viewport centre (toolbar buttons).
+  const zoomBy = (factor: number) => {
+    const geom = zoomGeomRef.current
+    const centre = (chartRef.current?.clientWidth ?? 0) / 2
+    requestZoom(geom.zoom * factor, centre)
+  }
+
+  // Reset View: back to fit-the-window (zoom 1) and scrolled to the start.
+  const resetView = () => {
+    pendingScrollLeftRef.current = 0
+    setZoom(1)
+  }
+
+  // Loading: show a spinner until data arrives (covers the isLoading + no-data
+  // window, which would otherwise render a blank zero-height chart).
+  if (isLoading && items.length === 0) {
+    return (
+      <div className={styles.root} style={{ height }}>
+        <div className={styles.empty}>
+          <Spin />
+        </div>
+      </div>
+    )
+  }
+
+  if (!isLoading && items.length === 0) {
+    return (
+      <div className={styles.root} style={{ height }}>
+        <div className={styles.empty}>{emptyMessage}</div>
+      </div>
+    )
+  }
+
+  const chartBackgrounds = resolved.items.filter((i) => i.kind === 'background')
+  const layoutItems = resolved.items.filter((i) => i.kind !== 'background')
+
+  // Group ids that have a row-scoped background → reserve label headroom in those
+  // rows so the timebox name sits above the bars. Chart-wide (ungrouped)
+  // backgrounds drive headroom on the flat row instead.
+  const backgroundGroupIds = new Set<string>()
+  let hasChartBackground = false
+  for (const bg of chartBackgrounds) {
+    if (bg.groupId) backgroundGroupIds.add(bg.groupId)
+    else hasChartBackground = true
+  }
+
+  const strategy = getLayoutStrategy(variant)
+  const base = strategy({
+    items: layoutItems,
+    groups: resolved.groups,
+    backgroundGroupIds,
+    hasChartBackground,
+    config: { laneHeight, rowPadding: ROW_PADDING },
+  })
+
+  // Grow rows whose wrapped group label is taller than the lane-based height,
+  // using heights measured in the rendered column (see GroupColumn onMeasure).
+  const { rows, totalHeight } = growRowsForLabels(base.rows, labelHeights)
+
+  // Virtualize: only rows intersecting the viewport (plus overscan) render.
+  // The full totalHeight is kept as a spacer so the scrollbar reflects all rows.
+  // During an image capture we bypass windowing so EVERY row is in the DOM (the
+  // capture renders the full vertical extent, including rows scrolled off-view).
+  const visibleRange = isCapturing
+    ? { startIndex: 0, endIndex: rows.length - 1 }
+    : getVisibleRange(rows, scrollTop, viewportHeight)
+  const visibleRows =
+    visibleRange.endIndex < 0
+      ? []
+      : rows.slice(visibleRange.startIndex, visibleRange.endIndex + 1)
+
+  const scale = createTimeScale(domainStart, domainEnd, chartWidth)
+  const geometry: GeometryConfig = { laneHeight, lanePadding: LANE_PADDING }
+  const groupsById = new Map<string, TimelineGroup>(
+    resolved.groups.map((g) => [g.id, g]),
+  )
+
+  // Show the group column + splitter only when the resolved level actually has
+  // groups. At drill level 1 there are none → render a flat, full-width chart.
+  const showGroupColumn = resolved.groups.length > 0
+
+  // The right pane (axis + chart) is shared by both grouped/ungrouped layouts.
+  const rightPane = (
+    <div className={styles.pane}>
+      <div className={styles.axisViewport} ref={axisViewportRef}>
+        {viewportWidth > 0 && <Axis scale={scale} height={AXIS_HEIGHT} />}
+      </div>
+      <div
+        className={styles.chartScroll}
+        ref={setChartRef}
+        onScroll={onChartScroll}
+        onPointerDown={onPanPointerDown}
+      >
+        {viewportWidth > 0 && (
+          <ChartCanvas
+            rows={visibleRows}
+            allRows={rows}
+            rowIndexOffset={visibleRange.startIndex}
+            totalHeight={totalHeight}
+            scale={scale}
+            geometry={geometry}
+            chartBackgrounds={chartBackgrounds}
+            editable={editable}
+            viewportLeft={scrollLeft}
+            itemRenderer={itemRenderer as ChartCanvasProps['itemRenderer']}
+            onItemClick={onItemClick as ChartCanvasProps['onItemClick']}
+            onItemDateChange={onItemDateChange}
+            onItemProgressChange={onItemProgressChange}
+            showCurrentTime={showCurrentTime}
+            canPan={
+              chartWidth > viewportWidth + 1 || totalHeight > viewportHeight + 1
+            }
+            dragMin={domainStart}
+            dragMax={domainEnd}
+          />
+        )}
+      </div>
+    </div>
+  )
+
+  return (
+    <div
+      ref={wrapperRef}
+      className={`${styles.wrapper} ${isFullScreen ? styles.fullscreen : ''}`}
+    >
+      {hasToolbar && (
+        <TimelineToolbar
+          leftSlot={
+            <>
+              {hasDrill && (
+                <DrillControl
+                  level={level}
+                  maxLevel={maxLevel}
+                  onChange={setUserLevel}
+                />
+              )}
+              {toolbarLeftSlot}
+            </>
+          }
+          rightSlot={toolbarRightSlot}
+          allowZoom={allowZoom}
+          onZoomIn={() => zoomBy(ZOOM_STEP)}
+          onZoomOut={() => zoomBy(1 / ZOOM_STEP)}
+          onResetView={resetView}
+          canZoomIn={effectiveZoom < zoomMax - 1e-6}
+          canZoomOut={effectiveZoom > zoomMin + 1e-6}
+          canReset={effectiveZoom > 1 + 1e-6 || scrollLeft > 0.5}
+          allowSaveAsImage={allowSaveAsImage}
+          onSaveAsImage={saveImage}
+          allowFullScreen={allowFullScreen}
+          isFullScreen={isFullScreen}
+          onToggleFullScreen={toggleFullScreen}
+          allowSettings={allowToggleCurrentTime}
+          showCurrentTime={showCurrentTime}
+          onToggleCurrentTime={setShowCurrentTime}
+          onRefresh={onRefresh}
+        />
+      )}
+      <div
+        ref={chartRootRef}
+        className={styles.root}
+        style={isFullScreen ? undefined : { height }}
+      >
+        {showGroupColumn ? (
+          <Splitter
+            // antd Splitter reads `defaultSize` only on mount; remount when the
+            // instance (storageKey) changes so a different roadmap's persisted
+            // width is applied.
+            key={storageKey ?? 'default'}
+            // Persist the resized group-column width (first panel) on drop. Using
+            // onResizeEnd (not onResize) avoids writing to storage on every frame.
+            onResizeEnd={(sizes) => {
+              const next = sizes[0]
+              if (typeof next === 'number' && next > 0) setColumnWidth(next)
+            }}
+          >
+            <Splitter.Panel
+              defaultSize={columnWidth}
+              min={MIN_GROUP_COLUMN_WIDTH}
+              max="60%"
+            >
+              <div className={styles.pane} data-timeline-group-pane>
+                {/* Corner spacer aligns the column under the axis header. */}
+                <div
+                  className={styles.headerCorner}
+                  style={{ height: AXIS_HEIGHT }}
+                />
+                <div
+                  className={styles.groupBody}
+                  ref={groupBodyRef}
+                  onScroll={onGroupScroll}
+                >
+                  <GroupColumn
+                    rows={rows}
+                    totalHeight={totalHeight}
+                    width="100%"
+                    groupsById={groupsById}
+                    groupRenderer={
+                      groupRenderer as React.ComponentProps<
+                        typeof GroupColumn
+                      >['groupRenderer']
+                    }
+                    onMeasure={onMeasureLabels}
+                  />
+                </div>
+              </div>
+            </Splitter.Panel>
+            <Splitter.Panel>{rightPane}</Splitter.Panel>
+          </Splitter>
+        ) : (
+          rightPane
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default WaydTimeline2

--- a/docs/reference/feature-flags.mdx
+++ b/docs/reference/feature-flags.mdx
@@ -12,7 +12,7 @@ Wayd uses Microsoft.FeatureManagement to control feature visibility. Feature fla
 ## How It Works
 
 1. Flags are **defined in code** (`FeatureFlags.cs`)
-2. On startup, the **seeder** creates any new flags in the database (disabled by default)
+2. On startup, the **seeder** creates any new flags in the database. New flags are seeded **disabled by default**, unless the definition sets `DefaultEnabled: true`. The seeder only sets the initial state on first creation — it never overwrites an existing flag's state, so admin toggles are preserved across deploys.
 3. Admins **enable/disable** flags through the Settings UI
 4. A **database-backed provider** serves flag state with caching
 
@@ -28,9 +28,14 @@ public static class FeatureFlags
     public static readonly FeatureFlagDefinition MyNewFeature =
         new(Names.MyNewFeature, "My New Feature", "Description of what this feature does.");
 
+    // Seed a flag as ENABLED by default (e.g. rolling out a replacement UI):
+    public static readonly FeatureFlagDefinition MyDefaultOnFeature =
+        new(Names.MyDefaultOnFeature, "My Default-On Feature", "Enabled on first seed.", DefaultEnabled: true);
+
     public static class Names
     {
         public const string MyNewFeature = "my-new-feature";
+        public const string MyDefaultOnFeature = "my-default-on-feature";
     }
 }
 ```
@@ -54,13 +59,16 @@ if (!await _featureManager.IsEnabledAsync(FeatureFlags.Names.MyNewFeature))
 
 Page-level gate:
 ```typescript
-export default requireFeatureFlag('MyNewFeature')(MyPage)
+export default requireFeatureFlag('my-new-feature')(MyPage)
 ```
 
-Conditional rendering:
+Conditional rendering (the hook returns `{ isEnabled, isLoading }` and takes the
+kebab-case flag name):
 ```typescript
-const isEnabled = useFeatureFlag('MyNewFeature')
-if (!isEnabled) return null
+const { isEnabled, isLoading } = useFeatureFlag('my-new-feature')
+if (isLoading) return <Spin />
+if (!isEnabled) return <LegacyView />
+return <NewView />
 ```
 
 ### 4. Gate Menus

--- a/docs/user-guide/settings/index.mdx
+++ b/docs/user-guide/settings/index.mdx
@@ -148,7 +148,7 @@ Wayd uses **feature flags** to control the visibility of features across the app
 ### How Feature Flags Work
 
 1. Flags are **defined in code** by developers
-2. On application startup, new flags are **automatically seeded** into the database (disabled by default)
+2. On application startup, new flags are **automatically seeded** into the database — usually disabled, though some (such as replacement UIs being rolled out) are seeded enabled. Seeding only sets a flag's **initial** state; your enable/disable choices are preserved across updates
 3. Administrators **enable or disable** flags through the Settings UI
 4. The application checks flag state to **show or hide** features
 


### PR DESCRIPTION
## New in-house timeline UI for Roadmaps (feature-flagged)

### Summary

Introduces **`WaydTimeline2`**, a purpose-built, React-native timeline component to replace the legacy `vis-timeline`, and wires it into the Roadmap details page behind a **default-on** `new-timeline-ui` feature flag. The old timeline stays in place and is selected automatically when the flag is off, so this can ship for early feedback with an instant rollback path.

This is the first of three planned migrations (Roadmaps → PI Objectives → Projects), all gated by the same flag.

### Why

`vis-timeline` is an imperative, non-React library that fights our stack: custom React item templates, theme-token theming without a full re-init, hover resize/progress handles, and row virtualization are all a constant struggle against it. `WaydTimeline2` is built as pure layout/geometry math + a variant-agnostic React render layer, so those capabilities are native. (Full rationale and decisions in `docs/contributing/specs/custom-timeline-requirements.md`.)

### What's included

**New component — `components/common/timeline2/`**
- `core/` — dependency-free pure functions: date↔pixel scale + calendar tick/tier generation (dayjs, no d3), interval lane-packing, geometry/box computation, row virtualization, zoom math. Heavily unit-tested.
- `layout/` — the only variant-aware seam: `timeline` (lane-packing + collapse-to-lane) and a `gantt` strategy (one row per record), both producing the same `ResolvedRow[]` contract.
- `render/` — variant-agnostic React: axis (two-tier, zoom-aware granularity), chart canvas, item bars (move/resize/progress drag), group column, toolbar, save-as-image.

**Capabilities (timeline variant / roadmap parity + extras)**
- Lane-packing, nested groups, collapse-to-lane, drill-through levels.
- Drag to move / resize endpoints / adjust progress (gated by editability), with day-snap and click-suppression.
- Hard time bounds (`minDate`/`maxDate`) matching the roadmap window — axis spans exactly the roadmap dates; out-of-bounds bars are clipped at the edge (legacy parity). Default-view window (`windowStart`/`windowEnd`) modeled separately for future use.
- Ctrl/Cmd-scroll zoom (cursor-anchored) + toolbar zoom in/out (centre-anchored) + Reset View; click-and-drag panning on whitespace alongside the native scrollbar.
- Row virtualization (only visible rows render; bypassed during image capture).
- Settings menu with a Show Current Time toggle.
- Per-instance group-column width persisted to localStorage (via `storageKey`).
- Save-as-image, fullscreen (browser-viewport overlay), refresh button (with toast feedback), loading + empty states.

**Feature flag**
- Added `new-timeline-ui` (default **enabled**) and a `DefaultEnabled` option on `FeatureFlagDefinition` so flags can seed on. The seeder only sets initial state — admin toggles are never overwritten.
- `RoadmapViewManager` picks `RoadmapTimelineV2` vs. the legacy `RoadmapsTimeline` via `useFeatureFlag`.

**Docs**
- Updated feature-flag reference + settings user-guide for the `DefaultEnabled` behavior; revised the timeline spec's rollout section (flag-gated, richest-surface-first).

### Testing
- ~10 unit/component test suites (~98 tests) covering scale/ticks/tiers, packing, geometry + bounds clamping, virtualization, zoom math, depth/drill resolution, both layout strategies (incl. gantt row-key uniqueness), and the component's loading/empty states.
- Manually verified in-browser: drill, drag-edit, zoom/pan/reset, group-width persistence across reload, save-as-image fidelity, refresh feedback, and flag on/off swapping.

### Rollout notes
- Flag defaults on, so the new timeline shows immediately on fresh environments. **On environments that already have the flag row, enable it once** via Settings → Feature Flags (the seeder won't flip an existing flag).
- Legacy `vis-timeline` is untouched and fully functional as the fallback; it'll be removed only after all three consumers migrate.

### Out of scope (deferred)
- Gantt variant rendering (the strategy exists but isn't wired to a page yet).
- Keyboard a11y for bar move/resize.
- Auto-zoom to a narrower default view when `windowStart`/`windowEnd` ⊂ `minDate`/`maxDate`.