### PR TITLE
Feature/update roadmapitems date logic

### DIFF
--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260628151746_RoadmapItemDateRollup.Designer.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260628151746_RoadmapItemDateRollup.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Wayd.Infrastructure.Persistence.Context;
 
@@ -12,9 +13,11 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations
 {
     [DbContext(typeof(WaydDbContext))]
-    partial class WaydDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628151746_RoadmapItemDateRollup")]
+    partial class RoadmapItemDateRollup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260628151746_RoadmapItemDateRollup.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure.Migrators.MSSQL/Migrations/20260628151746_RoadmapItemDateRollup.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Wayd.Infrastructure.Migrators.MSSQL.Migrations;
+
+/// <inheritdoc />
+public partial class RoadmapItemDateRollup : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        // Drop the index that duplicated the RoadmapManagers primary key (RoadmapId, ManagerId).
+        migrationBuilder.DropIndex(
+            name: "IX_RoadmapManagers_RoadmapId_ManagerId",
+            schema: "Planning",
+            table: "RoadmapManagers");
+
+        // Backfill parent date ranges so every Activity contains all of its descendants. This
+        // brings existing roadmaps in line with the date-rollup rule introduced in the domain,
+        // where a parent Activity always grows to cover its children (grow-only; never shrinks).
+        //
+        // Date columns: Activity/Timebox use [Start, End]; Milestone uses [Start] as its date
+        // (its effective range is [Start, Start]). Only Activities (Type = 1) can be parents.
+        //
+        // Hierarchies can be multiple levels deep, so we grow each parent from the span of its
+        // direct children and repeat until a pass makes no changes (a fixpoint), which lets the
+        // growth bubble all the way to the root.
+        migrationBuilder.Sql(
+            """
+            WHILE 1 = 1
+            BEGIN
+                UPDATE parent
+                SET
+                    parent.[Start] = CASE WHEN child.MinStart < parent.[Start] THEN child.MinStart ELSE parent.[Start] END,
+                    parent.[End]   = CASE WHEN child.MaxEnd   > parent.[End]   THEN child.MaxEnd   ELSE parent.[End]   END
+                FROM [Planning].[RoadmapItems] AS parent
+                INNER JOIN (
+                    SELECT
+                        c.[ParentId] AS ParentId,
+                        MIN(c.[Start]) AS MinStart,
+                        MAX(CASE WHEN c.[Type] = 2 THEN c.[Start] ELSE c.[End] END) AS MaxEnd
+                    FROM [Planning].[RoadmapItems] AS c
+                    WHERE c.[ParentId] IS NOT NULL
+                    GROUP BY c.[ParentId]
+                ) AS child ON child.ParentId = parent.[Id]
+                WHERE parent.[Type] = 1
+                  AND (child.MinStart < parent.[Start] OR child.MaxEnd > parent.[End]);
+
+                IF @@ROWCOUNT = 0
+                    BREAK;
+            END
+            """);
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        // Recreate the dropped index. The date backfill is a one-way data change with no
+        // retained original values, so there is nothing to revert for it.
+        migrationBuilder.CreateIndex(
+            name: "IX_RoadmapManagers_RoadmapId_ManagerId",
+            schema: "Planning",
+            table: "RoadmapManagers",
+            columns: ["RoadmapId", "ManagerId"]);
+    }
+}

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/PlanningConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Persistence/Configuration/PlanningConfiguration.cs
@@ -374,8 +374,6 @@ public class RoadmapManagerConfiguration : IEntityTypeConfiguration<RoadmapManag
         builder.HasIndex(rm => rm.RoadmapId)
             .IncludeProperties(rm => new { rm.ManagerId });
 
