### PR TITLE
Feature/timeline component enhancements

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
@@ -187,6 +187,14 @@ const RoadmapTimelineV2: FC<RoadmapTimelineV2Props> = (props) => {
   const windowStart = ms(props.roadmap.start)
   const windowEnd = ms(props.roadmap.end)
 
+  const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000
+  const itemStarts = items.map((i) => i.start)
+  const itemEnds = items.map((i) => i.end)
+  const earliestItem = itemStarts.length ? Math.min(...itemStarts) : windowStart
+  const latestItem = itemEnds.length ? Math.max(...itemEnds) : windowEnd
+  const minDate = earliestItem - ONE_YEAR_MS
+  const maxDate = latestItem + ONE_YEAR_MS
+
   const onItemDateChange = async (change: ItemDateChange) => {
     const source = items.find((i) => i.id === change.id)
     const dto = source?.data?.dto
@@ -220,11 +228,8 @@ const RoadmapTimelineV2: FC<RoadmapTimelineV2Props> = (props) => {
       groups={groups}
       windowStart={windowStart}
       windowEnd={windowEnd}
-      // Roadmaps hard-bound the timeline to the roadmap's own dates (matching the
-      // legacy timeline's min/max == start/end): the axis spans exactly the
-      // roadmap window and you can't pan/zoom outside it.
-      minDate={windowStart}
-      maxDate={windowEnd}
+      minDate={minDate}
+      maxDate={maxDate}
       storageKey={`roadmap-${props.roadmap.id}`}
       onRefresh={props.refreshRoadmapItems}
       height={650}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-timeline-v2.tsx
@@ -30,6 +30,8 @@ function mapPrograms(
   items: TimelineItem<ProgramPayload>[]
   windowStart: number
   windowEnd: number
+  minDate: number
+  maxDate: number
 } {
   const dated = programs.filter((p) => p.start && p.end)
 
@@ -53,10 +55,12 @@ function mapPrograms(
     }
   })
 
-  const windowStart = dayjs(minMs).subtract(14, 'days').valueOf()
-  const windowEnd = dayjs(maxMs).add(1, 'month').valueOf()
+  const windowStart = dayjs().subtract(6, 'months').valueOf()
+  const windowEnd = dayjs().add(6, 'months').valueOf()
+  const minDate = dayjs(minMs).subtract(1, 'month').valueOf()
+  const maxDate = dayjs(maxMs).add(1, 'month').valueOf()
 
-  return { items, windowStart, windowEnd }
+  return { items, windowStart, windowEnd, minDate, maxDate }
 }
 
 const ProgramsTimelineV2: FC<ProgramsTimelineV2Props> = ({
@@ -69,7 +73,7 @@ const ProgramsTimelineV2: FC<ProgramsTimelineV2Props> = ({
   const [selectedKey, setSelectedKey] = useState<number | null>(null)
   const { token } = theme.useToken()
 
-  const { items, windowStart, windowEnd } = mapPrograms(
+  const { items, windowStart, windowEnd, minDate, maxDate } = mapPrograms(
     isLoading ? [] : programs,
     token,
   )
@@ -81,8 +85,8 @@ const ProgramsTimelineV2: FC<ProgramsTimelineV2Props> = ({
         items={items}
         windowStart={windowStart}
         windowEnd={windowEnd}
-        minDate={windowStart}
-        maxDate={windowEnd}
+        minDate={minDate}
+        maxDate={maxDate}
         storageKey="ppm-programs"
         height={650}
         editable={false}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-timeline-v2.tsx
@@ -33,6 +33,8 @@ function mapProjects(
   groups: TimelineGroup[]
   windowStart: number
   windowEnd: number
+  minDate: number
+  maxDate: number
 } {
   const dated = projects.filter((p) => p.start && p.end)
 
@@ -78,10 +80,12 @@ function mapProjects(
     }
   }
 
-  const windowStart = dayjs(minMs).subtract(14, 'days').valueOf()
-  const windowEnd = dayjs(maxMs).add(1, 'month').valueOf()
+  const windowStart = dayjs().subtract(6, 'months').valueOf()
+  const windowEnd = dayjs().add(6, 'months').valueOf()
+  const minDate = dayjs(minMs).subtract(1, 'month').valueOf()
+  const maxDate = dayjs(maxMs).add(1, 'month').valueOf()
 
-  return { items, groups, windowStart, windowEnd }
+  return { items, groups, windowStart, windowEnd, minDate, maxDate }
 }
 
 const ProjectsTimelineV2: FC<ProjectsTimelineV2Props> = ({
@@ -95,7 +99,7 @@ const ProjectsTimelineV2: FC<ProjectsTimelineV2Props> = ({
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const { token } = theme.useToken()
 
-  const { items, groups, windowStart, windowEnd } = mapProjects(
+  const { items, groups, windowStart, windowEnd, minDate, maxDate } = mapProjects(
     isLoading ? [] : projects,
     groupByProgram,
     token,
@@ -111,8 +115,8 @@ const ProjectsTimelineV2: FC<ProjectsTimelineV2Props> = ({
         groups={groups.length > 0 ? groups : undefined}
         windowStart={windowStart}
         windowEnd={windowEnd}
-        minDate={windowStart}
-        maxDate={windowEnd}
+        minDate={minDate}
+        maxDate={maxDate}
         storageKey="ppm-projects"
         height={650}
         editable={false}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-timeline-v2.tsx
@@ -30,6 +30,8 @@ function mapStrategicInitiatives(
   items: TimelineItem<StrategicInitiativePayload>[]
   windowStart: number
   windowEnd: number
+  minDate: number
+  maxDate: number
 } {
   const dated = initiatives.filter((i) => i.start && i.end)
 
@@ -55,10 +57,12 @@ function mapStrategicInitiatives(
     },
   )
 
-  const windowStart = dayjs(minMs).subtract(14, 'days').valueOf()
-  const windowEnd = dayjs(maxMs).add(1, 'month').valueOf()
+  const windowStart = dayjs().subtract(6, 'months').valueOf()
+  const windowEnd = dayjs().add(6, 'months').valueOf()
+  const minDate = dayjs(minMs).subtract(1, 'month').valueOf()
+  const maxDate = dayjs(maxMs).add(1, 'month').valueOf()
 
-  return { items, windowStart, windowEnd }
+  return { items, windowStart, windowEnd, minDate, maxDate }
 }
 
 const StrategicInitiativesTimelineV2: FC<StrategicInitiativesTimelineV2Props> =
@@ -67,7 +71,7 @@ const StrategicInitiativesTimelineV2: FC<StrategicInitiativesTimelineV2Props> =
     const [selectedKey, setSelectedKey] = useState<number | null>(null)
     const { token } = theme.useToken()
 
-    const { items, windowStart, windowEnd } = mapStrategicInitiatives(
+    const { items, windowStart, windowEnd, minDate, maxDate } = mapStrategicInitiatives(
       isLoading ? [] : strategicInitiatives,
       token,
     )
@@ -79,8 +83,8 @@ const StrategicInitiativesTimelineV2: FC<StrategicInitiativesTimelineV2Props> =
           items={items}
           windowStart={windowStart}
           windowEnd={windowEnd}
-          minDate={windowStart}
-          maxDate={windowEnd}
+          minDate={minDate}
+          maxDate={maxDate}
           storageKey="ppm-strategic-initiatives"
           height={650}
           editable={false}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/_components/change-portfolio-status-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/_components/change-portfolio-status-form.tsx
@@ -112,7 +112,7 @@ const ChangePortfolioStatusForm = ({
         <div>
           {portfolio?.key} - {portfolio?.name}
         </div>
-        <Alert message="This action cannot be undone." type="warning" showIcon />
+        <Alert title="This action cannot be undone." type="warning" showIcon />
       </Space>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/programs/_components/change-program-status-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/programs/_components/change-program-status-form.tsx
@@ -123,7 +123,7 @@ const ChangeProgramStatusForm = ({
         <div>
           {program?.key} - {program?.name}
         </div>
-        <Alert message="This action cannot be undone." type="warning" showIcon />
+        <Alert title="This action cannot be undone." type="warning" showIcon />
       </Space>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/change-project-status-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/change-project-status-form.tsx
@@ -136,7 +136,7 @@ const ChangeProjectStatusForm = ({
         <div>
           {project?.key} - {project?.name}
         </div>
-        <Alert message="This action cannot be undone." type="warning" showIcon />
+        <Alert title="This action cannot be undone." type="warning" showIcon />
       </Space>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/change-strategic-initiative-status-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/change-strategic-initiative-status-form.tsx
@@ -136,7 +136,7 @@ const ChangeStrategicInitiativeStatusForm = ({
         <div>
           {strategicInitiative?.key} - {strategicInitiative?.name}
         </div>
-        <Alert message="This action cannot be undone." type="warning" showIcon />
+        <Alert title="This action cannot be undone." type="warning" showIcon />
       </Space>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.test.ts
@@ -44,6 +44,18 @@ describe('itemBox', () => {
     expect(box.height).toBe(32)
   })
 
+  it('shifts top down by half rowPadding so bars are vertically centred', () => {
+    // Arrange — rowPadding = 6 means 3px added above the bar area.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(0), end: day(1) }
+    const configWithPad = { laneHeight: 40, lanePadding: 4, rowPadding: 6 }
+    // Act
+    const box = itemBox(item, 0, row(0), scale, configWithPad)
+    // Assert — top = 0 + 0 (topInset) + 3 (halfRowPad) + 0 (lane 0) + 4 (lanePadding).
+    expect(box.top).toBe(7)
+    // Height is unaffected by rowPadding.
+    expect(box.height).toBe(32)
+  })
+
   it('enforces a minimum width for zero-duration ranges', () => {
     // Arrange — start === end.
     const item: TimelineItem = { id: 'a', kind: 'range', start: day(3), end: day(3) }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.ts
@@ -25,6 +25,9 @@ export interface GeometryConfig {
   laneHeight: number
   /** Inset within a lane so bars don't touch lane edges, px. */
   lanePadding: number
+  /** Padding added below the bar area in each row (from the layout). Half of
+   *  this is also added above so bars are vertically centred in the row. */
+  rowPadding?: number
 }
 
 /**
@@ -39,9 +42,12 @@ export function itemBox(
   scale: TimeScale,
   config: GeometryConfig,
 ): ItemBox {
-  // Offset bars below any reserved headroom (e.g. a timebox label band).
+  // Offset bars below any reserved headroom (e.g. a timebox label band), plus
+  // half the row padding so bars are vertically centred (the other half sits
+  // below the bar area as breathing room between rows).
+  const halfRowPad = (config.rowPadding ?? 0) / 2
   const top =
-    row.top + (row.topInset ?? 0) + lane * config.laneHeight + config.lanePadding
+    row.top + (row.topInset ?? 0) + halfRowPad + lane * config.laneHeight + config.lanePadding
   const height = config.laneHeight - config.lanePadding * 2
 
   if (item.kind === 'milestone') {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.test.ts
@@ -129,3 +129,46 @@ describe('createTimeScale — tiers', () => {
     expect(upper[upper.length - 1].endMs).toBe(midMonth + 90 * DAY)
   })
 })
+
+describe('createTimeScale — weekends', () => {
+  // 2026-01-05 is a Monday — gives a clean Mon–Sun week to test against.
+  const monday = dayjs('2026-01-05').startOf('day').valueOf()
+
+  it('returns Sat and Sun boxes when zoomed in (pxPerDay >= 6)', () => {
+    // Arrange — 7-day domain, 70px total (10px/day >= 6 threshold).
+    const scale = createTimeScale(monday, monday + 7 * DAY, 70)
+    // Act
+    const weekends = scale.weekends()
+    // Assert — exactly two boxes: Saturday (day 5) and Sunday (day 6).
+    expect(weekends).toHaveLength(2)
+    expect(weekends[0].left).toBeCloseTo(50) // 5 days * 10px
+    expect(weekends[0].width).toBeCloseTo(10)
+    expect(weekends[1].left).toBeCloseTo(60) // 6 days * 10px
+    expect(weekends[1].width).toBeCloseTo(10)
+  })
+
+  it('returns an empty array when zoomed out (pxPerDay < 6)', () => {
+    // Arrange — 30-day domain, 30px total (1px/day < 6 threshold).
+    const scale = createTimeScale(monday, monday + 30 * DAY, 30)
+    // Act / Assert
+    expect(scale.weekends()).toHaveLength(0)
+  })
+
+  it('clamps weekend boxes to the domain boundaries', () => {
+    // Arrange — domain starts mid-Saturday noon, ends mid-Sunday noon.
+    const satNoon = dayjs('2026-01-10').startOf('day').valueOf() + 12 * 3_600_000
+    const sunNoon = satNoon + DAY
+    const scale = createTimeScale(satNoon, sunNoon, 24 * 10) // 10px/hr
+    // Act
+    const weekends = scale.weekends()
+    // Assert — Saturday box is clamped to domain start (left = 0).
+    expect(weekends[0].left).toBeCloseTo(0)
+  })
+
+  it('returns no boxes for a domain with no weekend days', () => {
+    // Arrange — Mon–Fri only (5 days starting from monday).
+    const scale = createTimeScale(monday, monday + 5 * DAY, 50)
+    // Act / Assert
+    expect(scale.weekends()).toHaveLength(0)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.ts
@@ -149,8 +149,9 @@ export function createTimeScale(
       if (pxPerDay < 6) return []
       const out: Array<{ left: number; width: number }> = []
       let cursor = dayjs(startMs).startOf('day')
+      const daySpan = Math.ceil((safeEnd - startMs) / DAY) + 1
       let guard = 0
-      while (cursor.valueOf() < safeEnd && guard < 800) {
+      while (cursor.valueOf() < safeEnd && guard < daySpan) {
         const dow = cursor.day() // 0 = Sun, 6 = Sat
         if (dow === 0 || dow === 6) {
           const dayStart = Math.max(cursor.valueOf(), startMs)

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/scale.ts
@@ -26,6 +26,12 @@ export interface TimeScale {
   ticks: (count?: number) => number[]
   /** Two-tier header segments (upper = month/year, lower = week/day), span-aware. */
   tiers: () => { upper: ScaleSegment[]; lower: ScaleSegment[] }
+  /**
+   * Pixel boxes for each weekend day (Sat + Sun) in the domain. Returns an
+   * empty array when the zoom level is too coarse for weekend shading to be
+   * meaningful (less than 6px/day — matches the week-level tier threshold).
+   */
+  weekends: () => Array<{ left: number; width: number }>
 }
 
 /** A labeled header cell spanning [startMs, endMs). */
@@ -134,6 +140,26 @@ export function createTimeScale(
         out.push(cursor.valueOf())
         cursor = addStep(cursor, chosen.unit, chosen.step)
         guard += 1
+      }
+      return out
+    },
+    weekends: () => {
+      const pxPerDay = pxPerMs * DAY
+      // Below the week-tier threshold columns are too narrow for shading to read.
+      if (pxPerDay < 6) return []
+      const out: Array<{ left: number; width: number }> = []
+      let cursor = dayjs(startMs).startOf('day')
+      let guard = 0
+      while (cursor.valueOf() < safeEnd && guard < 800) {
+        const dow = cursor.day() // 0 = Sun, 6 = Sat
+        if (dow === 0 || dow === 6) {
+          const dayStart = Math.max(cursor.valueOf(), startMs)
+          const dayEnd = Math.min(cursor.add(1, 'day').valueOf(), safeEnd)
+          const left = (dayStart - startMs) * pxPerMs
+          out.push({ left, width: (dayEnd - startMs) * pxPerMs - left })
+        }
+        cursor = cursor.add(1, 'day')
+        guard++
       }
       return out
     },

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.test.ts
@@ -1,4 +1,4 @@
-import { clampZoom, maxZoom, anchoredScrollLeft } from './zoom'
+import { clampZoom, maxZoom, anchoredScrollLeft, initialScrollLeft } from './zoom'
 
 describe('clampZoom', () => {
   it('returns the value when within bounds', () => {
@@ -127,5 +127,67 @@ describe('anchoredScrollLeft', () => {
     })
     // Assert
     expect(result).toBe(0)
+  })
+})
+
+describe('initialScrollLeft', () => {
+  const DAY = 86_400_000
+
+  it('returns 0 when windowStart equals domainStart', () => {
+    // Arrange: window and domain start at the same point — no offset needed.
+    // Act
+    const result = initialScrollLeft(0, 365 * DAY, 0, 1000)
+    // Assert
+    expect(result).toBe(0)
+  })
+
+  it('scrolls to the correct pixel offset when windowStart is inside the domain', () => {
+    // Arrange: domain = year 1 (365 days), chartWidth = 3650px (10px/day).
+    // windowStart = day 100 → expected offset = 100/365 * 3650 ≈ 1000px.
+    const domainStart = 0
+    const domainMs = 365 * DAY
+    const windowStart = 100 * DAY
+    const chartWidth = 3650
+    // Act
+    const result = initialScrollLeft(domainStart, domainMs, windowStart, chartWidth)
+    // Assert
+    expect(result).toBeCloseTo(1000, 0)
+  })
+
+  it('reproduces the roadmap-7004 bug: windowStart is far inside a domain widened by item bounds', () => {
+    // Arrange: roadmap starts 2004-04-29, but items extend to 2023+, so
+    // minDate = earliest_item - 1yr ≈ 2022. The domain is ~18 years wide.
+    // windowStart is the roadmap start (2004), which is BEFORE the domain start
+    // (2022) → with the old behaviour (scrollLeft=0) the user sees 2022, not 2004.
+    // With initialScrollLeft, windowStart < domainStart clamps to 0, which means
+    // the timeline should start at domainStart — that's still wrong for this case,
+    // and the real fix is to ensure windowStart is clamped to the domain when
+    // computing the scroll. This test captures the pre-fix expectation so we can
+    // confirm the component uses the function correctly.
+    //
+    // Simpler repro: domain starts Jan 2022, windowStart is Jan 2004 (before domain).
+    const domainStart = Date.UTC(2022, 0, 1)
+    const domainEnd = Date.UTC(2025, 0, 1)
+    const domainMs = domainEnd - domainStart
+    const windowStart = Date.UTC(2004, 3, 29) // before domainStart
+    const chartWidth = 5000
+    // Act
+    const result = initialScrollLeft(domainStart, domainMs, windowStart, chartWidth)
+    // Assert: windowStart is before the domain → clamped to 0 (show domain start).
+    expect(result).toBe(0)
+  })
+
+  it('clamps to chartWidth when windowStart is beyond the domain end', () => {
+    // Arrange: windowStart past the end of the domain.
+    // Act
+    const result = initialScrollLeft(0, 100 * DAY, 200 * DAY, 1000)
+    // Assert
+    expect(result).toBe(1000)
+  })
+
+  it('returns 0 for degenerate inputs', () => {
+    // Arrange / Act / Assert
+    expect(initialScrollLeft(0, 0, 10 * DAY, 1000)).toBe(0)
+    expect(initialScrollLeft(0, 100 * DAY, 10 * DAY, 0)).toBe(0)
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/zoom.ts
@@ -6,6 +6,28 @@
 // owns ZOOM: clamping the factor and recomputing scrollLeft so a chosen anchor
 // point (cursor or viewport centre) stays fixed under the time axis as we zoom.
 
+/**
+ * Initial scrollLeft so the timeline opens with `windowStart` at the left edge
+ * of the viewport. Used on first mount when the domain is wider than the window
+ * (e.g. minDate/maxDate extend beyond the roadmap's own start/end).
+ *
+ * At zoom=1 the full domain maps to `chartWidth` pixels. The pixel offset of
+ * `windowStart` within the domain is:
+ *   (windowStart - domainStart) / domainMs * chartWidth
+ *
+ * Clamped to [0, chartWidth] so it's always a valid scrollLeft value.
+ */
+export function initialScrollLeft(
+  domainStart: number,
+  domainMs: number,
+  windowStart: number,
+  chartWidth: number,
+): number {
+  if (domainMs <= 0 || chartWidth <= 0) return 0
+  const offset = ((windowStart - domainStart) / domainMs) * chartWidth
+  return Math.min(chartWidth, Math.max(0, offset))
+}
+
 /** Bounds for the zoom factor (multiplier over the base, fit-to-window width). */
 export interface ZoomBounds {
   /** Smallest factor — fully zoomed out. Usually 1 (base = fit the window). */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/capture-timeline.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/capture-timeline.ts
@@ -38,16 +38,51 @@ export async function captureTimeline(
     scale,
     width,
     height,
+    // windowHeight must be >= height so html2canvas doesn't clip the render to
+    // the live element's viewport-constrained bounds.
     windowWidth: width,
-    windowHeight: height,
-    onclone: (_doc: Document, clonedRoot: HTMLElement) => {
-      // Un-clip vertical scrolling so all rows render; keep horizontal as-is so
-      // only the visible time window is captured. Let the container grow tall.
+    windowHeight: Math.max(height, window.innerHeight),
+    // Neutralise any page scroll offset so the capture starts at the element.
+    scrollY: -window.scrollY,
+    scrollX: -window.scrollX,
+    onclone: (doc: Document, clonedRoot: HTMLElement) => {
+      // Give the cloned document body enough room so absolutely/flex positioned
+      // descendants can expand to the full content height without clipping.
+      doc.body.style.height = `${height}px`
+      doc.body.style.minHeight = `${height}px`
+      doc.documentElement.style.height = `${height}px`
+
+      // Set the root to exactly the content height — no blank space below the
+      // last row, and no clipping if content is taller than the live element.
       clonedRoot.style.height = `${height}px`
+      clonedRoot.style.minHeight = 'unset'
+      clonedRoot.style.maxHeight = 'unset'
+      clonedRoot.style.overflow = 'visible'
+
+      // Un-clip vertical scrolling so all rows render.
       clonedRoot.querySelectorAll<HTMLElement>('*').forEach((node) => {
         const o = getComputedStyle(node)
         if (o.overflowY !== 'visible') node.style.overflowY = 'visible'
       })
+
+      // Walk every ancestor up to <body> and remove height constraints so the
+      // flex/fixed parent chain can't clip the root to the live element height.
+      let ancestor = clonedRoot.parentElement
+      while (ancestor && ancestor !== doc.body) {
+        ancestor.style.height = `${height}px`
+        ancestor.style.minHeight = 'unset'
+        ancestor.style.maxHeight = 'unset'
+        ancestor.style.overflow = 'visible'
+        // In fullscreen the .wrapper is position:fixed — reset to static so
+        // html2canvas doesn't offset the capture from the document origin.
+        if (getComputedStyle(ancestor).position === 'fixed') {
+          ancestor.style.position = 'static'
+          ancestor.style.inset = 'unset'
+          ancestor.style.zIndex = 'unset'
+          ancestor.style.width = `${width}px`
+        }
+        ancestor = ancestor.parentElement
+      }
 
       // Re-pin the group-label column to its live width so the clone wraps labels
       // exactly like the on-screen view (the Splitter's JS-computed widths are

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
@@ -50,6 +50,10 @@ export interface ChartCanvasProps {
    *  domain when omitted. */
   dragMin?: number
   dragMax?: number
+  /** When false, vertical gridlines are hidden. Default true. */
+  showGridlines?: boolean
+  /** When true, Saturday and Sunday columns are shaded. Default false. */
+  showWeekends?: boolean
 }
 
 export const ChartCanvas: FC<ChartCanvasProps> = ({
@@ -72,8 +76,13 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
   canPan,
   dragMin,
   dragMax,
+  showGridlines = true,
+  showWeekends = false,
 }) => {
-  const tickLines = scale.ticks(10)
+  // Use the lower-tier axis segments as gridline positions so lines align with
+  // every visible axis tick (month when zoomed out, week/day when zoomed in).
+  const tickLines = scale.tiers().lower.map((s) => s.startMs)
+  const weekendBoxes = showWeekends ? scale.weekends() : []
   // `Date.now()` is impure; read it once on mount (a current-time line that's
   // accurate to mount time is fine — re-render with a fresh `nowMs` prop to move
   // it). Lazy initializer keeps render pure.
@@ -155,8 +164,17 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
       className={`${styles.canvas} ${canPan ? styles.canvasPannable : ''}`}
       style={{ width: scale.width, height: totalHeight }}
     >
+      {/* Weekend shading — behind gridlines and rows */}
+      {weekendBoxes.map((box, i) => (
+        <div
+          key={`we-${i}`}
+          className={styles.weekend}
+          style={{ left: box.left, width: box.width }}
+        />
+      ))}
+
       {/* Vertical gridlines */}
-      {tickLines.map((ms) => (
+      {showGridlines && tickLines.map((ms) => (
         <div key={`gl-${ms}`} className={styles.gridline} style={{ left: scale.toX(ms) }} />
       ))}
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/group-column.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/group-column.tsx
@@ -22,6 +22,8 @@ export interface GroupColumnProps {
   groupRenderer?: FC<GroupRenderProps>
   /** Reports measured label heights (incl. cell padding) keyed by groupId. */
   onMeasure?: (heights: Map<string, number>) => void
+  /** Current lane height — used to scale the label font in compact mode. */
+  laneHeight?: number
 }
 
 const INDENT_PER_DEPTH = 14
@@ -35,7 +37,10 @@ export const GroupColumn: FC<GroupColumnProps> = ({
   groupsById,
   groupRenderer: Renderer,
   onMeasure,
+  laneHeight,
 }) => {
+  // Scale label font to match the lane height, capped at 13px (default size).
+  const labelFontSize = laneHeight ? Math.max(9, Math.min(Math.floor(laneHeight / 1.2), 13)) : undefined
   const containerRef = useRef<HTMLDivElement>(null)
 
   // Measure each label's natural height after layout (and on column resize) and
@@ -78,7 +83,10 @@ export const GroupColumn: FC<GroupColumnProps> = ({
             <span
               className={styles.groupLabel}
               data-row-key={row.rowKey ?? row.groupId}
-              style={{ paddingLeft: row.depth * INDENT_PER_DEPTH }}
+              style={{
+                paddingLeft: row.depth * INDENT_PER_DEPTH,
+                ...(labelFontSize ? { fontSize: labelFontSize } : undefined),
+              }}
             >
               {Renderer && group ? (
                 <Renderer

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.tsx
@@ -98,7 +98,14 @@ export const ItemBar: FC<ItemBarProps> = ({
 
       <span
         className={styles.barLabel}
-        style={labelOffset ? { marginLeft: labelOffset } : undefined}
+        style={{
+          ...(labelOffset ? { marginLeft: labelOffset } : undefined),
+          // Scale font to fit the bar height so text never clips vertically.
+          // Use lineHeight 1.2 to give descenders (g, p, y) room.
+          // Cap at 13px (default); floor at 9px for legibility.
+          fontSize: Math.max(9, Math.min(Math.floor(height / 1.2), 13)),
+          lineHeight: 1.2,
+        }}
       >
         {Renderer ? (
           <Renderer

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline-toolbar.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline-toolbar.tsx
@@ -6,11 +6,12 @@
 // will live; the built-in right-side actions are save-as-image and fullscreen.
 
 import { ReactNode } from 'react'
-import { Button, Dropdown, Space, Switch, type MenuProps } from 'antd'
+import { Button, Dropdown, Popover, Space, Switch, Typography, type MenuProps } from 'antd'
 import {
   FileImageOutlined,
   FullscreenExitOutlined,
   FullscreenOutlined,
+  QuestionCircleOutlined,
   ReloadOutlined,
   SettingOutlined,
   UndoOutlined,
@@ -42,8 +43,16 @@ export interface TimelineToolbarProps {
   allowSettings?: boolean
   showCurrentTime?: boolean
   onToggleCurrentTime?: (checked: boolean) => void
+  showVerticalGridlines?: boolean
+  onToggleVerticalGridlines?: (checked: boolean) => void
+  showWeekends?: boolean
+  onToggleWeekends?: (checked: boolean) => void
+  isCompact?: boolean
+  onToggleCompact?: (checked: boolean) => void
   /** Refresh action — shown (ReloadOutlined) only when provided, like WaydGrid. */
   onRefresh?: () => void
+  /** When true, the help popover includes drag/edit shortcuts. */
+  editable?: boolean
 }
 
 const TimelineToolbar = ({
@@ -64,21 +73,107 @@ const TimelineToolbar = ({
   allowSettings,
   showCurrentTime,
   onToggleCurrentTime,
+  showVerticalGridlines,
+  onToggleVerticalGridlines,
+  showWeekends,
+  onToggleWeekends,
+  isCompact,
+  onToggleCompact,
   onRefresh,
+  editable,
 }: TimelineToolbarProps) => {
-  // Settings menu: keep the dropdown open while toggling the switch (stopPropagation
-  // on the row), matching the legacy timeline's control menu behaviour.
+  const helpRows: Array<{ keys: string; action: string }> = [
+    { keys: 'Scroll', action: 'Pan vertically' },
+    { keys: 'Shift + Scroll', action: 'Pan horizontally' },
+    { keys: 'Click + Drag', action: 'Pan' },
+    ...(allowZoom
+      ? [
+          { keys: 'Ctrl + Scroll', action: 'Zoom in / out' },
+          { keys: '+  /  −', action: 'Zoom in / out' },
+        ]
+      : []),
+    ...(editable
+      ? [
+          { keys: 'Drag bar', action: 'Move item' },
+          { keys: 'Drag handle', action: 'Resize item' },
+          { keys: 'Esc', action: 'Cancel drag' },
+        ]
+      : []),
+  ]
+
+  const helpContent = (
+    <div style={{ minWidth: 240 }}>
+      <Typography.Text type="secondary" style={{ fontSize: 12 }}>
+        Keyboard &amp; mouse controls
+      </Typography.Text>
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: 8 }}>
+        <tbody>
+          {helpRows.map(({ keys, action }) => (
+            <tr key={keys}>
+              <td style={{ paddingBottom: 4, paddingRight: 16, whiteSpace: 'nowrap' }}>
+                <Typography.Text keyboard style={{ fontSize: 12 }}>{keys}</Typography.Text>
+              </td>
+              <td style={{ paddingBottom: 4, fontSize: 12 }}>{action}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+
+  // Settings menu: each item's onClick toggles the value and keeps the dropdown
+  // open (by stopping the event before antd closes it). The Switch is purely
+  // visual — the row click does the actual toggle so clicking the label works too.
   const settingsItems: MenuProps['items'] = [
     {
       key: 'show-current-time',
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation()
+        onToggleCurrentTime?.(!showCurrentTime)
+      },
       label: (
-        <Space onClick={(e) => e.stopPropagation()}>
-          <Switch
-            size="small"
-            checked={showCurrentTime}
-            onChange={(checked) => onToggleCurrentTime?.(checked)}
-          />
+        <Space>
+          <Switch size="small" checked={showCurrentTime} />
           Show Current Time
+        </Space>
+      ),
+    },
+    {
+      key: 'show-vertical-gridlines',
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation()
+        onToggleVerticalGridlines?.(!showVerticalGridlines)
+      },
+      label: (
+        <Space>
+          <Switch size="small" checked={showVerticalGridlines} />
+          Show Vertical Gridlines
+        </Space>
+      ),
+    },
+    {
+      key: 'show-weekends',
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation()
+        onToggleWeekends?.(!showWeekends)
+      },
+      label: (
+        <Space>
+          <Switch size="small" checked={showWeekends} />
+          Highlight Weekends
+        </Space>
+      ),
+    },
+    {
+      key: 'compact-mode',
+      onClick: ({ domEvent }) => {
+        domEvent.stopPropagation()
+        onToggleCompact?.(!isCompact)
+      },
+      label: (
+        <Space>
+          <Switch size="small" checked={isCompact} />
+          Compact Mode
         </Space>
       ),
     },
@@ -162,6 +257,15 @@ const TimelineToolbar = ({
             />
           </WaydTooltip>
         )}
+        <Popover
+          content={helpContent}
+          trigger="click"
+          placement="bottomRight"
+        >
+          <WaydTooltip title="Help">
+            <Button type="text" shape="circle" icon={<QuestionCircleOutlined />} />
+          </WaydTooltip>
+        </Popover>
         {allowSettings && (
           <Dropdown
             menu={{ items: settingsItems }}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline.module.css
@@ -188,7 +188,14 @@
 /* Chart scroll body — both axes; drives axis + group-column sync. */
 .chartScroll {
   flex: 1 1 auto;
-  overflow: auto;
+  overflow: scroll;
+  scrollbar-width: none; /* Firefox */
+  -ms-overflow-style: none; /* legacy Edge */
+}
+
+.chartScroll::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 /* Inner sized to full content height so the scrollbar reflects all rows. */
@@ -204,6 +211,15 @@
 
 .canvasPannable:active {
   cursor: grabbing;
+}
+
+/* Weekend column shading (Sat + Sun), behind gridlines and rows. */
+.weekend {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  background-color: var(--ant-color-fill-quaternary);
+  pointer-events: none;
 }
 
 /* Vertical gridlines aligned with axis ticks, behind everything. */
@@ -275,8 +291,6 @@
   background-color: var(--ant-color-primary);
   color: var(--ant-color-white);
   font-size: var(--ant-font-size-sm);
-  /* Use the theme line-height (not 1) so descenders (g, y, p) aren't clipped. */
-  line-height: var(--ant-line-height, 1.5);
   cursor: default;
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/use-bar-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/use-bar-drag.ts
@@ -61,6 +61,9 @@ export function useBarDrag(options: UseBarDragOptions): UseBarDrag {
       if (e.key !== 'Escape') return
       const s = session.current
       if (!s) return
+      // Stop propagation so parent modals/drawers don't also close on the same Esc.
+      e.preventDefault()
+      e.stopPropagation()
       window.removeEventListener('pointermove', s.move)
       window.removeEventListener('pointerup', s.up)
       session.current = null

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/use-bar-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/use-bar-drag.ts
@@ -6,7 +6,7 @@
 // date math itself lives in core/interaction.ts (pure, tested) — this hook only
 // captures pointer geometry and drives it.
 
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { applyDrag, type DragMode, type DragResult } from '../core/interaction'
 import { suppressNextClick } from './suppress-next-click'
 import type { TimelineItem } from '../core/types'
@@ -53,6 +53,25 @@ export function useBarDrag(options: UseBarDragOptions): UseBarDrag {
     move: (e: PointerEvent) => void
     up: () => void
   } | null>(null)
+
+  // Escape cancels an in-progress drag: removes listeners, reverts to the
+  // original position, and suppresses the click that follows pointer release.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return
+      const s = session.current
+      if (!s) return
+      window.removeEventListener('pointermove', s.move)
+      window.removeEventListener('pointerup', s.up)
+      session.current = null
+      setActive(null)
+      // The pointer is still down — when the user releases it a click fires.
+      // Suppress it so the item drawer doesn't open after a cancelled drag.
+      suppressNextClick()
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [])
 
   // Pixels the pointer must travel before it counts as a drag (vs. a click).
   const DRAG_THRESHOLD = 3

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
@@ -13,7 +13,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Spin, Splitter } from 'antd'
 import { captureTimeline } from './render/capture-timeline'
 import { createTimeScale } from './core/scale'
-import { clampZoom, maxZoom, anchoredScrollLeft } from './core/zoom'
+import { clampZoom, maxZoom, anchoredScrollLeft, initialScrollLeft } from './core/zoom'
 import { getLayoutStrategy } from './layout'
 import { ChartCanvas, type ChartCanvasProps } from './render/chart-canvas'
 import { GroupColumn } from './render/group-column'
@@ -282,9 +282,20 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
 
   // While true, every resize re-locks the scroll to windowStart (the "home" view).
   // Set to false the first time the user pans or zooms.
+  // Ref for synchronous reads in hot-path handlers (scroll, pan, zoom).
+  // State mirrors it for the render (canReset prop).
   const isInitialViewRef = useRef(true)
+  const [isInitialView, setIsInitialView] = useState(true)
   // Reset to the home view whenever the storageKey changes (different timeline
-  // instance). Done in a layout effect so refs aren't mutated during render.
+  // instance). Uses the state-during-render pattern (same as prevWidthKey above)
+  // so React can bail out without a double-render from an effect.
+  const [prevStorageKey, setPrevStorageKey] = useState(storageKey)
+  if (prevStorageKey !== storageKey) {
+    setPrevStorageKey(storageKey)
+    setIsInitialView(true)
+  }
+  // The isInitialViewRef mutation must stay in an effect — refs can't be written
+  // during render. Keep it in sync with the state transition above.
   const prevStorageKeyRef = useRef(storageKey)
   useLayoutEffect(() => {
     if (prevStorageKeyRef.current !== storageKey) {
@@ -293,8 +304,9 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     }
   }, [storageKey])
 
-  // Latest domain/window geometry — updated synchronously during render so the
-  // measure/resize callback always reads current props without a stale closure.
+  // Latest domain/window geometry — updated in a layout effect each render so
+  // the (stable) scroll/reset callbacks always read current props without a
+  // stale closure.
   const windowGeomRef = useRef({ domainStart: 0, domainMs: 1, windowStart: 0, windowMs: 1 })
 
   // Resolve the drill level: which activities stay groups vs. demote to bars,
@@ -405,15 +417,12 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // While in the initial view (no user pan/zoom), lock scroll to windowStart
   // on every render where the viewport is measured. Runs in useLayoutEffect so
   // it applies before paint — no flash of wrong position.
-  // We use chart.clientWidth (live DOM) instead of viewportWidth (React state)
-  // so the offset is always computed against the actual rendered canvas size.
   useLayoutEffect(() => {
     if (!isInitialViewRef.current) return
     const chart = chartRef.current
     if (!chart) return
-    const liveWidth = chart.clientWidth
-    if (liveWidth <= 0) return
-    const offset = windowMs > 0 ? ((windowStart - domainStart) / windowMs) * liveWidth : 0
+    if (chart.clientWidth <= 0) return
+    const offset = initialScrollLeft(domainStart, domainMs, windowStart, baseWidth)
     // Only apply if the canvas is wide enough to scroll to this offset.
     if (chart.scrollWidth <= offset) return
     chart.scrollLeft = offset
@@ -421,7 +430,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     // Defer state update to avoid setState-in-effect lint error; bar labels
     // tolerate a one-frame lag after a programmatic scroll to windowStart.
     requestAnimationFrame(() => setScrollLeft(offset))
-  }, [viewportWidth, domainStart, windowStart, windowMs, chartWidth])
+  }, [viewportWidth, domainStart, domainMs, windowStart, baseWidth, chartWidth])
 
   // Chart scroll drives: axis horizontal sync + group-column vertical sync, and
   // a debounced scrollLeft state so bar labels can stick to the visible left
@@ -429,6 +438,13 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   const onChartScroll = () => {
     const chart = chartRef.current
     if (!chart) return
+    // Any scroll (including Shift+wheel / trackpad horizontal pan) means the user
+    // has navigated away from the default window — clear the initial-view lock so
+    // a later viewport resize doesn't snap back to windowStart.
+    if (isInitialViewRef.current) {
+      isInitialViewRef.current = false
+      setIsInitialView(false)
+    }
     if (axisViewportRef.current) {
       axisViewportRef.current.scrollLeft = chart.scrollLeft
     }
@@ -471,6 +487,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     if (e.button !== 0) return
     if ((e.target as HTMLElement).closest('[data-timeline-item]')) return
     isInitialViewRef.current = false
+    setIsInitialView(false)
     const chart = chartRef.current
     if (!chart) return
     // Nothing to pan if content fits the viewport in both axes.
@@ -519,6 +536,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // wheel listener and the toolbar buttons. Stages the post-paint scrollLeft.
   const requestZoom = (nextZoomRaw: number, anchorX: number) => {
     isInitialViewRef.current = false
+    setIsInitialView(false)
     const geom = zoomGeomRef.current
     const next = clampZoom(nextZoomRaw, geom.bounds)
     if (next === geom.zoom) return
@@ -543,6 +561,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // Reset View: zoom=1 (window fills viewport) and scroll to windowStart.
   const resetView = () => {
     isInitialViewRef.current = true
+    setIsInitialView(true)
     const g = windowGeomRef.current
     const chart = chartRef.current
     const w = chart?.clientWidth ?? viewportWidth
@@ -696,7 +715,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
           onResetView={resetView}
           canZoomIn={effectiveZoom < zoomMax - 1e-6}
           canZoomOut={effectiveZoom > zoomMin + 1e-6}
-          canReset={Math.abs(effectiveZoom - 1) > 1e-6 || !isInitialViewRef.current}
+          canReset={Math.abs(effectiveZoom - 1) > 1e-6 || !isInitialView}
           allowSaveAsImage={allowSaveAsImage}
           onSaveAsImage={saveImage}
           allowFullScreen={allowFullScreen}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
@@ -30,6 +30,7 @@ import styles from './render/timeline.module.css'
 const AXIS_HEIGHT = 48
 const DEFAULT_HEIGHT = 600
 const DEFAULT_LANE_HEIGHT = 28
+const COMPACT_LANE_HEIGHT = 20
 const DEFAULT_GROUP_COLUMN_WIDTH = 220
 const MIN_GROUP_COLUMN_WIDTH = 120
 const LANE_PADDING = 3
@@ -135,6 +136,13 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
 
   // User-togglable current-time line (settings menu); seeded from the prop.
   const [showCurrentTime, setShowCurrentTime] = useState(showCurrentTimeDefault)
+  // User-togglable vertical gridlines (settings menu); default on.
+  const [showVerticalGridlines, setShowVerticalGridlines] = useState(true)
+  // User-togglable weekend shading (settings menu); default off.
+  const [showWeekends, setShowWeekends] = useState(false)
+  // User-togglable compact mode (settings menu); default off.
+  const [isCompact, setIsCompact] = useState(false)
+  const effectiveLaneHeight = isCompact ? COMPACT_LANE_HEIGHT : laneHeight
 
   // Group-column width. Self-persisted per instance when `storageKey` is set, so
   // a user's splitter resize survives reloads with no consumer wiring; otherwise
@@ -272,6 +280,23 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     allowZoom: true,
   })
 
+  // While true, every resize re-locks the scroll to windowStart (the "home" view).
+  // Set to false the first time the user pans or zooms.
+  const isInitialViewRef = useRef(true)
+  // Reset to the home view whenever the storageKey changes (different timeline
+  // instance). Done in a layout effect so refs aren't mutated during render.
+  const prevStorageKeyRef = useRef(storageKey)
+  useLayoutEffect(() => {
+    if (prevStorageKeyRef.current !== storageKey) {
+      prevStorageKeyRef.current = storageKey
+      isInitialViewRef.current = true
+    }
+  }, [storageKey])
+
+  // Latest domain/window geometry — updated synchronously during render so the
+  // measure/resize callback always reads current props without a stale closure.
+  const windowGeomRef = useRef({ domainStart: 0, domainMs: 1, windowStart: 0, windowMs: 1 })
+
   // Resolve the drill level: which activities stay groups vs. demote to bars,
   // remapping every item to its nearest surviving group. (timeline variant only;
   // gantt keeps one row per record.) Backgrounds are split AFTER remapping so a
@@ -287,16 +312,23 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // the axis matches the consumer's bounds exactly (e.g. the roadmap dates).
   // Items extending past the bounds are clipped at the canvas edge; we do NOT
   // widen the domain to fit them.
-  const domainStart = minDate ?? windowStart
-  const domainEnd = Math.max(domainStart + 1, maxDate ?? windowEnd)
+  // Domain must fully contain the window so the canvas is always wide enough to
+  // scroll windowStart to the left edge with windowEnd visible at the right.
+  const domainStart = Math.min(minDate ?? windowStart, windowStart)
+  const domainEnd = Math.max(domainStart + 1, maxDate ?? windowEnd, windowEnd)
   const domainMs = domainEnd - domainStart
-  const spanDays = Math.max(1, domainMs / DAY_MS)
-  // Base width fits the whole domain into the viewport (or a per-day minimum).
-  // Zoom scales it up; pan is native horizontal scroll over the widened content.
-  const baseWidth = Math.max(viewportWidth, spanDays * MIN_PX_PER_DAY)
-  // Cap zoom-in so the viewport never spans less than ZOOM_MIN_MS (1 day),
-  // matching the legacy timeline's `zoomMin`.
-  const zoomMin = 1
+  const windowMs = Math.max(1, windowEnd - windowStart)
+  // Base width is defined so that zoom=1 shows exactly the window
+  // (windowStart→windowEnd) in the viewport. The full canvas is wider by the
+  // domain/window ratio so the user can pan into minDate/maxDate on either side.
+  // We do NOT apply a per-day minimum here — that would make multi-year windows
+  // wider than the viewport at zoom=1. Users zoom in if they need finer detail.
+  const baseWidth = Math.max(viewportWidth, 1) * (domainMs / windowMs)
+  // zoomMin: the factor that fits the entire domain into the viewport (zoom out
+  // floor). At this zoom, chartWidth === viewportWidth and the user can see
+  // minDate→maxDate without scrolling. Always <= 1 since baseWidth >= viewportWidth.
+  const zoomMin = domainMs > 0 ? windowMs / domainMs : 1
+  // zoomMax: cap zoom-in so the viewport never spans less than ZOOM_MIN_MS (1 day).
   const zoomMax = maxZoom(baseWidth, viewportWidth, domainMs, ZOOM_MIN_MS)
   const effectiveZoom = clampZoom(zoom, { min: zoomMin, max: zoomMax })
   const chartWidth = baseWidth * effectiveZoom
@@ -311,6 +343,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     const measure = () => {
       setViewportWidth(el.clientWidth)
       setViewportHeight(el.clientHeight)
+      // Initial scroll is handled by the useLayoutEffect that watches viewportWidth.
     }
     measure()
     requestAnimationFrame(measure)
@@ -350,6 +383,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // so the user never sees an intermediate (mis-scrolled) frame. Also syncs the
   // axis viewport (it mirrors chart scroll).
   useLayoutEffect(() => {
+    windowGeomRef.current = { domainStart, domainMs, windowStart, windowMs }
     zoomGeomRef.current = {
       zoom: effectiveZoom,
       baseWidth,
@@ -366,7 +400,28 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
       if (axisViewportRef.current) axisViewportRef.current.scrollLeft = pending
       setScrollLeft(pending)
     }
-  }, [effectiveZoom, baseWidth, chartWidth, zoomMin, zoomMax, allowZoom])
+  }, [effectiveZoom, baseWidth, chartWidth, zoomMin, zoomMax, allowZoom, domainStart, domainMs, windowStart, windowMs])
+
+  // While in the initial view (no user pan/zoom), lock scroll to windowStart
+  // on every render where the viewport is measured. Runs in useLayoutEffect so
+  // it applies before paint — no flash of wrong position.
+  // We use chart.clientWidth (live DOM) instead of viewportWidth (React state)
+  // so the offset is always computed against the actual rendered canvas size.
+  useLayoutEffect(() => {
+    if (!isInitialViewRef.current) return
+    const chart = chartRef.current
+    if (!chart) return
+    const liveWidth = chart.clientWidth
+    if (liveWidth <= 0) return
+    const offset = windowMs > 0 ? ((windowStart - domainStart) / windowMs) * liveWidth : 0
+    // Only apply if the canvas is wide enough to scroll to this offset.
+    if (chart.scrollWidth <= offset) return
+    chart.scrollLeft = offset
+    if (axisViewportRef.current) axisViewportRef.current.scrollLeft = offset
+    // Defer state update to avoid setState-in-effect lint error; bar labels
+    // tolerate a one-frame lag after a programmatic scroll to windowStart.
+    requestAnimationFrame(() => setScrollLeft(offset))
+  }, [viewportWidth, domainStart, windowStart, windowMs, chartWidth])
 
   // Chart scroll drives: axis horizontal sync + group-column vertical sync, and
   // a debounced scrollLeft state so bar labels can stick to the visible left
@@ -415,6 +470,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     // Primary button only; ignore clicks that land on an interactive item.
     if (e.button !== 0) return
     if ((e.target as HTMLElement).closest('[data-timeline-item]')) return
+    isInitialViewRef.current = false
     const chart = chartRef.current
     if (!chart) return
     // Nothing to pan if content fits the viewport in both axes.
@@ -462,6 +518,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // fixed. Reads current geometry from the ref so it's safe to call from both the
   // wheel listener and the toolbar buttons. Stages the post-paint scrollLeft.
   const requestZoom = (nextZoomRaw: number, anchorX: number) => {
+    isInitialViewRef.current = false
     const geom = zoomGeomRef.current
     const next = clampZoom(nextZoomRaw, geom.bounds)
     if (next === geom.zoom) return
@@ -483,9 +540,24 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     requestZoom(geom.zoom * factor, centre)
   }
 
-  // Reset View: back to fit-the-window (zoom 1) and scrolled to the start.
+  // Reset View: zoom=1 (window fills viewport) and scroll to windowStart.
   const resetView = () => {
-    pendingScrollLeftRef.current = 0
+    isInitialViewRef.current = true
+    const g = windowGeomRef.current
+    const chart = chartRef.current
+    const w = chart?.clientWidth ?? viewportWidth
+    const offset = g.windowMs > 0 ? ((g.windowStart - g.domainStart) / g.windowMs) * w : 0
+    // Always apply the scroll immediately via DOM refs so panning-only resets
+    // work even when zoom is already 1 (setZoom(1) would be a no-op → no
+    // layout effect → pendingScrollLeftRef never consumed).
+    if (chart) {
+      chart.scrollLeft = offset
+      if (axisViewportRef.current) axisViewportRef.current.scrollLeft = offset
+      setScrollLeft(offset)
+    }
+    // Also stage via pendingScrollLeftRef as a fallback for when the zoom
+    // changes (layout effect fires on the next paint and re-applies it).
+    pendingScrollLeftRef.current = offset
     setZoom(1)
   }
 
@@ -528,7 +600,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     groups: resolved.groups,
     backgroundGroupIds,
     hasChartBackground,
-    config: { laneHeight, rowPadding: ROW_PADDING },
+    config: { laneHeight: effectiveLaneHeight, rowPadding: ROW_PADDING },
   })
 
   // Grow rows whose wrapped group label is taller than the lane-based height,
@@ -548,7 +620,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
       : rows.slice(visibleRange.startIndex, visibleRange.endIndex + 1)
 
   const scale = createTimeScale(domainStart, domainEnd, chartWidth)
-  const geometry: GeometryConfig = { laneHeight, lanePadding: LANE_PADDING }
+  const geometry: GeometryConfig = { laneHeight: effectiveLaneHeight, lanePadding: LANE_PADDING, rowPadding: ROW_PADDING }
   const groupsById = new Map<string, TimelineGroup>(
     resolved.groups.map((g) => [g.id, g]),
   )
@@ -585,6 +657,8 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
             onItemDateChange={onItemDateChange}
             onItemProgressChange={onItemProgressChange}
             showCurrentTime={showCurrentTime}
+            showGridlines={showVerticalGridlines}
+            showWeekends={showWeekends}
             canPan={
               chartWidth > viewportWidth + 1 || totalHeight > viewportHeight + 1
             }
@@ -622,7 +696,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
           onResetView={resetView}
           canZoomIn={effectiveZoom < zoomMax - 1e-6}
           canZoomOut={effectiveZoom > zoomMin + 1e-6}
-          canReset={effectiveZoom > 1 + 1e-6 || scrollLeft > 0.5}
+          canReset={Math.abs(effectiveZoom - 1) > 1e-6 || !isInitialViewRef.current}
           allowSaveAsImage={allowSaveAsImage}
           onSaveAsImage={saveImage}
           allowFullScreen={allowFullScreen}
@@ -631,7 +705,14 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
           allowSettings={allowToggleCurrentTime}
           showCurrentTime={showCurrentTime}
           onToggleCurrentTime={setShowCurrentTime}
+          showVerticalGridlines={showVerticalGridlines}
+          onToggleVerticalGridlines={setShowVerticalGridlines}
+          showWeekends={showWeekends}
+          onToggleWeekends={setShowWeekends}
+          isCompact={isCompact}
+          onToggleCompact={setIsCompact}
           onRefresh={onRefresh}
+          editable={editable}
         />
       )}
       <div
@@ -679,6 +760,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
                       >['groupRenderer']
                     }
                     onMeasure={onMeasureLabels}
+                    laneHeight={effectiveLaneHeight}
                   />
                 </div>
               </div>

--- a/docs/user-guide/planning/roadmaps.mdx
+++ b/docs/user-guide/planning/roadmaps.mdx
@@ -62,6 +62,46 @@ Clicking an item opens a **drawer** with full details, edit, and delete actions.
 
 Roadmaps can be **copied** to create new versions, preserving the full hierarchy of items.
 
+## Timeline Controls
+
+The timeline view includes a toolbar with controls for navigation, zoom, and display settings.
+
+### Navigation
+
+| Control | Action |
+|---------|--------|
+| Click + drag on empty space | Pan the timeline |
+| Scroll wheel | Pan vertically |
+| Shift + scroll | Pan horizontally |
+| Ctrl/Cmd + scroll | Zoom in / out |
+| **+** / **−** buttons | Zoom in / out (toolbar) |
+| Reset view button | Return to the default window and zoom |
+
+### Zoom
+
+The timeline starts with the roadmap's date range filling the viewport. Zoom in for day-level detail or zoom out to see the full domain (earliest item start to latest item end). The reset view button always returns to the original window.
+
+### Editing Items (managers only)
+
+| Control | Action |
+|---------|--------|
+| Drag bar | Move the item |
+| Drag left/right handle | Resize start or end date |
+| Esc during drag | Cancel the drag without saving |
+
+### Settings Menu
+
+Click the **gear icon** to toggle display options:
+
+- **Show Current Time** — Red vertical line marking today
+- **Show Vertical Gridlines** — Gridlines aligned to the current zoom unit (month, week, or day)
+- **Highlight Weekends** — Shaded columns for Saturday and Sunday (visible at week/day zoom)
+- **Compact Mode** — Reduces row height to fit more items without scrolling
+
+### Help
+
+Click the **? icon** to see a summary of keyboard and mouse controls.
+
 ## Common Tasks
 
 ### Creating a Roadmap

--- a/docs/user-guide/ppm/portfolios-programs.mdx
+++ b/docs/user-guide/ppm/portfolios-programs.mdx
@@ -125,6 +125,32 @@ The program detail page uses a two-column layout:
 
 A warning alert appears if dates are missing: *"Program Dates are required before activating."*
 
+## Timeline Views
+
+Programs, Projects, and Strategic Initiatives all support a **Timeline view** accessible via the view toggle in each tab. The timeline shows items as horizontal bars grouped by program (for projects) or as a flat list.
+
+### Default Window
+
+The timeline opens showing **today ±6 months** as the default visible window. The full domain extends to the earliest item start minus one month and the latest item end plus one month — you can zoom out to see this full range.
+
+### Controls
+
+| Control | Action |
+|---------|--------|
+| Click + drag on empty space | Pan the timeline |
+| Ctrl/Cmd + scroll | Zoom in / out |
+| **+** / **−** buttons | Zoom in / out (toolbar) |
+| Reset view button | Return to the default window and zoom |
+
+### Settings Menu
+
+Click the **gear icon** in the toolbar to toggle:
+
+- **Show Current Time** — Red vertical line marking today
+- **Show Vertical Gridlines** — Gridlines per zoom unit
+- **Highlight Weekends** — Shaded weekend columns (visible at week/day zoom)
+- **Compact Mode** — Reduces row height to fit more items without scrolling
+
 ## Common Tasks
 
 ### Creating a Portfolio


### PR DESCRIPTION
## Enhance WaydTimeline2 — gridlines, settings, compact mode, drag UX, and save-as-image

Continues the timeline replacement effort (epic https://github.com/destacey/Wayd/issues/628).

## Summary

A broad set of improvements to the `WaydTimeline2` component across navigation, display settings, editing UX, and image capture. All PPM timelines (programs, projects, strategic initiatives) now use a consistent today ±6 months default window with full domain zoom-out support.

**Gridlines & axis alignment**
- Vertical gridlines now align to the active axis lower-tier unit (one per month at the default zoom, one per week or day when zoomed in) instead of the previous ~3-month spacing
- Gridlines, weekend highlighting, and the current-time line all respect the same tier thresholds so the chart stays visually coherent at any zoom level

**Settings menu**
- Added three new toggleable settings alongside "Show Current Time": **Show Vertical Gridlines** (default on), **Highlight Weekends** (default off — shades Sat/Sun columns when zoomed to week/day level), and **Compact Mode** (default off — reduces lane height from 28 px to 20 px for higher row density)
- Fixed the settings menu so clicking anywhere on a row (the switch, the label, or the gap) triggers the toggle and keeps the dropdown open

**Help icon**
- Added a `?` toolbar button that opens a popover listing all keyboard and mouse controls; content is context-aware (zoom shortcuts hidden when zoom is disabled, drag/Esc shortcuts hidden when not editable)

**Reset view fix**
- Fixed a bug where Reset View did nothing when the user had panned without zooming — `setZoom(1)` was a no-op when zoom was already 1, so the scroll offset was never applied. Now applies the scroll directly to DOM refs before calling `setZoom`

**Drag UX — Escape to cancel**
- Pressing Escape during a move or resize drag now cancels the operation: the bar snaps back to its original position and the pending click is suppressed so the item drawer does not open unexpectedly

**Vertical centering**
- Bars were sitting closer to the top of their row than the bottom because `rowPadding` was only applied below the bar area. Fixed by offsetting bars down by `rowPadding / 2` so padding is split evenly top and bottom

**Compact mode font scaling**
- Both bar labels and group column labels now scale continuously with bar height using `Math.floor(height / 1.2)` (cap 13 px, floor 9 px) with `line-height: 1.2` — ensures descenders (g, p, y) never clip at any lane height

**Save-as-image fixes**
- Fixed captured images cutting off the last row group by walking the entire ancestor chain in the html2canvas `onclone` callback and removing all height constraints
- Fixed fullscreen captures starting at the wrong offset by resetting `position: fixed` ancestors to `static` in the clone
- Image now trims to exact content height with no blank space below the last row

**antd deprecation**
- Changed `<Alert message=` to `<Alert title=` in the four PPM status-change forms (projects, portfolios, programs, strategic initiatives)

**Tests**
- Added `createTimeScale — weekends` suite (4 tests: day-level boxes, coarse-zoom guard, domain clamping, weekday-only domain)
- Added `itemBox` test for `rowPadding` vertical centering offset

**Documentation**
- Added "Timeline Controls" section to the Roadmaps user guide (navigation, zoom, edit shortcuts, all settings options, help icon)
- Added "Timeline Views" section to the Portfolios & Programs user guide (default window, domain from item bounds, controls, settings)

## Test plan

- [ ] Vertical gridlines show one line per month at default zoom; increase to per-week/day when zoomed in
- [ ] Show Vertical Gridlines toggle hides/shows gridlines without page reload
- [ ] Highlight Weekends shows shaded columns only at week/day zoom level; disappears at month/year zoom
- [ ] Compact Mode reduces row height visibly; text remains readable with no descender clipping
- [ ] Reset View returns to default window after pan-only, zoom-only, and pan+zoom
- [ ] Pressing Escape during a drag reverts the bar; no item drawer opens on pointer release
- [ ] Help popover shows correct entries based on `allowZoom` and `editable` props
- [ ] Save as image: no blank space below last row in normal mode; correct capture in fullscreen mode
- [ ] All existing timeline tests pass (`npm test`)