### PR TITLE
Feature/migrate ppm timelines component

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/program-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/program-view-manager.tsx
@@ -2,13 +2,20 @@
 
 import { BuildOutlined, MenuOutlined } from '@ant-design/icons'
 import Segmented, { SegmentedLabeledOption } from 'antd/es/segmented'
+import { Spin } from 'antd'
 import { memo, useState } from 'react'
 import { ProgramListDto } from '@/src/services/wayd-api'
-import { Spin } from 'antd'
 import dynamic from 'next/dynamic'
+import { useFeatureFlag } from '@/src/hooks'
+import { useMessage } from '@/src/components/contexts/messaging'
 import ProgramsGrid from './programs-grid'
 
-const ProgramsTimeline = dynamic(() => import('./programs-timeline'), {
+const LegacyTimeline = dynamic(() => import('./programs-timeline'), {
+  ssr: false,
+  loading: () => <Spin />,
+})
+
+const TimelineV2 = dynamic(() => import('./programs-timeline-v2'), {
   ssr: false,
   loading: () => <Spin />,
 })
@@ -33,6 +40,15 @@ const viewSelectorOptions: SegmentedLabeledOption[] = [
 const ProgramViewManager = (props: ProgramViewManagerProps) => {
   const [currentView, setCurrentView] = useState<string | number>('List')
 
+  const { isEnabled: useNewTimeline, isLoading: isFlagLoading } =
+    useFeatureFlag('new-timeline-ui')
+  const messageApi = useMessage()
+
+  const refreshWithFeedback = async () => {
+    await props.refetch()
+    messageApi.success('Timeline refreshed.')
+  }
+
   const viewSelector = (
     <Segmented
       options={viewSelectorOptions}
@@ -52,14 +68,22 @@ const ProgramViewManager = (props: ProgramViewManagerProps) => {
           viewSelector={viewSelector}
         />
       )}
-      {currentView === 'Timeline' && (
-        <ProgramsTimeline
+      {currentView === 'Timeline' && (isFlagLoading || useNewTimeline ? (
+        <TimelineV2
+          programs={props.programs}
+          isLoading={props.isLoading}
+          refetch={props.refetch}
+          viewSelector={viewSelector}
+          onRefresh={refreshWithFeedback}
+        />
+      ) : (
+        <LegacyTimeline
           programs={props.programs}
           isLoading={props.isLoading}
           refetch={props.refetch}
           viewSelector={viewSelector}
         />
-      )}
+      ))}
     </>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline-v2.tsx
@@ -1,0 +1,115 @@
+'use client'
+
+import { FC, ReactNode, useState } from 'react'
+import dayjs from 'dayjs'
+import { theme } from 'antd'
+import { ProgramListDto } from '@/src/services/wayd-api'
+import { WaydTimeline2 } from '@/src/components/common/timeline2'
+import type { TimelineItem } from '@/src/components/common/timeline2'
+import { getLifecyclePhaseColorFromStatus } from '@/src/utils'
+import { ProgramDrawer } from '.'
+
+const ms = (d: dayjs.ConfigType) => dayjs(d).valueOf()
+
+interface ProgramPayload {
+  dto: ProgramListDto
+}
+
+export interface ProgramsTimelineV2Props {
+  programs: ProgramListDto[]
+  isLoading: boolean
+  refetch: () => void
+  viewSelector?: ReactNode
+  onRefresh?: () => void
+}
+
+function mapPrograms(
+  programs: ProgramListDto[],
+  token: ReturnType<typeof theme.useToken>['token'],
+): {
+  items: TimelineItem<ProgramPayload>[]
+  windowStart: number
+  windowEnd: number
+} {
+  const dated = programs.filter((p) => p.start && p.end)
+
+  let minMs = dayjs().valueOf()
+  let maxMs = dayjs().valueOf()
+
+  const items: TimelineItem<ProgramPayload>[] = dated.map((p, idx) => {
+    const start = ms(p.start!)
+    const end = ms(p.end!)
+    if (start < minMs) minMs = start
+    if (end > maxMs) maxMs = end
+    return {
+      id: String(p.id),
+      kind: 'range',
+      label: p.name ?? '',
+      color: getLifecyclePhaseColorFromStatus(p.status, token),
+      start,
+      end,
+      order: idx,
+      data: { dto: p },
+    }
+  })
+
+  const windowStart = dayjs(minMs).subtract(14, 'days').valueOf()
+  const windowEnd = dayjs(maxMs).add(1, 'month').valueOf()
+
+  return { items, windowStart, windowEnd }
+}
+
+const ProgramsTimelineV2: FC<ProgramsTimelineV2Props> = ({
+  programs,
+  isLoading,
+  viewSelector,
+  onRefresh,
+}) => {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [selectedKey, setSelectedKey] = useState<number | null>(null)
+  const { token } = theme.useToken()
+
+  const { items, windowStart, windowEnd } = mapPrograms(
+    isLoading ? [] : programs,
+    token,
+  )
+
+  return (
+    <>
+      <WaydTimeline2<ProgramPayload>
+        variant="timeline"
+        items={items}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        minDate={windowStart}
+        maxDate={windowEnd}
+        storageKey="ppm-programs"
+        height={650}
+        editable={false}
+        isLoading={isLoading}
+        allowFullScreen
+        allowSaveAsImage
+        saveImageFileName="Programs Timeline"
+        onRefresh={onRefresh}
+        toolbarRightSlot={viewSelector}
+        onItemClick={(item) => {
+          if (!item.data) return
+          setSelectedKey(item.data.dto.key)
+          setDrawerOpen(true)
+        }}
+      />
+      {selectedKey !== null && (
+        <ProgramDrawer
+          programKey={selectedKey}
+          drawerOpen={drawerOpen}
+          onDrawerClose={() => {
+            setDrawerOpen(false)
+            setSelectedKey(null)
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default ProgramsTimelineV2

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline-v2.tsx
@@ -33,8 +33,8 @@ function mapPrograms(
 } {
   const dated = programs.filter((p) => p.start && p.end)
 
-  let minMs = dayjs().valueOf()
-  let maxMs = dayjs().valueOf()
+  let minMs = dated.length > 0 ? ms(dated[0].start!) : dayjs().valueOf()
+  let maxMs = dated.length > 0 ? ms(dated[0].end!) : dayjs().valueOf()
 
   const items: TimelineItem<ProgramPayload>[] = dated.map((p, idx) => {
     const start = ms(p.start!)

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline.tsx
@@ -24,6 +24,7 @@ export interface ProgramsTimelineProps {
   isLoading: boolean
   refetch: () => void
   viewSelector?: ReactNode
+  onRefresh?: () => void
 }
 
 interface ProgramTimelineItem extends WaydDataItem<ProgramListDto, string> {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/project-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/project-view-manager.tsx
@@ -5,8 +5,7 @@ import {
   BuildOutlined,
   MenuOutlined,
 } from '@ant-design/icons'
-import { Segmented } from 'antd'
-import { Spin } from 'antd'
+import { Segmented, Spin } from 'antd'
 import { memo, useState } from 'react'
 import { ProjectListDto } from '@/src/services/wayd-api'
 import dynamic from 'next/dynamic'

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/project-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/project-view-manager.tsx
@@ -6,15 +6,22 @@ import {
   MenuOutlined,
 } from '@ant-design/icons'
 import { Segmented } from 'antd'
+import { Spin } from 'antd'
 import { memo, useState } from 'react'
 import { ProjectListDto } from '@/src/services/wayd-api'
-import { Spin } from 'antd'
 import dynamic from 'next/dynamic'
+import { useFeatureFlag } from '@/src/hooks'
+import { useMessage } from '@/src/components/contexts/messaging'
 import ProjectsGrid from './projects-grid'
 import ProjectsCardView from './projects-card-view'
 import ProjectDrawer from './project-drawer'
 
-const ProjectsTimeline = dynamic(() => import('./projects-timeline'), {
+const LegacyTimeline = dynamic(() => import('./projects-timeline'), {
+  ssr: false,
+  loading: () => <Spin />,
+})
+
+const TimelineV2 = dynamic(() => import('./projects-timeline-v2'), {
   ssr: false,
   loading: () => <Spin />,
 })
@@ -55,6 +62,15 @@ const ProjectViewManager = (props: ProjectViewManagerProps) => {
   )
   const [drawerOpen, setDrawerOpen] = useState(false)
 
+  const { isEnabled: useNewTimeline, isLoading: isFlagLoading } =
+    useFeatureFlag('new-timeline-ui')
+  const messageApi = useMessage()
+
+  const refreshWithFeedback = async () => {
+    await props.refetch()
+    messageApi.success('Timeline refreshed.')
+  }
+
   const onCardClick = (key: string) => {
     setSelectedProjectKey(key)
     setDrawerOpen(true)
@@ -89,15 +105,24 @@ const ProjectViewManager = (props: ProjectViewManagerProps) => {
           viewSelector={viewSelector}
         />
       )}
-      {currentView === 'Timeline' && (
-        <ProjectsTimeline
+      {currentView === 'Timeline' && (isFlagLoading || useNewTimeline ? (
+        <TimelineV2
+          projects={props.projects}
+          isLoading={props.isLoading}
+          refetch={props.refetch}
+          viewSelector={viewSelector}
+          groupByProgram={props.groupByProgram}
+          onRefresh={refreshWithFeedback}
+        />
+      ) : (
+        <LegacyTimeline
           projects={props.projects}
           isLoading={props.isLoading}
           refetch={props.refetch}
           viewSelector={viewSelector}
           groupByProgram={props.groupByProgram}
         />
-      )}
+      ))}
       {selectedProjectKey && (
         <ProjectDrawer
           projectKey={selectedProjectKey}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline-v2.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import { FC, ReactNode, useState } from 'react'
+import dayjs from 'dayjs'
+import { theme } from 'antd'
+import { ProjectListDto } from '@/src/services/wayd-api'
+import { WaydTimeline2 } from '@/src/components/common/timeline2'
+import type { TimelineItem, TimelineGroup } from '@/src/components/common/timeline2'
+import { getLifecyclePhaseColorFromStatus } from '@/src/utils'
+import { ProjectDrawer } from '.'
+
+const ms = (d: dayjs.ConfigType) => dayjs(d).valueOf()
+
+interface ProjectPayload {
+  dto: ProjectListDto
+}
+
+export interface ProjectsTimelineV2Props {
+  projects: ProjectListDto[]
+  isLoading: boolean
+  refetch: () => void
+  viewSelector?: ReactNode
+  groupByProgram?: boolean
+  onRefresh?: () => void
+}
+
+function mapProjects(
+  projects: ProjectListDto[],
+  groupByProgram: boolean,
+  token: ReturnType<typeof theme.useToken>['token'],
+): {
+  items: TimelineItem<ProjectPayload>[]
+  groups: TimelineGroup[]
+  windowStart: number
+  windowEnd: number
+} {
+  const dated = projects.filter((p) => p.start && p.end)
+
+  let minMs = dayjs().valueOf()
+  let maxMs = dayjs().valueOf()
+
+  const items: TimelineItem<ProjectPayload>[] = dated.map((p, idx) => {
+    const start = ms(p.start!)
+    const end = ms(p.end!)
+    if (start < minMs) minMs = start
+    if (end > maxMs) maxMs = end
+    return {
+      id: String(p.id),
+      kind: 'range',
+      label: p.name ?? '',
+      color: getLifecyclePhaseColorFromStatus(p.status, token),
+      start,
+      end,
+      groupId: groupByProgram ? (p.program?.name ?? 'No Program') : undefined,
+      order: idx,
+      data: { dto: p },
+    }
+  })
+
+  // Build groups: alphabetical, 'No Program' last — skip if only one group and
+  // it would be 'No Program' (matches legacy: returns [] when all ungrouped).
+  let groups: TimelineGroup[] = []
+  if (groupByProgram) {
+    const seen = new Map<string, TimelineGroup>()
+    for (const p of dated) {
+      const name = p.program?.name ?? 'No Program'
+      if (!seen.has(name)) {
+        seen.set(name, { id: name, label: name })
+      }
+    }
+    const all = [...seen.values()]
+    if (!(all.length === 1 && all[0].id === 'No Program')) {
+      groups = all.sort((a, b) => {
+        if (a.id === 'No Program') return 1
+        if (b.id === 'No Program') return -1
+        return a.id.localeCompare(b.id)
+      })
+    }
+  }
+
+  const windowStart = dayjs(minMs).subtract(14, 'days').valueOf()
+  const windowEnd = dayjs(maxMs).add(1, 'month').valueOf()
+
+  return { items, groups, windowStart, windowEnd }
+}
+
+const ProjectsTimelineV2: FC<ProjectsTimelineV2Props> = ({
+  projects,
+  isLoading,
+  viewSelector,
+  groupByProgram = false,
+  onRefresh,
+}) => {
+  const [drawerOpen, setDrawerOpen] = useState(false)
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const { token } = theme.useToken()
+
+  const { items, groups, windowStart, windowEnd } = mapProjects(
+    isLoading ? [] : projects,
+    groupByProgram,
+    token,
+  )
+
+  const noDatesCount = projects.filter((p) => !p.start).length
+
+  return (
+    <>
+      <WaydTimeline2<ProjectPayload>
+        variant="timeline"
+        items={items}
+        groups={groups.length > 0 ? groups : undefined}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        minDate={windowStart}
+        maxDate={windowEnd}
+        storageKey="ppm-projects"
+        height={650}
+        editable={false}
+        isLoading={isLoading}
+        allowFullScreen
+        allowSaveAsImage
+        saveImageFileName="Projects Timeline"
+        onRefresh={onRefresh}
+        toolbarRightSlot={viewSelector}
+        onItemClick={(item) => {
+          if (!item.data) return
+          setSelectedKey(item.data.dto.key)
+          setDrawerOpen(true)
+        }}
+        emptyMessage={
+          noDatesCount > 0
+            ? `${noDatesCount} ${noDatesCount === 1 ? 'project is' : 'projects are'} not shown due to missing dates.`
+            : undefined
+        }
+      />
+      {selectedKey && (
+        <ProjectDrawer
+          projectKey={selectedKey}
+          drawerOpen={drawerOpen}
+          onDrawerClose={() => {
+            setDrawerOpen(false)
+            setSelectedKey(null)
+          }}
+        />
+      )}
+    </>
+  )
+}
+
+export default ProjectsTimelineV2

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline-v2.tsx
@@ -36,8 +36,8 @@ function mapProjects(
 } {
   const dated = projects.filter((p) => p.start && p.end)
 
-  let minMs = dayjs().valueOf()
-  let maxMs = dayjs().valueOf()
+  let minMs = dated.length > 0 ? ms(dated[0].start!) : dayjs().valueOf()
+  let maxMs = dated.length > 0 ? ms(dated[0].end!) : dayjs().valueOf()
 
   const items: TimelineItem<ProjectPayload>[] = dated.map((p, idx) => {
     const start = ms(p.start!)
@@ -101,7 +101,7 @@ const ProjectsTimelineV2: FC<ProjectsTimelineV2Props> = ({
     token,
   )
 
-  const noDatesCount = projects.filter((p) => !p.start).length
+  const noDatesCount = projects.filter((p) => !p.start || !p.end).length
 
   return (
     <>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline.tsx
@@ -26,6 +26,7 @@ export interface ProjectsTimelineProps {
   refetch: () => void
   viewSelector?: ReactNode
   groupByProgram?: boolean
+  onRefresh?: () => void
 }
 
 interface ProjectTimelineItem extends WaydDataItem<ProjectListDto, string> {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiative-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiative-view-manager.tsx
@@ -2,14 +2,24 @@
 
 import { BuildOutlined, MenuOutlined } from '@ant-design/icons'
 import Segmented, { SegmentedLabeledOption } from 'antd/es/segmented'
+import { Spin } from 'antd'
 import { memo, useState } from 'react'
 import { StrategicInitiativeListDto } from '@/src/services/wayd-api'
-import { Spin } from 'antd'
 import dynamic from 'next/dynamic'
+import { useFeatureFlag } from '@/src/hooks'
+import { useMessage } from '@/src/components/contexts/messaging'
 import { StrategicInitiativesGrid } from '.'
 
-const StrategicInitiativesTimeline = dynamic(
+const LegacyTimeline = dynamic(
   () => import('./strategic-initiatives-timeline'),
+  {
+    ssr: false,
+    loading: () => <Spin />,
+  },
+)
+
+const TimelineV2 = dynamic(
+  () => import('./strategic-initiatives-timeline-v2'),
   {
     ssr: false,
     loading: () => <Spin />,
@@ -38,6 +48,15 @@ const StrategicInitiativeViewManager = (
 ) => {
   const [currentView, setCurrentView] = useState<string | number>('List')
 
+  const { isEnabled: useNewTimeline, isLoading: isFlagLoading } =
+    useFeatureFlag('new-timeline-ui')
+  const messageApi = useMessage()
+
+  const refreshWithFeedback = async () => {
+    await props.refetch()
+    messageApi.success('Timeline refreshed.')
+  }
+
   const viewSelector = (
     <Segmented
       options={viewSelectorOptions}
@@ -58,14 +77,22 @@ const StrategicInitiativeViewManager = (
           viewSelector={viewSelector}
         />
       )}
-      {currentView === 'Timeline' && (
-        <StrategicInitiativesTimeline
+      {currentView === 'Timeline' && (isFlagLoading || useNewTimeline ? (
+        <TimelineV2
+          strategicInitiatives={props.strategicInitiatives}
+          isLoading={props.isLoading}
+          refetch={props.refetch}
+          viewSelector={viewSelector}
+          onRefresh={refreshWithFeedback}
+        />
+      ) : (
+        <LegacyTimeline
           strategicInitiatives={props.strategicInitiatives}
           isLoading={props.isLoading}
           refetch={props.refetch}
           viewSelector={viewSelector}
         />
-      )}
+      ))}
     </>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline-v2.tsx
@@ -33,8 +33,8 @@ function mapStrategicInitiatives(
 } {
   const dated = initiatives.filter((i) => i.start && i.end)
 
-  let minMs = dayjs().valueOf()
-  let maxMs = dayjs().valueOf()
+  let minMs = dated.length > 0 ? ms(dated[0].start!) : dayjs().valueOf()
+  let maxMs = dated.length > 0 ? ms(dated[0].end!) : dayjs().valueOf()
 
   const items: TimelineItem<StrategicInitiativePayload>[] = dated.map(
     (i, idx) => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline-v2.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { FC, ReactNode, useState } from 'react'
+import dayjs from 'dayjs'
+import { theme } from 'antd'
+import { StrategicInitiativeListDto } from '@/src/services/wayd-api'
+import { WaydTimeline2 } from '@/src/components/common/timeline2'
+import type { TimelineItem } from '@/src/components/common/timeline2'
+import { getLifecyclePhaseColorFromStatus } from '@/src/utils'
+import { StrategicInitiativeDrawer } from '.'
+
+const ms = (d: dayjs.ConfigType) => dayjs(d).valueOf()
+
+interface StrategicInitiativePayload {
+  dto: StrategicInitiativeListDto
+}
+
+export interface StrategicInitiativesTimelineV2Props {
+  strategicInitiatives: StrategicInitiativeListDto[]
+  isLoading: boolean
+  refetch: () => void
+  viewSelector?: ReactNode
+  onRefresh?: () => void
+}
+
+function mapStrategicInitiatives(
+  initiatives: StrategicInitiativeListDto[],
+  token: ReturnType<typeof theme.useToken>['token'],
+): {
+  items: TimelineItem<StrategicInitiativePayload>[]
+  windowStart: number
+  windowEnd: number
+} {
+  const dated = initiatives.filter((i) => i.start && i.end)
+
+  let minMs = dayjs().valueOf()
+  let maxMs = dayjs().valueOf()
+
+  const items: TimelineItem<StrategicInitiativePayload>[] = dated.map(
+    (i, idx) => {
+      const start = ms(i.start!)
+      const end = ms(i.end!)
+      if (start < minMs) minMs = start
+      if (end > maxMs) maxMs = end
+      return {
+        id: String(i.id),
+        kind: 'range',
+        label: i.name ?? '',
+        color: getLifecyclePhaseColorFromStatus(i.status, token),
+        start,
+        end,
+        order: idx,
+        data: { dto: i },
+      }
+    },
+  )
+
+  const windowStart = dayjs(minMs).subtract(14, 'days').valueOf()
+  const windowEnd = dayjs(maxMs).add(1, 'month').valueOf()
+
+  return { items, windowStart, windowEnd }
+}
+
+const StrategicInitiativesTimelineV2: FC<StrategicInitiativesTimelineV2Props> =
+  ({ strategicInitiatives, isLoading, viewSelector, onRefresh }) => {
+    const [drawerOpen, setDrawerOpen] = useState(false)
+    const [selectedKey, setSelectedKey] = useState<number | null>(null)
+    const { token } = theme.useToken()
+
+    const { items, windowStart, windowEnd } = mapStrategicInitiatives(
+      isLoading ? [] : strategicInitiatives,
+      token,
+    )
+
+    return (
+      <>
+        <WaydTimeline2<StrategicInitiativePayload>
+          variant="timeline"
+          items={items}
+          windowStart={windowStart}
+          windowEnd={windowEnd}
+          minDate={windowStart}
+          maxDate={windowEnd}
+          storageKey="ppm-strategic-initiatives"
+          height={650}
+          editable={false}
+          isLoading={isLoading}
+          allowFullScreen
+          allowSaveAsImage
+          saveImageFileName="Strategic Initiatives Timeline"
+          onRefresh={onRefresh}
+          toolbarRightSlot={viewSelector}
+          onItemClick={(item) => {
+            if (!item.data) return
+            setSelectedKey(item.data.dto.key)
+            setDrawerOpen(true)
+          }}
+        />
+        {selectedKey !== null && (
+          <StrategicInitiativeDrawer
+            strategicInitiativeKey={selectedKey}
+            drawerOpen={drawerOpen}
+            onDrawerClose={() => {
+              setDrawerOpen(false)
+              setSelectedKey(null)
+            }}
+          />
+        )}
+      </>
+    )
+  }
+
+export default StrategicInitiativesTimelineV2

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline.tsx
@@ -24,6 +24,7 @@ export interface StrategicInitiativesTimelineProps {
   isLoading: boolean
   refetch: () => void
   viewSelector?: ReactNode
+  onRefresh?: () => void
 }
 
 interface StrategicInitiativeTimelineItem extends WaydDataItem<


### PR DESCRIPTION
## Summary

- Migrates all three PPM timeline surfaces (Projects, Programs, Strategic Initiatives) from the legacy `WaydTimeline` (vis-timeline) to `WaydTimeline2`, completing step 3 of 3 in the timeline replacement effort (epic #628)
- Creates three new V2 adapter components (`projects-timeline-v2.tsx`, `programs-timeline-v2.tsx`, `strategic-initiatives-timeline-v2.tsx`) following the pattern established in PRs #629 (Roadmaps) and #630 (PI Objectives)
- Updates the three existing PPM view managers (`project-view-manager.tsx`, `program-view-manager.tsx`, `strategic-initiative-view-manager.tsx`) to gate on the `new-timeline-ui` feature flag — new timeline is default-on while the flag loads, legacy is the fallback when the flag is explicitly disabled

## Details

All three V2 adapters:
- Map domain DTOs to `TimelineItem<Payload>` with epoch-ms timestamps and lifecycle-phase colors via `getLifecyclePhaseColorFromStatus`
- Auto-fit the visible window to data extents (−14 days / +1 month)
- Are read-only (`editable: false`) with fullscreen, save-as-image, and a refresh toolbar button
- Pass the view selector (`Segmented` control) into `toolbarRightSlot` so it renders inside the WaydTimeline2 toolbar (no separate Flex/Card wrapper)
- Open the existing domain drawer on item click

Projects additionally supports the existing `groupByProgram` option — groups are built alphabetically with "No Program" last, and collapsed to a flat ungrouped chart when all projects belong to a single "No Program" group (matching legacy behavior).

`onRefresh?: () => void` added to the three legacy props interfaces for forward compatibility.

## Related

- Closes step 3 of epic #628
- Follows patterns from PR #629 (Roadmaps) and PR #630 (PI Objectives)
- After this lands: remove the `new-timeline-ui` flag + gating, delete `src/components/common/timeline/`, drop `vis-timeline` + `vis-data` deps

## Test plan

- [ ] Navigate to a portfolio or program detail page → switch to Timeline view → verify Projects timeline renders with bars, colors, and group column (when programs exist)
- [ ] Navigate to a program list page → switch to Timeline view → verify Programs timeline renders
- [ ] Navigate to a strategic initiatives page → switch to Timeline view → verify SI timeline renders
- [ ] Click a bar on each timeline → verify the correct drawer opens
- [ ] Verify the refresh button appears in the toolbar and shows "Timeline refreshed." toast on click
- [ ] Verify fullscreen and save-as-image work on each surface
- [ ] Disable the `new-timeline-ui` feature flag in Settings → verify all three surfaces fall back to the legacy vis-timeline