### PR TITLE
Feature/add roadmap color management

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260627192624_AddRoadmapColors.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260627192624_AddRoadmapColors.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260627192624_AddRoadmapColors")]
+    partial class AddRoadmapColors
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260627192624_AddRoadmapColors.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260627192624_AddRoadmapColors.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class AddRoadmapColors : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AddColumn<string>(
+            name: "Colors",
+            schema: "Planning",
+            table: "Roadmaps",
+            type: "nvarchar(max)",
+            nullable: true);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropColumn(
+            name: "Colors",
+            schema: "Planning",
+            table: "Roadmaps");
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/PlanningConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/PlanningConfiguration.cs
@@ -340,6 +340,16 @@ public class RoadmapConfig : IEntityTypeConfiguration<Roadmap>
             options.Property(d => d.End).HasColumnName("End").IsRequired();
         });
 
+        // Colors are managed as a whole and never queried independently, so they are stored as a
+        // JSON column on the Roadmap rather than a separate table.
+        builder.OwnsMany(r => r.Colors, c =>
+        {
+            c.ToJson();
+            c.UsePropertyAccessMode(PropertyAccessMode.Field);
+        });
+        builder.Navigation(r => r.Colors)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         // Relationships
         builder.HasMany(r => r.RoadmapManagers)
             .WithOne()

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapColorsCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapColorsCommand.cs
@@ -1,0 +1,85 @@
+using Ardalis.GuardClauses;
+using Wayd.Planning.Domain.Interfaces.Roadmaps;
+using Wayd.Planning.Domain.Models.Roadmaps;
+
+namespace Wayd.Planning.Application.Roadmaps.Commands;
+
+public sealed record UpdateRoadmapColorsCommand(Guid RoadmapId, List<UpsertRoadmapColorModel> Colors) : ICommand;
+
+public sealed record UpsertRoadmapColorModel(string Color, string Name, int Order, bool IsDefault) : IUpsertRoadmapColor;
+
+public sealed class UpdateRoadmapColorsCommandValidator : AbstractValidator<UpdateRoadmapColorsCommand>
+{
+    public UpdateRoadmapColorsCommandValidator()
+    {
+        RuleFor(x => x.RoadmapId)
+            .NotEmpty();
+
+        RuleFor(x => x.Colors)
+            .NotNull()
+            .Must(colors => colors.Count <= Roadmap.MaxColors)
+                .WithMessage($"A Roadmap cannot have more than {Roadmap.MaxColors} colors.")
+            .Must(colors => colors.Count(c => c.IsDefault) <= 1)
+                .WithMessage("Only one color can be marked as the default.");
+
+        RuleForEach(x => x.Colors).ChildRules(color =>
+        {
+            color.RuleFor(c => c.Color)
+                .NotEmpty()
+                .Matches("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
+                    .WithMessage("Color must be a valid hex color code.");
+
+            color.RuleFor(c => c.Name)
+                .NotEmpty()
+                .MaximumLength(32);
+        });
+    }
+}
+
+internal sealed class UpdateRoadmapColorsCommandHandler(IPlanningDbContext planningDbContext, ICurrentUser currentUser, ILogger<UpdateRoadmapColorsCommandHandler> logger) : ICommandHandler<UpdateRoadmapColorsCommand>
+{
+    private const string AppRequestName = nameof(UpdateRoadmapColorsCommand);
+
+    private readonly IPlanningDbContext _planningDbContext = planningDbContext;
+    private readonly Guid _currentUserEmployeeId = Guard.Against.NullOrEmpty(currentUser.GetEmployeeId());
+    private readonly ILogger<UpdateRoadmapColorsCommandHandler> _logger = logger;
+
+    public async Task<Result> Handle(UpdateRoadmapColorsCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var roadmap = await _planningDbContext.Roadmaps
+                .Include(x => x.RoadmapManagers)
+                .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
+
+            if (roadmap is null)
+            {
+                _logger.LogInformation("Roadmap with id {RoadmapId} not found.", request.RoadmapId);
+                return Result.Failure($"Roadmap with id {request.RoadmapId} not found");
+            }
+
+            var updateResult = roadmap.UpdateColors(request.Colors, _currentUserEmployeeId);
+
+            if (updateResult.IsFailure)
+            {
+                // Reset the entity
+                await _planningDbContext.Entry(roadmap).ReloadAsync(cancellationToken);
+                roadmap.ClearDomainEvents();
+
+                _logger.LogError("Unable to update colors for Roadmap {RoadmapId}.  Error message: {Error}", request.RoadmapId, updateResult.Error);
+                return Result.Failure(updateResult.Error);
+            }
+
+            await _planningDbContext.SaveChangesAsync(cancellationToken);
+
+            _logger.LogInformation("Colors for Roadmap {RoadmapId} updated.", request.RoadmapId);
+
+            return Result.Success();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Exception handling {CommandName} command for request {@Request}.", AppRequestName, request);
+            return Result.Failure($"Error handling {AppRequestName} command.");
+        }
+    }
+}

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Dtos/RoadmapColorDto.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Dtos/RoadmapColorDto.cs
@@ -1,0 +1,26 @@
+using Wayd.Planning.Domain.Models.Roadmaps;
+
+namespace Wayd.Planning.Application.Roadmaps.Dtos;
+
+public sealed record RoadmapColorDto : IMapFrom<RoadmapColor>
+{
+    /// <summary>
+    /// The color, as a hex code (e.g. "#4096FF").
+    /// </summary>
+    public required string Color { get; set; }
+
+    /// <summary>
+    /// The caption describing what the color represents on this Roadmap.
+    /// </summary>
+    public required string Name { get; set; }
+
+    /// <summary>
+    /// The order of the color within the Roadmap's configured colors.
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Whether this is the default color applied to activities that have no color of their own.
+    /// </summary>
+    public bool IsDefault { get; set; }
+}

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Dtos/RoadmapDetailsDto.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Dtos/RoadmapDetailsDto.cs
@@ -49,6 +49,11 @@ public sealed record RoadmapDetailsDto : IMapFrom<Roadmap>
     /// </summary>
     public required List<EmployeeNavigationDto> RoadmapManagers { get; set; }
 