-        builder.HasIndex(rm => new { rm.RoadmapId, rm.ManagerId });
-
         builder.Property(rm => rm.RoadmapId)
             .IsRequired();
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/CreateRoadmapItemCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/CreateRoadmapItemCommand.cs
@@ -63,6 +63,7 @@ internal sealed class CreateRoadmapItemCommandHandler(IPlanningDbContext plannin
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/DeleteRoadmapCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/DeleteRoadmapCommand.cs
@@ -25,6 +25,7 @@ internal sealed class DeleteRoadmapCommandHandler(IPlanningDbContext planningDbC
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.Id, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/DeleteRoadmapItemCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/DeleteRoadmapItemCommand.cs
@@ -28,6 +28,7 @@ internal sealed class DeleteRoadmapItemCommandHandler(IPlanningDbContext plannin
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapActivityPlacementCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapActivityPlacementCommand.cs
@@ -67,6 +67,7 @@ internal sealed class UpdateRoadmapActivityPlacementCommandHandler(IPlanningDbCo
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapItemCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapItemCommand.cs
@@ -66,6 +66,7 @@ internal sealed class UpdateRoadmapItemCommandHandler(IPlanningDbContext plannin
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapItemDatesCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapItemDatesCommand.cs
@@ -68,6 +68,7 @@ internal sealed class UpdateRoadmapItemDatesCommandHandler(IPlanningDbContext pl
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapRootActivitiesOrderCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapRootActivitiesOrderCommand.cs
@@ -36,6 +36,7 @@ internal sealed class UpdateRoadmapRootActivitiesOrderCommandHandler(IPlanningDb
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapRootActivityOrderCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Roadmaps/Commands/UpdateRoadmapRootActivityOrderCommand.cs
@@ -39,6 +39,7 @@ internal sealed class UpdateRoadmapRootActivityOrderCommandHandler(IPlanningDbCo
             var roadmap = await _planningDbContext.Roadmaps
                 .Include(x => x.RoadmapManagers)
                 .Include(x => x.Items)
+                .AsSplitQuery()
                 .FirstOrDefaultAsync(r => r.Id == request.RoadmapId, cancellationToken);
 
             if (roadmap is null)

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/BaseRoadmapItem.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/BaseRoadmapItem.cs
@@ -85,4 +85,17 @@ public abstract class BaseRoadmapItem : BaseAuditableEntity
         Parent = newParentActivity;
         newParentActivity?.AddChild(this);
     }
+
+    /// <summary>
+    /// Links this item's parent navigation to the given Activity without modifying the parent's
+    /// children collection. Used when the item is created already inside the parent's children
+    /// (e.g. <see cref="RoadmapActivity.CreateChildActivity" />) so the in-memory parent chain is
+    /// established for date rollup, independent of EF relationship fixup.
+    /// </summary>
+    /// <param name="parentActivity">The parent activity to link to.</param>
+    internal void LinkParent(RoadmapActivity parentActivity)
+    {
+        ParentId = parentActivity.Id;
+        Parent = parentActivity;
+    }
 }

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapActivity.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapActivity.cs
@@ -2,6 +2,7 @@
 using CSharpFunctionalExtensions;
 using Wayd.Planning.Domain.Enums;
 using Wayd.Planning.Domain.Interfaces.Roadmaps;
+using NodaTime;
 
 namespace Wayd.Planning.Domain.Models.Roadmaps;
 
@@ -55,7 +56,8 @@ public sealed class RoadmapActivity : BaseRoadmapItem
     {
         // TODO: this initial implementation requires going through the Roadmap to update the Roadmap Activity. This is needed to verify permissions against the Roadmap within the Domain layer.
 
-        if (ParentId != roadmapActivity.ParentId)
+        var parentChanged = ParentId != roadmapActivity.ParentId;
+        if (parentChanged)
         {
             var changeParentResult = ChangeParent(parentActivity);
             if (changeParentResult.IsFailure)
@@ -66,21 +68,172 @@ public sealed class RoadmapActivity : BaseRoadmapItem
 
         Name = roadmapActivity.Name;
         Description = roadmapActivity.Description;
-        DateRange = roadmapActivity.DateRange;
         Color = roadmapActivity.Color;
 
-        return Result.Success();
+        // Apply the dates. A pure shift (same duration) moves the whole subtree; otherwise the range
+        // is resized in place and must still contain the children. When the parent is also changing
+        // in this same update, treat the date change as a resize (a subtree shift would be ambiguous).
+        return ApplyDateRange(roadmapActivity.DateRange, allowShift: !parentChanged);
     }
 
     /// <summary>
-    /// Updates the date range of the Roadmap Activity.
+    /// Updates the date range of the Roadmap Activity. An Activity's range must contain all of its
+    /// children, so a range that would fall inside the children (i.e. shrinking the parent behind a
+    /// child) is rejected rather than silently clamped.
     /// </summary>
     /// <param name="dateRange"></param>
     /// <returns></returns>
     internal Result UpdateDateRange(IUpsertRoadmapActivityDateRange dateRange)
     {
-        DateRange = dateRange.DateRange;
+        return ApplyDateRange(dateRange.DateRange, allowShift: true);
+    }
+
+    /// <summary>
+    /// Applies a new date range to the Activity. When <paramref name="allowShift"/> is set and the
+    /// new range preserves the duration and both endpoints move by the same amount (a pure shift),
+    /// the entire subtree is moved by that delta so children keep their relative position. Otherwise
+    /// the range is resized in place and must still contain all children (a range that would fall
+    /// inside the children is rejected).
+    /// </summary>
+    private Result ApplyDateRange(LocalDateRange newRange, bool allowShift)
+    {
+        if (allowShift && _children.Count > 0 && TryGetShiftDays(newRange, out var days))
+        {
+            ShiftDates(days);
+            Parent?.RecalculateDateRangeFromChildren();
+            return Result.Success();
+        }
+
+        var containsChildrenResult = EnsureRangeContainsChildren(newRange);
+        if (containsChildrenResult.IsFailure)
+        {
+            return containsChildrenResult;
+        }
+
+        DateRange = newRange;
+
+        // The range already contains the children (guarded above); bubble up so any ancestor grows.
+        Parent?.RecalculateDateRangeFromChildren();
+
         return Result.Success();
+    }
+
+    /// <summary>
+    /// Determines whether the proposed range is a pure shift of the current range: same duration and
+    /// both endpoints moved by the same non-zero number of days. Returns that day delta via
+    /// <paramref name="days"/>.
+    /// </summary>
+    private bool TryGetShiftDays(LocalDateRange newRange, out int days)
+    {
+        var startDelta = Period.DaysBetween(DateRange.Start, newRange.Start);
+        var endDelta = Period.DaysBetween(DateRange.End, newRange.End);
+
+        days = startDelta;
+        return startDelta != 0 && startDelta == endDelta;
+    }
+
+    /// <summary>
+    /// Validates that the proposed range fully contains every child (child Activity/Timebox ranges
+    /// and child Milestone dates). Returns a failure naming the offending child when the range would
+    /// fall inside the children. Activities with no children always pass.
+    /// </summary>
+    private Result EnsureRangeContainsChildren(LocalDateRange proposedRange)
+    {
+        foreach (var child in _children)
+        {
+            var (name, start, end) = child switch
+            {
+                RoadmapActivity activity => (activity.Name, activity.DateRange.Start, activity.DateRange.End),
+                RoadmapTimebox timebox => (timebox.Name, timebox.DateRange.Start, timebox.DateRange.End),
+                RoadmapMilestone milestone => (milestone.Name, milestone.Date, milestone.Date),
+                _ => (child.Name, proposedRange.Start, proposedRange.End)
+            };
+
+            if (start < proposedRange.Start || end > proposedRange.End)
+            {
+                return Result.Failure(
+                    $"The date range must contain all child items. \"{name}\" falls outside the selected range.");
+            }
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Shifts this Activity and its entire subtree (all descendant Activities, Timeboxes, and
+    /// Milestones) by the given number of days (negative shifts earlier). Relative positions are
+    /// preserved, so containment is maintained automatically. This is the "move the whole branch"
+    /// behavior used when a parent's date range is moved without changing its duration.
+    /// </summary>
+    /// <param name="days"></param>
+    internal void ShiftDates(int days)
+    {
+        if (days == 0)
+        {
+            return;
+        }
+
+        DateRange = new LocalDateRange(DateRange.Start.PlusDays(days), DateRange.End.PlusDays(days));
+
+        foreach (var child in _children)
+        {
+            switch (child)
+            {
+                case RoadmapActivity activity:
+                    activity.ShiftDates(days);
+                    break;
+                case RoadmapTimebox timebox:
+                    timebox.ShiftDates(days);
+                    break;
+                case RoadmapMilestone milestone:
+                    milestone.ShiftDate(days);
+                    break;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Recalculates this Activity's date range so that it always contains all of its children
+    /// (child Activity/Timebox ranges and child Milestone dates). The range only grows: a parent
+    /// keeps its own (wider) range and stretches to cover any child that falls outside it; it is
+    /// never shrunk below its own stored range. When the range changes, the new range bubbles up
+    /// to ancestor Activities so the whole branch stays consistent up to the root.
+    /// </summary>
+    internal void RecalculateDateRangeFromChildren()
+    {
+        if (_children.Count == 0)
+        {
+            return;
+        }
+
+        LocalDate? childrenStart = null;
+        LocalDate? childrenEnd = null;
+
+        foreach (var child in _children)
+        {
+            var (start, end) = child switch
+            {
+                RoadmapActivity activity => (activity.DateRange.Start, activity.DateRange.End),
+                RoadmapTimebox timebox => (timebox.DateRange.Start, timebox.DateRange.End),
+                RoadmapMilestone milestone => (milestone.Date, milestone.Date),
+                _ => (DateRange.Start, DateRange.End)
+            };
+
+            childrenStart = childrenStart is null ? start : LocalDate.Min(childrenStart.Value, start);
+            childrenEnd = childrenEnd is null ? end : LocalDate.Max(childrenEnd.Value, end);
+        }
+
+        var newStart = childrenStart is null ? DateRange.Start : LocalDate.Min(DateRange.Start, childrenStart.Value);
+        var newEnd = childrenEnd is null ? DateRange.End : LocalDate.Max(DateRange.End, childrenEnd.Value);
+
+        if (newStart == DateRange.Start && newEnd == DateRange.End)
+        {
+            return;
+        }
+
+        DateRange = new LocalDateRange(newStart, newEnd);
+
+        Parent?.RecalculateDateRangeFromChildren();
     }
 
     /// <summary>
@@ -162,6 +315,9 @@ public sealed class RoadmapActivity : BaseRoadmapItem
         var newRoadmapActivity = new RoadmapActivity(RoadmapId, roadmapActivity.Name, roadmapActivity.Description, roadmapActivity.DateRange, Id, roadmapActivity.Color, order);
 
         _children.Add(newRoadmapActivity);
+        newRoadmapActivity.LinkParent(this);
+
+        RecalculateDateRangeFromChildren();
 
         return newRoadmapActivity;
     }
@@ -176,6 +332,9 @@ public sealed class RoadmapActivity : BaseRoadmapItem
         var newTimebox = RoadmapTimebox.Create(RoadmapId, Id, timebox);
 
         _children.Add(newTimebox);
+        newTimebox.LinkParent(this);
+
+        RecalculateDateRangeFromChildren();
 
         return newTimebox;
     }
@@ -190,6 +349,9 @@ public sealed class RoadmapActivity : BaseRoadmapItem
         var newMilestone = RoadmapMilestone.Create(RoadmapId, Id, milestone);
 
         _children.Add(newMilestone);
+        newMilestone.LinkParent(this);
+
+        RecalculateDateRangeFromChildren();
 
         return newMilestone;
     }
@@ -221,6 +383,8 @@ public sealed class RoadmapActivity : BaseRoadmapItem
             default:
                 return Result.Failure("Child type not supported.");
         }
+
+        RecalculateDateRangeFromChildren();
 
         return Result.Success();
     }

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapMilestone.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapMilestone.cs
@@ -45,6 +45,8 @@ public sealed class RoadmapMilestone : BaseRoadmapItem
         Date = roadmapMilestone.Date;
         Color = roadmapMilestone.Color;
 
+        Parent?.RecalculateDateRangeFromChildren();
+
         return Result.Success();
     }
 
@@ -56,7 +58,23 @@ public sealed class RoadmapMilestone : BaseRoadmapItem
     internal Result UpdateDate(IUpsertRoadmapMilestoneDate date)
     {
         Date = date.Date;
+        Parent?.RecalculateDateRangeFromChildren();
         return Result.Success();
+    }
+
+    /// <summary>
+    /// Shifts the Milestone's date by the given number of days (negative shifts earlier). Used when
+    /// an ancestor Activity is moved as a whole and the entire subtree shifts with it.
+    /// </summary>
+    /// <param name="days"></param>
+    internal void ShiftDate(int days)
+    {
+        if (days == 0)
+        {
+            return;
+        }
+
+        Date = Date.PlusDays(days);
     }
 
     /// <summary>

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapTimebox.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Domain/Models/Roadmaps/RoadmapTimebox.cs
@@ -54,6 +54,8 @@ public sealed class RoadmapTimebox : BaseRoadmapItem
         DateRange = roadmapTimebox.DateRange;
         Color = roadmapTimebox.Color;
 
+        Parent?.RecalculateDateRangeFromChildren();
+
         return Result.Success();
     }
 
@@ -65,7 +67,23 @@ public sealed class RoadmapTimebox : BaseRoadmapItem
     internal Result UpdateDateRange(IUpsertRoadmapTimeboxDateRange dateRange)
     {
         DateRange = dateRange.DateRange;
+        Parent?.RecalculateDateRangeFromChildren();
         return Result.Success();
+    }
+
+    /// <summary>
+    /// Shifts the Timebox's date range by the given number of days (negative shifts earlier). Used
+    /// when an ancestor Activity is moved as a whole and the entire subtree shifts with it.
+    /// </summary>
+    /// <param name="days"></param>
+    internal void ShiftDates(int days)
+    {
+        if (days == 0)
+        {
+            return;
+        }
+
+        DateRange = new LocalDateRange(DateRange.Start.PlusDays(days), DateRange.End.PlusDays(days));
     }
 
     /// <summary>

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Sut/Roadmaps/Commands/UpdateRoadmapItemDatesCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Application.Tests/Sut/Roadmaps/Commands/UpdateRoadmapItemDatesCommandHandlerTests.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.Logging;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Models;
+using Wayd.Planning.Application.Roadmaps.Commands;
+using Wayd.Planning.Application.Tests.Infrastructure;
+using Wayd.Planning.Domain.Interfaces.Roadmaps;
+using Wayd.Planning.Domain.Models.Roadmaps;
+using Wayd.Planning.Domain.Tests.Data;
+using Moq;
+using NodaTime;
+using OneOf;
+
+namespace Wayd.Planning.Application.Tests.Sut.Roadmaps.Commands;
+
+public class UpdateRoadmapItemDatesCommandHandlerTests : IDisposable
+{
+    private readonly FakePlanningDbContext _dbContext;
+    private readonly Mock<ILogger<UpdateRoadmapItemDatesCommandHandler>> _mockLogger;
+    private readonly Mock<ICurrentUser> _mockCurrentUser;
+    private readonly Guid _currentEmployeeId = Guid.NewGuid();
+    private readonly RoadmapFaker _faker = new();
+    private readonly LocalDate _today = LocalDate.FromDateTime(DateTime.Today);
+
+    public UpdateRoadmapItemDatesCommandHandlerTests()
+    {
+        _dbContext = new FakePlanningDbContext();
+        _mockLogger = new Mock<ILogger<UpdateRoadmapItemDatesCommandHandler>>();
+        _mockCurrentUser = new Mock<ICurrentUser>();
+        _mockCurrentUser.Setup(u => u.GetEmployeeId()).Returns(_currentEmployeeId);
+    }
+
+    private UpdateRoadmapItemDatesCommandHandler CreateHandler() =>
+        new(_dbContext, _mockCurrentUser.Object, _mockLogger.Object);
+
+    private Roadmap CreateActiveRoadmap()
+    {
+        var fakeRoadmap = _faker.Generate();
+        return Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [_currentEmployeeId]).Value;
+    }
+
+    [Fact]
+    public async Task Handle_WhenChildGrowsBeyondParent_ShouldRollUpParentAndSave()
+    {
+        // Arrange - a parent activity with a child whose range starts inside the parent
+        var roadmap = CreateActiveRoadmap();
+
+        var parentActivity = new UpsertActivity(new LocalDateRange(_today, _today.PlusDays(10)));
+        var parentResult = roadmap.CreateActivity(parentActivity, _currentEmployeeId);
+        parentResult.IsSuccess.Should().BeTrue();
+
+        var childActivity = new UpsertActivity(new LocalDateRange(_today, _today.PlusDays(10)), parentResult.Value.Id);
+        var childResult = roadmap.CreateActivity(childActivity, _currentEmployeeId);
+        childResult.IsSuccess.Should().BeTrue();
+
+        _dbContext.AddRoadmap(roadmap);
+        var handler = CreateHandler();
+
+        // Widen the child well beyond the parent's end via the date-update command
+        var newChildRange = new LocalDateRange(_today, _today.PlusDays(40));
+        var dates = OneOf<IUpsertRoadmapActivityDateRange, IUpsertRoadmapMilestoneDate, IUpsertRoadmapTimeboxDateRange>
+            .FromT0(new UpsertActivityDateRange(newChildRange));
+        var command = new UpdateRoadmapItemDatesCommand(roadmap.Id, childResult.Value.Id, dates);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert - the parent rolled up to contain the widened child, and the change was persisted
+        result.IsSuccess.Should().BeTrue();
+        parentResult.Value.DateRange.End.Should().Be(_today.PlusDays(40));
+        _dbContext.SaveChangesCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_WhenParentShrunkBehindChild_ShouldFailAndNotSave()
+    {
+        // Arrange - a parent activity with a child; the child grows the parent to [0, 30]
+        var roadmap = CreateActiveRoadmap();
+
+        var parentActivity = new UpsertActivity(new LocalDateRange(_today, _today.PlusDays(10)));
+        var parentResult = roadmap.CreateActivity(parentActivity, _currentEmployeeId);
+        parentResult.IsSuccess.Should().BeTrue();
+
+        var childActivity = new UpsertActivity(
+            new LocalDateRange(_today, _today.PlusDays(30)),
+            parentResult.Value.Id);
+        var childResult = roadmap.CreateActivity(childActivity, _currentEmployeeId);
+        childResult.IsSuccess.Should().BeTrue();
+
+        _dbContext.AddRoadmap(roadmap);
+        var handler = CreateHandler();
+
+        // Attempt to shrink the PARENT behind its child's end
+        var dates = OneOf<IUpsertRoadmapActivityDateRange, IUpsertRoadmapMilestoneDate, IUpsertRoadmapTimeboxDateRange>
+            .FromT0(new UpsertActivityDateRange(new LocalDateRange(_today, _today.PlusDays(5))));
+        var command = new UpdateRoadmapItemDatesCommand(roadmap.Id, parentResult.Value.Id, dates);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert - rejected and nothing persisted
+        result.IsFailure.Should().BeTrue();
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRoadmapNotFound_ShouldFailAndNotSave()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var dates = OneOf<IUpsertRoadmapActivityDateRange, IUpsertRoadmapMilestoneDate, IUpsertRoadmapTimeboxDateRange>
+            .FromT0(new UpsertActivityDateRange(new LocalDateRange(_today, _today.PlusDays(5))));
+        var command = new UpdateRoadmapItemDatesCommand(Guid.NewGuid(), Guid.NewGuid(), dates);
+
+        // Act
+        var result = await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        _dbContext.SaveChangesCallCount.Should().Be(0);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private sealed record UpsertActivity(LocalDateRange DateRange, Guid? ParentId = null) : IUpsertRoadmapActivity
+    {
+        public string Name { get; init; } = "Activity";
+        public string? Description { get; init; }
+        public string? Color { get; init; }
+    }
+
+    private sealed record UpsertActivityDateRange(LocalDateRange DateRange) : IUpsertRoadmapActivityDateRange;
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Data/RoadmapActivityFaker.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Data/RoadmapActivityFaker.cs
@@ -90,6 +90,12 @@ public static class RoadmapActivityFakerExtensions
         return faker;
     }
 
+    /// <summary>
+    /// Generates an Activity with <paramref name="childrenCount"/> child Activities already attached,
+    /// in a valid rolled-up state: every child's date range falls within the parent's date range.
+    /// The parent's range is recalculated to contain its children so the returned aggregate honors
+    /// the date-rollup invariant enforced by the domain.
+    /// </summary>
     public static RoadmapActivity WithChildren(this RoadmapActivityFaker faker, int childrenCount)
     {
         var activity = faker.Generate();
@@ -104,6 +110,9 @@ public static class RoadmapActivityFakerExtensions
         }
 
         typeof(RoadmapActivity).GetField("_children", BindingFlags.NonPublic | BindingFlags.Instance)!.SetValue(activity, children);
+
+        // Grow the parent to contain its children so the aggregate starts in a valid rolled-up state.
+        activity.RecalculateDateRangeFromChildren();
 
         return activity;
     }

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/RoadmapTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/RoadmapTests.cs
@@ -1195,6 +1195,242 @@ public class RoadmapTests
 
     #endregion Update Item Dates Tests
 
+    #region Date Rollup Tests
+
+    private Roadmap CreateRoadmapWithManager(out Guid managerId)
+    {
+        var fakeRoadmap = _faker.Generate();
+        managerId = Guid.NewGuid();
+        return Roadmap.Create(fakeRoadmap.Name, fakeRoadmap.Description, fakeRoadmap.DateRange, fakeRoadmap.Visibility, [managerId]).Value;
+    }
+
+    private RoadmapActivity CreateActivity(Roadmap roadmap, Guid managerId, LocalDateRange dateRange, Guid? parentId = null)
+    {
+        var activity = _activityFaker.WithDateRange(dateRange).WithParentId(parentId).Generate();
+        var result = roadmap.CreateActivity(new TestUpsertRoadmapActivity(activity), managerId);
+        result.IsSuccess.Should().BeTrue();
+        return result.Value;
+    }
+
+    [Fact]
+    public void CreateActivity_ChildEndsAfterParent_ShouldGrowParentEnd()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+
+        // Act
+        CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today.PlusDays(5), _dateTimeProvider.Today.PlusDays(20)),
+            parent.Id);
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void CreateActivity_ChildStartsBeforeParent_ShouldGrowParentStart()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today.PlusDays(10), _dateTimeProvider.Today.PlusDays(20)));
+
+        // Act
+        CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(15)),
+            parent.Id);
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void CreateActivity_ChildFullyInsideParent_ShouldLeaveParentUnchanged()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parentRange = new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(30));
+        var parent = CreateActivity(roadmap, managerId, parentRange);
+
+        // Act
+        CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today.PlusDays(5), _dateTimeProvider.Today.PlusDays(10)),
+            parent.Id);
+
+        // Assert
+        parent.DateRange.Should().Be(parentRange);
+    }
+
+    [Fact]
+    public void CreateMilestone_ChildDateOutsideParent_ShouldGrowParent()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+        var milestoneDate = _dateTimeProvider.Today.PlusDays(25);
+        var milestone = _milestoneFaker.WithDate(milestoneDate).WithParentId(parent.Id).Generate();
+
+        // Act
+        var result = roadmap.CreateMilestone(new TestUpsertRoadmapMilestone(milestone), managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(milestoneDate);
+    }
+
+    [Fact]
+    public void CreateTimebox_ChildRangeOutsideParent_ShouldGrowParent()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+        var timeboxRange = new LocalDateRange(_dateTimeProvider.Today.PlusDays(8), _dateTimeProvider.Today.PlusDays(18));
+        var timebox = _timeboxFaker.WithDateRange(timeboxRange).WithParentId(parent.Id).Generate();
+
+        // Act
+        var result = roadmap.CreateTimebox(new TestUpsertRoadmapTimebox(timebox), managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(18));
+    }
+
+    [Fact]
+    public void UpdateRoadmapItemDates_ChildGrowsBeyondParent_ShouldBubbleUpToRoot()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var grandparent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)),
+            grandparent.Id);
+        var child = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)),
+            parent.Id);
+
+        var newChildRange = new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(40));
+        var dateUpdate = OneOf<IUpsertRoadmapActivityDateRange, IUpsertRoadmapMilestoneDate, IUpsertRoadmapTimeboxDateRange>.FromT0(
+            new TestUpsertRoadmapActivityDateRange(newChildRange));
+
+        // Act
+        var result = roadmap.UpdateRoadmapItemDates(child.Id, dateUpdate, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(40));
+        grandparent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(40));
+    }
+
+    [Fact]
+    public void UpdateRoadmapItemDates_ParentWithNoChildren_ShouldApplyRangeUnchanged()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var activity = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+
+        var newRange = new LocalDateRange(_dateTimeProvider.Today.PlusDays(2), _dateTimeProvider.Today.PlusDays(6));
+        var dateUpdate = OneOf<IUpsertRoadmapActivityDateRange, IUpsertRoadmapMilestoneDate, IUpsertRoadmapTimeboxDateRange>.FromT0(
+            new TestUpsertRoadmapActivityDateRange(newRange));
+
+        // Act
+        var result = roadmap.UpdateRoadmapItemDates(activity.Id, dateUpdate, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        activity.DateRange.Should().Be(newRange);
+    }
+
+    [Fact]
+    public void UpdateRoadmapItemDates_ParentWiderThanChildren_ShouldKeepParentRange()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+        CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today.PlusDays(2), _dateTimeProvider.Today.PlusDays(6)),
+            parent.Id);
+
+        // Set the parent wider than its child
+        var widerRange = new LocalDateRange(_dateTimeProvider.Today.PlusDays(-5), _dateTimeProvider.Today.PlusDays(30));
+        var dateUpdate = OneOf<IUpsertRoadmapActivityDateRange, IUpsertRoadmapMilestoneDate, IUpsertRoadmapTimeboxDateRange>.FromT0(
+            new TestUpsertRoadmapActivityDateRange(widerRange));
+
+        // Act
+        var result = roadmap.UpdateRoadmapItemDates(parent.Id, dateUpdate, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(widerRange);
+    }
+
+    [Fact]
+    public void UpdateActivity_FormUpdateGrowsChildBeyondParent_ShouldGrowParent()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        var parent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+        var child = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)),
+            parent.Id);
+
+        // Form update that widens the child past the parent's end
+        var updateChild = new TestUpsertRoadmapActivity(child)
+        {
+            ParentId = parent.Id,
+            DateRange = new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(35))
+        };
+
+        // Act
+        var result = roadmap.UpdateActivity(child.Id, updateChild, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(35));
+    }
+
+    [Fact]
+    public void MoveActivity_ChildExtendsBeyondNewParent_ShouldGrowNewParent()
+    {
+        // Arrange
+        var roadmap = CreateRoadmapWithManager(out var managerId);
+        roadmap.SetPrivate(x => x.Id, Guid.NewGuid());
+
+        var originalParent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(40)));
+        originalParent.SetPrivate(x => x.Id, Guid.NewGuid());
+
+        var newParent = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)));
+        newParent.SetPrivate(x => x.Id, Guid.NewGuid());
+
+        var child = CreateActivity(roadmap, managerId,
+            new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(30)),
+            originalParent.Id);
+        child.SetPrivate(x => x.Id, Guid.NewGuid());
+        child.SetPrivate(x => x.Parent, originalParent);
+
+        // Act
+        var result = roadmap.MoveActivity(child.Id, newParent.Id, 1, managerId);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        newParent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(30));
+    }
+
+    #endregion Date Rollup Tests
+
     #region Update Colors Tests
 
     [Fact]

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/BaseRoadmapItemTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/BaseRoadmapItemTests.cs
@@ -1,4 +1,5 @@
-﻿using Wayd.Planning.Domain.Models.Roadmaps;
+﻿using Wayd.Common.Models;
+using Wayd.Planning.Domain.Models.Roadmaps;
 using Wayd.Planning.Domain.Tests.Data;
 using Wayd.Planning.Domain.Tests.Models;
 using Wayd.Tests.Shared;
@@ -90,6 +91,41 @@ public class BaseRoadmapItemTests
         // Assert
         result.IsFailure.Should().BeTrue();
         result.Error.Should().Be("Unable to make the Roadmap Item a child of itself.");
