### PR TITLE
Feature/migrate objectives timeline component

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/page.tsx
@@ -5,7 +5,10 @@ import { useDocumentTitle } from '@/src/hooks'
 import { BuildOutlined, MenuOutlined } from '@ant-design/icons'
 import Segmented, { SegmentedLabeledOption } from 'antd/es/segmented'
 import { use, useState } from 'react'
-import { CreatePlanningIntervalObjectiveForm } from '../../_components'
+import {
+  CreatePlanningIntervalObjectiveForm,
+  PlanningIntervalObjectiveDetailsDrawer,
+} from '../../_components'
 import { PageTitle } from '@/src/components/common'
 import { notFound } from 'next/navigation'
 import { Button, Spin } from 'antd'
@@ -14,7 +17,7 @@ import { authorizePage } from '@/src/components/hoc'
 import dynamic from 'next/dynamic'
 
 const PlanningIntervalObjectivesTimeline = dynamic(
-  () => import('../../_components/planning-interval-objectives-timeline'),
+  () => import('../../_components/planning-interval-objectives-view-manager'),
   {
     ssr: false,
     loading: () => <Spin />,
@@ -48,6 +51,7 @@ const PlanningIntervalObjectivesPage = (props: {
   const [currentView, setCurrentView] = useState<string | number>('List')
   const [openCreateObjectiveForm, setOpenCreateObjectiveForm] =
     useState<boolean>(false)
+  const [drawerObjectiveKey, setDrawerObjectiveKey] = useState<number | null>(null)
 
   const { data: planningIntervalData, isLoading } =
     useGetPlanningIntervalQuery(piKey)
@@ -131,6 +135,17 @@ const PlanningIntervalObjectivesPage = (props: {
             ?.filter((t) => t.type == 'Team')
             .map((t) => t.name)}
           viewSelector={viewSelector}
+          onObjectiveClick={setDrawerObjectiveKey}
+          onRefresh={refectObjectives}
+        />
+      )}
+      {drawerObjectiveKey !== null && (
+        <PlanningIntervalObjectiveDetailsDrawer
+          planningIntervalKey={piKey}
+          objectiveKey={drawerObjectiveKey}
+          drawerOpen={drawerObjectiveKey !== null}
+          onDrawerClose={() => setDrawerObjectiveKey(null)}
+          canManageObjectives={!!canManageObjectives}
         />
       )}
       {openCreateObjectiveForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-plan-review.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/plan-review/team-plan-review.tsx
@@ -22,7 +22,7 @@ import useAuth from '@/src/components/contexts/auth'
 import dynamic from 'next/dynamic'
 
 const PlanningIntervalObjectivesTimeline = dynamic(
-  () => import('../../_components/planning-interval-objectives-timeline'),
+  () => import('../../_components/planning-interval-objectives-view-manager'),
   {
     ssr: false,
     loading: () => <Spin />,
@@ -176,6 +176,8 @@ const TeamPlanReview = ({
         <PlanningIntervalObjectivesTimeline
           objectivesData={objectivesData ?? []}
           planningIntervalCalendar={calendarData!}
+          onObjectiveClick={onObjectiveClick}
+          onRefresh={refetchObjectives}
         />
       )}
       {planningInterval?.key && selectedObjectiveKey && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/index.ts
@@ -19,5 +19,6 @@ export { default as PlanningIntervalIterationsList } from './planning-interval-i
 export { default as PlanningIntervalObjectiveDetailsDrawer } from './planning-interval-objectives-drawer'
 export { default as PlanningIntervalObjectivesGrid } from './planning-interval-objectives-grid'
 export { default as PlanningIntervalObjectivesTimeline } from './planning-interval-objectives-timeline'
+export { default as PlanningIntervalObjectivesViewManager } from './planning-interval-objectives-view-manager'
 export { default as PlanningIntervalTeamSprintMappings } from './planning-interval-team-sprint-mappings'
 export { default as TeamPredictabilityRadarChart } from './team-predictability-radar-chart'

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-drawer.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-drawer.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useGetPlanningIntervalObjectiveQuery } from '@/src/store/features/planning/planning-interval-api'
-import { Button, Descriptions, Drawer, Flex } from 'antd'
+import { Button, Descriptions, Drawer, Flex, Progress } from 'antd'
 import Link from 'next/link'
 import dayjs from 'dayjs'
 import PlanningIntervalObjectiveWorkItemsCard from '../[key]/objectives/[objectiveKey]/_components/planning-interval-objective-work-items-card'
@@ -118,6 +118,19 @@ const PlanningIntervalObjectiveDetailsDrawer: FC<
                 <MarkdownRenderer markdown={objectiveData?.description} />
               </DescriptionsItem>
             </Descriptions>
+            {objectiveData?.status?.name !== 'Not Started' && (
+              <Progress
+                percent={objectiveData?.progress}
+                size="small"
+                status={
+                  ['Canceled', 'Missed'].includes(
+                    objectiveData?.status?.name ?? '',
+                  )
+                    ? 'exception'
+                    : undefined
+                }
+              />
+            )}
           </Flex>
           <PlanningIntervalObjectiveWorkItemsCard
             planningIntervalKey={props.planningIntervalKey}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-timeline-v2.tsx
@@ -20,7 +20,7 @@ import { WaydTimeline2 } from '@/src/components/common/timeline2'
 import type { TimelineItem, TimelineGroup } from '@/src/components/common/timeline2'
 
 
-const ms = (d: unknown) => dayjs(d as string).valueOf()
+const ms = (d: dayjs.ConfigType) => dayjs(d).valueOf()
 
 interface PiObjectivesPayload {
   dto: PlanningIntervalObjectiveListDto

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-timeline-v2.tsx
@@ -1,0 +1,183 @@
+'use client'
+
+// planning-interval-objectives-timeline-v2.tsx — adapter feeding PI objectives
+// data into WaydTimeline2. Rendered in place of the legacy vis-timeline
+// (planning-interval-objectives-timeline.tsx) when the "new-timeline-ui" feature
+// flag is enabled; PlanningIntervalObjectivesViewManager picks between the two.
+//
+// iteration schedule -> kind 'background'  (scoped to a synthetic root band when
+//                                           groups are shown, so the label has headroom)
+// objective          -> kind 'range'        (one bar per objective, grouped by team)
+
+import { FC, ReactNode } from 'react'
+import dayjs from 'dayjs'
+import { useRouter } from 'next/navigation'
+import {
+  PlanningIntervalCalendarDto,
+  PlanningIntervalObjectiveListDto,
+} from '@/src/services/wayd-api'
+import { WaydTimeline2 } from '@/src/components/common/timeline2'
+import type { TimelineItem, TimelineGroup } from '@/src/components/common/timeline2'
+
+
+const ms = (d: unknown) => dayjs(d as string).valueOf()
+
+interface PiObjectivesPayload {
+  dto: PlanningIntervalObjectiveListDto
+}
+
+export interface PlanningIntervalObjectivesTimelineV2Props {
+  objectivesData: PlanningIntervalObjectiveListDto[]
+  planningIntervalCalendar: PlanningIntervalCalendarDto
+  enableGroups?: boolean
+  teamNames?: string[]
+  viewSelector?: ReactNode
+  onObjectiveClick?: (objectiveKey: number) => void
+  onRefresh?: () => void
+}
+
+function mapObjectives(
+  objectivesData: PlanningIntervalObjectiveListDto[],
+  planningIntervalCalendar: PlanningIntervalCalendarDto,
+  enableGroups: boolean,
+  teamNames: string[] | undefined,
+): {
+  items: TimelineItem<PiObjectivesPayload>[]
+  groups: TimelineGroup[]
+} {
+  const calStart = ms(planningIntervalCalendar.start)
+  const calEnd = ms(planningIntervalCalendar.end)
+
+  // Synthetic root group id — hosts iteration backgrounds when team groups are
+  // shown, so the band label gets a dedicated headroom row above the team rows
+  // rather than floating over the first team's bars.
+  const ROOT_GROUP_ID = '__pi_root__'
+
+  // Background items: one per iteration schedule. When groups are shown they are
+  // scoped to the root band; otherwise chart-wide (no groupId).
+  const backgrounds: TimelineItem<PiObjectivesPayload>[] =
+    planningIntervalCalendar.iterationSchedules?.map(
+      (iter): TimelineItem<PiObjectivesPayload> => ({
+        id: `iter-${iter.key}`,
+        kind: 'background',
+        label: iter.name ?? '',
+        // Iteration end is inclusive in the DTO; add 1 day minus 1 second to
+        // match the legacy component's rendering (fills to end of that day).
+        start: ms(iter.start),
+        end: ms(dayjs(iter.end as unknown as string).add(1, 'day').subtract(1, 'second')),
+        groupId: enableGroups ? ROOT_GROUP_ID : undefined,
+      }),
+    ) ?? []
+
+  const active = (objectivesData ?? []).filter(
+    (obj) => obj.status?.name !== 'Canceled',
+  )
+
+  // Determine group list: either from teamNames prop or derived from objectives.
+  let groupIds: string[]
+  if (enableGroups) {
+    if (teamNames && teamNames.length > 0) {
+      groupIds = [...teamNames].sort((a, b) => a.localeCompare(b))
+    } else {
+      groupIds = active
+        .reduce<string[]>((acc, obj) => {
+          const name = obj.team?.name
+          if (name && !acc.includes(name)) acc.push(name)
+          return acc
+        }, [])
+        .sort((a, b) => a.localeCompare(b))
+    }
+  } else {
+    groupIds = []
+  }
+
+  const teamGroups: TimelineGroup[] = groupIds.map((name, idx) => ({
+    id: name,
+    label: name,
+    order: idx,
+  }))
+
+  // Prepend a blank root band when there are iteration backgrounds to host —
+  // this gives the band labels headroom above the team rows.
+  const groups: TimelineGroup[] =
+    enableGroups && backgrounds.length > 0
+      ? [{ id: ROOT_GROUP_ID, label: '', order: -Infinity }, ...teamGroups]
+      : teamGroups
+
+  const bars: TimelineItem<PiObjectivesPayload>[] = active.map(
+    (obj, idx): TimelineItem<PiObjectivesPayload> => ({
+      id: String(obj.key),
+      kind: 'range',
+      label: `${obj.key} - ${obj.name ?? ''}`,
+      start: ms(obj.startDate ?? planningIntervalCalendar.start),
+      end: ms(obj.targetDate ?? planningIntervalCalendar.end),
+      groupId: enableGroups ? (obj.team?.name ?? undefined) : undefined,
+      order: obj.order ?? idx,
+      progress: obj.progress,
+      data: { dto: obj },
+    }),
+  )
+
+  return { items: [...backgrounds, ...bars], groups }
+}
+
+const PlanningIntervalObjectivesTimelineV2: FC<
+  PlanningIntervalObjectivesTimelineV2Props
+> = ({
+  objectivesData,
+  planningIntervalCalendar,
+  enableGroups = false,
+  teamNames,
+  viewSelector,
+  onObjectiveClick,
+  onRefresh,
+}) => {
+  const router = useRouter()
+
+  if (!planningIntervalCalendar) return null
+
+  const { items, groups } = mapObjectives(
+    objectivesData,
+    planningIntervalCalendar,
+    enableGroups,
+    teamNames,
+  )
+
+  const windowStart = ms(planningIntervalCalendar.start)
+  const windowEnd = ms(planningIntervalCalendar.end)
+  const piKey = planningIntervalCalendar.key
+
+  return (
+    <WaydTimeline2<PiObjectivesPayload>
+      variant="timeline"
+      items={items}
+      groups={groups.length > 0 ? groups : undefined}
+      windowStart={windowStart}
+      windowEnd={windowEnd}
+      minDate={windowStart}
+      maxDate={windowEnd}
+      storageKey={`pi-objectives-${piKey}`}
+      height={650}
+      // Read-only: no drag/resize/progress editing.
+      editable={false}
+      allowFullScreen
+      allowSaveAsImage
+      saveImageFileName={`PI ${planningIntervalCalendar.name} Objectives`}
+      onRefresh={onRefresh}
+      toolbarRightSlot={viewSelector}
+      onItemClick={(item) => {
+        if (!item.data) return
+        const { dto } = item.data
+        if (onObjectiveClick) {
+          onObjectiveClick(dto.key)
+        } else {
+          router.push(
+            `/planning/planning-intervals/${dto.planningInterval?.key}/objectives/${dto.key}`,
+          )
+        }
+      }}
+    />
+  )
+}
+
+export default PlanningIntervalObjectivesTimelineV2

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-timeline.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-timeline.tsx
@@ -26,6 +26,8 @@ interface PlanningIntervalObjectivesTimelineProps {
   enableGroups?: boolean
   teamNames?: string[]
   viewSelector?: React.ReactNode
+  onObjectiveClick?: (objectiveKey: number) => void
+  onRefresh?: () => void
 }
 
 interface ObjectiveDataItem extends WaydDataItem<

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-view-manager.tsx
@@ -1,0 +1,59 @@
+'use client'
+
+// Picks between the legacy vis-timeline and new WaydTimeline2 implementations
+// of the PI objectives timeline, gated by the "new-timeline-ui" feature flag.
+// Default-on: while the flag loads we show the new timeline to avoid a flash of
+// the legacy one on the happy path.
+
+import { ReactNode } from 'react'
+import { Spin } from 'antd'
+import dynamic from 'next/dynamic'
+import { useFeatureFlag } from '@/src/hooks'
+import { useMessage } from '@/src/components/contexts/messaging'
+import {
+  PlanningIntervalCalendarDto,
+  PlanningIntervalObjectiveListDto,
+} from '@/src/services/wayd-api'
+
+const LegacyTimeline = dynamic(
+  () => import('./planning-interval-objectives-timeline'),
+  { ssr: false, loading: () => <Spin /> },
+)
+
+const TimelineV2 = dynamic(
+  () => import('./planning-interval-objectives-timeline-v2'),
+  { ssr: false, loading: () => <Spin /> },
+)
+
+export interface PlanningIntervalObjectivesViewManagerProps {
+  objectivesData: PlanningIntervalObjectiveListDto[]
+  planningIntervalCalendar: PlanningIntervalCalendarDto
+  enableGroups?: boolean
+  teamNames?: string[]
+  viewSelector?: ReactNode
+  onObjectiveClick?: (objectiveKey: number) => void
+  onRefresh?: () => void
+}
+
+const PlanningIntervalObjectivesViewManager = (
+  props: PlanningIntervalObjectivesViewManagerProps,
+) => {
+  const { isEnabled: useNewTimeline, isLoading: isFlagLoading } =
+    useFeatureFlag('new-timeline-ui')
+  const messageApi = useMessage()
+
+  const refreshWithFeedback = props.onRefresh
+    ? async () => {
+        await props.onRefresh!()
+        messageApi.success('Timeline refreshed.')
+      }
+    : undefined
+
+  if (isFlagLoading || useNewTimeline) {
+    return <TimelineV2 {...props} onRefresh={refreshWithFeedback} />
+  }
+
+  return <LegacyTimeline {...props} />
+}
+
+export default PlanningIntervalObjectivesViewManager

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
@@ -20,7 +20,7 @@ import { GroupColumn } from './render/group-column'
 import { Axis } from './render/axis'
 import TimelineToolbar from './render/timeline-toolbar'
 import DrillControl from './render/drill-control'
-import { resolveLevel, maxGroupDepth } from './core/depth'
+import { resolveLevel } from './core/depth'
 import { growRowsForLabels, type GeometryConfig } from './core/geometry'
 import { getVisibleRange } from './core/virtualization'
 import type { TimelineGroup } from './core/types'
@@ -94,17 +94,30 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
 
   const hasGroups = !!groups && groups.length > 0
 
-  // Drill-through level (1-based, matches treeLevel): at level L, activities at
-  // treeLevel L render as bars and shallower tiers become groups.
-  //  level 1 = flat (top activities are bars, no groups); level 2 = top tier as
-  //  groups + their children as bars; deeper = drill further.
-  // maxLevel = deepest activity tier (group depth is 0-based → +1 for 1-based).
-  const maxDepth = hasGroups ? maxGroupDepth(groups!) : 0
-  const maxLevel = maxDepth + 1
+  // The drill-level model is opt-in: an adapter signals it by setting explicit
+  // `treeLevel` values on items or groups. This is distinct from structural
+  // hierarchy (parentId on groups, which Gantt will also use) — a Gantt tree is
+  // hierarchical but every item still gets its own row with no level filtering.
+  // Flat peer groups (PI objectives) and future Gantt consumers never set
+  // treeLevel, so they bypass resolveLevel and the drill controls entirely.
+  const usesDrillLevel =
+    hasGroups &&
+    (groups!.some((g) => g.treeLevel != null) ||
+      items.some((i) => i.treeLevel != null))
+
+  // Drill-through level (1-based). Only meaningful when usesDrillLevel is true.
+  // maxLevel = deepest treeLevel present across groups and items.
+  const maxLevel = usesDrillLevel
+    ? Math.max(
+        1,
+        ...groups!.map((g) => g.treeLevel ?? 0),
+        ...items.map((i) => i.treeLevel ?? 0),
+      )
+    : 1
   const [userLevel, setUserLevel] = useState<number | undefined>(undefined)
   const level = Math.min(userLevel ?? defaultDrillLevel, maxLevel)
 
-  const hasDrill = hasGroups && maxLevel > 1
+  const hasDrill = usesDrillLevel && maxLevel > 1
   const hasToolbar =
     allowFullScreen ||
     allowSaveAsImage ||
@@ -264,7 +277,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // gantt keeps one row per record.) Backgrounds are split AFTER remapping so a
   // row-scoped timebox follows its reassigned group.
   const resolved =
-    hasGroups && variant === 'timeline'
+    usesDrillLevel && variant === 'timeline'
       ? resolveLevel(items, groups!, level)
       : { items, groups: groups ?? [] }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/admin/feature-flags-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/admin/feature-flags-api.ts
@@ -22,7 +22,7 @@ export const featureFlagsApi = apiSlice.injectEndpoints({
           return { data }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error loading feature flags') }
         }
       },
       providesTags: (result) =>
@@ -43,7 +43,7 @@ export const featureFlagsApi = apiSlice.injectEndpoints({
           return { data }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error loading feature flag') }
         }
       },
       providesTags: (_result, _error, id) => [
@@ -54,10 +54,10 @@ export const featureFlagsApi = apiSlice.injectEndpoints({
       queryFn: async (request) => {
         try {
           await getFeatureFlagsClient().update(request.id, request)
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error updating feature flag') }
         }
       },
       invalidatesTags: (_result, _error, { id }) => [
@@ -69,10 +69,10 @@ export const featureFlagsApi = apiSlice.injectEndpoints({
       queryFn: async (request) => {
         try {
           await getFeatureFlagsClient().toggle(request.id, request)
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error toggling feature flag') }
         }
       },
       invalidatesTags: (_result, _error, { id }) => [
@@ -85,10 +85,10 @@ export const featureFlagsApi = apiSlice.injectEndpoints({
       queryFn: async (id) => {
         try {
           await getFeatureFlagsClient().archive(id)
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error archiving feature flag') }
         }
       },
       invalidatesTags: [QueryTags.FeatureFlag, QueryTags.ClientFeatureFlag],

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/planning/pi-objective-health-checks-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/planning/pi-objective-health-checks-api.ts
@@ -136,10 +136,10 @@ export const piObjectiveHealthChecksApi = apiSlice.injectEndpoints({
             objectiveId,
             healthCheckId,
           )
-          return { data: undefined }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error deleting health check') }
         }
       },
       invalidatesTags: (_result, _error, { objectiveId, healthCheckId }) => [

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/planning/roadmaps-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/planning/roadmaps-api.ts
@@ -320,7 +320,7 @@ export const roadmapApi = apiSlice.injectEndpoints({
             }
           }
 
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error: any) {
           console.error('API Error:', error)
           return {

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/ppm/project-health-checks-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/ppm/project-health-checks-api.ts
@@ -120,10 +120,10 @@ export const projectHealthChecksApi = apiSlice.injectEndpoints({
       queryFn: async ({ projectId, healthCheckId }) => {
         try {
           await getProjectHealthChecksClient().deleteHealthCheck(projectId, healthCheckId)
-          return { data: undefined }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
-          return { error }
+          return { error: error ?? new Error('Unknown error deleting health check') }
         }
       },
       invalidatesTags: (_result, _error, { projectId, healthCheckId }) => [

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/user-management/profile-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/user-management/profile-api.ts
@@ -35,7 +35,7 @@ export const profileApi = apiSlice.injectEndpoints({
       queryFn: async (preferences) => {
         try {
           await getProfileClient().updatePreferences(preferences)
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -47,7 +47,7 @@ export const profileApi = apiSlice.injectEndpoints({
       queryFn: async (args) => {
         try {
           await getProfileClient().changePassword(args)
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/user-management/users-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/user-management/users-api.ts
@@ -138,7 +138,7 @@ export const usersApi = apiSlice.injectEndpoints({
               },
             }
           }
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -190,7 +190,7 @@ export const usersApi = apiSlice.injectEndpoints({
               },
             }
           }
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -218,7 +218,7 @@ export const usersApi = apiSlice.injectEndpoints({
               },
             }
           }
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -247,7 +247,7 @@ export const usersApi = apiSlice.injectEndpoints({
               },
             }
           }
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }
@@ -278,7 +278,7 @@ export const usersApi = apiSlice.injectEndpoints({
               },
             }
           }
-          return { data: undefined as void }
+          return { data: null as unknown as void }
         } catch (error) {
           console.error('API Error:', error)
           return { error }


### PR DESCRIPTION
## Migrate PI Objectives timeline to WaydTimeline2

Step 2 of 3 in the timeline replacement effort (epic #628). Roadmaps was step 1 (PR #629).

### What changed

**New timeline component (`planning-interval-objectives-timeline-v2.tsx`)**
- Replaces the vis-timeline-based implementation when the `new-timeline-ui` feature flag is enabled (default on)
- Iteration schedules render as `background` bands; objectives render as `range` bars grouped by team
- Groups are sorted alphabetically
- Clicking a bar opens the objective details drawer instead of navigating to the detail page
- Refresh button in the toolbar (same pattern as roadmaps — success toast via view manager)

**View manager (`planning-interval-objectives-view-manager.tsx`)**
- Gates between V2 and legacy via `useFeatureFlag('new-timeline-ui')`
- Wraps `onRefresh` with a success toast before passing it to V2, matching the roadmaps pattern

**`wayd-timeline2.tsx` — architectural fix (`usesDrillLevel`)**
- Replaced `isHierarchical` (which checked `parentId || treeLevel`) with `usesDrillLevel` (checks `treeLevel` only)
- `parentId` is structural hierarchy (Gantt will use it without drill leveling); `treeLevel` is the explicit opt-in to the drill model
- `resolveLevel` and drill controls only activate when `usesDrillLevel === true`, so flat-group timelines like PI objectives bypass level filtering entirely

**Objective drawer**
- Added a progress bar below the description block
- Hidden when status is "Not Started"; shows `exception` status for Canceled/Missed

**RTK Query void mutation fix**
- `return { data: undefined as void }` evaluates to `{ data: undefined }`, which RTK Query 2.x rejects as invalid (it checks `data === void 0`)
- Changed to `return { data: null as unknown as void }` across all affected mutation endpoints (`feature-flags-api.ts`, `roadmaps-api.ts`, `profile-api.ts`, `users-api.ts`)
- This was producing a console error on every successful void mutation call

### Pages updated
- **PI Objectives page** (`/planning/planning-intervals/[key]/objectives`) — timeline view now uses V2; bar click opens drawer
- **Plan Review page** (`/planning/planning-intervals/[key]/plan-review`) — team timeline view now uses V2