+    /// <summary>
+    /// The colors configured on the Roadmap, ordered by their configured order.
+    /// </summary>
+    public required List<RoadmapColorDto> Colors { get; set; }
+
     public void ConfigureMapping(TypeAdapterConfig config)
     {
         config.NewConfig<Roadmap, RoadmapDetailsDto>()
@@ -56,6 +61,7 @@ public sealed record RoadmapDetailsDto : IMapFrom<Roadmap>
             .Map(dest => dest.End, src => src.DateRange.End)
             .Map(dest => dest.Visibility, src => SimpleNavigationDto.FromEnum(src.Visibility))
             .Map(dest => dest.State, src => SimpleNavigationDto.FromEnum(src.State))
-            .Map(dest => dest.RoadmapManagers, src => src.RoadmapManagers.Select(m => EmployeeNavigationDto.From(m.Manager!)));
+            .Map(dest => dest.RoadmapManagers, src => src.RoadmapManagers.Select(m => EmployeeNavigationDto.From(m.Manager!)))
+            .Map(dest => dest.Colors, src => src.Colors.OrderBy(c => c.Order));
     }
 }

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Interfaces/Roadmaps/IUpsertRoadmapColor.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Interfaces/Roadmaps/IUpsertRoadmapColor.cs
@@ -1,0 +1,9 @@
+namespace Wayd.Planning.Domain.Interfaces.Roadmaps;
+
+public interface IUpsertRoadmapColor
+{
+    string Color { get; }
+    string Name { get; }
+    int Order { get; }
+    bool IsDefault { get; }
+}

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/Roadmap.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/Roadmap.cs
@@ -12,9 +12,16 @@ namespace Wayd.Planning.Domain.Models.Roadmaps;
 
 public sealed class Roadmap : BaseAuditableEntity, ILocalSchedule, IHasIdAndKey
 {
+    /// <summary>
+    /// The maximum number of colors that can be configured on a Roadmap. Colors are persisted as a
+    /// JSON column, so this guards against an unbounded payload.
+    /// </summary>
+    public const int MaxColors = 30;
+
     private readonly bool _objectConstruction = false;
     private readonly List<RoadmapManager> _roadmapManagers = [];
     private readonly List<BaseRoadmapItem> _items = [];
+    private readonly List<RoadmapColor> _colors = [];
 
     private Roadmap() { }
 
@@ -90,6 +97,12 @@ public sealed class Roadmap : BaseAuditableEntity, ILocalSchedule, IHasIdAndKey
     /// </summary>
     public IReadOnlyList<BaseRoadmapItem> Items => _items.AsReadOnly();
 
+    /// <summary>
+    /// The configured colors for the Roadmap. These define the named colors available when
+    /// coloring activities, and drive the timeline legend.
+    /// </summary>
+    public IReadOnlyList<RoadmapColor> Colors => _colors.AsReadOnly();
+
     private IReadOnlyList<RoadmapActivity> RootActivities => [.. _items.OfType<RoadmapActivity>().Where(x => x.ParentId is null).OrderBy(x => x.Order)];
 
     /// <summary>
@@ -131,7 +144,7 @@ public sealed class Roadmap : BaseAuditableEntity, ILocalSchedule, IHasIdAndKey
 
     private Result SyncManagers(IEnumerable<Guid> roadmapManagerIds, Guid currentUserEmployeeId)
     {
-        // TODO: This is a temporary solution to sync managers. 
+        // TODO: This is a temporary solution to sync managers.
         var managerIdsToAdd = roadmapManagerIds.Where(x => !_roadmapManagers.Any(y => y.ManagerId == x)).ToArray();
         var managerIdsToRemove = _roadmapManagers.Where(x => !roadmapManagerIds.Contains(x.ManagerId)).Select(x => x.ManagerId).ToArray();
 
@@ -143,6 +156,53 @@ public sealed class Roadmap : BaseAuditableEntity, ILocalSchedule, IHasIdAndKey
         foreach (var managerId in managerIdsToRemove)
         {
             RemoveManager(managerId, currentUserEmployeeId);
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Replaces the Roadmap's configured colors with the provided set. Colors are managed as a
+    /// whole: the existing set is discarded and rebuilt from the input. Colors must be distinct by
+    /// hex (the color is the natural key), and at most one may be marked as the default.
+    /// </summary>
+    /// <param name="colors">The desired set of colors.</param>
+    /// <param name="currentUserEmployeeId">The employee performing the update.</param>
+    public Result UpdateColors(IEnumerable<IUpsertRoadmapColor> colors, Guid currentUserEmployeeId)
+    {
+        var isManagerResult = CanModify(currentUserEmployeeId);
+        if (isManagerResult.IsFailure)
+        {
+            return isManagerResult;
+        }
+
+        var incoming = colors.ToArray();
+
+        if (incoming.Length > MaxColors)
+        {
+            return Result.Failure($"A Roadmap cannot have more than {MaxColors} colors.");
+        }
+
+        if (incoming.Count(x => x.IsDefault) > 1)
+        {
+            return Result.Failure("Only one color can be marked as the default.");
+        }
+
+        var normalizedColors = incoming
+            .Select(x => x.Color?.Trim())
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x!.ToUpperInvariant())
+            .ToArray();
+
+        if (normalizedColors.Length != normalizedColors.Distinct().Count())
+        {
+            return Result.Failure("A Roadmap cannot have two colors with the same value.");
+        }
+
+        _colors.Clear();
+        foreach (var color in incoming)
+        {
+            _colors.Add(new RoadmapColor(color.Color, color.Name, color.Order, color.IsDefault));
         }
 
         return Result.Success();

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapColor.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapColor.cs
@@ -1,0 +1,61 @@
+using Ardalis.GuardClauses;
+using CSharpFunctionalExtensions;
+
+namespace Wayd.Planning.Domain.Models.Roadmaps;
+
+/// <summary>
+/// A named color configured on a Roadmap. Roadmap colors define the color vocabulary for a
+/// Roadmap: each one pairs a color with a caption, and one can be marked as the default applied
+/// to activities that have no color of their own. A Roadmap color has no identity of its own — it
+/// is defined entirely by its values.
+/// </summary>
+public sealed class RoadmapColor : ValueObject
+{
+    private RoadmapColor() { }
+
+    internal RoadmapColor(string color, string name, int order, bool isDefault)
+    {
+        Color = color;
+        Name = name;
+        Order = order;
+        IsDefault = isDefault;
+    }
+
+    /// <summary>
+    /// The color, stored as a hex code (e.g. "#4096FF"). The color is the natural key for a
+    /// Roadmap color: a Roadmap cannot have two colors with the same hex.
+    /// </summary>
+    public string Color
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Color)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The caption describing what the color represents on this Roadmap.
+    /// </summary>
+    public string Name
+    {
+        get;
+        private set => field = Guard.Against.NullOrWhiteSpace(value, nameof(Name)).Trim();
+    } = default!;
+
+    /// <summary>
+    /// The order of the color within the Roadmap's configured colors.
+    /// </summary>
+    public int Order { get; private set; }
+
+    /// <summary>
+    /// Whether this is the default color applied to activities that have no color of their own.
+    /// At most one Roadmap color can be the default.
+    /// </summary>
+    public bool IsDefault { get; private set; }
+
+    protected override IEnumerable<IComparable> GetEqualityComponents()
+    {
+        yield return Color;
+        yield return Name;
+        yield return Order;
+        yield return IsDefault;
+    }
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Sut/Roadmaps/Commands/UpdateRoadmapColorsCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Sut/Roadmaps/Commands/UpdateRoadmapColorsCommandHandlerTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.Extensions.Logging;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Planning.Application.Roadmaps.Commands;
+using Wayd.Planning.Application.Tests.Infrastructure;
+using Wayd.Planning.Domain.Models.Roadmaps;
+using Wayd.Planning.Domain.Tests.Data;
+using Moq;
+
+namespace Wayd.Planning.Application.Tests.Sut.Roadmaps.Commands;
+
+public class UpdateRoadmapColorsCommandHandlerTests : IDisposable
+{
+    private readonly FakePlanningDbContext _dbContext;
+    private readonly Mock<ILogger<UpdateRoadmapColorsCommandHandler>> _mockLogger;
+    private readonly Mock<ICurrentUser> _mockCurrentUser;
+    private readonly Guid _currentEmployeeId = Guid.NewGuid();
+    private readonly RoadmapFaker _faker;
+
+    public UpdateRoadmapColorsCommandHandlerTests()
+    {
+        _dbContext = new FakePlanningDbContext();
+        _mockLogger = new Mock<ILogger<UpdateRoadmapColorsCommandHandler>>();
+        _mockCurrentUser = new Mock<ICurrentUser>();
+        _mockCurrentUser.Setup(u => u.GetEmployeeId()).Returns(_currentEmployeeId);
+        _faker = new RoadmapFaker();
+    }
+
+    private UpdateRoadmapColorsCommandHandler CreateHandler() =>
+        new(_dbContext, _mockCurrentUser.Object, _mockLogger.Object);
+
+    private Roadmap CreateActiveRoadmap(Guid? managerId = null)
+    {
+        var mgrId = managerId ?? _currentEmployeeId;
+        var fakeRoadmap = _faker.Generate();
+        return Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [mgrId]).Value;
+    }
+
+    [Fact]
+    public async Task Handle_ShouldUpdateColors_WhenValidAndUserIsManager()
+    {
+        // Arrange
+        var roadmap = CreateActiveRoadmap();
+        _dbContext.AddRoadmap(roadmap);
+        var handler = CreateHandler();
+
+        var command = new UpdateRoadmapColorsCommand(roadmap.Id,
+        [
+            new UpsertRoadmapColorModel("#FF0000", "At Risk", 1, true),
+            new UpsertRoadmapColorModel("#00FF00", "On Track", 2, false),
+        ]);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().HaveCount(2);
+        roadmap.Colors.Should().ContainSingle(c => c.Color == "#FF0000" && c.Name == "At Risk" && c.IsDefault);
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldReplaceExistingColors()
+    {
+        // Arrange
+        var roadmap = CreateActiveRoadmap();
+        roadmap.UpdateColors(
+            [new UpsertRoadmapColorModel("#111111", "Old", 1, false)],
+            _currentEmployeeId);
+        _dbContext.AddRoadmap(roadmap);
+        var handler = CreateHandler();
+
+        var command = new UpdateRoadmapColorsCommand(roadmap.Id,
+        [
+            new UpsertRoadmapColorModel("#222222", "New", 1, false),
+        ]);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().ContainSingle(c => c.Color == "#222222");
+        roadmap.Colors.Should().NotContain(c => c.Color == "#111111");
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldClearColors_WhenEmptyCollection()
+    {
+        // Arrange
+        var roadmap = CreateActiveRoadmap();
+        roadmap.UpdateColors(
+            [new UpsertRoadmapColorModel("#111111", "Old", 1, false)],
+            _currentEmployeeId);
+        _dbContext.AddRoadmap(roadmap);
+        var handler = CreateHandler();
+
+        var command = new UpdateRoadmapColorsCommand(roadmap.Id, []);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().BeEmpty();
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldFail_WhenRoadmapNotFound()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var command = new UpdateRoadmapColorsCommand(Guid.NewGuid(),
+        [
+            new UpsertRoadmapColorModel("#FF0000", "At Risk", 1, false),
+        ]);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("not found");
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_ShouldNotSave_WhenUserIsNotManager()
+    {
+        // Arrange
+        var otherManagerId = Guid.NewGuid();
+        var roadmap = CreateActiveRoadmap(managerId: otherManagerId);
+        _dbContext.AddRoadmap(roadmap);
+        var handler = CreateHandler();
+
+        var command = new UpdateRoadmapColorsCommand(roadmap.Id,
+        [
+            new UpsertRoadmapColorModel("#FF0000", "At Risk", 1, false),
+        ]);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        roadmap.Colors.Should().BeEmpty();
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Data/RoadmapColorFaker.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Data/RoadmapColorFaker.cs
@@ -1,0 +1,46 @@
+using Wayd.Planning.Domain.Models.Roadmaps;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Planning.Domain.Tests.Data;
+
+public class RoadmapColorFaker : PrivateConstructorFaker<RoadmapColor>
+{
+    public RoadmapColorFaker()
+    {
+        RuleFor(x => x.Color, f => string.Format("#{0:X6}", f.Random.Hexadecimal(0x1000000)));
+        RuleFor(x => x.Name, f => f.Random.Words(2));
+        RuleFor(x => x.Order, f => f.Random.Int(1, 1000));
+        RuleFor(x => x.IsDefault, f => false);
+    }
+}
+
+public static class RoadmapColorFakerExtensions
+{
+    public static RoadmapColorFaker WithColor(this RoadmapColorFaker faker, string? color)
+    {
+        faker.RuleFor(x => x.Color, color);
+
+        return faker;
+    }
+
+    public static RoadmapColorFaker WithName(this RoadmapColorFaker faker, string? name)
+    {
+        faker.RuleFor(x => x.Name, name);
+
+        return faker;
+    }
+
+    public static RoadmapColorFaker WithOrder(this RoadmapColorFaker faker, int? order)
+    {
+        faker.RuleFor(x => x.Order, order);
+
+        return faker;
+    }
+
+    public static RoadmapColorFaker WithIsDefault(this RoadmapColorFaker faker, bool? isDefault)
+    {
+        faker.RuleFor(x => x.IsDefault, isDefault);
+
+        return faker;
+    }
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Data/RoadmapFaker.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Data/RoadmapFaker.cs
@@ -69,6 +69,45 @@ public static class RoadmapFakerExtensions
         return faker;
     }
 
+    public static RoadmapFaker WithColors(this RoadmapFaker faker, IEnumerable<RoadmapColor> colors)
+    {
+        var colorList = colors.ToList();
+
+        if (colorList.Count(c => c.IsDefault) > 1)
+        {
+            throw new ArgumentException("Only one color can be marked as the default.", nameof(colors));
+        }
+
+        var distinctColorCount = colorList
+            .Select(c => c.Color.Trim().ToUpperInvariant())
+            .Distinct()
+            .Count();
+
+        if (distinctColorCount != colorList.Count)
+        {
+            throw new ArgumentException("A Roadmap cannot have two colors with the same value.", nameof(colors));
+        }
+
+        faker.RuleFor("_colors", f => colorList);
+
+        return faker;
+    }
+
+    public static RoadmapFaker WithColors(this RoadmapFaker faker, int count)
+    {
+        var colorFaker = new RoadmapColorFaker();
+
+        var colors = Enumerable.Range(0, count)
+            .Select(i => colorFaker
+                .WithColor($"#{i:X6}") // distinct, since color is the natural key
+                .WithOrder(i + 1)
+                .WithIsDefault(i == 0) // exactly one default
+                .Generate())
+            .ToList();
+
+        return faker.WithColors(colors);
+    }
+
     //public static Roadmap WithChildren(this RoadmapFaker faker, int childrenCount)
     //{
     //    var roadmapId = Guid.NewGuid();

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Models/TestUpsertRoadmapColor.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Models/TestUpsertRoadmapColor.cs
@@ -1,0 +1,22 @@
+using Wayd.Planning.Domain.Interfaces.Roadmaps;
+using Wayd.Planning.Domain.Models.Roadmaps;
+
+namespace Wayd.Planning.Domain.Tests.Models;
+
+internal record TestUpsertRoadmapColor : IUpsertRoadmapColor
+{
+    public TestUpsertRoadmapColor() { }
+
+    public TestUpsertRoadmapColor(RoadmapColor color)
+    {
+        Color = color.Color;
+        Name = color.Name;
+        Order = color.Order;
+        IsDefault = color.IsDefault;
+    }
+
+    public string Color { get; set; } = default!;
+    public string Name { get; set; } = default!;
+    public int Order { get; set; }
+    public bool IsDefault { get; set; }
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/RoadmapTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/RoadmapTests.cs
@@ -1195,6 +1195,242 @@ public class RoadmapTests
 
     #endregion Update Item Dates Tests
 
+    #region Update Colors Tests
+
+    [Fact]
+    public void UpdateColors_WhenValidColors_ShouldReplaceColors()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#FF0000", Name = "At Risk", Order = 1, IsDefault = true },
+            new TestUpsertRoadmapColor { Color = "#00FF00", Name = "On Track", Order = 2, IsDefault = false },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().HaveCount(2);
+        roadmap.Colors.Should().ContainSingle(c => c.Color == "#FF0000" && c.Name == "At Risk" && c.Order == 1 && c.IsDefault);
+        roadmap.Colors.Should().ContainSingle(c => c.Color == "#00FF00" && c.Name == "On Track" && c.Order == 2 && !c.IsDefault);
+    }
+
+    [Fact]
+    public void UpdateColors_WhenRoadmapHasExistingColors_ShouldReplaceThemEntirely()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        roadmap.UpdateColors(
+            [new TestUpsertRoadmapColor { Color = "#111111", Name = "Old", Order = 1, IsDefault = false }],
+            managerId);
+
+        var newColors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#222222", Name = "New", Order = 1, IsDefault = false },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(newColors, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().ContainSingle();
+        roadmap.Colors.Should().ContainSingle(c => c.Color == "#222222");
+        roadmap.Colors.Should().NotContain(c => c.Color == "#111111");
+    }
+
+    [Fact]
+    public void UpdateColors_WhenEmptyCollection_ShouldClearColors()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        roadmap.UpdateColors(
+            [new TestUpsertRoadmapColor { Color = "#111111", Name = "Old", Order = 1, IsDefault = false }],
+            managerId);
+
+        // Act
+        var result = roadmap.UpdateColors([], managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void UpdateColors_WhenMoreThanOneDefault_ShouldReturnFailure()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#FF0000", Name = "At Risk", Order = 1, IsDefault = true },
+            new TestUpsertRoadmapColor { Color = "#00FF00", Name = "On Track", Order = 2, IsDefault = true },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Only one color can be marked as the default.");
+    }
+
+    [Fact]
+    public void UpdateColors_WhenDuplicateColors_ShouldReturnFailure()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#FF0000", Name = "At Risk", Order = 1, IsDefault = false },
+            new TestUpsertRoadmapColor { Color = "#FF0000", Name = "Blocked", Order = 2, IsDefault = false },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("A Roadmap cannot have two colors with the same value.");
+    }
+
+    [Fact]
+    public void UpdateColors_WhenDuplicateColorsDifferByCase_ShouldReturnFailure()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#abc123", Name = "Lower", Order = 1, IsDefault = false },
+            new TestUpsertRoadmapColor { Color = "#ABC123", Name = "Upper", Order = 2, IsDefault = false },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("A Roadmap cannot have two colors with the same value.");
+    }
+
+    [Fact]
+    public void UpdateColors_WhenExceedingMaxColors_ShouldReturnFailure()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = Enumerable.Range(0, Roadmap.MaxColors + 1)
+            .Select(i => new TestUpsertRoadmapColor
+            {
+                Color = $"#{i:X6}",
+                Name = $"Color {i}",
+                Order = i + 1,
+                IsDefault = false,
+            })
+            .ToArray();
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be($"A Roadmap cannot have more than {Roadmap.MaxColors} colors.");
+    }
+
+    [Fact]
+    public void UpdateColors_WhenAtMaxColors_ShouldReturnSuccess()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = Enumerable.Range(0, Roadmap.MaxColors)
+            .Select(i => new TestUpsertRoadmapColor
+            {
+                Color = $"#{i:X6}",
+                Name = $"Color {i}",
+                Order = i + 1,
+                IsDefault = false,
+            })
+            .ToArray();
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        roadmap.Colors.Should().HaveCount(Roadmap.MaxColors);
+    }
+
+    [Fact]
+    public void UpdateColors_WhenNotManager_ShouldReturnFailure()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+
+        var colors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#FF0000", Name = "At Risk", Order = 1, IsDefault = false },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(colors, Guid.NewGuid());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("User is not a roadmap manager of this roadmap.");
+    }
+
+    [Fact]
+    public void UpdateColors_WhenArchived_ShouldReturnFailure()
+    {
+        // Arrange
+        var fakeRoadmap = _faker.Generate();
+        var managerId = Guid.NewGuid();
+        var roadmap = Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+        roadmap.Archive(managerId);
+
+        var colors = new[]
+        {
+            new TestUpsertRoadmapColor { Color = "#FF0000", Name = "At Risk", Order = 1, IsDefault = false },
+        };
+
+        // Act
+        var result = roadmap.UpdateColors(colors, managerId);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Be("Archived roadmaps cannot be modified.");
+    }
+
+    #endregion Update Colors Tests
+
     //[Fact]
     //public void SetChildrenOrder_ForAll_WhenValidChildrenProvided_ShouldReturnSuccess()
     //{

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/RoadmapsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/RoadmapsController.cs
@@ -114,6 +114,24 @@ public class RoadmapsController : ControllerBase
             : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
+    [HttpPut("{id}/colors")]
+    [MustHavePermission(ApplicationAction.Update, ApplicationResource.Roadmaps)]
+    [OpenApiOperation("Update the configured colors for a roadmap.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<ActionResult> UpdateColors(Guid id, [FromBody] UpdateRoadmapColorsRequest request, CancellationToken cancellationToken)
+    {
+        if (id != request.RoadmapId)
+            return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
+
+        var result = await _sender.Send(request.ToUpdateRoadmapColorsCommand(), cancellationToken);
+
+        return result.IsSuccess
+            ? NoContent()
+            : BadRequest(result.ToBadRequestObject(HttpContext));
+    }
+
     [HttpDelete("{id}")]
     [MustHavePermission(ApplicationAction.Delete, ApplicationResource.Roadmaps)]
     [OpenApiOperation("Delete a roadmap.", "")]

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapColorsRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Planning/Roadmaps/UpdateRoadmapColorsRequest.cs
@@ -1,0 +1,77 @@
+using Wayd.Planning.Application.Roadmaps.Commands;
+using Wayd.Planning.Domain.Models.Roadmaps;
+
+namespace Wayd.Web.Api.Models.Planning.Roadmaps;
+
+public sealed record UpdateRoadmapColorsRequest
+{
+    /// <summary>
+    /// The unique identifier of the Roadmap.
+    /// </summary>
+    public Guid RoadmapId { get; set; }
+
+    /// <summary>
+    /// The colors to configure on the Roadmap. The provided set fully replaces the existing colors.
+    /// </summary>
+    public List<UpsertRoadmapColorRequest> Colors { get; set; } = default!;
+
+    public UpdateRoadmapColorsCommand ToUpdateRoadmapColorsCommand()
+    {
+        return new UpdateRoadmapColorsCommand(
+            RoadmapId,
+            Colors.Select(c => new UpsertRoadmapColorModel(c.Color, c.Name, c.Order, c.IsDefault)).ToList());
+    }
+}
+
+public sealed record UpsertRoadmapColorRequest
+{
+    /// <summary>
+    /// The color, as a hex code (e.g. "#4096FF").
+    /// </summary>
+    public string Color { get; set; } = default!;
+
+    /// <summary>
+    /// The caption describing what the color represents on this Roadmap.
+    /// </summary>
+    public string Name { get; set; } = default!;
+
+    /// <summary>
+    /// The order of the color within the Roadmap's configured colors.
+    /// </summary>
+    public int Order { get; set; }
+
+    /// <summary>
+    /// Whether this is the default color applied to activities that have no color of their own.
+    /// </summary>
+    public bool IsDefault { get; set; }
+}
+
+public sealed class UpdateRoadmapColorsRequestValidator : CustomValidator<UpdateRoadmapColorsRequest>
+{
+    public UpdateRoadmapColorsRequestValidator()
+    {
+        RuleLevelCascadeMode = CascadeMode.Stop;
+
+        RuleFor(t => t.RoadmapId)
+            .NotEmpty();
+
+        RuleFor(t => t.Colors)
+            .NotNull()
+            .Must(colors => colors.Count <= Roadmap.MaxColors)
+                .WithMessage($"A Roadmap cannot have more than {Roadmap.MaxColors} colors.")
+            .Must(colors => colors.Count(c => c.IsDefault) <= 1)
+                .WithMessage("Only one color can be marked as the default.");
+
+        RuleForEach(t => t.Colors).ChildRules(color =>
+        {
+            color.RuleFor(c => c.Color)
+                .NotEmpty()
+                .Matches("^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$")
+                    .WithMessage("Color must be a valid hex color code.");
+
+            color.RuleFor(c => c.Name)
+                .NotEmpty()
+                .MaximumLength(32);
+        });
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -14813,6 +14813,71 @@
         ]
       }
     },
+    "/api/planning/roadmaps/{id}/colors": {
+      "put": {
+        "tags": [
+          "Roadmaps"
+        ],
+        "summary": "Update the configured colors for a roadmap.",
+        "operationId": "Roadmaps_UpdateColors",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRoadmapColorsRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 2
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
     "/api/planning/roadmaps/{id}/archive": {
       "post": {
         "tags": [
@@ -34000,6 +34065,7 @@
           "visibility",
           "state",
           "roadmapManagers",
+          "colors",
           "id",
           "key"
         ],
@@ -34040,6 +34106,37 @@
             "items": {
               "$ref": "#/components/schemas/EmployeeNavigationDto"
             }
+          },
+          "colors": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RoadmapColorDto"
+            }
+          }
+        }
+      },
+      "RoadmapColorDto": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "color",
+          "name",
+          "order",
+          "isDefault"
+        ],
+        "properties": {
+          "color": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isDefault": {
+            "type": "boolean"
           }
         }
       },