+    }
+
+    [Fact]
+    public void ChangeParent_WhenChildExtendsBeyondNewParent_ShouldGrowNewParent()
+    {
+        // Arrange
+        var newParent = _faker
+            .WithDateRange(new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(10)))
+            .Generate();
+        var activity = _faker
+            .WithDateRange(new LocalDateRange(_dateTimeProvider.Today, _dateTimeProvider.Today.PlusDays(30)))
+            .Generate();
+
+        // Act
+        var result = activity.ChangeParent(newParent);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        newParent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(30));
+    }
+
+    [Fact]
+    public void LinkParent_ShouldSetParentNavigation_WithoutAddingToChildren()
+    {
+        // Arrange
+        var parent = _faker.Generate();
+        var activity = _faker.Generate();
+
+        // Act
+        activity.LinkParent(parent);
+
+        // Assert
+        activity.ParentId.Should().Be(parent.Id);
+        activity.Parent.Should().Be(parent);
+        parent.Children.Should().NotContain(activity);
     }
 
     //[Fact]

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/RoadmapActivityTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/RoadmapActivityTests.cs
@@ -1,0 +1,369 @@
+using Wayd.Common.Models;
+using Wayd.Planning.Domain.Models.Roadmaps;
+using Wayd.Planning.Domain.Tests.Data;
+using Wayd.Planning.Domain.Tests.Models;
+using Wayd.Tests.Shared;
+using NodaTime.Extensions;
+using NodaTime.Testing;
+
+namespace Wayd.Planning.Domain.Tests.Sut.Models.Roadmaps;
+
+public class RoadmapActivityTests
+{
+    private readonly TestingDateTimeProvider _dateTimeProvider;
+    private readonly RoadmapActivityFaker _activityFaker;
+    private readonly RoadmapMilestoneFaker _milestoneFaker;
+    private readonly RoadmapTimeboxFaker _timeboxFaker;
+
+    public RoadmapActivityTests()
+    {
+        _dateTimeProvider = new(new FakeClock(DateTime.UtcNow.ToInstant()));
+        _activityFaker = new RoadmapActivityFaker(Guid.NewGuid(), _dateTimeProvider.Today);
+        _milestoneFaker = new RoadmapMilestoneFaker(localDate: _dateTimeProvider.Today);
+        _timeboxFaker = new RoadmapTimeboxFaker(localDate: _dateTimeProvider.Today);
+    }
+
+    private RoadmapActivity GenerateActivity(LocalDateRange dateRange) =>
+        _activityFaker.WithDateRange(dateRange).Generate();
+
+    private LocalDateRange Range(int startOffsetDays, int endOffsetDays) =>
+        new(_dateTimeProvider.Today.PlusDays(startOffsetDays), _dateTimeProvider.Today.PlusDays(endOffsetDays));
+
+    #region CreateChildActivity Rollup
+
+    [Fact]
+    public void CreateChildActivity_ChildEndsAfterParent_ShouldGrowParentEnd()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var child = GenerateActivity(Range(5, 20));
+
+        // Act
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(child));
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void CreateChildActivity_ChildStartsBeforeParent_ShouldGrowParentStart()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(10, 20));
+        var child = GenerateActivity(Range(0, 15));
+
+        // Act
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(child));
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void CreateChildActivity_ChildFullyInsideParent_ShouldLeaveParentUnchanged()
+    {
+        // Arrange
+        var parentRange = Range(0, 30);
+        var parent = GenerateActivity(parentRange);
+        var child = GenerateActivity(Range(5, 10));
+
+        // Act
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(child));
+
+        // Assert
+        parent.DateRange.Should().Be(parentRange);
+    }
+
+    [Fact]
+    public void CreateChildActivity_ShouldLinkChildToParent()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var child = GenerateActivity(Range(0, 10));
+
+        // Act
+        var created = parent.CreateChildActivity(new TestUpsertRoadmapActivity(child));
+
+        // Assert
+        created.ParentId.Should().Be(parent.Id);
+        created.Parent.Should().Be(parent);
+    }
+
+    #endregion CreateChildActivity Rollup
+
+    #region CreateChildMilestone / CreateChildTimebox Rollup
+
+    [Fact]
+    public void CreateChildMilestone_DateAfterParent_ShouldGrowParentEnd()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var milestone = _milestoneFaker.WithDate(_dateTimeProvider.Today.PlusDays(25)).Generate();
+
+        // Act
+        parent.CreateChildMilestone(new TestUpsertRoadmapMilestone(milestone));
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(25));
+    }
+
+    [Fact]
+    public void CreateChildMilestone_DateBeforeParent_ShouldGrowParentStart()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(10, 20));
+        var milestone = _milestoneFaker.WithDate(_dateTimeProvider.Today.PlusDays(2)).Generate();
+
+        // Act
+        parent.CreateChildMilestone(new TestUpsertRoadmapMilestone(milestone));
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today.PlusDays(2));
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void CreateChildTimebox_RangeOutsideParent_ShouldGrowParent()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var timebox = _timeboxFaker.WithDateRange(Range(8, 18)).Generate();
+
+        // Act
+        parent.CreateChildTimebox(new TestUpsertRoadmapTimebox(timebox));
+
+        // Assert
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today);
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(18));
+    }
+
+    #endregion CreateChildMilestone / CreateChildTimebox Rollup
+
+    #region UpdateDateRange Rollup
+
+    [Fact]
+    public void UpdateDateRange_NoChildren_ShouldApplyRangeUnchanged()
+    {
+        // Arrange
+        var activity = GenerateActivity(Range(0, 10));
+        var newRange = Range(2, 6);
+
+        // Act
+        var result = activity.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(newRange));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        activity.DateRange.Should().Be(newRange);
+    }
+
+    [Fact]
+    public void UpdateDateRange_NarrowerThanChildren_ShouldFailAndNotChangeRange()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(0, 20))));
+        // The child grew the parent to [0, 20] on creation.
+        var rangeBefore = parent.DateRange;
+
+        // Act - attempt to shrink the parent behind its child's end
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(0, 5)));
+
+        // Assert - rejected, range untouched
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("must contain all child items");
+        parent.DateRange.Should().Be(rangeBefore);
+    }
+
+    [Fact]
+    public void UpdateDateRange_WiderThanChildren_ShouldKeepWiderRange()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(2, 6))));
+        var widerRange = Range(-5, 30);
+
+        // Act
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(widerRange));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(widerRange);
+    }
+
+    [Fact]
+    public void UpdateDateRange_ExactlyContainsChildren_ShouldSucceed()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 30));
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(5, 20))));
+        var tightRange = Range(5, 20);
+
+        // Act - shrink the parent to exactly the child's span (boundary is allowed)
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(tightRange));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(tightRange);
+    }
+
+    [Fact]
+    public void UpdateDateRange_StartAfterChildStart_ShouldFail()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 30));
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(0, 10))));
+        var rangeBefore = parent.DateRange;
+
+        // Act - move the parent start ahead of the child's start
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(5, 30)));
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("must contain all child items");
+        parent.DateRange.Should().Be(rangeBefore);
+    }
+
+    #endregion UpdateDateRange Rollup
+
+    #region RecalculateDateRangeFromChildren
+
+    [Fact]
+    public void RecalculateDateRangeFromChildren_ShouldBubbleUpToGrandparent()
+    {
+        // Arrange
+        var grandparent = GenerateActivity(Range(0, 10));
+        var parent = grandparent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(0, 10))));
+        var child = parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(0, 10))));
+
+        // Act - grow the leaf child, then trigger a recalculate from its parent
+        child.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(0, 40)));
+
+        // Assert - growth bubbled all the way to the root
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(40));
+        grandparent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(40));
+    }
+
+    [Fact]
+    public void RecalculateDateRangeFromChildren_NoChildren_ShouldLeaveRangeUnchanged()
+    {
+        // Arrange
+        var range = Range(0, 10);
+        var activity = GenerateActivity(range);
+
+        // Act
+        activity.RecalculateDateRangeFromChildren();
+
+        // Assert
+        activity.DateRange.Should().Be(range);
+    }
+
+    #endregion RecalculateDateRangeFromChildren
+
+    #region Subtree Shift
+
+    [Fact]
+    public void UpdateDateRange_PureShiftForward_ShouldMoveAllDescendantsBySameDelta()
+    {
+        // Arrange - parent [0,30] with an activity child [5,15] that itself has a grandchild [6,10]
+        var parent = GenerateActivity(Range(0, 30));
+        var child = parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(5, 15))));
+        var grandchild = child.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(6, 10))));
+
+        // Act - shift the parent forward by 7 days (same duration)
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(7, 37)));
+
+        // Assert - every node moved by exactly 7 days
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(Range(7, 37));
+        child.DateRange.Should().Be(Range(12, 22));
+        grandchild.DateRange.Should().Be(Range(13, 17));
+    }
+
+    [Fact]
+    public void UpdateDateRange_PureShiftBackward_ShouldMoveAllDescendantsBySameDelta()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(10, 30));
+        var child = parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(12, 20))));
+
+        // Act - shift the parent back by 5 days
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(5, 25)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(Range(5, 25));
+        child.DateRange.Should().Be(Range(7, 15));
+    }
+
+    [Fact]
+    public void UpdateDateRange_PureShift_ShouldMoveTimeboxAndMilestoneChildren()
+    {
+        // Arrange - parent with a timebox and a milestone child
+        var parent = GenerateActivity(Range(0, 30));
+        var timebox = parent.CreateChildTimebox(
+            new TestUpsertRoadmapTimebox(_timeboxFaker.WithDateRange(Range(2, 8)).Generate()));
+        var milestone = parent.CreateChildMilestone(
+            new TestUpsertRoadmapMilestone(_milestoneFaker.WithDate(_dateTimeProvider.Today.PlusDays(15)).Generate()));
+
+        // Act - shift the parent forward by 10 days
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(10, 40)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        timebox.DateRange.Should().Be(Range(12, 18));
+        milestone.Date.Should().Be(_dateTimeProvider.Today.PlusDays(25));
+    }
+
+    [Fact]
+    public void UpdateDateRange_ResizeNotShift_ShouldNotMoveChildren()
+    {
+        // Arrange - parent [0,30] wide enough to resize without a uniform shift
+        var parent = GenerateActivity(Range(0, 30));
+        var child = parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(5, 15))));
+        var childRangeBefore = child.DateRange;
+
+        // Act - move only the end (start delta 0, end delta -5): a resize, not a shift
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(0, 25)));
+
+        // Assert - the parent resized; the child did not move
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(Range(0, 25));
+        child.DateRange.Should().Be(childRangeBefore);
+    }
+
+    [Fact]
+    public void UpdateDateRange_PureShiftWithNoChildren_ShouldJustMoveActivity()
+    {
+        // Arrange - a leaf activity
+        var activity = GenerateActivity(Range(0, 10));
+
+        // Act - shift it forward (no children to move)
+        var result = activity.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(7, 17)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        activity.DateRange.Should().Be(Range(7, 17));
+    }
+
+    [Fact]
+    public void UpdateDateRange_PureShift_ShouldGrowAncestorToFitShiftedChild()
+    {
+        // Arrange - grandparent just barely contains the parent it owns
+        var grandparent = GenerateActivity(Range(0, 30));
+        var parent = grandparent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(5, 25))));
+        parent.CreateChildActivity(new TestUpsertRoadmapActivity(GenerateActivity(Range(6, 20))));
+
+        // Act - shift the parent forward by 10 days; its end (35) now exceeds the grandparent (30)
+        var result = parent.UpdateDateRange(new TestUpsertRoadmapActivityDateRange(Range(15, 35)));
+
+        // Assert - the grandparent grew to contain the shifted subtree
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(Range(15, 35));
+        grandparent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(35));
+    }
+
+    #endregion Subtree Shift
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/RoadmapMilestoneTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/RoadmapMilestoneTests.cs
@@ -1,0 +1,134 @@
+using Wayd.Common.Models;
+using Wayd.Planning.Domain.Enums;
+using Wayd.Planning.Domain.Models.Roadmaps;
+using Wayd.Planning.Domain.Tests.Data;
+using Wayd.Planning.Domain.Tests.Models;
+using Wayd.Tests.Shared;
+using NodaTime.Extensions;
+using NodaTime.Testing;
+
+namespace Wayd.Planning.Domain.Tests.Sut.Models.Roadmaps;
+
+public class RoadmapMilestoneTests
+{
+    private readonly TestingDateTimeProvider _dateTimeProvider;
+    private readonly RoadmapActivityFaker _activityFaker;
+    private readonly RoadmapMilestoneFaker _milestoneFaker;
+
+    public RoadmapMilestoneTests()
+    {
+        _dateTimeProvider = new(new FakeClock(DateTime.UtcNow.ToInstant()));
+        _activityFaker = new RoadmapActivityFaker(Guid.NewGuid(), _dateTimeProvider.Today);
+        _milestoneFaker = new RoadmapMilestoneFaker(localDate: _dateTimeProvider.Today);
+    }
+
+    private RoadmapActivity GenerateActivity(LocalDateRange dateRange) =>
+        _activityFaker.WithDateRange(dateRange).Generate();
+
+    private RoadmapMilestone CreateChildMilestone(RoadmapActivity parent, LocalDate date)
+    {
+        var milestone = _milestoneFaker.WithDate(date).Generate();
+        return parent.CreateChildMilestone(new TestUpsertRoadmapMilestone(milestone));
+    }
+
+    private LocalDateRange Range(int startOffsetDays, int endOffsetDays) =>
+        new(_dateTimeProvider.Today.PlusDays(startOffsetDays), _dateTimeProvider.Today.PlusDays(endOffsetDays));
+
+    [Fact]
+    public void Create_ShouldSetType()
+    {
+        // Arrange
+        var milestone = _milestoneFaker.Generate();
+
+        // Act
+        var result = RoadmapMilestone.Create(milestone.RoadmapId, null, new TestUpsertRoadmapMilestone(milestone));
+
+        // Assert
+        result.Type.Should().Be(RoadmapItemType.Milestone);
+        result.ParentId.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateDate_DateAfterParent_ShouldGrowParentEnd()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var milestone = CreateChildMilestone(parent, _dateTimeProvider.Today.PlusDays(5));
+
+        // Act
+        var result = milestone.UpdateDate(new TestUpsertRoadmapMilestoneDate(_dateTimeProvider.Today.PlusDays(25)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        milestone.Date.Should().Be(_dateTimeProvider.Today.PlusDays(25));
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(25));
+    }
+
+    [Fact]
+    public void UpdateDate_DateBeforeParent_ShouldGrowParentStart()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(10, 20));
+        var milestone = CreateChildMilestone(parent, _dateTimeProvider.Today.PlusDays(15));
+
+        // Act
+        var result = milestone.UpdateDate(new TestUpsertRoadmapMilestoneDate(_dateTimeProvider.Today.PlusDays(2)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today.PlusDays(2));
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void UpdateDate_DateInsideParent_ShouldLeaveParentUnchanged()
+    {
+        // Arrange
+        var parentRange = Range(0, 30);
+        var parent = GenerateActivity(parentRange);
+        var milestone = CreateChildMilestone(parent, _dateTimeProvider.Today.PlusDays(5));
+
+        // Act
+        var result = milestone.UpdateDate(new TestUpsertRoadmapMilestoneDate(_dateTimeProvider.Today.PlusDays(10)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(parentRange);
+    }
+
+    [Fact]
+    public void UpdateDate_WhenNoParent_ShouldUpdateDate()
+    {
+        // Arrange
+        var milestone = _milestoneFaker.WithDate(_dateTimeProvider.Today).Generate();
+        var newDate = _dateTimeProvider.Today.PlusDays(7);
+
+        // Act
+        var result = milestone.UpdateDate(new TestUpsertRoadmapMilestoneDate(newDate));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        milestone.Date.Should().Be(newDate);
+    }
+
+    [Fact]
+    public void Update_DateOutsideParent_ShouldGrowParent()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var milestone = CreateChildMilestone(parent, _dateTimeProvider.Today.PlusDays(5));
+
+        var update = new TestUpsertRoadmapMilestone(milestone)
+        {
+            ParentId = parent.Id,
+            Date = _dateTimeProvider.Today.PlusDays(40)
+        };
+
+        // Act
+        var result = milestone.Update(update, parent);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(40));
+    }
+}

--- a/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/RoadmapTimeboxTests.cs
+++ b/Wayd.Services/Wayd.Planning/tests/Wayd.Planning.Domain.Tests/Sut/Models/Roadmaps/RoadmapTimeboxTests.cs
@@ -1,0 +1,134 @@
+using Wayd.Common.Models;
+using Wayd.Planning.Domain.Enums;
+using Wayd.Planning.Domain.Models.Roadmaps;
+using Wayd.Planning.Domain.Tests.Data;
+using Wayd.Planning.Domain.Tests.Models;
+using Wayd.Tests.Shared;
+using NodaTime.Extensions;
+using NodaTime.Testing;
+
+namespace Wayd.Planning.Domain.Tests.Sut.Models.Roadmaps;
+
+public class RoadmapTimeboxTests
+{
+    private readonly TestingDateTimeProvider _dateTimeProvider;
+    private readonly RoadmapActivityFaker _activityFaker;
+    private readonly RoadmapTimeboxFaker _timeboxFaker;
+
+    public RoadmapTimeboxTests()
+    {
+        _dateTimeProvider = new(new FakeClock(DateTime.UtcNow.ToInstant()));
+        _activityFaker = new RoadmapActivityFaker(Guid.NewGuid(), _dateTimeProvider.Today);
+        _timeboxFaker = new RoadmapTimeboxFaker(localDate: _dateTimeProvider.Today);
+    }
+
+    private RoadmapActivity GenerateActivity(LocalDateRange dateRange) =>
+        _activityFaker.WithDateRange(dateRange).Generate();
+
+    private RoadmapTimebox CreateChildTimebox(RoadmapActivity parent, LocalDateRange dateRange)
+    {
+        var timebox = _timeboxFaker.WithDateRange(dateRange).Generate();
+        return parent.CreateChildTimebox(new TestUpsertRoadmapTimebox(timebox));
+    }
+
+    private LocalDateRange Range(int startOffsetDays, int endOffsetDays) =>
+        new(_dateTimeProvider.Today.PlusDays(startOffsetDays), _dateTimeProvider.Today.PlusDays(endOffsetDays));
+
+    [Fact]
+    public void Create_ShouldSetType()
+    {
+        // Arrange
+        var timebox = _timeboxFaker.Generate();
+
+        // Act
+        var result = RoadmapTimebox.Create(timebox.RoadmapId, null, new TestUpsertRoadmapTimebox(timebox));
+
+        // Assert
+        result.Type.Should().Be(RoadmapItemType.Timebox);
+        result.ParentId.Should().BeNull();
+    }
+
+    [Fact]
+    public void UpdateDateRange_RangeEndsAfterParent_ShouldGrowParentEnd()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var timebox = CreateChildTimebox(parent, Range(2, 8));
+
+        // Act
+        var result = timebox.UpdateDateRange(new TestUpsertRoadmapTimeboxDateRange(Range(2, 25)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        timebox.DateRange.Should().Be(Range(2, 25));
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(25));
+    }
+
+    [Fact]
+    public void UpdateDateRange_RangeStartsBeforeParent_ShouldGrowParentStart()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(10, 20));
+        var timebox = CreateChildTimebox(parent, Range(12, 18));
+
+        // Act
+        var result = timebox.UpdateDateRange(new TestUpsertRoadmapTimeboxDateRange(Range(2, 18)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Start.Should().Be(_dateTimeProvider.Today.PlusDays(2));
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(20));
+    }
+
+    [Fact]
+    public void UpdateDateRange_RangeInsideParent_ShouldLeaveParentUnchanged()
+    {
+        // Arrange
+        var parentRange = Range(0, 30);
+        var parent = GenerateActivity(parentRange);
+        var timebox = CreateChildTimebox(parent, Range(5, 10));
+
+        // Act
+        var result = timebox.UpdateDateRange(new TestUpsertRoadmapTimeboxDateRange(Range(8, 12)));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.Should().Be(parentRange);
+    }
+
+    [Fact]
+    public void UpdateDateRange_WhenNoParent_ShouldUpdateRange()
+    {
+        // Arrange
+        var timebox = _timeboxFaker.WithDateRange(Range(0, 10)).Generate();
+        var newRange = Range(3, 8);
+
+        // Act
+        var result = timebox.UpdateDateRange(new TestUpsertRoadmapTimeboxDateRange(newRange));
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        timebox.DateRange.Should().Be(newRange);
+    }
+
+    [Fact]
+    public void Update_RangeOutsideParent_ShouldGrowParent()
+    {
+        // Arrange
+        var parent = GenerateActivity(Range(0, 10));
+        var timebox = CreateChildTimebox(parent, Range(2, 8));
+
+        var update = new TestUpsertRoadmapTimebox(timebox)
+        {
+            ParentId = parent.Id,
+            DateRange = Range(2, 40)
+        };
+
+        // Act
+        var result = timebox.Update(update, parent);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        parent.DateRange.End.Should().Be(_dateTimeProvider.Today.PlusDays(40));
+    }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/package.json
+++ b/Wayd.Web/src/wayd.web.reactclient/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:docs": "jest --config jest.docs.config.ts --no-coverage"

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-activity-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-activity-form.tsx
@@ -9,9 +9,13 @@ import {
   useGetRoadmapQuery,
 } from '@/src/store/features/planning/roadmaps-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
-import { DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
+import { Alert, DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
 import { useEffect } from 'react'
 import RoadmapColorPicker from './roadmap-color-picker'
+import {
+  findParentActivityRange,
+  getParentExpansionHint,
+} from './roadmap-parent-date-hint'
 
 const { Item } = Form
 const { TextArea } = Input
@@ -96,6 +100,14 @@ const CreateRoadmapActivityForm = ({
       permission: 'Permissions.Roadmaps.Update',
     })
 
+  const selectedParentId = Form.useWatch('parentId', form)
+  const selectedRange = Form.useWatch('range', form)
+  const parentExpansionHint = getParentExpansionHint(
+    findParentActivityRange(activities, selectedParentId),
+    selectedRange?.[0],
+    selectedRange?.[1],
+  )
+
   // Query error display
   useEffect(() => {
     if (activitiesError) {
@@ -173,9 +185,9 @@ const CreateRoadmapActivityForm = ({
                   )
                 }
                 const [start, end] = value
-                if (!start || !end || !start.isBefore(end)) {
+                if (!start || !end || end.isBefore(start, 'day')) {
                   return Promise.reject(
-                    new Error('End date must be after start date'),
+                    new Error('End date must be on or after start date'),
                   )
                 }
                 return Promise.resolve()
@@ -185,6 +197,14 @@ const CreateRoadmapActivityForm = ({
         >
           <RangePicker />
         </Item>
+        {parentExpansionHint && (
+          <Alert
+            type="info"
+            showIcon
+            message={parentExpansionHint}
+            style={{ marginBottom: 16 }}
+          />
+        )}
         <Item name="color" label="Color">
           {roadmapColors.length > 0 ? (
             <RoadmapColorPicker entries={roadmapColors} />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-form.tsx
@@ -170,9 +170,9 @@ const CreateRoadmapForm = ({
                   )
                 }
                 const [start, end] = value
-                if (!start || !end || !start.isBefore(end)) {
+                if (!start || !end || end.isBefore(start, 'day')) {
                   return Promise.reject(
-                    new Error('End date must be after start date'),
+                    new Error('End date must be on or after start date'),
                   )
                 }
                 return Promise.resolve()

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-timebox-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/create-roadmap-timebox-form.tsx
@@ -9,8 +9,12 @@ import {
   useGetRoadmapActivitiesQuery,
 } from '@/src/store/features/planning/roadmaps-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
-import { DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
+import { Alert, DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
 import { useEffect } from 'react'
+import {
+  findParentActivityRange,
+  getParentExpansionHint,
+} from './roadmap-parent-date-hint'
 
 const { Item } = Form
 const { TextArea } = Input
@@ -92,6 +96,14 @@ const CreateRoadmapTimeboxForm = ({
       permission: 'Permissions.Roadmaps.Update',
     })
 
+  const selectedParentId = Form.useWatch('parentId', form)
+  const selectedRange = Form.useWatch('range', form)
+  const parentExpansionHint = getParentExpansionHint(
+    findParentActivityRange(activities, selectedParentId),
+    selectedRange?.[0],
+    selectedRange?.[1],
+  )
+
   // Query error display
   useEffect(() => {
     if (activitiesError) {
@@ -169,9 +181,9 @@ const CreateRoadmapTimeboxForm = ({
                   )
                 }
                 const [start, end] = value
-                if (!start || !end || !start.isBefore(end)) {
+                if (!start || !end || end.isBefore(start, 'day')) {
                   return Promise.reject(
-                    new Error('End date must be after start date'),
+                    new Error('End date must be on or after start date'),
                   )
                 }
                 return Promise.resolve()
@@ -181,6 +193,14 @@ const CreateRoadmapTimeboxForm = ({
         >
           <RangePicker />
         </Item>
+        {parentExpansionHint && (
+          <Alert
+            type="info"
+            showIcon
+            message={parentExpansionHint}
+            style={{ marginBottom: 16 }}
+          />
+        )}
         {/* Hide for now */}
         {/* <Item name="color" label="Color">
           <WaydColorPicker

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-activity-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-activity-form.tsx
@@ -13,13 +13,19 @@ import {
   useUpdateRoadmapItemMutation,
 } from '@/src/store/features/planning/roadmaps-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
-import { DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
+import { Alert, DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
 import { useEffect, useState } from 'react'
 import dayjs from 'dayjs'
 import { MarkdownEditor } from '@/src/components/common/markdown'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { useModalForm } from '@/src/hooks'
 import RoadmapColorPicker from './roadmap-color-picker'
+import {
+  findOwnChildrenSpan,
+  findParentActivityRange,
+  getChildrenContainmentError,
+  getParentExpansionHint,
+} from './roadmap-parent-date-hint'
 
 const { Item } = Form
 const { TextArea } = Input
@@ -155,6 +161,16 @@ const EditRoadmapActivityForm = ({
     })
   }, [activities, activitiesIsLoading, activityData, activityId, form])
 
+  const selectedParentId = Form.useWatch('parentActivityId', form)
+  const selectedRange = Form.useWatch('range', form)
+  const parentExpansionHint = getParentExpansionHint(
+    findParentActivityRange(activities, selectedParentId),
+    selectedRange?.[0],
+    selectedRange?.[1],
+  )
+  // This activity's own children constrain its range: it cannot be shrunk behind them.
+  const ownChildrenSpan = findOwnChildrenSpan(activities, activityId)
+
   // Query error display
   useEffect(() => {
     if (activityDataError) {
@@ -231,10 +247,18 @@ const EditRoadmapActivityForm = ({
                   )
                 }
                 const [start, end] = value
-                if (!start || !end || !start.isBefore(end)) {
+                if (!start || !end || end.isBefore(start, 'day')) {
                   return Promise.reject(
-                    new Error('End date must be after start date'),
+                    new Error('End date must be on or after start date'),
                   )
+                }
+                const containmentError = getChildrenContainmentError(
+                  ownChildrenSpan,
+                  start,
+                  end,
+                )
+                if (containmentError) {
+                  return Promise.reject(new Error(containmentError))
                 }
                 return Promise.resolve()
               },
@@ -243,6 +267,14 @@ const EditRoadmapActivityForm = ({
         >
           <RangePicker />
         </Item>
+        {parentExpansionHint && (
+          <Alert
+            type="info"
+            showIcon
+            message={parentExpansionHint}
+            style={{ marginBottom: 16 }}
+          />
+        )}
         <Item name="color" label="Color">
           {roadmapColors.length > 0 ? (
             <RoadmapColorPicker entries={roadmapColors} />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-form.tsx
@@ -191,9 +191,9 @@ const EditRoadmapForm = ({
                   )
                 }
                 const [start, end] = value
-                if (!start || !end || !start.isBefore(end)) {
+                if (!start || !end || end.isBefore(start, 'day')) {
                   return Promise.reject(
-                    new Error('End date must be after start date'),
+                    new Error('End date must be on or after start date'),
                   )
                 }
                 return Promise.resolve()

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-timebox-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/edit-roadmap-timebox-form.tsx
@@ -1,4 +1,5 @@
 import {
+  RoadmapActivityListDto,
   RoadmapTimeboxDetailsDto,
   RoadmapTimeboxListDto,
   UpdateRoadmapTimeboxRequest,
@@ -9,12 +10,16 @@ import {
   useUpdateRoadmapItemMutation,
 } from '@/src/store/features/planning/roadmaps-api'
 import { toFormErrors, isApiError, type ApiError } from '@/src/utils'
-import { DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
+import { Alert, DatePicker, Form, Input, Modal, TreeSelect } from 'antd'
 import { useEffect, useState } from 'react'
 import dayjs from 'dayjs'
 import { MarkdownEditor } from '@/src/components/common/markdown'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { useModalForm } from '@/src/hooks'
+import {
+  findParentActivityRange,
+  getParentExpansionHint,
+} from './roadmap-parent-date-hint'
 
 const { Item } = Form
 const { TextArea } = Input
@@ -130,6 +135,17 @@ const EditRoadmapTimeboxForm = ({
     })
   }, [activities, activitiesIsLoading, timeboxData, form])
 
+  const selectedParentId = Form.useWatch('parentActivityId', form)
+  const selectedRange = Form.useWatch('range', form)
+  const parentExpansionHint = getParentExpansionHint(
+    findParentActivityRange(
+      activities as RoadmapActivityListDto[] | undefined,
+      selectedParentId,
+    ),
+    selectedRange?.[0],
+    selectedRange?.[1],
+  )
+
   // Query error display
   useEffect(() => {
     if (timeboxDataError) {
@@ -206,9 +222,9 @@ const EditRoadmapTimeboxForm = ({
                   )
                 }
                 const [start, end] = value
-                if (!start || !end || !start.isBefore(end)) {
+                if (!start || !end || end.isBefore(start, 'day')) {
                   return Promise.reject(
-                    new Error('End date must be after start date'),
+                    new Error('End date must be on or after start date'),
                   )
                 }
                 return Promise.resolve()
@@ -218,6 +234,14 @@ const EditRoadmapTimeboxForm = ({
         >
           <RangePicker />
         </Item>
+        {parentExpansionHint && (
+          <Alert
+            type="info"
+            showIcon
+            message={parentExpansionHint}
+            style={{ marginBottom: 16 }}
+          />
+        )}
       </Form>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-items-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-items-grid.tsx
@@ -90,6 +90,50 @@ const parseRoadmapCalendarDate = (value: unknown): Date | null => {
   return Number.isNaN(parsed.getTime()) ? null : parsed
 }
 
+// The effective [start, end] of a child node: a range for Activity/Timebox, the date for a Milestone.
+const childNodeRange = (
+  child: RoadmapItemTreeNode,
+): [dayjs.Dayjs, dayjs.Dayjs] | null => {
+  if (child.type === 'Milestone' && child.date) {
+    const d = dayjs(child.date)
+    return [d, d]
+  }
+  if (child.start && child.end) {
+    return [dayjs(child.start), dayjs(child.end)]
+  }
+  return null
+}
+
+/**
+ * Validates that an item's range contains all of its direct children. Returns the
+ * offending field + message when the range would fall inside the children, matching
+ * the domain rule that a parent cannot be shrunk behind a child.
+ */
+const childrenContainmentError = (
+  item: RoadmapItemTreeNode,
+  start: dayjs.Dayjs,
+  end: dayjs.Dayjs,
+): { field: 'start' | 'end'; message: string } | null => {
+  for (const child of item.children ?? []) {
+    const range = childNodeRange(child)
+    if (!range) continue
+    const [childStart, childEnd] = range
+    if (childStart.isBefore(start, 'day')) {
+      return {
+        field: 'start',
+        message: `Start must be on or before child “${child.name}” (${childStart.format('MMM D, YYYY')}).`,
+      }
+    }
+    if (childEnd.isAfter(end, 'day')) {
+      return {
+        field: 'end',
+        message: `End must be on or after child “${child.name}” (${childEnd.format('MMM D, YYYY')}).`,
+      }
+    }
+  }
+  return null
+}
+
 function mapToTreeNode(item: RoadmapItemUnion): RoadmapItemTreeNode {
   const node: RoadmapItemTreeNode = {
     id: item.id,
@@ -521,8 +565,8 @@ const RoadmapItemsGrid: FC<RoadmapItemsGridProps> = ({
         const message = 'Start and end dates are required.'
         errors.start = message
         errors.end = message
-      } else if (!dayjs(start).isBefore(dayjs(end), 'day')) {
-        errors.end = 'End date must be after start date.'
+      } else if (dayjs(end).isBefore(dayjs(start), 'day')) {
+        errors.end = 'End date must be on or after start date.'
       }
 
       return errors
@@ -559,8 +603,15 @@ const RoadmapItemsGrid: FC<RoadmapItemsGridProps> = ({
         const message = 'Start and end dates are required.'
         errors.start = message
         errors.end = message
-      } else if (!dayjs(start).isBefore(dayjs(end), 'day')) {
-        errors.end = 'End date must be after start date.'
+      } else if (dayjs(end).isBefore(dayjs(start), 'day')) {
+        errors.end = 'End date must be on or after start date.'
+      } else {
+        // An activity's range must contain all of its children (matches the domain
+        // rule that a parent cannot be shrunk behind a child).
+        const containment = childrenContainmentError(item, dayjs(start), dayjs(end))
+        if (containment) {
+          errors[containment.field] = containment.message
+        }
       }
 
       return errors

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-parent-date-hint.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-parent-date-hint.ts
@@ -1,0 +1,176 @@
+import dayjs, { Dayjs } from 'dayjs'
+import type {
+  RoadmapActivityListDto,
+  RoadmapItemListDto,
+} from '@/src/services/wayd-api'
+
+/**
+ * Helpers for the non-blocking "this will expand the parent" hints shown on the
+ * roadmap item forms.
+ *
+ * These are intentionally informational only: the domain auto-expands a parent
+ * activity to contain its children (date rollup), so a child falling outside its
+ * parent is valid — we just set the user's expectation that the parent will grow.
+ */
+
+interface ParentRange {
+  name: string
+  start: Dayjs
+  end: Dayjs
+}
+
+/**
+ * Finds an activity anywhere in the (possibly nested) activities tree and returns
+ * its name and date range, or null when not found / no parent selected.
+ */
+export const findParentActivityRange = (
+  activities: RoadmapActivityListDto[] | undefined,
+  parentId: string | undefined,
+): ParentRange | null => {
+  if (!activities || !parentId) return null
+
+  const stack: RoadmapActivityListDto[] = [...activities]
+  while (stack.length > 0) {
+    const node = stack.pop()!
+    if (node.id === parentId) {
+      return {
+        name: node.name ?? 'parent activity',
+        start: dayjs(node.start),
+        end: dayjs(node.end),
+      }
+    }
+    const children = node.children as RoadmapActivityListDto[] | undefined
+    if (children?.length) {
+      stack.push(...children)
+    }
+  }
+
+  return null
+}
+
+/**
+ * Builds the hint for a ranged child (Activity / Timebox). Returns null when the
+ * child range is fully inside the parent (no expansion) or inputs are incomplete.
+ */
+export const getParentExpansionHint = (
+  parent: ParentRange | null,
+  childStart: Dayjs | null | undefined,
+  childEnd: Dayjs | null | undefined,
+): string | null => {
+  if (!parent || !childStart || !childEnd) return null
+
+  const extendsBefore = childStart.isBefore(parent.start, 'day')
+  const extendsAfter = childEnd.isAfter(parent.end, 'day')
+  if (!extendsBefore && !extendsAfter) return null
+
+  return `These dates fall outside the parent activity “${parent.name}”, which will expand to include them.`
+}
+
+/**
+ * Builds the hint for a milestone child whose single date falls outside the
+ * parent activity. Returns null when inside the parent or inputs are incomplete.
+ */
+export const getMilestoneParentExpansionHint = (
+  parent: ParentRange | null,
+  date: Dayjs | null | undefined,
+): string | null => {
+  if (!parent || !date) return null
+
+  const outside = date.isBefore(parent.start, 'day') || date.isAfter(parent.end, 'day')
+  if (!outside) return null
+
+  return `This date falls outside the parent activity “${parent.name}”, which will expand to include it.`
+}
+
+interface ChildrenSpan {
+  start: Dayjs
+  end: Dayjs
+  /** The child whose start/end defines the relevant boundary, for messaging. */
+  earliest: string
+  latest: string
+}
+
+/** The effective [start, end] of a child item: a range for Activity/Timebox, the date for a Milestone. */
+const childItemRange = (child: RoadmapItemListDto): [Dayjs, Dayjs] | null => {
+  const anyChild = child as RoadmapItemListDto & {
+    start?: Date
+    end?: Date
+    date?: Date
+  }
+  if (anyChild.date) {
+    const d = dayjs(anyChild.date)
+    return [d, d]
+  }
+  if (anyChild.start && anyChild.end) {
+    return [dayjs(anyChild.start), dayjs(anyChild.end)]
+  }
+  return null
+}
+
+/**
+ * Finds an activity by id in the (possibly nested) tree and returns the collective
+ * span of its direct children, or null when not found / it has no dated children.
+ */
+export const findOwnChildrenSpan = (
+  activities: RoadmapActivityListDto[] | undefined,
+  itemId: string | undefined,
+): ChildrenSpan | null => {
+  if (!activities || !itemId) return null
+
+  const stack: RoadmapActivityListDto[] = [...activities]
+  while (stack.length > 0) {
+    const node = stack.pop()!
+    if (node.id === itemId) {
+      const children = (node.children ?? []) as RoadmapItemListDto[]
+      let span: ChildrenSpan | null = null
+      for (const child of children) {
+        const range = childItemRange(child)
+        if (!range) continue
+        const [start, end] = range
+        if (!span) {
+          span = { start, end, earliest: child.name ?? '', latest: child.name ?? '' }
+        } else {
+          if (start.isBefore(span.start, 'day')) {
+            span.start = start
+            span.earliest = child.name ?? ''
+          }
+          if (end.isAfter(span.end, 'day')) {
+            span.end = end
+            span.latest = child.name ?? ''
+          }
+        }
+      }
+      return span
+    }
+    const childActivities = node.children as RoadmapActivityListDto[] | undefined
+    if (childActivities?.length) {
+      stack.push(...childActivities)
+    }
+  }
+
+  return null
+}
+
+/**
+ * Blocking validation for the item being edited: an Activity's range must contain
+ * all of its own children. Returns an error message when the proposed range would
+ * fall inside the children, or null when valid / not applicable.
+ *
+ * This mirrors the domain rule (a parent cannot be shrunk behind its children) so
+ * the user gets feedback before the API call.
+ */
+export const getChildrenContainmentError = (
+  span: ChildrenSpan | null,
+  start: Dayjs | null | undefined,
+  end: Dayjs | null | undefined,
+): string | null => {
+  if (!span || !start || !end) return null
+
+  if (start.isAfter(span.start, 'day')) {
+    return `Start date must be on or before child item “${span.earliest}” (${span.start.format('MMM D, YYYY')}).`
+  }
+  if (end.isBefore(span.end, 'day')) {
+    return `End date must be on or after child item “${span.latest}” (${span.end.format('MMM D, YYYY')}).`
+  }
+  return null
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmap-timeline-v2.tsx
@@ -47,6 +47,15 @@ enum RoadmapItemType {
 }
 
 const ms = (d: unknown) => dayjs(d as string).valueOf()
+const formatTooltipDate = (d: unknown) =>
+  dayjs(d as string).format('MMM D, YYYY')
+const formatRangeTooltip = (
+  name: string | undefined,
+  start: unknown,
+  end: unknown,
+) => `${name ?? ''}\n${formatTooltipDate(start)} - ${formatTooltipDate(end)}`
+const formatDateTooltip = (name: string | undefined, date: unknown) =>
+  `${name ?? ''}\n${formatTooltipDate(date)}`
 
 interface RoadmapPayload {
   dto: RoadmapItemListDto
@@ -116,6 +125,7 @@ function mapRoadmap(
             id,
             kind: 'range',
             label: a.name,
+            tooltip: formatRangeTooltip(a.name, a.start, a.end),
             // Activities with no color of their own fall back to the roadmap's
             // configured default color (display-time only; nothing is stored).
             color: a.color ?? defaultActivityColor,
@@ -135,6 +145,7 @@ function mapRoadmap(
             id,
             kind: 'milestone',
             label: m.name,
+            tooltip: formatDateTooltip(m.name, m.date),
             color: m.color,
             start: ms(m.date),
             end: ms(m.date),
@@ -151,6 +162,7 @@ function mapRoadmap(
             id,
             kind: 'background',
             label: t.name,
+            tooltip: formatRangeTooltip(t.name, t.start, t.end),
             color: t.color,
             start: ms(t.start),
             end: ms(t.end),
@@ -186,8 +198,9 @@ const RoadmapTimelineV2: FC<RoadmapTimelineV2Props> = (props) => {
   const [updateRoadmapItemDates] = useUpdateRoadmapItemDatesMutation()
   const [updatingId, setUpdatingId] = useState<string | null>(null)
 
-  const defaultActivityColor = props.roadmap.colors.find((c) => c.isDefault)
-    ?.color
+  const defaultActivityColor = props.roadmap.colors.find(
+    (c) => c.isDefault,
+  )?.color
 
   const { items, groups } = mapRoadmap(
     props.roadmapItems,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-card-view.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-card-view.test.tsx
@@ -49,10 +49,12 @@ jest.mock('../projects/_components', () => ({
 function createProject(
   overrides: Partial<ProjectListDto> & { key: string; name: string },
 ): ProjectListDto {
+  const { key, name, ...rest } = overrides
+
   return {
-    id: overrides.key,
-    key: overrides.key,
-    name: overrides.name,
+    id: key,
+    key,
+    name,
     status: { id: 1, name: 'Active' } as any,
     portfolio: { id: 'portfolio-1', key: 1, name: 'Portfolio' } as any,
     projectSponsors: [],
@@ -63,7 +65,7 @@ function createProject(
     phases: [],
     rank: 0,
     canManageProject: true,
-    ...overrides,
+    ...rest,
   } as ProjectListDto
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.test.ts
@@ -56,13 +56,25 @@ describe('itemBox', () => {
     expect(box.height).toBe(32)
   })
 
-  it('enforces a minimum width for zero-duration ranges', () => {
-    // Arrange — start === end.
-    const item: TimelineItem = { id: 'a', kind: 'range', start: day(3), end: day(3) }
+  it('floors a one-day range to a square when the day is narrower than the bar height', () => {
+    // Arrange — a single-day range at a zoomed-OUT scale where one day < bar height.
+    // 2px/day scale: one day = 2px, well under the 32px bar height.
+    const zoomedOut = createTimeScale(day(0), day(500), 1000)
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(3), end: day(4) }
+    // Act
+    const box = itemBox(item, 0, row(0), zoomedOut, config)
+    // Assert — floored to a square of the bar height (32) so it's an easy target.
+    expect(box.width).toBe(box.height)
+    expect(box.width).toBe(32)
+  })
+
+  it('keeps a one-day range at its natural width when the day is wider than the square', () => {
+    // Arrange — at 100px/day, one day (100px) already exceeds the 32px square floor.
+    const item: TimelineItem = { id: 'a', kind: 'range', start: day(3), end: day(4) }
     // Act
     const box = itemBox(item, 0, row(0), scale, config)
-    // Assert
-    expect(box.width).toBeGreaterThanOrEqual(4)
+    // Assert — natural width wins.
+    expect(box.width).toBeCloseTo(100)
   })
 
   it('clamps a range that extends past the domain end to the right edge', () => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/geometry.ts
@@ -19,6 +19,8 @@ export interface ItemBox extends Box {
 
 /** Minimum rendered width so zero/short-duration ranges stay clickable. */
 const MIN_RANGE_WIDTH = 4
+/** Milliseconds in a day — a range shorter than this is a single-day item. */
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
 /** Milestone diamonds are square; sized to the lane height at render time. */
 
 export interface GeometryConfig {
@@ -65,9 +67,14 @@ export function itemBox(
   // Does the (unclamped) item overlap the visible domain at all? A point item
   // (start === end) counts as intersecting when it sits within [0, width].
   const intersects = rawX2 >= 0 && rawX1 <= scale.width
+  // A one-day (or shorter) range is too narrow to be a useful bar, so render it
+  // as a small square (its height) — an easy click target, with the label drawn
+  // beside it. Longer ranges keep the slim min-width floor.
+  const isOneDay = item.end - item.start <= ONE_DAY_MS
+  const minWidth = isOneDay ? height : MIN_RANGE_WIDTH
   // Outside the domain → zero width (nothing to show). Inside → keep the
   // min-width floor so short/zero-duration ranges remain visible/clickable.
-  const width = intersects ? Math.max(MIN_RANGE_WIDTH, x2 - x1) : 0
+  const width = intersects ? Math.max(minWidth, x2 - x1) : 0
   return { item, left: x1, top, width, height }
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/labels.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/labels.test.ts
@@ -1,0 +1,19 @@
+import { truncateOneDayLabel } from './labels'
+
+describe('truncateOneDayLabel', () => {
+  it('keeps labels at or below the limit unchanged', () => {
+    // Arrange / Act / Assert
+    expect(truncateOneDayLabel('Exactly twenty chars')).toBe(
+      'Exactly twenty chars',
+    )
+  })
+
+  it('truncates long labels near 20 characters at a word boundary', () => {
+    // Arrange / Act
+    const label = truncateOneDayLabel('This one-day item name is too long')
+
+    // Assert
+    expect(label).toBe('This one-day item…')
+    expect(label.length).toBeLessThanOrEqual(20)
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/labels.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/labels.ts
@@ -1,0 +1,15 @@
+export const ONE_DAY_LABEL_MAX_CHARS = 20
+const ELLIPSIS = '…'
+
+export function truncateOneDayLabel(label: string): string {
+  if (label.length <= ONE_DAY_LABEL_MAX_CHARS) {
+    return label
+  }
+
+  const prefix = label.slice(0, ONE_DAY_LABEL_MAX_CHARS - ELLIPSIS.length)
+  const lastSpace = prefix.lastIndexOf(' ')
+  const trimmedPrefix =
+    lastSpace > 0 ? prefix.slice(0, lastSpace).trimEnd() : prefix.trimEnd()
+
+  return `${trimmedPrefix}${ELLIPSIS}`
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.test.ts
@@ -124,6 +124,19 @@ describe('packLanes', () => {
     expect(result.lanes.get('m')).toBe(0)
   })
 
+  it('uses custom collision ends when provided', () => {
+    // Arrange — item a's visible label extends to day 4, so b cannot share lane 0.
+    const items = [range('a', 0, 1), range('b', 2, 3)]
+    // Act
+    const result = packLanes(items, {
+      getCollisionEnd: (item) => (item.id === 'a' ? day(4) : item.end),
+    })
+    // Assert
+    expect(result.laneCount).toBe(2)
+    expect(result.lanes.get('a')).toBe(0)
+    expect(result.lanes.get('b')).toBe(1)
+  })
+
   it('excludes background items from packing', () => {
     // Arrange
     const items: TimelineItem[] = [

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/packing.ts
@@ -5,6 +5,11 @@
 
 import type { PackResult, TimelineItem } from './types'
 
+export interface PackOptions {
+  /** Optional effective exclusive end for collision detection. */
+  getCollisionEnd?: (item: TimelineItem) => number
+}
+
 /**
  * Greedy interval-scheduling lane assignment.
  *
@@ -19,7 +24,10 @@ import type { PackResult, TimelineItem } from './types'
  *
  * Background items are excluded — they are not lane-packed (they render behind).
  */
-export function packLanes(items: TimelineItem[]): PackResult {
+export function packLanes(
+  items: TimelineItem[],
+  options: PackOptions = {},
+): PackResult {
   const packable = items.filter((i) => i.kind !== 'background')
 
   const sorted = [...packable].sort((a, b) => {
@@ -36,7 +44,11 @@ export function packLanes(items: TimelineItem[]): PackResult {
 
   for (const item of sorted) {
     // Milestones occupy an instant; treat end as start so they pack tightly.
-    const itemEnd = item.kind === 'milestone' ? item.start : item.end
+    const defaultEnd = item.kind === 'milestone' ? item.start : item.end
+    const itemEnd = Math.max(
+      defaultEnd,
+      options.getCollisionEnd?.(item) ?? defaultEnd,
+    )
 
     let placed = -1
     for (let lane = 0; lane < laneEnds.length; lane += 1) {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/core/types.ts
@@ -23,6 +23,8 @@ export interface TimelineItem<T = unknown> {
   end: number
   /** Display label shown on the bar (first-class; default renderer uses it). */
   label?: string
+  /** Optional full tooltip/title text. Falls back to label when omitted. */
+  tooltip?: string
   /** Bar background color (any CSS color). Text contrast is auto-derived. */
   color?: string
   /** Group this item belongs to; undefined = ungrouped. */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/layout-strategy.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/layout-strategy.ts
@@ -33,6 +33,8 @@ export interface LayoutInput<TItem = unknown, TGroup = unknown> {
    * reserves top headroom for their labels above the bars.
    */
   hasChartBackground?: boolean
+  /** Optional effective exclusive end used only for lane collision detection. */
+  getCollisionEnd?: (item: TimelineItem<TItem>) => number
   config?: Partial<LayoutConfig>
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.test.ts
@@ -12,9 +12,18 @@ const range = (
   startDay: number,
   endDay: number,
   extra: Partial<TimelineItem> = {},
-): TimelineItem => ({ id, kind: 'range', start: day(startDay), end: day(endDay), ...extra })
+): TimelineItem => ({
+  id,
+  kind: 'range',
+  start: day(startDay),
+  end: day(endDay),
+  ...extra,
+})
 
-const group = (id: string, extra: Partial<TimelineGroup> = {}): TimelineGroup => ({
+const group = (
+  id: string,
+  extra: Partial<TimelineGroup> = {},
+): TimelineGroup => ({
   id,
   ...extra,
 })
@@ -96,7 +105,10 @@ describe('timelineLayout', () => {
   it('collapses children onto the parent lane (collapse-to-lane)', () => {
     // Arrange — g1 collapsed; its child g1a's items fold up into g1's row.
     // Parent item p (0-2) and child item c (3-5) don't overlap => 1 lane.
-    const groups = [group('g1', { collapsed: true }), group('g1a', { parentId: 'g1' })]
+    const groups = [
+      group('g1', { collapsed: true }),
+      group('g1a', { parentId: 'g1' }),
+    ]
     const items = [
       range('p', 0, 2, { groupId: 'g1' }),
       range('c', 3, 5, { groupId: 'g1a' }),
@@ -113,7 +125,10 @@ describe('timelineLayout', () => {
 
   it('packs collapsed descendants into multiple lanes when they overlap', () => {
     // Arrange — collapsed parent; parent + child items overlap => 2 lanes.
-    const groups = [group('g1', { collapsed: true }), group('g1a', { parentId: 'g1' })]
+    const groups = [
+      group('g1', { collapsed: true }),
+      group('g1a', { parentId: 'g1' }),
+    ]
     const items = [
       range('p', 0, 5, { groupId: 'g1' }),
       range('c', 2, 7, { groupId: 'g1a' }),
@@ -141,7 +156,11 @@ describe('timelineLayout', () => {
     const out = timelineLayout({ items, groups })
     // Assert
     expect(out.rows).toHaveLength(1)
-    expect(out.rows[0].items.map((i) => i.item.id).sort()).toEqual(['c', 'gc', 'p'])
+    expect(out.rows[0].items.map((i) => i.item.id).sort()).toEqual([
+      'c',
+      'gc',
+      'p',
+    ])
   })
 
   it('assigns each placed item a lane index', () => {
@@ -155,5 +174,19 @@ describe('timelineLayout', () => {
       .sort((x, y) => (x.item.id < y.item.id ? -1 : 1))
       .map((i) => i.lane)
     expect(lanes).toEqual([0, 1])
+  })
+
+  it('packs items using effective collision ends for outside labels', () => {
+    // Arrange — a ends at day 1, but its outside label reserves space to day 4.
+    const items = [range('a', 0, 1), range('b', 2, 3)]
+    // Act
+    const out = timelineLayout({
+      items,
+      getCollisionEnd: (item) => (item.id === 'a' ? day(4) : item.end),
+    })
+    // Assert
+    expect(out.rows[0].laneCount).toBe(2)
+    expect(out.rows[0].items.find((i) => i.item.id === 'a')?.lane).toBe(0)
+    expect(out.rows[0].items.find((i) => i.item.id === 'b')?.lane).toBe(1)
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/layout/timeline-layout.ts
@@ -32,8 +32,9 @@ function buildRow(
   laneHeight: number,
   rowPadding: number,
   topInset = 0,
+  getCollisionEnd?: (item: TimelineItem) => number,
 ): ResolvedRow {
-  const packed = packLanes(items)
+  const packed = packLanes(items, { getCollisionEnd })
   const placed = items.map((item) => ({
     item,
     lane: packed.lanes.get(item.id) ?? 0,
@@ -69,7 +70,16 @@ export function timelineLayout(input: LayoutInput): LayoutOutput {
     // Chart-wide timeboxes (e.g. level-1 root timeboxes) reserve top headroom
     // for their labels above the bars.
     const inset = input.hasChartBackground ? laneHeight : 0
-    const row = buildRow(items, undefined, 0, 0, laneHeight, rowPadding, inset)
+    const row = buildRow(
+      items,
+      undefined,
+      0,
+      0,
+      laneHeight,
+      rowPadding,
+      inset,
+      input.getCollisionEnd,
+    )
     return { rows: [row], totalHeight: row.height }
   }
 
@@ -107,7 +117,9 @@ export function timelineLayout(input: LayoutInput): LayoutOutput {
     const node = nodes.get(id)
     if (!node) return []
     const own = directItems.get(id) ?? []
-    const fromChildren = node.childIds.flatMap((childId) => subtreeItems(childId))
+    const fromChildren = node.childIds.flatMap((childId) =>
+      subtreeItems(childId),
+    )
     return [...own, ...fromChildren]
   }
 
@@ -132,7 +144,7 @@ export function timelineLayout(input: LayoutInput): LayoutOutput {
     const collapsed = node.group.collapsed === true
 
     // Collapsed => fold the whole subtree onto this row; expanded => direct only.
-    const rowItems = collapsed ? subtreeItems(id) : directItems.get(id) ?? []
+    const rowItems = collapsed ? subtreeItems(id) : (directItems.get(id) ?? [])
     const row = buildRow(
       rowItems,
       id,
@@ -141,6 +153,7 @@ export function timelineLayout(input: LayoutInput): LayoutOutput {
       laneHeight,
       rowPadding,
       insetFor(id),
+      input.getCollisionEnd,
     )
     rows.push(row)
     top += row.height

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.test.tsx
@@ -1,0 +1,182 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import type { TimeScale } from '../core/scale'
+import type { TimelineItem } from '../core/types'
+import { ChartCanvas } from './chart-canvas'
+
+const DAY = 24 * 60 * 60 * 1000
+const scale: TimeScale = {
+  width: 500,
+  pxPerMs: 500 / (10 * DAY),
+  domain: [0, 10 * DAY],
+  toX: (ms) => (ms / (10 * DAY)) * 500,
+  toMs: (x) => (x / 500) * 10 * DAY,
+  ticks: () => [],
+  tiers: () => ({ upper: [], lower: [] }),
+  weekends: () => [],
+}
+
+const rect = (
+  left: number,
+  top: number,
+  width: number,
+  height: number,
+): DOMRect => ({
+  x: left,
+  y: top,
+  left,
+  top,
+  width,
+  height,
+  right: left + width,
+  bottom: top + height,
+  toJSON: () => ({}),
+})
+
+const pointerMove = (
+  element: Element,
+  { clientX, clientY }: { clientX: number; clientY: number },
+) => {
+  const event = new Event('pointermove', { bubbles: true })
+  Object.defineProperties(event, {
+    clientX: { value: clientX },
+    clientY: { value: clientY },
+  })
+  fireEvent(element, event)
+}
+
+describe('ChartCanvas', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.runOnlyPendingTimers()
+    jest.useRealTimers()
+  })
+
+  it('renders custom background tooltips on hover', () => {
+    // Arrange
+    const tooltip = 'Planning Timebox\nJan 1, 2026 - Jan 5, 2026'
+    const background: TimelineItem = {
+      id: 'timebox-1',
+      kind: 'background',
+      start: 0,
+      end: 4 * DAY,
+      label: 'Planning Timebox',
+      tooltip,
+    }
+
+    // Act
+    const { container } = render(
+      <ChartCanvas
+        rows={[]}
+        totalHeight={120}
+        scale={scale}
+        geometry={{ laneHeight: 32, lanePadding: 3, rowPadding: 6 }}
+        chartBackgrounds={[background]}
+      />,
+    )
+    const canvas = container.firstElementChild as HTMLElement
+    canvas.getBoundingClientRect = jest.fn(() => rect(0, 0, 500, 120))
+    container.getBoundingClientRect = jest.fn(() => rect(0, 0, 500, 120))
+
+    // Assert
+    const label = screen.getByText('Planning Timebox')
+    expect(label).not.toHaveAttribute('title')
+    expect(label.parentElement).toHaveAttribute('data-tooltip', tooltip)
+    expect(label.parentElement).not.toHaveAttribute('title')
+
+    pointerMove(label, { clientX: 80, clientY: 90 })
+
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
+    expect(screen.getByRole('tooltip')).toHaveTextContent('Planning Timebox')
+    expect(screen.getByRole('tooltip')).toHaveTextContent(
+      'Jan 1, 2026 - Jan 5, 2026',
+    )
+  })
+
+  it('positions tooltips from the pointer instead of the hovered item center', () => {
+    // Arrange
+    const tooltip = 'Long Timebox\nOct 1, 2024 - Dec 15, 2024'
+    const background: TimelineItem = {
+      id: 'timebox-1',
+      kind: 'background',
+      start: 0,
+      end: 10 * DAY,
+      label: 'Long Timebox',
+      tooltip,
+    }
+
+    const { container } = render(
+      <ChartCanvas
+        rows={[]}
+        totalHeight={160}
+        scale={scale}
+        geometry={{ laneHeight: 32, lanePadding: 3, rowPadding: 6 }}
+        chartBackgrounds={[background]}
+      />,
+    )
+    const canvas = container.firstElementChild as HTMLElement
+    canvas.getBoundingClientRect = jest.fn(() => rect(0, 0, 500, 160))
+    container.getBoundingClientRect = jest.fn(() => rect(0, 0, 500, 160))
+
+    // Act
+    pointerMove(screen.getByText('Long Timebox'), {
+      clientX: 80,
+      clientY: 90,
+    })
+
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
+    // Assert
+    expect(screen.getByRole('tooltip')).toHaveStyle({
+      left: '92px',
+      top: '30px',
+    })
+  })
+
+  it('cancels the pending tooltip when the pointer leaves before the delay', () => {
+    // Arrange
+    const background: TimelineItem = {
+      id: 'timebox-1',
+      kind: 'background',
+      start: 0,
+      end: 4 * DAY,
+      label: 'Planning Timebox',
+      tooltip: 'Planning Timebox\nJan 1, 2026 - Jan 5, 2026',
+    }
+
+    const { container } = render(
+      <ChartCanvas
+        rows={[]}
+        totalHeight={120}
+        scale={scale}
+        geometry={{ laneHeight: 32, lanePadding: 3, rowPadding: 6 }}
+        chartBackgrounds={[background]}
+      />,
+    )
+    const canvas = container.firstElementChild as HTMLElement
+    canvas.getBoundingClientRect = jest.fn(() => rect(0, 0, 500, 120))
+    container.getBoundingClientRect = jest.fn(() => rect(0, 0, 500, 120))
+
+    // Act
+    pointerMove(screen.getByText('Planning Timebox'), {
+      clientX: 80,
+      clientY: 90,
+    })
+    fireEvent.pointerLeave(canvas)
+    act(() => {
+      jest.advanceTimersByTime(500)
+    })
+
+    // Assert
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
@@ -6,7 +6,14 @@
 // interaction (move/resize via useBarDrag; progress via a pointer handler),
 // applying the live draft to the dragged bar and committing on release.
 
-import { FC, useCallback, useRef, useState } from 'react'
+import {
+  FC,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react'
 import type { TimeScale } from '../core/scale'
 import type { ResolvedRow, TimelineItem } from '../core/types'
 import { itemBox, backgroundBox, type GeometryConfig } from '../core/geometry'
@@ -20,6 +27,23 @@ import type {
   ItemProgressChange,
 } from '../types'
 import styles from './timeline.module.css'
+
+const TOOLTIP_OFFSET = 12
+const TOOLTIP_VIEWPORT_MARGIN = 8
+const TOOLTIP_SHOW_DELAY_MS = 500
+const FALLBACK_TOOLTIP_WIDTH = 240
+const FALLBACK_TOOLTIP_HEIGHT = 48
+
+type CanvasTooltip = {
+  text: string
+  left: number
+  top: number
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  if (max < min) return min
+  return Math.min(Math.max(value, min), max)
+}
 
 export interface ChartCanvasProps {
   /** Visible (virtualized) rows to render. */
@@ -113,10 +137,17 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
   // listeners are stored on the session ref so they can reference each other
   // for teardown without a declaration cycle.
   const canvasRef = useRef<HTMLDivElement>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const tooltipTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
+    null,
+  )
+  const pendingTooltipRef = useRef<CanvasTooltip | null>(null)
+  const pendingTooltipTargetRef = useRef<HTMLElement | null>(null)
   const [progressDraft, setProgressDraft] = useState<{
     id: string
     progress: number
   } | null>(null)
+  const [tooltip, setTooltip] = useState<CanvasTooltip | null>(null)
   const progressSession = useRef<{
     item: TimelineItem
     box: { left: number; width: number }
@@ -133,7 +164,10 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
         if (!canvas || !s) return
         s.moved = true
         const x = e.clientX - canvas.getBoundingClientRect().left
-        setProgressDraft({ id: item.id, progress: progressFromX(x, box.left, box.width) })
+        setProgressDraft({
+          id: item.id,
+          progress: progressFromX(x, box.left, box.width),
+        })
       }
       const up = () => {
         const s = progressSession.current
@@ -158,11 +192,122 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
     [onItemProgressChange],
   )
 
+  const clearTooltipTimer = useCallback(() => {
+    if (tooltipTimerRef.current === null) return
+    window.clearTimeout(tooltipTimerRef.current)
+    tooltipTimerRef.current = null
+  }, [])
+
+  const hideTooltip = useCallback(() => {
+    clearTooltipTimer()
+    pendingTooltipRef.current = null
+    pendingTooltipTargetRef.current = null
+    setTooltip(null)
+  }, [clearTooltipTimer])
+
+  useEffect(
+    () => () => {
+      clearTooltipTimer()
+    },
+    [clearTooltipTimer],
+  )
+
+  const handleTooltipPointerMove = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      if (active || progressDraft) {
+        hideTooltip()
+        return
+      }
+
+      const target = (e.target as HTMLElement | null)?.closest<HTMLElement>(
+        '[data-tooltip]',
+      )
+      const text = target?.dataset.tooltip
+      const canvas = canvasRef.current
+
+      if (!target || !text || !canvas) {
+        hideTooltip()
+        return
+      }
+
+      const viewport = canvas.parentElement
+      const canvasRect = canvas.getBoundingClientRect()
+      const viewportRect = viewport?.getBoundingClientRect() ?? canvasRect
+      const tooltipWidth =
+        tooltipRef.current?.offsetWidth || FALLBACK_TOOLTIP_WIDTH
+      const tooltipHeight =
+        tooltipRef.current?.offsetHeight || FALLBACK_TOOLTIP_HEIGHT
+
+      const viewportLeft = viewportRect.left - canvasRect.left
+      const viewportRight = viewportRect.right - canvasRect.left
+      const viewportTop = viewportRect.top - canvasRect.top
+      const viewportBottom = viewportRect.bottom - canvasRect.top
+      const eventClientX = Number.isFinite(e.clientX)
+        ? e.clientX
+        : canvasRect.left
+      const eventClientY = Number.isFinite(e.clientY)
+        ? e.clientY
+        : canvasRect.top
+      const cursorX = eventClientX - canvasRect.left
+      const cursorY = eventClientY - canvasRect.top
+
+      let left = cursorX + TOOLTIP_OFFSET
+      if (left + tooltipWidth > viewportRight - TOOLTIP_VIEWPORT_MARGIN) {
+        left = cursorX - tooltipWidth - TOOLTIP_OFFSET
+      }
+
+      let top = cursorY - tooltipHeight - TOOLTIP_OFFSET
+      if (top < viewportTop + TOOLTIP_VIEWPORT_MARGIN) {
+        top = cursorY + TOOLTIP_OFFSET
+      }
+
+      const nextTooltip = {
+        text,
+        left: clamp(
+          left,
+          viewportLeft + TOOLTIP_VIEWPORT_MARGIN,
+          viewportRight - tooltipWidth - TOOLTIP_VIEWPORT_MARGIN,
+        ),
+        top: clamp(
+          top,
+          viewportTop + TOOLTIP_VIEWPORT_MARGIN,
+          viewportBottom - tooltipHeight - TOOLTIP_VIEWPORT_MARGIN,
+        ),
+      }
+
+      pendingTooltipRef.current = nextTooltip
+
+      if (tooltip) {
+        setTooltip(nextTooltip)
+        pendingTooltipTargetRef.current = target
+        return
+      }
+
+      if (
+        tooltipTimerRef.current !== null &&
+        pendingTooltipTargetRef.current === target
+      ) {
+        return
+      }
+
+      clearTooltipTimer()
+      pendingTooltipTargetRef.current = target
+      tooltipTimerRef.current = window.setTimeout(() => {
+        tooltipTimerRef.current = null
+        setTooltip(pendingTooltipRef.current)
+      }, TOOLTIP_SHOW_DELAY_MS)
+    },
+    [active, clearTooltipTimer, hideTooltip, progressDraft, tooltip],
+  )
+
   return (
     <div
       ref={canvasRef}
       className={`${styles.canvas} ${canPan ? styles.canvasPannable : ''}`}
       style={{ width: scale.width, height: totalHeight }}
+      onPointerMove={handleTooltipPointerMove}
+      onPointerLeave={hideTooltip}
+      onPointerDown={hideTooltip}
     >
       {/* Weekend shading — behind gridlines and rows */}
       {weekendBoxes.map((box, i) => (
@@ -174,9 +319,14 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
       ))}
 
       {/* Vertical gridlines */}
-      {showGridlines && tickLines.map((ms) => (
-        <div key={`gl-${ms}`} className={styles.gridline} style={{ left: scale.toX(ms) }} />
-      ))}
+      {showGridlines &&
+        tickLines.map((ms) => (
+          <div
+            key={`gl-${ms}`}
+            className={styles.gridline}
+            style={{ left: scale.toX(ms) }}
+          />
+        ))}
 
       {/* Row stripes — alternation keyed off the ABSOLUTE row index so it stays
           stable as rows scroll in/out of the virtualized window. */}
@@ -198,6 +348,7 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
       {chartBackgrounds?.map((bg) => {
         const row = bg.groupId ? rowsByGroupId.get(bg.groupId) : undefined
         const box = backgroundBox(bg, row ?? null, scale, totalHeight)
+        const tooltip = bg.tooltip ?? bg.label
         return (
           <div
             key={`bg-${bg.id}`}
@@ -209,9 +360,12 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
               height: box.height,
               ...(bg.color ? { backgroundColor: bg.color } : {}),
             }}
-            title={bg.label}
+            data-tooltip={tooltip}
+            aria-label={tooltip}
           >
-            {bg.label && <span className={styles.backgroundLabel}>{bg.label}</span>}
+            {bg.label && (
+              <span className={styles.backgroundLabel}>{bg.label}</span>
+            )}
           </div>
         )
       })}
@@ -231,7 +385,10 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
           const box = itemBox(withProgress, lane, row, scale, geometry)
           // Push the label right so it stays visible when the bar starts before
           // the viewport's left edge (clamped so it never leaves the bar).
-          const labelOffset = Math.max(0, Math.min(viewportLeft - box.left, box.width))
+          const labelOffset = Math.max(
+            0,
+            Math.min(viewportLeft - box.left, box.width),
+          )
           return (
             <ItemBar
               key={item.id}
@@ -245,7 +402,10 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
               onProgressDragStart={(e, dragItem) => {
                 e.preventDefault()
                 e.stopPropagation()
-                beginProgressDrag(dragItem, { left: box.left, width: box.width })
+                beginProgressDrag(dragItem, {
+                  left: box.left,
+                  width: box.width,
+                })
               }}
             />
           )
@@ -256,6 +416,16 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
       {nowVisible && (
         <div className={styles.nowLine} style={{ left: scale.toX(now) }} />
       )}
+
+      <div
+        ref={tooltipRef}
+        role="tooltip"
+        aria-hidden={!tooltip}
+        className={`${styles.tooltip} ${tooltip ? styles.tooltipVisible : ''}`}
+        style={tooltip ? { left: tooltip.left, top: tooltip.top } : undefined}
+      >
+        {tooltip?.text}
+      </div>
     </div>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/chart-canvas.tsx
@@ -138,9 +138,7 @@ export const ChartCanvas: FC<ChartCanvasProps> = ({
   // for teardown without a declaration cycle.
   const canvasRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<HTMLDivElement>(null)
-  const tooltipTimerRef = useRef<ReturnType<typeof window.setTimeout> | null>(
-    null,
-  )
+  const tooltipTimerRef = useRef<number | null>(null)
   const pendingTooltipRef = useRef<CanvasTooltip | null>(null)
   const pendingTooltipTargetRef = useRef<HTMLElement | null>(null)
   const [progressDraft, setProgressDraft] = useState<{

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.test.tsx
@@ -1,0 +1,163 @@
+import { render, screen } from '@testing-library/react'
+import type { ItemBox } from '../core/geometry'
+import type { TimelineItem } from '../core/types'
+import { ItemBar } from './item-bar'
+
+const DAY = 24 * 60 * 60 * 1000
+
+const rangeItem = (overrides: Partial<TimelineItem> = {}): TimelineItem => ({
+  id: 'item-1',
+  kind: 'range',
+  start: 0,
+  end: 5 * DAY,
+  label: 'Feature window',
+  color: '#1677ff',
+  ...overrides,
+})
+
+const boxFor = (
+  item: TimelineItem,
+  overrides: Partial<ItemBox> = {},
+): ItemBox => ({
+  item,
+  left: 40,
+  top: 12,
+  width: 160,
+  height: 32,
+  ...overrides,
+})
+
+describe('ItemBar', () => {
+  it('renders one-day ranges as a fixed circle centered in the day span', () => {
+    // Arrange
+    const item = rangeItem({
+      end: DAY,
+      label: 'Launch day',
+    })
+
+    // Act
+    const { container } = render(
+      <ItemBar box={boxFor(item)} selected={false} />,
+    )
+
+    // Assert
+    const marker = container.querySelector('[data-timeline-item]')
+    expect(marker).toHaveStyle({
+      left: '104px',
+      top: '12px',
+      width: '32px',
+      height: '32px',
+    })
+
+    const label = screen.getByText('Launch day')
+    expect(label).toHaveStyle({
+      left: '140px',
+      top: '12px',
+      height: '32px',
+      lineHeight: '32px',
+    })
+  })
+
+  it('truncates one-day outside labels while preserving the full tooltip', () => {
+    // Arrange
+    const item = rangeItem({
+      end: DAY,
+      label: 'This one-day item name is too long',
+    })
+
+    // Act
+    const { container } = render(
+      <ItemBar box={boxFor(item)} selected={false} />,
+    )
+
+    // Assert
+    expect(screen.getByText('This one-day item…')).toBeInTheDocument()
+    expect(container.querySelector('[data-timeline-item]')).toHaveAttribute(
+      'data-tooltip',
+      'This one-day item name is too long',
+    )
+    expect(screen.getByText('This one-day item…')).toHaveAttribute(
+      'data-tooltip',
+      'This one-day item name is too long',
+    )
+    expect(container.querySelector('[data-timeline-item]')).not.toHaveAttribute(
+      'title',
+    )
+    expect(screen.getByText('This one-day item…')).not.toHaveAttribute('title')
+  })
+
+  it('keeps multi-day ranges at their full timeline width with the label inside', () => {
+    // Arrange
+    const item = rangeItem()
+
+    // Act
+    const { container } = render(
+      <ItemBar box={boxFor(item)} selected={false} />,
+    )
+
+    // Assert
+    const marker = container.querySelector('[data-timeline-item]')
+    expect(marker).toHaveStyle({
+      left: '40px',
+      top: '12px',
+      width: '160px',
+      height: '32px',
+    })
+    expect(screen.getByText('Feature window')).toBe(marker?.firstElementChild)
+  })
+
+  it('uses explicit tooltips for range bars', () => {
+    // Arrange
+    const item = rangeItem({
+      tooltip: 'Feature window\nJan 1, 2026 - Jan 5, 2026',
+    })
+
+    // Act
+    const { container } = render(
+      <ItemBar box={boxFor(item)} selected={false} />,
+    )
+
+    // Assert
+    expect(container.querySelector('[data-timeline-item]')).toHaveAttribute(
+      'data-tooltip',
+      'Feature window\nJan 1, 2026 - Jan 5, 2026',
+    )
+    expect(container.querySelector('[data-timeline-item]')).toHaveAttribute(
+      'aria-label',
+      'Feature window\nJan 1, 2026 - Jan 5, 2026',
+    )
+    expect(container.querySelector('[data-timeline-item]')).not.toHaveAttribute(
+      'title',
+    )
+  })
+
+  it('uses explicit tooltips for milestone markers', () => {
+    // Arrange
+    const item: TimelineItem = {
+      id: 'milestone-1',
+      kind: 'milestone',
+      start: DAY,
+      end: DAY,
+      label: 'Launch',
+      tooltip: 'Launch\nJan 1, 2026',
+    }
+
+    // Act
+    const { container } = render(
+      <ItemBar box={boxFor(item)} selected={false} />,
+    )
+
+    // Assert
+    expect(container.querySelector('[data-timeline-item]')).toHaveAttribute(
+      'data-tooltip',
+      'Launch\nJan 1, 2026',
+    )
+    expect(container.querySelector('[data-timeline-item]')).toHaveAttribute(
+      'aria-label',
+      'Launch\nJan 1, 2026',
+    )
+    expect(container.querySelector('[data-timeline-item]')).not.toHaveAttribute(
+      'title',
+    )
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/item-bar.tsx
@@ -8,8 +8,14 @@ import { FC } from 'react'
 import type { ItemBox } from '../core/geometry'
 import type { DragMode } from '../core/interaction'
 import { contrastText } from '../core/color'
+import { truncateOneDayLabel } from '../core/labels'
 import type { ItemRenderProps, TimelineItem } from '../types'
 import styles from './timeline.module.css'
+
+/** Milliseconds in a day — a range shorter than this is treated as a single-day item. */
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+/** Gap (px) between a one-day bar and its outside label. */
+const ONE_DAY_LABEL_GAP = 4
 
 export interface ItemBarProps {
   box: ItemBox
@@ -41,6 +47,7 @@ export const ItemBar: FC<ItemBarProps> = ({
   onProgressDragStart,
 }) => {
   const { item, left, top, width, height } = box
+  const tooltip = item.tooltip ?? item.label
 
   if (item.kind === 'milestone') {
     // Square rotated 45°; sized to the lane height, centered on its date.
@@ -56,7 +63,8 @@ export const ItemBar: FC<ItemBarProps> = ({
           height,
           ...(item.color ? { backgroundColor: item.color } : {}),
         }}
-        title={item.label}
+        data-tooltip={tooltip}
+        aria-label={tooltip}
         onPointerDown={
           editable && onDragStart
             ? (e) => onDragStart(e, item, 'move')
@@ -67,79 +75,120 @@ export const ItemBar: FC<ItemBarProps> = ({
     )
   }
 
+  // A one-day range is too narrow to fit its title inside the bar, so the label
+  // is rendered just outside it (to the right), in the chart's normal text color
+  // — the standard Gantt treatment for single-day items.
+  const isOneDay = item.end - item.start <= ONE_DAY_MS
+  const visualLeft = isOneDay ? left + Math.max(0, (width - height) / 2) : left
+  const visualWidth = isOneDay ? height : width
   const hasProgress = typeof item.progress === 'number'
-  const progressX = hasProgress ? (width * (item.progress ?? 0)) / 100 : 0
+  const progressX = hasProgress ? (visualWidth * (item.progress ?? 0)) / 100 : 0
   const fontColor = contrastText(item.color)
+  const labelFontSize = Math.max(9, Math.min(Math.floor(height / 1.2), 13))
+  const textLabel = item.label ?? item.id
+  const labelContent = Renderer ? (
+    <Renderer
+      item={item}
+      fontColor={fontColor}
+      backgroundColor={item.color ?? 'var(--ant-color-primary)'}
+      selected={selected}
+    />
+  ) : (
+    textLabel
+  )
+  const oneDayLabelContent = Renderer
+    ? labelContent
+    : truncateOneDayLabel(textLabel)
 
   return (
-    <div
-      data-timeline-item
-      className={`${styles.bar} ${selected ? styles.barSelected : ''} ${
-        editable ? styles.barEditable : ''
-      }`}
-      style={{
-        left,
-        top,
-        width,
-        height,
-        ...(item.color ? { backgroundColor: item.color, color: fontColor } : {}),
-      }}
-      onPointerDown={
-        editable && onDragStart
-          ? (e) => onDragStart(e, item, 'move')
-          : undefined
-      }
-      onClick={() => onClick?.(item)}
-    >
-      {/* Progress fill underlay */}
-      {hasProgress && (
-        <div className={styles.progressFill} style={{ width: progressX }} />
-      )}
-
-      <span
-        className={styles.barLabel}
+    <>
+      <div
+        data-timeline-item
+        className={`${styles.bar} ${isOneDay ? styles.barOneDay : ''} ${
+          selected ? styles.barSelected : ''
+        } ${editable ? styles.barEditable : ''}`}
         style={{
-          ...(labelOffset ? { marginLeft: labelOffset } : undefined),
-          // Scale font to fit the bar height so text never clips vertically.
-          // Use lineHeight 1.2 to give descenders (g, p, y) room.
-          // Cap at 13px (default); floor at 9px for legibility.
-          fontSize: Math.max(9, Math.min(Math.floor(height / 1.2), 13)),
-          lineHeight: 1.2,
+          left: visualLeft,
+          top,
+          width: visualWidth,
+          height,
+          ...(item.color
+            ? { backgroundColor: item.color, color: fontColor }
+            : {}),
         }}
+        data-tooltip={tooltip}
+        aria-label={tooltip}
+        onPointerDown={
+          editable && onDragStart
+            ? (e) => onDragStart(e, item, 'move')
+            : undefined
+        }
+        onClick={() => onClick?.(item)}
       >
-        {Renderer ? (
-          <Renderer
-            item={item}
-            fontColor={fontColor}
-            backgroundColor={item.color ?? 'var(--ant-color-primary)'}
-            selected={selected}
-          />
-        ) : (
-          item.label ?? item.id
+        {/* Progress fill underlay */}
+        {hasProgress && (
+          <div className={styles.progressFill} style={{ width: progressX }} />
         )}
-      </span>
 
-      {editable && onDragStart && (
-        <>
-          {/* Resize handles — circles revealed on hover (CSS). */}
+        {/* One-day bars render their label outside (below); inside otherwise. */}
+        {!isOneDay && (
           <span
-            className={`${styles.handle} ${styles.handleStart}`}
-            onPointerDown={(e) => onDragStart(e, item, 'resize-start')}
-          />
-          <span
-            className={`${styles.handle} ${styles.handleEnd}`}
-            onPointerDown={(e) => onDragStart(e, item, 'resize-end')}
-          />
-        </>
-      )}
+            className={styles.barLabel}
+            style={{
+              ...(labelOffset ? { marginLeft: labelOffset } : undefined),
+              // Scale font to fit the bar height so text never clips vertically.
+              // Use lineHeight 1.2 to give descenders (g, p, y) room.
+              // Cap at 13px (default); floor at 9px for legibility.
+              fontSize: labelFontSize,
+              lineHeight: 1.2,
+            }}
+          >
+            {labelContent}
+          </span>
+        )}
 
-      {editable && hasProgress && onProgressDragStart && (
+        {editable && onDragStart && (
+          <>
+            {/* Resize handles — circles revealed on hover (CSS). */}
+            <span
+              className={`${styles.handle} ${styles.handleStart}`}
+              onPointerDown={(e) => onDragStart(e, item, 'resize-start')}
+            />
+            <span
+              className={`${styles.handle} ${styles.handleEnd}`}
+              onPointerDown={(e) => onDragStart(e, item, 'resize-end')}
+            />
+          </>
+        )}
+
+        {editable && hasProgress && onProgressDragStart && (
+          <span
+            className={styles.progressHandle}
+            style={{ left: progressX }}
+            onPointerDown={(e) => onProgressDragStart(e, item)}
+          />
+        )}
+      </div>
+
+      {/* One-day bar: title sits just to the right of the (tiny) bar so it stays
+          readable, in the chart's normal text color rather than the bar's. */}
+      {isOneDay && (
         <span
-          className={styles.progressHandle}
-          style={{ left: progressX }}
-          onPointerDown={(e) => onProgressDragStart(e, item)}
-        />
+          className={styles.barLabelOutside}
+          style={{
+            left: visualLeft + visualWidth + ONE_DAY_LABEL_GAP,
+            top,
+            height,
+            fontSize: labelFontSize,
+            lineHeight: `${height}px`,
+          }}
+          data-tooltip={tooltip}
+          aria-label={tooltip}
+          onClick={() => onClick?.(item)}
+        >
+          {oneDayLabelContent}
+        </span>
       )}
-    </div>
+    </>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/render/timeline.module.css
@@ -259,7 +259,7 @@
 .background {
   position: absolute;
   z-index: 1;
-  pointer-events: none;
+  pointer-events: auto;
   /* Solid, readable block (matches the legacy timebox look) — not a faint wash. */
   background-color: var(--ant-color-fill-secondary);
   border: 1px solid var(--ant-color-border);
@@ -282,6 +282,7 @@
 .bar {
   position: absolute;
   z-index: 2;
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   border-radius: var(--ant-border-radius);
@@ -294,11 +295,31 @@
   cursor: default;
 }
 
+/* A one-day range: too narrow to be a useful bar, rendered as a circle (an easy
+   click target) with its label beside it. Distinct from the milestone diamond and
+   the multi-day rectangular bar. Reverts to a normal bar automatically when a
+   resize drag extends it past one day (the shape is duration-driven). */
+.barOneDay {
+  border-radius: 50%;
+  padding: 0;
+}
+
 .barLabel {
   position: relative;
   z-index: 1;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Label rendered beside a one-day bar (too narrow to hold text inside). Uses the
+   chart's normal text color and sits outside the bar's clipped box. */
+.barLabelOutside {
+  position: absolute;
+  z-index: 2;
+  white-space: nowrap;
+  color: var(--ant-color-text);
+  pointer-events: auto;
+  cursor: default;
 }
 
 .barSelected {
@@ -378,6 +399,30 @@
   z-index: 2;
   background-color: var(--ant-color-warning);
   transform: translateX(-50%) rotate(45deg);
+}
+
+/* One shared tooltip for timeline bars, milestones, and timeboxes. Kept inside
+   the canvas so virtualization and horizontal scrolling stay simple. */
+.tooltip {
+  position: absolute;
+  z-index: 5;
+  max-width: 280px;
+  padding: var(--ant-padding-xxs) var(--ant-padding-xs);
+  border: 1px solid var(--ant-color-border-secondary);
+  border-radius: var(--ant-border-radius);
+  background-color: var(--ant-color-bg-elevated);
+  color: var(--ant-color-text);
+  box-shadow: var(--ant-box-shadow-secondary);
+  font-size: var(--ant-font-size-sm);
+  line-height: var(--ant-line-height, 1.5);
+  white-space: pre-line;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.tooltipVisible {
+  opacity: 1;
 }
 
 /* ── Empty / loading ───────────────────────────────────────────────────── */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
@@ -13,7 +13,12 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { Spin, Splitter } from 'antd'
 import { captureTimeline } from './render/capture-timeline'
 import { createTimeScale } from './core/scale'
-import { clampZoom, maxZoom, anchoredScrollLeft, initialScrollLeft } from './core/zoom'
+import {
+  clampZoom,
+  maxZoom,
+  anchoredScrollLeft,
+  initialScrollLeft,
+} from './core/zoom'
 import { getLayoutStrategy } from './layout'
 import { ChartCanvas, type ChartCanvasProps } from './render/chart-canvas'
 import { GroupColumn } from './render/group-column'
@@ -22,6 +27,7 @@ import TimelineToolbar from './render/timeline-toolbar'
 import DrillControl from './render/drill-control'
 import { resolveLevel } from './core/depth'
 import { growRowsForLabels, type GeometryConfig } from './core/geometry'
+import { truncateOneDayLabel } from './core/labels'
 import { getVisibleRange } from './core/virtualization'
 import type { TimelineGroup } from './core/types'
 import type { WaydTimeline2Props } from './types'
@@ -37,6 +43,8 @@ const LANE_PADDING = 3
 const ROW_PADDING = 6
 const MIN_PX_PER_DAY = 3
 const DAY_MS = 86_400_000
+const ONE_DAY_LABEL_GAP = 4
+const ONE_DAY_LABEL_EXTRA_PX = 8
 // Minimum visible time span when fully zoomed in (1 day), matching the legacy
 // timeline's `zoomMin`.
 const ZOOM_MIN_MS = DAY_MS
@@ -307,7 +315,12 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   // Latest domain/window geometry — updated in a layout effect each render so
   // the (stable) scroll/reset callbacks always read current props without a
   // stale closure.
-  const windowGeomRef = useRef({ domainStart: 0, domainMs: 1, windowStart: 0, windowMs: 1 })
+  const windowGeomRef = useRef({
+    domainStart: 0,
+    domainMs: 1,
+    windowStart: 0,
+    windowMs: 1,
+  })
 
   // Resolve the drill level: which activities stay groups vs. demote to bars,
   // remapping every item to its nearest surviving group. (timeline variant only;
@@ -384,7 +397,8 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     () => () => {
       observerRef.current?.disconnect()
       wheelCleanupRef.current?.()
-      if (scrollRafRef.current != null) cancelAnimationFrame(scrollRafRef.current)
+      if (scrollRafRef.current != null)
+        cancelAnimationFrame(scrollRafRef.current)
     },
     [],
   )
@@ -412,7 +426,18 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
       if (axisViewportRef.current) axisViewportRef.current.scrollLeft = pending
       setScrollLeft(pending)
     }
-  }, [effectiveZoom, baseWidth, chartWidth, zoomMin, zoomMax, allowZoom, domainStart, domainMs, windowStart, windowMs])
+  }, [
+    effectiveZoom,
+    baseWidth,
+    chartWidth,
+    zoomMin,
+    zoomMax,
+    allowZoom,
+    domainStart,
+    domainMs,
+    windowStart,
+    windowMs,
+  ])
 
   // While in the initial view (no user pan/zoom), lock scroll to windowStart
   // on every render where the viewport is measured. Runs in useLayoutEffect so
@@ -422,7 +447,12 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     const chart = chartRef.current
     if (!chart) return
     if (chart.clientWidth <= 0) return
-    const offset = initialScrollLeft(domainStart, domainMs, windowStart, baseWidth)
+    const offset = initialScrollLeft(
+      domainStart,
+      domainMs,
+      windowStart,
+      baseWidth,
+    )
     // Only apply if the canvas is wide enough to scroll to this offset.
     if (chart.scrollWidth <= offset) return
     chart.scrollLeft = offset
@@ -565,7 +595,8 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     const g = windowGeomRef.current
     const chart = chartRef.current
     const w = chart?.clientWidth ?? viewportWidth
-    const offset = g.windowMs > 0 ? ((g.windowStart - g.domainStart) / g.windowMs) * w : 0
+    const offset =
+      g.windowMs > 0 ? ((g.windowStart - g.domainStart) / g.windowMs) * w : 0
     // Always apply the scroll immediately via DOM refs so panning-only resets
     // work even when zoom is already 1 (setZoom(1) would be a no-op → no
     // layout effect → pendingScrollLeftRef never consumed).
@@ -613,12 +644,40 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
     else hasChartBackground = true
   }
 
+  const scale = createTimeScale(domainStart, domainEnd, chartWidth)
+  const oneDayMarkerSize = effectiveLaneHeight - LANE_PADDING * 2
+  const oneDayLabelFontSize = Math.max(
+    9,
+    Math.min(Math.floor(oneDayMarkerSize / 1.2), 13),
+  )
+  const estimateOneDayLabelWidth = (label: string) =>
+    label.length * oneDayLabelFontSize * 0.58 + ONE_DAY_LABEL_EXTRA_PX
+  const getCollisionEnd = (item: (typeof layoutItems)[number]) => {
+    if (item.kind !== 'range' || item.end - item.start > DAY_MS) {
+      return item.kind === 'milestone' ? item.start : item.end
+    }
+
+    const rawX1 = scale.toX(item.start)
+    const rawX2 = scale.toX(item.end)
+    const spanWidth = Math.max(oneDayMarkerSize, rawX2 - rawX1)
+    const markerLeft = rawX1 + Math.max(0, (spanWidth - oneDayMarkerSize) / 2)
+    const label = truncateOneDayLabel(item.label ?? item.id)
+    const labelRight =
+      markerLeft +
+      oneDayMarkerSize +
+      ONE_DAY_LABEL_GAP +
+      estimateOneDayLabelWidth(label)
+
+    return Math.max(item.end, scale.toMs(labelRight))
+  }
+
   const strategy = getLayoutStrategy(variant)
   const base = strategy({
     items: layoutItems,
     groups: resolved.groups,
     backgroundGroupIds,
     hasChartBackground,
+    getCollisionEnd,
     config: { laneHeight: effectiveLaneHeight, rowPadding: ROW_PADDING },
   })
 
@@ -638,8 +697,11 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
       ? []
       : rows.slice(visibleRange.startIndex, visibleRange.endIndex + 1)
 
-  const scale = createTimeScale(domainStart, domainEnd, chartWidth)
-  const geometry: GeometryConfig = { laneHeight: effectiveLaneHeight, lanePadding: LANE_PADDING, rowPadding: ROW_PADDING }
+  const geometry: GeometryConfig = {
+    laneHeight: effectiveLaneHeight,
+    lanePadding: LANE_PADDING,
+    rowPadding: ROW_PADDING,
+  }
   const groupsById = new Map<string, TimelineGroup>(
     resolved.groups.map((g) => [g.id, g]),
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/timeline2/wayd-timeline2.tsx
@@ -29,7 +29,7 @@ import { resolveLevel } from './core/depth'
 import { growRowsForLabels, type GeometryConfig } from './core/geometry'
 import { truncateOneDayLabel } from './core/labels'
 import { getVisibleRange } from './core/virtualization'
-import type { TimelineGroup } from './core/types'
+import type { TimelineGroup, TimelineItem } from './core/types'
 import type { WaydTimeline2Props } from './types'
 import styles from './render/timeline.module.css'
 
@@ -652,7 +652,7 @@ export function WaydTimeline2<TItem = unknown, TGroup = unknown>(
   )
   const estimateOneDayLabelWidth = (label: string) =>
     label.length * oneDayLabelFontSize * 0.58 + ONE_DAY_LABEL_EXTRA_PX
-  const getCollisionEnd = (item: (typeof layoutItems)[number]) => {
+  const getCollisionEnd = (item: TimelineItem) => {
     if (item.kind !== 'range' || item.end - item.start > DAY_MS) {
       return item.kind === 'milestone' ? item.start : item.end
     }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/tree-grid/tree-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/tree-grid/tree-grid.tsx
@@ -447,7 +447,6 @@ function TreeGridInner<T extends TreeNode>(
     [data, draftTasks.length],
   )
 
-  // eslint-disable-next-line react-hooks/incompatible-library -- TanStack Table does not yet support React Compiler
   const table = useReactTable({
     data: dataWithDrafts,
     columns,
@@ -485,7 +484,6 @@ function TreeGridInner<T extends TreeNode>(
     initialState: { expanded: true },
   })
 
-  // eslint-disable-next-line react-compiler/react-compiler -- table is from useReactTable (incompatible library)
   tableRef.current = table
 
   const displayedRowCount = table.getRowModel().rows.length

--- a/docs/ai/domain-glossary.mdx
+++ b/docs/ai/domain-glossary.mdx
@@ -39,8 +39,8 @@ This glossary defines the key terms and concepts used throughout Wayd. It is des
 | **Risk** | A potential circumstance that could impact delivery. Tracked with Status (Open/Closed), ROAM Category, Impact, Likelihood, Exposure, Assignee, and Follow-Up Date. |
 | **ROAM** | Risk categorization model: Resolved (eliminated), Owned (being managed), Accepted (acknowledged), Mitigated (impact reduced). |
 | **Exposure** | Calculated risk severity from Impact × Likelihood. Low (less than 4), Medium (equals 4), High (greater than 4). Each dimension is Low=1, Medium=2, High=3. |
-| **Roadmap** | A visual timeline for planning work. Has Visibility (Public/Private), Managers (min 1), and hierarchical Items (Activities, Milestones, Timeboxes). Can be copied. Optionally has a **Color palette** — an ordered set of named colors (one optional default) used to color activities and drive the timeline legend. |
-| **Activity** | A roadmap item with a date range that can contain child items (other activities, milestones, timeboxes). Ordered within parent. |
+| **Roadmap** | A visual timeline for planning work. Has Visibility (Public/Private), Managers (min 1), and hierarchical Items (Activities, Milestones, Timeboxes). Date ranges are inclusive, so start and end may be the same day. Can be copied. Optionally has a **Color palette** — an ordered set of named colors (one optional default) used to color activities and drive the timeline legend. |
+| **Activity** | A roadmap item with an inclusive date range that can contain child items (other activities, milestones, timeboxes). Ordered within parent. Parent activities auto-expand to contain child dates; shrinking an activity behind its children is rejected; moving an activity without changing duration shifts the whole subtree. |
 | **Milestone** | A roadmap item representing a single point in time (key date or achievement). |
 | **Timebox** | A roadmap item representing a fixed time period (e.g., a sprint or phase). |
 | **Planning Poker** | Collaborative estimation using estimation scales and real-time voting via SignalR. Behind `planning-poker` feature flag. |

--- a/docs/contributing/specs/ppm-project-date-rollup.md
+++ b/docs/contributing/specs/ppm-project-date-rollup.md
@@ -1,0 +1,203 @@
+# PPM Project Date Rollup
+
+## Problem
+
+Roadmaps now keep parent activity dates aligned with child dates: parents expand to contain children, parents cannot be shrunk behind children, and moving a parent without changing duration shifts the whole subtree. Project planning should behave the same way for project phases and project tasks so the PPM plan tree stays coherent.
+
+The important PPM difference is optional planning dates. Project phases and regular tasks can be undated today, and that should remain valid for leaf items and empty containers. A phase or parent task becomes required to have dates only when any of its children have dates.
+
+## Scope
+
+Apply date rollup to:
+
+- `ProjectPhase.DateRange`
+- `ProjectTask.PlannedDateRange` for `ProjectTaskType.Task`
+- `ProjectTask.PlannedDate` for `ProjectTaskType.Milestone`
+
+Do not change:
+
+- Project-level `Project.DateRange`
+- Strategic initiative, program, or portfolio dates
+- Finish-to-start dependency scheduling rules
+- The existing milestone rule that milestones require a `PlannedDate`
+
+## Domain Rules
+
+### Date Shapes
+
+- Phase dates remain nullable: `ProjectPhase.DateRange` can be `null`.
+- Regular task dates remain nullable: `ProjectTask.PlannedDateRange` can be `null`.
+- Milestone dates stay required: `ProjectTask.PlannedDate` must be present.
+- Ranges are inclusive. A start and end on the same day is valid.
+
+### Rollup Containers
+
+A rollup container is either:
+
+- A project phase containing root tasks.
+- A regular project task containing child tasks.
+
+Milestones cannot be containers because milestones cannot have children.
+
+### Effective Child Span
+
+For rollup purposes:
+
+- A dated regular task contributes `[PlannedDateRange.Start, PlannedDateRange.End]`.
+- A milestone contributes `[PlannedDate, PlannedDate]`.
+- An undated regular task contributes nothing unless it has dated descendants and is therefore rolled up first.
+- A child task whose own dates rolled up from descendants contributes its resulting date range.
+
+### Parent Date Requirement
+
+- If a phase or parent task has no dated children, its dates may remain `null`.
+- If a phase or parent task has at least one dated child, it must have a non-null date range.
+- When a dated child is created, updated, or moved into an undated phase or parent task, that parent receives a date range equal to the dated child span, then ancestors roll up as needed.
+- If multiple children have dates, the parent range must cover the minimum child start through the maximum child end.
+
+### Auto-Expansion
+
+- Creating a dated root task outside its phase date range expands the phase.
+- Creating a dated child task outside its parent task date range expands the parent task and then the owning phase or ancestor tasks as needed.
+- Updating a regular task date range or milestone planned date outside its parent expands ancestors.
+- Moving a dated task or subtree to a new parent expands the new parent and ancestors.
+- Auto-expansion only grows a container to include children; it does not shrink a wider manually entered range.
+
+### Blocking Shrinks
+
+- A phase cannot be updated to `null` or to a range that excludes any dated root task.
+- A parent task cannot be updated to `null` or to a range that excludes any dated direct child.
+- The failure should name the offending child where practical, for example: `The date range must contain all child items. "Design Complete" falls outside the selected range.`
+- Leaf regular tasks can still be updated to `null`.
+
+### Moving Whole Subtrees
+
+When a regular task with children is updated from one non-null range to another range with the same duration and both endpoints move by the same non-zero number of days, treat it as a move:
+
+- Shift that task and every dated descendant by the same day delta.
+- Preserve null dates on undated descendant regular tasks that have no dated descendants.
+- Recalculate ancestors after the shift.
+
+When the range duration changes, treat the update as a resize:
+
+- Do not move children.
+- Reject the update if the proposed range does not contain all dated direct children.
+
+When the task parent changes in the same operation, treat date changes as a resize, not a subtree move.
+
+### Clearing Dates
+
+Allowed:
+
+- Clear dates on a leaf regular task.
+- Clear dates on a phase with no dated root tasks.
+- Clear dates on a parent regular task with no dated children.
+
+Rejected:
+
+- Clear dates on a phase with any dated root task.
+- Clear dates on a parent regular task with any dated child.
+- Clear milestone `PlannedDate`.
+
+When a leaf task is cleared and its parent has no remaining dated children, do not automatically clear the parent. Rollup is grow-only to preserve manually entered dates. Users can clear the parent explicitly when no dated children require it.
+
+## Implementation Notes
+
+### Domain
+
+Add date rollup behavior near the aggregate that owns the hierarchy:
+
+- `Project` should coordinate phase/task lookup and ancestor recalculation because phases and tasks live in the same aggregate.
+- `ProjectTask` should expose small internal helpers for:
+  - effective date span
+  - shifting task/subtree dates
+  - applying planned dates with resize vs move semantics
+  - linking/reconciling parent navigation if needed for in-memory tests
+- `ProjectPhase` should expose an internal date update method that validates child containment through data supplied by `Project`, or a domain method on `Project` should perform the phase update.
+
+Commands that load the aggregate must include enough hierarchy for rollup:
+
+- `CreateProjectTaskCommand` already loads `Project` with `Phases` and `Tasks`.
+- `UpdateProjectTaskPlacementCommand` already loads `Project` with `Phases` and `Tasks`.
+- `UpdateProjectTaskCommand` currently loads the task alone for most updates and loads `Project` only for parent changes. It should load the project with phases and tasks for date-sensitive updates so ancestor rollup happens consistently.
+- `UpdateProjectPhaseCommand` currently loads only the phase. It should load the project with phases and tasks or delegate to a query/update path that has the project aggregate.
+- JSON patch endpoints for phases/tasks should use the same command/domain path as full update forms.
+
+### Migration and Backfill
+
+Add a migration that backfills existing PPM plan data so persisted containers satisfy the new rule:
+
+- For each parent task, compute the recursive dated descendant span bottom-up.
+- Set `PlannedStart` and `PlannedEnd` when the parent task is missing dates but has dated descendants.
+- Expand parent task dates when any dated descendant falls outside the current range.
+- For each phase, compute the span of root tasks after task rollup.
+- Set or expand phase dates when dated root tasks fall outside the current phase range.
+- Preserve wider existing phase/task ranges.
+- Do not add dates to undated leaf regular tasks.
+
+No schema change is expected unless existing database constraints currently prevent same-day ranges.
+
+### Frontend
+
+Update the project plan UI to mirror roadmap hints and validation:
+
+- Full create/edit task forms should show an informational hint when selected child dates fall outside the selected parent phase/task and saving will expand that parent.
+- Full edit phase/task forms and inline grid edits should block shrinking a phase or parent task behind dated children before the API call.
+- Inline phase/task date clearing should be blocked when dated children exist.
+- Same-day ranges should be accepted in forms and inline cells.
+- If a parent task range is moved by the same duration, communicate that descendants will move with it where the interaction makes that clear.
+
+Relevant files:
+
+- `Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/create-project-task-form.tsx`
+- `Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/edit-project-task-form.tsx`
+- `Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/edit-project-phase-form.tsx`
+- `Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-plan-table.tsx`
+- `Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-task-patch.ts`
+
+## Tests
+
+### Domain Tests
+
+Add focused tests for:
+
+- Creating a dated root task expands an undated phase.
+- Creating a dated child task expands an undated parent task and phase.
+- Creating/updating a milestone outside a parent expands ancestors.
+- Updating a child task beyond its parent bubbles up through task ancestors and phase.
+- Updating a phase to exclude a dated root task fails.
+- Updating a parent task to exclude a dated child fails.
+- Clearing a leaf regular task date succeeds.
+- Clearing a phase or parent task with dated children fails.
+- Moving a parent task by the same duration shifts dated descendants.
+- Resizing a parent task keeps children fixed and fails when the range would exclude them.
+- Moving a dated task/subtree to a new phase or parent expands the new container.
+
+### Application Tests
+
+Cover command paths:
+
+- `CreateProjectTaskCommandHandler`
+- `UpdateProjectTaskCommandHandler`
+- `UpdateProjectTaskPlacementCommandHandler`
+- `UpdateProjectPhaseCommandHandler`
+- Phase/task JSON patch endpoints if they bypass the full command handlers.
+
+### Frontend Tests
+
+Cover:
+
+- Same-day date ranges pass validation.
+- Parent expansion hints appear for dated children outside the selected parent.
+- Phase/task inline edits reject clearing or shrinking when dated children exist.
+- Null dates remain allowed for leaf regular tasks.
+
+## Documentation Updates
+
+After implementation, update:
+
+- `docs/user-guide/ppm/projects.mdx`
+- `docs/ai/domain-glossary.mdx`
+- `docs/llms-full.txt`
+
+Document that phase and parent task dates roll up from child dates, while leaf regular task dates remain optional.

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -138,9 +138,10 @@ Potential circumstances that could impact delivery. Properties:
 
 Visual timelines with hierarchical items. Properties:
 - Name, Description, Date Range, Visibility (Public/Private), Managers (min 1)
+- Date ranges are inclusive; start and end may be the same day.
 
 Item types:
-- Activity: Date range, can contain children (other activities, milestones, timeboxes), ordered
+- Activity: Date range, can contain children (other activities, milestones, timeboxes), ordered. Parent activities auto-expand to contain child dates; shrinking an activity behind its children is rejected; moving an activity without changing duration shifts the whole subtree.
 - Milestone: Single date point
 - Timebox: Date range period
 

--- a/docs/user-guide/planning/roadmaps.mdx
+++ b/docs/user-guide/planning/roadmaps.mdx
@@ -42,13 +42,26 @@ graph TD
 - **Milestone** — A point-in-time marker representing a key date or achievement.
 - **Timebox** — A time-bounded period (e.g., a sprint or phase).
 
+Roadmap and item date ranges are inclusive: the end date can be the same as the start date, which creates a single-day range.
+
 All items support an optional **Color** property for visual differentiation. When a roadmap has a [color palette](#roadmap-colors) configured, activities are colored by choosing from those named colors; otherwise any color can be picked freely.
+
+## Activity Date Rollup
+
+Activities automatically stay large enough to contain their child items:
+
+- Creating or moving a child item outside its parent activity expands the parent activity to include it.
+- Updating a child activity, milestone, or timebox outside its parent also expands the parent. The change rolls up through ancestor activities when needed.
+- Editing an activity to shrink it inside any of its children is blocked. The activity date range must contain every direct child item.
+- Moving an activity without changing its duration shifts the whole subtree by the same number of days, preserving the relative dates of descendant activities, milestones, and timeboxes.
+
+When a form detects that a child date falls outside the selected parent activity, it shows an informational hint before saving so managers know the parent will expand.
 
 ## Roadmap Detail Page
 
 The roadmap detail page offers two views:
 
-**Timeline View** (default) — Visual timeline showing activities, milestones, and timeboxes. Managers can drag and drop items to reorder them.
+**Timeline View** (default) — Visual timeline showing activities, milestones, and timeboxes. Managers can drag and drop items to reorder them. Single-day activity and timebox ranges use a compact marker treatment with the label beside the marker.
 
 **List View** — Hierarchical tree grid showing all items with Name, Type, Start Date, End Date, and Status. Supports inline editing for managers and keyboard shortcuts.
 
@@ -115,6 +128,8 @@ The timeline starts with the roadmap's date range filling the viewport. Zoom in 
 | Drag bar | Move the item |
 | Drag left/right handle | Resize start or end date |
 | Esc during drag | Cancel the drag without saving |
+
+Moving a parent activity by dragging its bar keeps the same duration, so all descendant items move with it. Resizing a parent activity changes only the parent's range and must still leave every child item inside that range.
 
 ### Settings Menu
 


### PR DESCRIPTION
## Summary

- Adds roadmap date rollup behavior for parent activities, including automatic parent date expansion/shifting when child dates change.
- Updates roadmap forms, grids, and timeline behavior to support required parent date rules and clearer date guidance.
- Improves timeline rendering for one-day roadmap items:
  - One-day ranges render as fixed circles.
  - Labels render to the right and are truncated after 20 characters.
  - Layout packing accounts for the outside label so other items do not overlap it.
- Adds timeline tooltip support for activities, milestones, and timeboxes with date information.
- Replaces native browser `title` tooltips in the timeline with a custom Wayd-styled tooltip using `data-tooltip`.
- Adds tooltip delay, pointer-based placement, viewport clamping, and cancellation on pointer leave/drag.
- Updates roadmap user docs and AI/domain docs.
- Adds a new PPM project phase/task date rollup spec.

## Testing

- Added/updated roadmap domain tests for parent date behavior.
- Added/updated timeline tests for:
  - One-day item geometry
  - Label truncation
  - Label collision packing
  - Tooltip data attributes
  - Custom tooltip hover behavior
  - Tooltip placement
  - Tooltip delay/cancellation