@@ -34205,6 +34302,61 @@
             "type": "integer",
             "description": "The visibility id for the Roadmap. If the Roadmap is public, all users can see the Roadmap. Otherwise, only the Roadmap Managers can see the Roadmap.",
             "format": "int32"
+          }
+        }
+      },
+      "UpdateRoadmapColorsRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "roadmapId",
+          "colors"
+        ],
+        "properties": {
+          "roadmapId": {
+            "type": "string",
+            "description": "The unique identifier of the Roadmap.",
+            "format": "guid",
+            "minLength": 1,
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "colors": {
+            "type": "array",
+            "description": "The colors to configure on the Roadmap. The provided set fully replaces the existing colors.",
+            "nullable": false,
+            "items": {
+              "$ref": "#/components/schemas/UpsertRoadmapColorRequest"
+            }
+          }
+        }
+      },
+      "UpsertRoadmapColorRequest": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "color",
+          "name",
+          "order",
+          "isDefault"
+        ],
+        "properties": {
+          "color": {
+            "type": "string",
+            "description": "The color, as a hex code (e.g. \"#4096FF\")."
+          },
+          "name": {
+            "type": "string",
+            "description": "The caption describing what the color represents on this Roadmap."
+          },
+          "order": {
+            "type": "integer",
+            "description": "The order of the color within the Roadmap's configured colors.",
+            "format": "int32"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "description": "Whether this is the default color applied to activities that have no color of their own."
           }
         }
       },

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/[key]/page.tsx
@@ -18,6 +18,7 @@ import { Descriptions, Divider, MenuProps, Space, Tag } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import {
   ChangeRoadmapStateForm,
+  ConfigureRoadmapColorsForm,
   CopyRoadmapForm,
   DeleteRoadmapForm,
   EditRoadmapForm,
@@ -44,6 +45,8 @@ const RoadmapDetailsPage = (props: { params: Promise<{ key: string }> }) => {
   const [openCreateTimeboxForm, setOpenCreateTimeboxForm] =
     useState<boolean>(false)
   const [openEditRoadmapForm, setOpenEditRoadmapForm] = useState<boolean>(false)
+  const [openConfigureColorsForm, setOpenConfigureColorsForm] =
+    useState<boolean>(false)
   const [openCopyRoadmapForm, setOpenCopyRoadmapForm] = useState<boolean>(false)
   const [openDeleteRoadmapForm, setOpenDeleteRoadmapForm] =
     useState<boolean>(false)
@@ -120,46 +123,64 @@ const RoadmapDetailsPage = (props: { params: Promise<{ key: string }> }) => {
   const actionsMenuItems: MenuProps['items'] = (() => {
     const items: ItemType[] = []
 
-    // Copy is available to anyone who can view the roadmap and create roadmaps
+    // First section: roadmap-management actions (managers only).
+    if (isRoadmapManager) {
+      if (canUpdateRoadmap && !isArchived) {
+        items.push({
+          key: 'edit',
+          label: 'Edit',
+          onClick: () => setOpenEditRoadmapForm(true),
+        })
+      }
+      if (canUpdateRoadmap && !isArchived) {
+        items.push({
+          key: 'archive',
+          label: 'Archive',
+          onClick: () => setOpenChangeStateForm(RoadmapStateAction.Archive),
+        })
+      }
+      if (canDeleteRoadmap && !isArchived) {
+        items.push({
+          key: 'delete',
+          label: 'Delete',
+          onClick: () => setOpenDeleteRoadmapForm(true),
+        })
+      }
+      if (canUpdateRoadmap && isArchived) {
+        items.push({
+          key: 'activate',
+          label: 'Activate',
+          onClick: () => setOpenChangeStateForm(RoadmapStateAction.Activate),
+        })
+      }
+    }
+
+    // Second section: configure colors (managers only) and copy (anyone who can
+    // create roadmaps).
+    const secondSection: ItemType[] = []
+    if (isRoadmapManager && canUpdateRoadmap && !isArchived) {
+      secondSection.push({
+        key: 'configure-colors',
+        label: 'Configure Colors',
+        onClick: () => setOpenConfigureColorsForm(true),
+      })
+    }
     if (canCreateRoadmap) {
-      items.push({
+      secondSection.push({
         key: 'copy',
         label: 'Copy',
         onClick: () => setOpenCopyRoadmapForm(true),
       })
     }
+    if (secondSection.length > 0) {
+      if (items.length > 0) {
+        items.push({ key: 'second-section-divider', type: 'divider' })
+      }
+      items.push(...secondSection)
+    }
 
-    if (!isRoadmapManager) return items
-
-    if (canUpdateRoadmap && !isArchived) {
-      items.push({
-        key: 'edit',
-        label: 'Edit',
-        onClick: () => setOpenEditRoadmapForm(true),
-      })
-    }
-    if (canUpdateRoadmap && !isArchived) {
-      items.push({
-        key: 'archive',
-        label: 'Archive',
-        onClick: () => setOpenChangeStateForm(RoadmapStateAction.Archive),
-      })
-    }
-    if (canDeleteRoadmap && !isArchived) {
-      items.push({
-        key: 'delete',
-        label: 'Delete',
-        onClick: () => setOpenDeleteRoadmapForm(true),
-      })
-    }
-    if (canUpdateRoadmap && isArchived) {
-      items.push({
-        key: 'activate',
-        label: 'Activate',
-        onClick: () => setOpenChangeStateForm(RoadmapStateAction.Activate),
-      })
-    }
-    if (canUpdateRoadmap && !isArchived) {
+    // Third section: create actions (managers only).
+    if (isRoadmapManager && canUpdateRoadmap && !isArchived) {
       items.push(
         {
           key: 'create-divider',
@@ -183,6 +204,13 @@ const RoadmapDetailsPage = (props: { params: Promise<{ key: string }> }) => {
 
   const onEditRoadmapFormClosed = (wasSaved: boolean) => {
     setOpenEditRoadmapForm(false)
+    if (wasSaved) {
+      refetchRoadmap()
+    }
+  }
+
+  const onConfigureColorsFormClosed = (wasSaved: boolean) => {
+    setOpenConfigureColorsForm(false)
     if (wasSaved) {
       refetchRoadmap()
     }
@@ -294,6 +322,13 @@ const RoadmapDetailsPage = (props: { params: Promise<{ key: string }> }) => {
           roadmapKey={roadmapKey}
           onFormComplete={() => onEditRoadmapFormClosed(true)}
           onFormCancel={() => onEditRoadmapFormClosed(false)}
+        />
+      )}
+      {openConfigureColorsForm && (
+        <ConfigureRoadmapColorsForm
+          roadmap={roadmapData}
+          onFormComplete={() => onConfigureColorsFormClosed(true)}
+          onFormCancel={() => onConfigureColorsFormClosed(false)}
         />
       )}
       {openCopyRoadmapForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/configure-roadmap-colors-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/configure-roadmap-colors-form.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useMessage } from '@/src/components/contexts/messaging'
+import { useConfirmModal } from '@/src/hooks'
+import { RoadmapDetailsDto } from '@/src/services/wayd-api'
+import { useUpdateRoadmapColorsMutation } from '@/src/store/features/planning/roadmaps-api'
+import { isApiError, type ApiError } from '@/src/utils'
+import { Modal } from 'antd'
+import { useState } from 'react'
+import RoadmapColorConfig, {
+  RoadmapColorConfigEntry,
+  RoadmapColorConfigErrors,
+  validateColorEntries,
+} from './roadmap-color-config'
+
+export interface ConfigureRoadmapColorsFormProps {
+  roadmap: RoadmapDetailsDto
+  onFormComplete: () => void
+  onFormCancel: () => void
+}
+
+const toConfigEntries = (
+  roadmap: RoadmapDetailsDto,
+): RoadmapColorConfigEntry[] =>
+  [...roadmap.colors]
+    .sort((a, b) => a.order - b.order)
+    .map((c) => ({
+      key: crypto.randomUUID(),
+      color: c.color,
+      name: c.name,
+      isDefault: c.isDefault,
+    }))
+
+const ConfigureRoadmapColorsForm = ({
+  roadmap,
+  onFormComplete,
+  onFormCancel,
+}: ConfigureRoadmapColorsFormProps) => {
+  const messageApi = useMessage()
+  const [entries, setEntries] = useState<RoadmapColorConfigEntry[]>(() =>
+    toConfigEntries(roadmap),
+  )
+
+  const errors: RoadmapColorConfigErrors = validateColorEntries(entries)
+  const isValid = !errors.hasErrors
+
+  const [updateRoadmapColors] = useUpdateRoadmapColorsMutation()
+
+  const { isOpen, isSaving, handleOk, handleCancel } = useConfirmModal({
+    onSubmit: async () => {
+      if (!isValid) return false
+
+      try {
+        const response = await updateRoadmapColors({
+          roadmapId: roadmap.id,
+          cacheKey: roadmap.key,
+          request: {
+            roadmapId: roadmap.id,
+            colors: entries.map((e, index) => ({
+              color: e.color!,
+              name: e.name.trim(),
+              order: index + 1,
+              isDefault: e.isDefault,
+            })),
+          },
+        })
+
+        if (response?.error) throw response.error
+
+        messageApi.success('Roadmap colors updated successfully.')
+        return true
+      } catch (error) {
+        const apiError: ApiError = isApiError(error) ? error : {}
+        messageApi.error(
+          apiError.detail ??
+            'An error occurred while updating the roadmap colors. Please try again.',
+        )
+        console.error(error)
+        return false
+      }
+    },
+    onComplete: onFormComplete,
+    onCancel: onFormCancel,
+    errorMessage:
+      'An error occurred while updating the roadmap colors. Please try again.',
+    permission: 'Permissions.Roadmaps.Update',
+  })
+
+  return (
+    <Modal
+      title="Configure Colors"
+      open={isOpen}
+      onOk={handleOk}
+      okButtonProps={{ disabled: !isValid }}
+      okText="Save"
+      confirmLoading={isSaving}
+      onCancel={handleCancel}
+      keyboard={false}
+      destroyOnHidden
+    >
+      <RoadmapColorConfig
+        value={entries}
+        onChange={setEntries}
+        errors={errors}
+      />
+    </Modal>
+  )
+}
+
+export default ConfigureRoadmapColorsForm
+

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-activity-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-activity-form.tsx
@@ -6,10 +6,12 @@ import { CreateRoadmapActivityRequest } from '@/src/services/wayd-api'
 import {
   useCreateRoadmapItemMutation,
   useGetRoadmapActivitiesQuery,
+  useGetRoadmapQuery,
 } from '@/src/store/features/planning/roadmaps-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
 import { DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
 import { useEffect } from 'react'
+import RoadmapColorPicker from './roadmap-color-picker'
 
 const { Item } = Form
 const { TextArea } = Input
@@ -56,6 +58,9 @@ const CreateRoadmapActivityForm = ({
     data: activities,
     error: activitiesError,
   } = useGetRoadmapActivitiesQuery(roadmapId)
+
+  const { data: roadmap } = useGetRoadmapQuery(roadmapId)
+  const roadmapColors = roadmap?.colors ?? []
 
   const [createRoadmapActivity] = useCreateRoadmapItemMutation()
 
@@ -181,7 +186,11 @@ const CreateRoadmapActivityForm = ({
           <RangePicker />
         </Item>
         <Item name="color" label="Color">
-          <WaydColorPicker />
+          {roadmapColors.length > 0 ? (
+            <RoadmapColorPicker entries={roadmapColors} />
+          ) : (
+            <WaydColorPicker />
+          )}
         </Item>
       </Form>
     </Modal>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-activity-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-activity-form.tsx
@@ -9,6 +9,7 @@ import {
 import {
   useGetRoadmapActivitiesQuery,
   useGetRoadmapItemQuery,
+  useGetRoadmapQuery,
   useUpdateRoadmapItemMutation,
 } from '@/src/store/features/planning/roadmaps-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
@@ -18,6 +19,7 @@ import dayjs from 'dayjs'
 import { MarkdownEditor } from '@/src/components/common/markdown'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { useModalForm } from '@/src/hooks'
+import RoadmapColorPicker from './roadmap-color-picker'
 
 const { Item } = Form
 const { TextArea } = Input
@@ -98,6 +100,9 @@ const EditRoadmapActivityForm = ({
     isLoading: activitiesIsLoading,
     error: activitiesError,
   } = useGetRoadmapActivitiesQuery(roadmapId)
+
+  const { data: roadmap } = useGetRoadmapQuery(roadmapId)
+  const roadmapColors = roadmap?.colors ?? []
 
   const [updateRoadmapActivity] = useUpdateRoadmapItemMutation()
 
@@ -239,7 +244,11 @@ const EditRoadmapActivityForm = ({
           <RangePicker />
         </Item>
         <Item name="color" label="Color">
-          <WaydColorPicker />
+          {roadmapColors.length > 0 ? (
+            <RoadmapColorPicker entries={roadmapColors} />
+          ) : (
+            <WaydColorPicker />
+          )}
         </Item>
       </Form>
     </Modal>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/index.ts
@@ -1,4 +1,5 @@
 export { default as ChangeRoadmapStateForm } from './change-roadmap-state-form'
+export { default as ConfigureRoadmapColorsForm } from './configure-roadmap-colors-form'
 export { default as CreateRoadmapForm } from './create-roadmap-form'
 export { default as CopyRoadmapForm } from './copy-roadmap-form'
 export { default as DeleteRoadmapForm } from './delete-roadmap-form'

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.test.ts
@@ -1,0 +1,98 @@
+import {
+  validateColorEntries,
+  type RoadmapColorConfigEntry,
+} from './roadmap-color-config'
+
+let keyCounter = 0
+const entry = (
+  overrides: Partial<RoadmapColorConfigEntry> = {},
+): RoadmapColorConfigEntry => ({
+  key: `key-${keyCounter++}`,
+  color: '#FF0000',
+  name: 'At Risk',
+  isDefault: false,
+  ...overrides,
+})
+
+describe('validateColorEntries', () => {
+  it('returns no errors for a valid set', () => {
+    const entries = [
+      entry({ color: '#FF0000', name: 'At Risk' }),
+      entry({ color: '#00FF00', name: 'On Track' }),
+    ]
+
+    const result = validateColorEntries(entries)
+
+    expect(result.hasErrors).toBe(false)
+    expect(result.byKey).toEqual({})
+  })
+
+  it('returns no errors for an empty set', () => {
+    const result = validateColorEntries([])
+
+    expect(result.hasErrors).toBe(false)
+    expect(result.byKey).toEqual({})
+  })
+
+  it('flags a missing color', () => {
+    const target = entry({ color: undefined, name: 'At Risk' })
+
+    const result = validateColorEntries([target])
+
+    expect(result.hasErrors).toBe(true)
+    expect(result.byKey[target.key]?.color).toBeDefined()
+    expect(result.byKey[target.key]?.name).toBeUndefined()
+  })
+
+  it('flags a missing caption', () => {
+    const target = entry({ color: '#FF0000', name: '   ' })
+
+    const result = validateColorEntries([target])
+
+    expect(result.hasErrors).toBe(true)
+    expect(result.byKey[target.key]?.name).toBeDefined()
+    expect(result.byKey[target.key]?.color).toBeUndefined()
+  })
+
+  it('flags duplicate colors on every offending row', () => {
+    const first = entry({ color: '#FF0000', name: 'At Risk' })
+    const second = entry({ color: '#FF0000', name: 'Blocked' })
+
+    const result = validateColorEntries([first, second])
+
+    expect(result.hasErrors).toBe(true)
+    expect(result.byKey[first.key]?.color).toBeDefined()
+    expect(result.byKey[second.key]?.color).toBeDefined()
+  })
+
+  it('treats colors that differ only by case as duplicates', () => {
+    const first = entry({ color: '#abc123', name: 'Lower' })
+    const second = entry({ color: '#ABC123', name: 'Upper' })
+
+    const result = validateColorEntries([first, second])
+
+    expect(result.hasErrors).toBe(true)
+    expect(result.byKey[first.key]?.color).toBeDefined()
+    expect(result.byKey[second.key]?.color).toBeDefined()
+  })
+
+  it('does not flag distinct colors as duplicates', () => {
+    const entries = [
+      entry({ color: '#FF0000', name: 'At Risk' }),
+      entry({ color: '#FF0001', name: 'Almost At Risk' }),
+    ]
+
+    const result = validateColorEntries(entries)
+
+    expect(result.hasErrors).toBe(false)
+  })
+
+  it('reports both a missing color and a missing caption on the same row', () => {
+    const target = entry({ color: undefined, name: '' })
+
+    const result = validateColorEntries([target])
+
+    expect(result.byKey[target.key]?.color).toBeDefined()
+    expect(result.byKey[target.key]?.name).toBeDefined()
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.test.ts
@@ -1,4 +1,5 @@
 import {
+  MAX_ROADMAP_COLORS,
   validateColorEntries,
   type RoadmapColorConfigEntry,
 } from './roadmap-color-config'
@@ -94,5 +95,27 @@ describe('validateColorEntries', () => {
 
     expect(result.byKey[target.key]?.color).toBeDefined()
     expect(result.byKey[target.key]?.name).toBeDefined()
+  })
+
+  it('flags exceeding the maximum number of colors', () => {
+    const entries = Array.from({ length: MAX_ROADMAP_COLORS + 1 }, (_, i) =>
+      entry({ color: `#${i.toString(16).padStart(6, '0')}`, name: `Color ${i}` }),
+    )
+
+    const result = validateColorEntries(entries)
+
+    expect(result.tooMany).toBe(true)
+    expect(result.hasErrors).toBe(true)
+  })
+
+  it('does not flag a palette at exactly the maximum', () => {
+    const entries = Array.from({ length: MAX_ROADMAP_COLORS }, (_, i) =>
+      entry({ color: `#${i.toString(16).padStart(6, '0')}`, name: `Color ${i}` }),
+    )
+
+    const result = validateColorEntries(entries)
+
+    expect(result.tooMany).toBe(false)
+    expect(result.hasErrors).toBe(false)
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.tsx
@@ -1,0 +1,292 @@
+'use client'
+
+import { WaydColorPicker } from '@/src/components/common'
+import {
+  DndContext,
+  DragEndEvent,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import {
+  DeleteOutlined,
+  HolderOutlined,
+  PlusOutlined,
+  StarFilled,
+  StarOutlined,
+} from '@ant-design/icons'
+import { Button, Input, Space, Tooltip, Typography, theme } from 'antd'
+import { CSSProperties } from 'react'
+
+const { Text } = Typography
+const { useToken } = theme
+
+/**
+ * A single configurable color on the roadmap. `key` is a stable client-side identifier
+ * used for list rendering and drag reordering only; it is not persisted (the color hex is
+ * the natural key on the server).
+ */
+export interface RoadmapColorConfigEntry {
+  key: string
+  color?: string
+  name: string
+  isDefault: boolean
+}
+
+/** Per-row validation errors, keyed by entry key, plus an overall flag. */
+export interface RoadmapColorConfigErrors {
+  hasErrors: boolean
+  byKey: Record<string, { color?: string; name?: string }>
+}
+
+/**
+ * Validates the configured colors: every entry needs a color and a caption, and colors
+ * must be unique (the color is the natural key). Returns per-row errors so the form can
+ * render them inline and disable Save.
+ */
+export const validateColorEntries = (
+  entries: RoadmapColorConfigEntry[],
+): RoadmapColorConfigErrors => {
+  const byKey: RoadmapColorConfigErrors['byKey'] = {}
+
+  // Count colors to flag duplicates (case-insensitive, matching the domain).
+  const colorCounts = new Map<string, number>()
+  for (const e of entries) {
+    if (e.color) {
+      const normalized = e.color.toUpperCase()
+      colorCounts.set(normalized, (colorCounts.get(normalized) ?? 0) + 1)
+    }
+  }
+
+  for (const e of entries) {
+    const rowErrors: { color?: string; name?: string } = {}
+    if (!e.color) {
+      rowErrors.color = 'Select a color.'
+    } else if ((colorCounts.get(e.color.toUpperCase()) ?? 0) > 1) {
+      rowErrors.color = 'Duplicate color.'
+    }
+    if (!e.name.trim()) {
+      rowErrors.name = 'Enter a caption.'
+    }
+    if (rowErrors.color || rowErrors.name) {
+      byKey[e.key] = rowErrors
+    }
+  }
+
+  return { hasErrors: Object.keys(byKey).length > 0, byKey }
+}
+
+export interface RoadmapColorConfigProps {
+  value: RoadmapColorConfigEntry[]
+  onChange: (entries: RoadmapColorConfigEntry[]) => void
+  errors?: RoadmapColorConfigErrors
+}
+
+interface ColorConfigRowProps {
+  entry: RoadmapColorConfigEntry
+  errors?: { color?: string; name?: string }
+  onColorChange: (color: string | undefined) => void
+  onNameChange: (name: string) => void
+  onToggleDefault: () => void
+  onRemove: () => void
+}
+
+const ColorConfigRow = ({
+  entry,
+  errors,
+  onColorChange,
+  onNameChange,
+  onToggleDefault,
+  onRemove,
+}: ColorConfigRowProps) => {
+  const { token } = useToken()
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    useSortable({ id: entry.key })
+
+  const style: CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+    padding: '4px 0',
+  }
+
+  const rowError = errors?.color ?? errors?.name
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <Button
+          type="text"
+          size="small"
+          icon={<HolderOutlined />}
+          style={{ cursor: 'grab', color: token.colorTextTertiary }}
+          {...attributes}
+          {...listeners}
+          aria-label="Drag to reorder"
+        />
+        <WaydColorPicker value={entry.color} onChange={onColorChange} />
+        <Input
+          size="small"
+          placeholder="Caption (e.g. At Risk)"
+          value={entry.name}
+          maxLength={32}
+          showCount
+          status={errors?.name ? 'error' : undefined}
+          onChange={(e) => onNameChange(e.target.value)}
+          style={{ flex: 1 }}
+        />
+      <Tooltip
+        title={entry.isDefault ? 'Default color' : 'Set as default color'}
+      >
+        <Button
+          type="text"
+          size="small"
+          icon={
+            entry.isDefault ? (
+              <StarFilled style={{ color: token.colorWarning }} />
+            ) : (
+              <StarOutlined />
+            )
+          }
+          onClick={onToggleDefault}
+          aria-label={entry.isDefault ? 'Default color' : 'Set as default color'}
+        />
+      </Tooltip>
+        <Button
+          type="text"
+          size="small"
+          danger
+          icon={<DeleteOutlined />}
+          onClick={onRemove}
+          aria-label="Remove color"
+        />
+      </div>
+      {rowError && (
+        <Text
+          type="danger"
+          style={{ fontSize: token.fontSizeSM, paddingLeft: 40 }}
+        >
+          {rowError}
+        </Text>
+      )}
+    </div>
+  )
+}
+
+/**
+ * An editable, reorderable list of a roadmap's configured colors. Each row pairs a color
+ * with a caption; one row may be marked as the default. The list is managed as a whole and
+ * saved together.
+ */
+const RoadmapColorConfig = ({
+  value,
+  onChange,
+  errors,
+}: RoadmapColorConfigProps) => {
+  const { token } = useToken()
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  )
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+
+    const oldIndex = value.findIndex((e) => e.key === active.id)
+    const newIndex = value.findIndex((e) => e.key === over.id)
+    if (oldIndex === -1 || newIndex === -1) return
+
+    onChange(arrayMove(value, oldIndex, newIndex))
+  }
+
+  const updateEntry = (
+    key: string,
+    changes: Partial<RoadmapColorConfigEntry>,
+  ) => {
+    onChange(value.map((e) => (e.key === key ? { ...e, ...changes } : e)))
+  }
+
+  const toggleDefault = (key: string) => {
+    onChange(
+      value.map((e) => ({
+        ...e,
+        // Only one entry can be the default; toggling one clears the others.
+        isDefault: e.key === key ? !e.isDefault : false,
+      })),
+    )
+  }
+
+  const removeEntry = (key: string) => {
+    onChange(value.filter((e) => e.key !== key))
+  }
+
+  const addEntry = () => {
+    onChange([
+      ...value,
+      {
+        key: crypto.randomUUID(),
+        color: undefined,
+        name: '',
+        isDefault: false,
+      },
+    ])
+  }
+
+  return (
+    <Space orientation="vertical" style={{ width: '100%' }} size={8}>
+      <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+        {value.length === 0
+          ? 'No colors configured. Activities use the standard color palette and the theme color when no color is set.'
+          : 'Activities without a color use your theme color, unless one of these colors is marked as the default (★).'}
+      </Text>
+
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={value.map((e) => e.key)}
+          strategy={verticalListSortingStrategy}
+        >
+          {value.map((entry) => (
+            <ColorConfigRow
+              key={entry.key}
+              entry={entry}
+              errors={errors?.byKey[entry.key]}
+              // Ignore clears: a configured color must always have a value
+              // (no "transparent" option). The picker emits undefined when the
+              // active swatch is toggled off.
+              onColorChange={(color) =>
+                color && updateEntry(entry.key, { color })
+              }
+              onNameChange={(name) => updateEntry(entry.key, { name })}
+              onToggleDefault={() => toggleDefault(entry.key)}
+              onRemove={() => removeEntry(entry.key)}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
+
+      <Button
+        type="dashed"
+        size="small"
+        icon={<PlusOutlined />}
+        onClick={addEntry}
+        style={{ width: '100%', color: token.colorTextSecondary }}
+      >
+        Add color
+      </Button>
+    </Space>
+  )
+}
+
+export default RoadmapColorConfig

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-config.tsx
@@ -30,6 +30,12 @@ const { Text } = Typography
 const { useToken } = theme
 
 /**
+ * The maximum number of colors a roadmap may have. Mirrors the domain's `Roadmap.MaxColors`,
+ * which the API also enforces — kept in sync so the UI blocks the limit before a request is sent.
+ */
+export const MAX_ROADMAP_COLORS = 30
+
+/**
  * A single configurable color on the roadmap. `key` is a stable client-side identifier
  * used for list rendering and drag reordering only; it is not persisted (the color hex is
  * the natural key on the server).
@@ -41,9 +47,11 @@ export interface RoadmapColorConfigEntry {
   isDefault: boolean
 }
 
-/** Per-row validation errors, keyed by entry key, plus an overall flag. */
+/** Per-row validation errors, keyed by entry key, plus overall flags. */
 export interface RoadmapColorConfigErrors {
   hasErrors: boolean
+  /** True when the palette exceeds the maximum allowed number of colors. */
+  tooMany: boolean
   byKey: Record<string, { color?: string; name?: string }>
 }
 
@@ -81,7 +89,13 @@ export const validateColorEntries = (
     }
   }
 
-  return { hasErrors: Object.keys(byKey).length > 0, byKey }
+  const tooMany = entries.length > MAX_ROADMAP_COLORS
+
+  return {
+    hasErrors: tooMany || Object.keys(byKey).length > 0,
+    tooMany,
+    byKey,
+  }
 }
 
 export interface RoadmapColorConfigProps {
@@ -281,10 +295,17 @@ const RoadmapColorConfig = ({
         size="small"
         icon={<PlusOutlined />}
         onClick={addEntry}
+        disabled={value.length >= MAX_ROADMAP_COLORS}
         style={{ width: '100%', color: token.colorTextSecondary }}
       >
         Add color
       </Button>
+
+      {value.length >= MAX_ROADMAP_COLORS && (
+        <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+          {`A roadmap can have at most ${MAX_ROADMAP_COLORS} colors.`}
+        </Text>
+      )}
     </Space>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-legend.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-legend.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { RoadmapColorDto } from '@/src/services/wayd-api'
+import { contrastText } from '@/src/components/common/timeline2/core/color'
+import { Space, Tag, Typography, theme } from 'antd'
+
+const { Text } = Typography
+const { useToken } = theme
+
+export interface RoadmapColorLegendProps {
+  colors: RoadmapColorDto[]
+}
+
+/**
+ * A read-only legend describing the meaning of a roadmap's configured colors. Rendered
+ * below the timeline when the roadmap has colors configured. Each color is shown as a
+ * filled tag, mirroring how the color appears on the timeline bars.
+ */
+const RoadmapColorLegend = ({ colors }: RoadmapColorLegendProps) => {
+  const { token } = useToken()
+
+  if (colors.length === 0) return null
+
+  const ordered = [...colors].sort((a, b) => a.order - b.order)
+
+  return (
+    <Space
+      wrap
+      size={[8, 8]}
+      style={{ padding: `${token.paddingSM}px ${token.padding}px` }}
+    >
+      <Text type="secondary" style={{ fontSize: token.fontSizeSM }}>
+        Legend:
+      </Text>
+      {ordered.map((color) => (
+        // antd's `color` prop tints custom hex values rather than filling them,
+        // so set the fill explicitly to mirror the solid timeline bars.
+        <Tag
+          key={color.color}
+          style={{
+            backgroundColor: color.color,
+            borderColor: color.color,
+            color: contrastText(color.color),
+            marginInlineEnd: 0,
+          }}
+        >
+          {color.name}
+        </Tag>
+      ))}
+    </Space>
+  )
+}
+
+export default RoadmapColorLegend

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-picker.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-color-picker.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { RoadmapColorDto } from '@/src/services/wayd-api'
+import { Select, theme } from 'antd'
+import { ReactNode } from 'react'
+
+const { useToken } = theme
+
+export interface RoadmapColorPickerProps {
+  /** The colors configured on the roadmap. */
+  entries: RoadmapColorDto[]
+  // The following are supplied by antd Form.Item when used as a custom control.
+  id?: string
+  value?: string
+  onChange?: (value: string | undefined) => void
+}
+
+const ColorOptionLabel = ({
+  color,
+  children,
+}: {
+  color: string
+  children: ReactNode
+}) => {
+  const { token } = useToken()
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: token.marginXS,
+        height: '100%',
+        verticalAlign: 'middle',
+      }}
+    >
+      <span
+        style={{
+          display: 'inline-block',
+          width: 14,
+          height: 14,
+          borderRadius: token.borderRadiusSM,
+          backgroundColor: color,
+          border: `1px solid ${token.colorBorderSecondary}`,
+          flex: 'none',
+          verticalAlign: 'middle',
+        }}
+      />
+      <span>{children}</span>
+    </span>
+  )
+}
+
+/**
+ * A color selector that constrains the choice to the roadmap's configured colors,
+ * presented as a dropdown of labeled swatches. Used in place of the freeform color picker
+ * when a roadmap has colors configured. If the current value is not one of the configured
+ * colors (e.g. it was set before the roadmap's colors were configured), it is shown as an
+ * additional "Custom" option so the existing value stays visible.
+ */
+const RoadmapColorPicker = ({
+  id,
+  entries,
+  value,
+  onChange,
+}: RoadmapColorPickerProps) => {
+  const hasMatch = entries.some(
+    (e) => e.color.toUpperCase() === value?.toUpperCase(),
+  )
+
+  const options = entries.map((e) => ({
+    value: e.color,
+    label: e.name,
+  }))
+
+  if (value && !hasMatch) {
+    options.push({ value, label: 'Custom' })
+  }
+
+  return (
+    <Select<string>
+      id={id}
+      value={value}
+      onChange={(next) => onChange?.(next)}
+      allowClear
+      placeholder="Select a color"
+      style={{ width: '100%' }}
+      options={options}
+      optionRender={(option) => (
+        <ColorOptionLabel color={String(option.value)}>
+          {option.label}
+        </ColorOptionLabel>
+      )}
+      labelRender={(label) =>
+        label.value ? (
+          <ColorOptionLabel color={String(label.value)}>
+            {label.label}
+          </ColorOptionLabel>
+        ) : (
+          label.label
+        )
+      }
+    />
+  )
+}
+
+export default RoadmapColorPicker

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
@@ -28,6 +28,7 @@ import type {
 import { useUpdateRoadmapItemDatesMutation } from '@/src/store/features/planning/roadmaps-api'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { isApiError, type ApiError } from '@/src/utils'
+import RoadmapColorLegend from './roadmap-color-legend'
 
 export interface RoadmapTimelineV2Props {
   roadmap: RoadmapDetailsDto
@@ -66,6 +67,10 @@ const ROOT_GROUP_ID = '__roadmap_root__'
 function mapRoadmap(
   items: RoadmapItemListDto[],
   openDrawer: (id: string) => void,
+  // The roadmap's default color, applied at display time to activities that have
+  // no color of their own. Undefined when no default is configured (falls through
+  // to the timeline's theme color).
+  defaultActivityColor: string | undefined,
 ): { items: TimelineItem<RoadmapPayload>[]; groups: TimelineGroup[] } {
   const out: TimelineItem<RoadmapPayload>[] = []
   const groups: TimelineGroup[] = []
@@ -111,7 +116,9 @@ function mapRoadmap(
             id,
             kind: 'range',
             label: a.name,
-            color: a.color,
+            // Activities with no color of their own fall back to the roadmap's
+            // configured default color (display-time only; nothing is stored).
+            color: a.color ?? defaultActivityColor,
             start: ms(a.start),
             end: ms(a.end),
             groupId: id,
@@ -179,9 +186,13 @@ const RoadmapTimelineV2: FC<RoadmapTimelineV2Props> = (props) => {
   const [updateRoadmapItemDates] = useUpdateRoadmapItemDatesMutation()
   const [updatingId, setUpdatingId] = useState<string | null>(null)
 
+  const defaultActivityColor = props.roadmap.colors.find((c) => c.isDefault)
+    ?.color
+
   const { items, groups } = mapRoadmap(
     props.roadmapItems,
     props.openRoadmapItemDrawer,
+    defaultActivityColor,
   )
 
   const windowStart = ms(props.roadmap.start)
@@ -222,27 +233,30 @@ const RoadmapTimelineV2: FC<RoadmapTimelineV2Props> = (props) => {
   }
 
   return (
-    <WaydTimeline2<RoadmapPayload>
-      variant="timeline"
-      items={items}
-      groups={groups}
-      windowStart={windowStart}
-      windowEnd={windowEnd}
-      minDate={minDate}
-      maxDate={maxDate}
-      storageKey={`roadmap-${props.roadmap.id}`}
-      onRefresh={props.refreshRoadmapItems}
-      height={650}
-      isLoading={props.isRoadmapItemsLoading || updatingId !== null}
-      editable={props.isRoadmapManager}
-      allowFullScreen
-      allowSaveAsImage
-      saveImageFileName={props.roadmap.name}
-      // The view selector (Timeline/List) renders inside the toolbar, like WaydGrid.
-      toolbarRightSlot={props.viewSelector}
-      onItemDateChange={onItemDateChange}
-      onItemClick={(item) => item.data?.openDrawer(item.id)}
-    />
+    <>
+      <WaydTimeline2<RoadmapPayload>
+        variant="timeline"
+        items={items}
+        groups={groups}
+        windowStart={windowStart}
+        windowEnd={windowEnd}
+        minDate={minDate}
+        maxDate={maxDate}
+        storageKey={`roadmap-${props.roadmap.id}`}
+        onRefresh={props.refreshRoadmapItems}
+        height={650}
+        isLoading={props.isRoadmapItemsLoading || updatingId !== null}
+        editable={props.isRoadmapManager}
+        allowFullScreen
+        allowSaveAsImage
+        saveImageFileName={props.roadmap.name}
+        // The view selector (Timeline/List) renders inside the toolbar, like WaydGrid.
+        toolbarRightSlot={props.viewSelector}
+        onItemDateChange={onItemDateChange}
+        onItemClick={(item) => item.data?.openDrawer(item.id)}
+      />
+      <RoadmapColorLegend colors={props.roadmap.colors} />
+    </>
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -17901,6 +17901,74 @@ export class RoadmapsClient {
     }
 
     /**
+     * Update the configured colors for a roadmap.
+     */
+    updateColors(id: string, request: UpdateRoadmapColorsRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/planning/roadmaps/{id}/colors";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "PUT",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processUpdateColors(_response);
+        });
+    }
+
+    protected processUpdateColors(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status === 422) {
+            const _responseText = response.data;
+            let result422: any = null;
+            let resultData422  = _responseText;
+            result422 = resultData422;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result422);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
      * Archive a roadmap.
      */
     archive(id: string, cancelToken?: CancelToken): Promise<void> {
@@ -31184,6 +31252,14 @@ export interface RoadmapDetailsDto {
     visibility: SimpleNavigationDto;
     state: SimpleNavigationDto;
     roadmapManagers: EmployeeNavigationDto[];
+    colors: RoadmapColorDto[];
+}
+
+export interface RoadmapColorDto {
+    color: string;
+    name: string;
+    order: number;
+    isDefault: boolean;
 }
 
 export interface CreateRoadmapRequest {
@@ -31227,6 +31303,24 @@ export interface UpdateRoadmapRequest {
     roadmapManagerIds: string[];
     /** The visibility id for the Roadmap. If the Roadmap is public, all users can see the Roadmap. Otherwise, only the Roadmap Managers can see the Roadmap. */
     visibilityId: number;
+}
+
+export interface UpdateRoadmapColorsRequest {
+    /** The unique identifier of the Roadmap. */
+    roadmapId: string;
+    /** The colors to configure on the Roadmap. The provided set fully replaces the existing colors. */
+    colors: UpsertRoadmapColorRequest[];
+}
+
+export interface UpsertRoadmapColorRequest {
+    /** The color, as a hex code (e.g. "#4096FF"). */
+    color: string;
+    /** The caption describing what the color represents on this Roadmap. */
+    name: string;
+    /** The order of the color within the Roadmap's configured colors. */
+    order: number;
+    /** Whether this is the default color applied to activities that have no color of their own. */
+    isDefault: boolean;
 }
 
 export interface RoadmapItemListDto {

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/planning/roadmaps-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/planning/roadmaps-api.ts
@@ -21,6 +21,7 @@ import {
   CreateRoadmapRequest,
   RoadmapDetailsDto,
   RoadmapListDto,
+  UpdateRoadmapColorsRequest,
   UpdateRoadmapRequest,
 } from '@/src/services/wayd-api'
 import { apiSlice } from '../apiSlice'
@@ -166,6 +167,28 @@ export const roadmapApi = apiSlice.injectEndpoints({
           { type: QueryTags.Roadmap, id: arg.cacheKey },
         ]
       },
+    }),
+    updateRoadmapColors: builder.mutation<
+      void,
+      {
+        roadmapId: string
+        request: UpdateRoadmapColorsRequest
+        cacheKey: number
+      }
+    >({
+      queryFn: async ({ roadmapId, request }) => {
+        try {
+          const data = await getRoadmapsClient().updateColors(roadmapId, request)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: (result, error, { cacheKey }) => [
+        { type: QueryTags.Roadmap, id: 'LIST' },
+        { type: QueryTags.Roadmap, id: cacheKey },
+      ],
     }),
     deleteRoadmap: builder.mutation<void, string>({
       queryFn: async (roadmapId) => {
@@ -521,6 +544,7 @@ export const {
   useCreateRoadmapMutation,
   useCopyRoadmapMutation,
   useUpdateRoadmapMutation,
+  useUpdateRoadmapColorsMutation,
   useDeleteRoadmapMutation,
   useArchiveRoadmapMutation,
   useActivateRoadmapMutation,

--- a/docs/ai/domain-glossary.mdx
+++ b/docs/ai/domain-glossary.mdx
@@ -39,7 +39,7 @@ This glossary defines the key terms and concepts used throughout Wayd. It is des
 | **Risk** | A potential circumstance that could impact delivery. Tracked with Status (Open/Closed), ROAM Category, Impact, Likelihood, Exposure, Assignee, and Follow-Up Date. |
 | **ROAM** | Risk categorization model: Resolved (eliminated), Owned (being managed), Accepted (acknowledged), Mitigated (impact reduced). |
 | **Exposure** | Calculated risk severity from Impact × Likelihood. Low (less than 4), Medium (equals 4), High (greater than 4). Each dimension is Low=1, Medium=2, High=3. |
-| **Roadmap** | A visual timeline for planning work. Has Visibility (Public/Private), Managers (min 1), and hierarchical Items (Activities, Milestones, Timeboxes). Can be copied. |
+| **Roadmap** | A visual timeline for planning work. Has Visibility (Public/Private), Managers (min 1), and hierarchical Items (Activities, Milestones, Timeboxes). Can be copied. Optionally has a **Color palette** — an ordered set of named colors (one optional default) used to color activities and drive the timeline legend. |
 | **Activity** | A roadmap item with a date range that can contain child items (other activities, milestones, timeboxes). Ordered within parent. |
 | **Milestone** | A roadmap item representing a single point in time (key date or achievement). |
 | **Timebox** | A roadmap item representing a fixed time period (e.g., a sprint or phase). |

--- a/docs/user-guide/planning/roadmaps.mdx
+++ b/docs/user-guide/planning/roadmaps.mdx
@@ -42,7 +42,7 @@ graph TD
 - **Milestone** — A point-in-time marker representing a key date or achievement.
 - **Timebox** — A time-bounded period (e.g., a sprint or phase).
 
-All items support an optional **Color** property for visual differentiation.
+All items support an optional **Color** property for visual differentiation. When a roadmap has a [color palette](#roadmap-colors) configured, activities are colored by choosing from those named colors; otherwise any color can be picked freely.
 
 ## Roadmap Detail Page
 
@@ -56,11 +56,38 @@ Clicking an item opens a **drawer** with full details, edit, and delete actions.
 
 **Actions (for managers):**
 - Edit Roadmap (name, description, dates, visibility, managers)
+- Configure Colors (define the roadmap's named color palette — see [Roadmap Colors](#roadmap-colors))
 - Create Activity, Create Timebox
 - Copy Roadmap (creates a deep copy with new name and managers)
 - Delete Roadmap
 
 Roadmaps can be **copied** to create new versions, preserving the full hierarchy of items.
+
+## Roadmap Colors
+
+By default, activity colors are picked freely and mean whatever each person intends — which makes it hard to read a roadmap at a glance. To give colors a shared meaning, managers can define a **color palette** for the roadmap: an ordered list of named colors (for example, *Platform Team*, *At Risk*, *Customer Commitment*).
+
+Open **Actions → Configure Colors** to manage the palette:
+
+- **Add a color** — pick a color and give it a caption describing what it represents.
+- **Reorder** — drag colors to change the order they appear in the picker and the legend.
+- **Set a default** — mark one color (★) as the default. Activities that have no color of their own are shown in this color.
+- **Remove** — delete a color from the palette.
+
+Each color must have a caption, and a color can only be used once per roadmap.
+
+### How the palette is used
+
+Once a palette is configured:
+
+- **Activity colors** are chosen from the palette's named colors instead of a free color picker. Leaving an activity's color empty lets it fall back to the roadmap's default color.
+- A **legend** appears beneath the timeline, showing each color and its caption so viewers can interpret the roadmap at a glance.
+
+The default color is applied when the timeline is displayed — it is not written onto the activities. Changing the default (or any color in the palette) instantly updates every activity that relies on it, with no need to edit items individually.
+
+:::note
+Color palettes apply to **activities**. Milestones and timeboxes still use their own colors. If a roadmap has no palette configured, activities use the standard free color picker and no legend is shown.
+:::
 
 ## Timeline Controls
 


### PR DESCRIPTION
## Roadmap color configuration with named legend

Closes #635

### Summary

Roadmaps let users color activities, but colors had no shared meaning — teams used the same colors differently, making timelines hard to read at a glance. This PR adds **roadmap-level color configuration**: an ordered palette of named colors that defines the color vocabulary for a roadmap.

When a palette is configured, activity color pickers offer those named colors, a legend appears beneath the timeline, and a configurable default color is applied (at display time) to activities that have no color of their own.

### Scope

- **Activities only.** Milestones and timeboxes keep their own colors.
- **No enforcement.** Item colors aren't constrained to the palette server-side — this is a UX/presentation improvement, not a validation system.

### Behaviour

**Configure Colors** (new action in the roadmap Actions menu → dedicated modal, managers only):

- Add named colors (color + caption), drag to reorder, remove
- Mark one color as the **default** (★)
- Inline validation with the Save button disabled until valid; captions show a character count (max 32); colors must be unique per roadmap

**Activity color picker** (create/edit forms):

- When a palette exists → a `Select` of named colors (swatch + caption) instead of the freeform picker
- Falls back to the existing freeform `WaydColorPicker` when no palette is configured (no regression)
- An activity whose color isn't in the palette shows it as a **"Custom"** option so the value stays visible
- The create form starts with **no color selected** (an empty activity falls back to the default)

**Default color** is applied at **display time** — it is never written onto activities. Changing the default (or any palette color) instantly reflows every uncolored activity, with no per-item edits.

**Timeline legend** — a `Legend:` row of filled color tags appears below the (V2) timeline when a palette is configured; hidden otherwise.

### Implementation notes

- **Persistence:** colors are stored as a **JSON column** on `Roadmaps` (`OwnsMany(...).ToJson()`), following the existing `WorkItem.Tags` precedent — managed as a whole, never queried independently, so no separate table or FK. Single-column migration.
- **Domain:** `RoadmapColor` is a `ValueObject` (color hex is the natural key — no `Id`). `Roadmap.UpdateColors(...)` does clear-and-replace with invariants: ≤30 colors, ≤1 default, distinct colors (case-insensitive), manager + active roadmap required.
- **API:** new `PUT /api/planning/roadmaps/{id}/colors` endpoint; `RoadmapDetailsDto` now includes the ordered `colors`.
- **Frontend:** the activity forms resolve the palette via `useGetRoadmapQuery(roadmapId)` (the endpoint accepts id-or-key), so no prop-drilling through the grid/drawer was needed.

### Testing

- **Backend:** 11 domain tests for `UpdateColors` (happy path, replace, clear, >1 default, duplicates, case-insensitive duplicates, max/at-max, not-manager, archived); handler tests for the command; new fakers. 157 domain + 109 application tests pass.
- **Frontend:** 8 unit tests for `validateColorEntries` (the disable-Save / inline-error logic).
- **Manual (Playwright):** verified end-to-end in the running app — configure → save → persisted legend → named-chip picker → default pre-fill on uncolored activities → live reflow when the default changes → freeform fallback on palettes-not-configured roadmaps.

> Note: manual verification caught a bug the unit tests couldn't — the handler originally loaded the roadmap without `.Include(RoadmapManagers)`, so the domain manager check always failed (`FakePlanningDbContext` doesn't enforce includes). Fixed.

### Docs

- New **Roadmap Colors** section in `docs/user-guide/planning/roadmaps.mdx` (config, usage, display-time default, activities-only scope) + updated Actions list and Color property note
- Updated the **Roadmap** entry in `docs/ai/domain-glossary.mdx`
