### PR TITLE
Feature/integrate time provider

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Domain/Identity/PersonalAccessToken.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Identity/PersonalAccessToken.cs
@@ -101,12 +101,12 @@ public sealed class PersonalAccessToken : BaseAuditableEntity
     public string? RevokedBy { get; private set; }
 
     /// <summary>
-    /// Indicates whether this token is currently active (not expired and not revoked).
+    /// Indicates whether this token is active at the specified timestamp.
     /// </summary>
     public bool IsActiveAt(Instant timestamp) => !IsExpiredAt(timestamp) && !IsRevoked;
 
     /// <summary>
-    /// Indicates whether this token has expired.
+    /// Indicates whether this token is expired at the specified timestamp.
     /// </summary>
     public bool IsExpiredAt(Instant timestamp) => ExpiresAt <= timestamp;
 

--- a/Wayd.Common/src/Wayd.Common.Domain/Identity/PersonalAccessToken.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Identity/PersonalAccessToken.cs
@@ -103,12 +103,12 @@ public sealed class PersonalAccessToken : BaseAuditableEntity
     /// <summary>
     /// Indicates whether this token is currently active (not expired and not revoked).
     /// </summary>
-    public bool IsActive => !IsExpired && !IsRevoked;
+    public bool IsActiveAt(Instant timestamp) => !IsExpiredAt(timestamp) && !IsRevoked;
 
     /// <summary>
     /// Indicates whether this token has expired.
     /// </summary>
-    public bool IsExpired => ExpiresAt <= SystemClock.Instance.GetCurrentInstant();
+    public bool IsExpiredAt(Instant timestamp) => ExpiresAt <= timestamp;
 
     /// <summary>
     /// Indicates whether this token has been revoked.

--- a/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Identity/PersonalAccessTokenTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Domain.Tests/Sut/Identity/PersonalAccessTokenTests.cs
@@ -38,8 +38,8 @@ public sealed class PersonalAccessTokenTests
         token.EmployeeId.Should().Be(fakePat.EmployeeId);
         token.ExpiresAt.Should().Be(fakePat.ExpiresAt);
         token.Scopes.Should().Be(fakePat.Scopes);
-        token.IsActive.Should().BeTrue();
-        token.IsExpired.Should().BeFalse();
+        token.IsActiveAt(_now).Should().BeTrue();
+        token.IsExpiredAt(_now).Should().BeFalse();
         token.IsRevoked.Should().BeFalse();
         token.LastUsedAt.Should().BeNull();
         token.RevokedAt.Should().BeNull();
@@ -172,7 +172,7 @@ public sealed class PersonalAccessTokenTests
         token.RevokedAt.Should().Be(revokeTime);
         token.RevokedBy.Should().Be(revokedBy);
         token.IsRevoked.Should().BeTrue();
-        token.IsActive.Should().BeFalse();
+        token.IsActiveAt(revokeTime).Should().BeFalse();
     }
 
     [Fact]
@@ -281,34 +281,29 @@ public sealed class PersonalAccessTokenTests
     }
 
     [Fact]
-    public void IsExpired_ShouldReturnTrue_WhenCurrentTimeIsAfterExpiration()
+    public void IsExpiredAt_ShouldReturnTrue_WhenTimestampIsAfterExpiration()
     {
         // Arrange
         var expiresAt = _now.Plus(Duration.FromDays(1));
         var token = PersonalAccessToken.Create("Test", "hash1234", "hash1234567890", "user1", null, expiresAt, null, _now).Value;
 
         // Act & Assert
-        token.IsExpired.Should().BeFalse(); // Initially not expired
+        token.IsExpiredAt(_now).Should().BeFalse();
 
-        // Fast forward time
         var futureTime = expiresAt.Plus(Duration.FromMinutes(1));
 
-        // The IsExpired property uses SystemClock.Instance.GetCurrentInstant()
-        // In a real scenario, we'd need to mock SystemClock or test at the right time
-        // For now, just verify the logic works with ValidateForUse
-        var validationResult = token.ValidateForUse(futureTime);
-        validationResult.IsFailure.Should().BeTrue();
+        token.IsExpiredAt(futureTime).Should().BeTrue();
     }
 
     [Fact]
-    public void IsActive_ShouldReturnFalse_WhenTokenIsExpiredOrRevoked()
+    public void IsActiveAt_ShouldReturnFalse_WhenTokenIsExpiredOrRevoked()
     {
         // Arrange - Revoked token
         var revokedBy = Guid.NewGuid().ToString();
         var revokedToken = _tokenFaker.WithRevokedToken(revokedBy, _now).Generate();
 
         // Assert
-        revokedToken.IsActive.Should().BeFalse();
+        revokedToken.IsActiveAt(_now).Should().BeFalse();
     }
 
     [Fact]

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Oidc/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Auth/Oidc/ConfigureServices.cs
@@ -13,7 +13,6 @@ internal static class ConfigureServices
     /// </summary>
     internal static IServiceCollection AddOidcProviderRegistry(this IServiceCollection services)
     {
-        services.AddSingleton(TimeProvider.System);
         services.AddSingleton<IOidcProviderRegistry, OidcProviderRegistry>();
         services.AddSingleton<IOidcConfigurationManagerFactory, OidcConfigurationManagerFactory>();
 

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Common/Services/DateTimeProvider.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Common/Services/DateTimeProvider.cs
@@ -2,11 +2,9 @@
 
 namespace Wayd.Infrastructure.Common.Services;
 
-public class DateTimeProvider(IClock clock) : IDateTimeProvider
+public class DateTimeProvider(TimeProvider timeProvider) : IDateTimeProvider
 {
-    private readonly IClock _clock = clock;
+    public Instant Now => Instant.FromDateTimeOffset(timeProvider.GetUtcNow());
 
-    public Instant Now => _clock.GetCurrentInstant();
-
-    public LocalDate Today => _clock.GetCurrentInstant().InUtc().Date;
+    public LocalDate Today => Now.InUtc().Date;
 }

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConfigureServices.cs
@@ -27,8 +27,6 @@ using Wayd.Integrations.Workday;
 using Wayd.Integrations.Workday.Soap;
 using Wayd.Common.Application.Interfaces.ExternalPeople;
 using Wayd.Planning.Application.PokerSessions.Interfaces;
-using NodaTime;
-
 namespace Wayd.Infrastructure;
 
 public static class ConfigureServices
@@ -77,7 +75,7 @@ public static class ConfigureServices
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
         TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);
 
-        services.AddSingleton<IClock>(SystemClock.Instance);
+        services.AddSingleton(TimeProvider.System);
 
         services.AddMemoryCache();
 

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Common/Services/DateTimeProviderTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Common/Services/DateTimeProviderTests.cs
@@ -1,0 +1,39 @@
+using Wayd.Infrastructure.Common.Services;
+
+namespace Wayd.Infrastructure.Tests.Sut.Common.Services;
+
+public sealed class DateTimeProviderTests
+{
+    [Fact]
+    public void Now_ShouldReturnInstantFromInjectedTimeProvider()
+    {
+        // Arrange
+        var now = new DateTimeOffset(2026, 7, 1, 23, 45, 30, TimeSpan.Zero);
+        var sut = new DateTimeProvider(new FixedTimeProvider(now));
+
+        // Act
+        var result = sut.Now;
+
+        // Assert
+        result.Should().Be(Instant.FromUtc(2026, 7, 1, 23, 45, 30));
+    }
+
+    [Fact]
+    public void Today_ShouldReturnUtcDateFromInjectedTimeProvider()
+    {
+        // Arrange
+        var now = new DateTimeOffset(2026, 7, 1, 23, 45, 30, TimeSpan.Zero);
+        var sut = new DateTimeProvider(new FixedTimeProvider(now));
+
+        // Act
+        var result = sut.Today;
+
+        // Assert
+        result.Should().Be(new LocalDate(2026, 7, 1));
+    }
+
+    private sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => utcNow;
+    }
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.Workday/Soap/WorkdayStaffingClient.cs
@@ -20,9 +20,10 @@ namespace Wayd.Integrations.Workday.Soap;
 /// WWS contract is forward+backward compatible for read operations across the supported window.
 /// Field-level changes are absorbed by the response parser (missing element → null).
 /// </remarks>
-public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<WorkdayStaffingClient> logger)
+public sealed class WorkdayStaffingClient(HttpClient httpClient, TimeProvider timeProvider, ILogger<WorkdayStaffingClient> logger)
 {
     private readonly HttpClient _httpClient = httpClient;
+    private readonly TimeProvider _timeProvider = timeProvider;
     private readonly ILogger<WorkdayStaffingClient> _logger = logger;
 
     // Workday's two primary namespaces. The envelope name is suffixed with the WWS version on the
@@ -44,7 +45,7 @@ public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<Workday
         int pageSize,
         CancellationToken cancellationToken)
     {
-        var envelope = BuildGetWorkersEnvelope(context, page, pageSize);
+        var envelope = BuildGetWorkersEnvelope(context, page, pageSize, _timeProvider.GetUtcNow());
         var responseXml = await PostAsync(context, envelope, cancellationToken);
 
         // Find all wd:Worker elements anywhere in the response — Workday nests them under
@@ -58,7 +59,7 @@ public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<Workday
         return new GetWorkersResponse(workers, page, totalPages, totalResults);
     }
 
-    private static XDocument BuildGetWorkersEnvelope(WorkdayRequestContext context, int page, int pageSize)
+    private static XDocument BuildGetWorkersEnvelope(WorkdayRequestContext context, int page, int pageSize, DateTimeOffset now)
     {
         var requestCriteria = new XElement(Wd + "Request_Criteria",
             new XElement(Wd + "Exclude_Inactive_Workers", context.IncludeInactive ? "0" : "1"));
@@ -76,11 +77,10 @@ public sealed class WorkdayStaffingClient(HttpClient httpClient, ILogger<Workday
         //      both are Required!". We pair the watermark with "now" to close the range.
         if (context.IncrementalUpdatedFrom is { } since)
         {
-            var now = DateTime.UtcNow;
             requestCriteria.Add(new XElement(Wd + "Transaction_Log_Criteria_Data",
                 new XElement(Wd + "Transaction_Date_Range_Data",
                     new XElement(Wd + "Updated_From", since.ToDateTimeUtc().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)),
-                    new XElement(Wd + "Updated_Through", now.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)))));
+                    new XElement(Wd + "Updated_Through", now.UtcDateTime.ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture)))));
         }
 
         // Response_Group controls how much Workday serializes per worker — the dominant driver of

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/Infrastructure/FixedTimeProvider.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/Infrastructure/FixedTimeProvider.cs
@@ -1,0 +1,6 @@
+namespace Wayd.Integrations.Workday.Tests.Infrastructure;
+
+internal sealed class FixedTimeProvider(DateTimeOffset utcNow) : TimeProvider
+{
+    public override DateTimeOffset GetUtcNow() => utcNow;
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayConnectionInitializerTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayConnectionInitializerTests.cs
@@ -30,7 +30,7 @@ public class WorkdayConnectionInitializerTests
     {
         var handler = new FakeHttpMessageHandler();
         var httpClient = new HttpClient(handler);
-        var client = new WorkdayStaffingClient(httpClient, NullLogger<WorkdayStaffingClient>.Instance);
+        var client = new WorkdayStaffingClient(httpClient, TimeProvider.System, NullLogger<WorkdayStaffingClient>.Instance);
         var initializer = new WorkdayConnectionInitializer(client, NullLogger<WorkdayConnectionInitializer>.Instance);
         return (initializer, handler);
     }

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayConnectionInitializerTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayConnectionInitializerTests.cs
@@ -10,6 +10,8 @@ namespace Wayd.Integrations.Workday.Tests;
 
 public class WorkdayConnectionInitializerTests
 {
+    private static readonly DateTimeOffset TestNow = new(2026, 7, 1, 15, 30, 45, TimeSpan.Zero);
+
     private static WorkdayRequestContext BuildContext(
         WorkdayWorkerKey key = WorkdayWorkerKey.Wid,
         bool useUserIdAsEmailFallback = false,
@@ -30,7 +32,7 @@ public class WorkdayConnectionInitializerTests
     {
         var handler = new FakeHttpMessageHandler();
         var httpClient = new HttpClient(handler);
-        var client = new WorkdayStaffingClient(httpClient, TimeProvider.System, NullLogger<WorkdayStaffingClient>.Instance);
+        var client = new WorkdayStaffingClient(httpClient, new FixedTimeProvider(TestNow), NullLogger<WorkdayStaffingClient>.Instance);
         var initializer = new WorkdayConnectionInitializer(client, NullLogger<WorkdayConnectionInitializer>.Instance);
         return (initializer, handler);
     }

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayStaffingServiceTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayStaffingServiceTests.cs
@@ -10,20 +10,23 @@ namespace Wayd.Integrations.Workday.Tests;
 
 public class WorkdayStaffingServiceTests
 {
+    private static readonly DateTimeOffset TestNow = new(2026, 7, 1, 15, 30, 45, TimeSpan.Zero);
+
     private static WorkdayRequestContext BuildContext(
         WorkdayWorkerKey key = WorkdayWorkerKey.Wid,
         bool useUserIdAsEmailFallback = false,
         bool usePreferredName = false,
         bool normalizeNameCasing = false,
         string? departmentOrganizationTypeId = null,
-        IReadOnlyList<WorkdayOrgExclusion>? orgExclusions = null) => new(
+        IReadOnlyList<WorkdayOrgExclusion>? orgExclusions = null,
+        NodaTime.Instant? incrementalUpdatedFrom = null) => new(
         SoapEndpoint: "https://wd3-impl-services1.workday.com/ccx/service/acme_corp1/Staffing/v46.1",
         TenantAlias: "acme_corp1",
         WsdlVersion: "v46.1",
         Credentials: new WorkdayCredentials("wayd_isu@acme_corp1", "secret"),
         WorkerKey: key,
         IncludeInactive: false,
-        IncrementalUpdatedFrom: null,
+        IncrementalUpdatedFrom: incrementalUpdatedFrom,
         UseUserIdAsEmailFallback: useUserIdAsEmailFallback,
         UsePreferredName: usePreferredName,
         NormalizeNameCasing: normalizeNameCasing,
@@ -34,7 +37,7 @@ public class WorkdayStaffingServiceTests
     {
         var handler = new FakeHttpMessageHandler();
         var httpClient = new HttpClient(handler);
-        var client = new WorkdayStaffingClient(httpClient, TimeProvider.System, NullLogger<WorkdayStaffingClient>.Instance);
+        var client = new WorkdayStaffingClient(httpClient, new FixedTimeProvider(TestNow), NullLogger<WorkdayStaffingClient>.Instance);
         var service = new WorkdayStaffingService(client, NullLogger<WorkdayStaffingService>.Instance);
         return (service, handler);
     }
@@ -343,6 +346,22 @@ public class WorkdayStaffingServiceTests
         body.Should().Contain("secret");
         body.Should().Contain("Get_Workers_Request");
         sent.RequestUri!.ToString().Should().Be("https://wd3-impl-services1.workday.com/ccx/service/acme_corp1/Staffing/v46.1");
+    }
+
+    [Fact]
+    public async Task GetEmployees_incrementalRequest_usesInjectedClockForUpdatedThrough()
+    {
+        var (service, handler) = BuildService();
+        handler.EnqueueXml(File.ReadAllText("Fixtures/get-workers-healthy-page1.xml"));
+
+        await service.GetEmployees(
+            BuildContext(incrementalUpdatedFrom: NodaTime.Instant.FromUtc(2026, 6, 30, 12, 0)),
+            CancellationToken.None);
+
+        var body = await handler.Captured.Single().Content!.ReadAsStringAsync(TestContext.Current.CancellationToken);
+
+        body.Should().Contain("<wd:Updated_From>2026-06-30T12:00:00Z</wd:Updated_From>");
+        body.Should().Contain("<wd:Updated_Through>2026-07-01T15:30:45Z</wd:Updated_Through>");
     }
 
     [Fact]

--- a/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayStaffingServiceTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.Workday.Tests/WorkdayStaffingServiceTests.cs
@@ -34,7 +34,7 @@ public class WorkdayStaffingServiceTests
     {
         var handler = new FakeHttpMessageHandler();
         var httpClient = new HttpClient(handler);
-        var client = new WorkdayStaffingClient(httpClient, NullLogger<WorkdayStaffingClient>.Instance);
+        var client = new WorkdayStaffingClient(httpClient, TimeProvider.System, NullLogger<WorkdayStaffingClient>.Instance);
         var service = new WorkdayStaffingService(client, NullLogger<WorkdayStaffingService>.Instance);
         return (service, handler);
     }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/CreateWorkdayConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/CreateWorkdayConnectionCommand.cs
@@ -134,6 +134,6 @@ internal sealed class CreateWorkdayConnectionCommandHandler(
             result.Warnings,
             result.AuthError,
             result.DiscoveredOrgTypes?.Select(d => new WorkdayOrgType(d.TypeId, d.DisplayName, d.Count)).ToList(),
-            DateTimeOffset.UtcNow);
+            _dateTimeProvider.Now.ToDateTimeOffset());
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/InitWorkdayConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/InitWorkdayConnectionCommand.cs
@@ -14,10 +14,12 @@ public sealed record InitWorkdayConnectionCommand(Guid Id) : ICommand<Connection
 
 internal sealed class InitWorkdayConnectionCommandHandler(
     IAppIntegrationDbContext appIntegrationDbContext,
+    IDateTimeProvider dateTimeProvider,
     IWorkdayConnectionInitializer initializer,
     ILogger<InitWorkdayConnectionCommandHandler> logger) : ICommandHandler<InitWorkdayConnectionCommand, ConnectionInitResult>
 {
     private readonly IAppIntegrationDbContext _appIntegrationDbContext = appIntegrationDbContext;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
     private readonly IWorkdayConnectionInitializer _initializer = initializer;
     private readonly ILogger<InitWorkdayConnectionCommandHandler> _logger = logger;
 
@@ -53,7 +55,7 @@ internal sealed class InitWorkdayConnectionCommandHandler(
                 result.Warnings,
                 result.AuthError,
                 result.DiscoveredOrgTypes?.Select(d => new WorkdayOrgType(d.TypeId, d.DisplayName, d.Count)).ToList(),
-                DateTimeOffset.UtcNow);
+                _dateTimeProvider.Now.ToDateTimeOffset());
 
             await _appIntegrationDbContext.SaveChangesAsync(cancellationToken);
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/UpdateWorkdayConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/UpdateWorkdayConnectionCommand.cs
@@ -147,6 +147,6 @@ internal sealed class UpdateWorkdayConnectionCommandHandler(
             result.Warnings,
             result.AuthError,
             result.DiscoveredOrgTypes?.Select(d => new WorkdayOrgType(d.TypeId, d.DisplayName, d.Count)).ToList(),
-            DateTimeOffset.UtcNow);
+            _dateTimeProvider.Now.ToDateTimeOffset());
     }
 }

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetFunctionalOrganizationChartQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetFunctionalOrganizationChartQuery.cs
@@ -16,7 +16,7 @@ internal sealed class GetFunctionalOrganizationChartQueryHandler(IOrganizationDb
 
     public async Task<FunctionalOrganizationChartDto> Handle(GetFunctionalOrganizationChartQuery request, CancellationToken cancellationToken)
     {
-        var asOfDate = request.AsOfDate ?? _dateTimeProvider.Now.InUtc().Date;
+        var asOfDate = request.AsOfDate ?? _dateTimeProvider.Today;
 
         _logger.LogInformation("{RequestName}: Retrieving functional organization chart as of {AsOfDate}", RequestName, asOfDate);
 

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamMembershipsQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamMembershipsQuery.cs
@@ -33,7 +33,6 @@ internal sealed class GetTeamMembershipsQueryHandler : IQueryHandler<GetTeamMemb
 
     public async Task<IReadOnlyList<TeamMembershipDto>> Handle(GetTeamMembershipsQuery request, CancellationToken cancellationToken)
     {
-        var today = _dateTimeProvider.Now.InUtc().Date;
         var query = _organizationDbContext.Teams
             .Include(t => t.ParentMemberships)
                 .ThenInclude(m => m.Target)

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamOperatingModelAsOfQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamOperatingModelAsOfQuery.cs
@@ -26,7 +26,7 @@ internal sealed class GetTeamOperatingModelAsOfQueryHandler(IOrganizationDbConte
         if (request.AsOfDate is null)
         {
             // Current model: has started and hasn't ended
-            var today = LocalDate.FromDateTime(_dateTimeProvider.Now.ToDateTimeUtc());
+            var today = _dateTimeProvider.Today;
             query = query.Where(x =>
                 x.Model.DateRange.Start <= today &&
                 (x.Model.DateRange.End == null || x.Model.DateRange.End >= today));

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamOperatingModelsForTeamsQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamOperatingModelsForTeamsQuery.cs
@@ -25,7 +25,7 @@ internal sealed class GetTeamOperatingModelsForTeamsQueryHandler(IOrganizationDb
             return [];
         }
 
-        var asOfDate = request.AsOfDate ?? LocalDate.FromDateTime(_dateTimeProvider.Now.ToDateTimeUtc());
+        var asOfDate = request.AsOfDate ?? _dateTimeProvider.Today;
 
         var query = _organizationDbContext.Teams
             .Where(t => teamIdList.Contains(t.Id))

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamQuery.cs
@@ -50,7 +50,7 @@ internal sealed class GetTeamQueryHandler(
             throw exception;
         }
 
-        var today = _dateTimeProvider.Now.InUtc().Date;
+        var today = _dateTimeProvider.Today;
         var cfg = TeamDetailsDto.CreateTypeAdapterConfig(today);
 
         return await query

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamsQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Teams/Queries/GetTeamsQuery.cs
@@ -34,7 +34,7 @@ internal sealed class GetTeamsQueryHandler(
             query = query.Where(e => request.TeamIds.Contains(e.Id));
 
 
-        var today = _dateTimeProvider.Now.InUtc().Date;
+        var today = _dateTimeProvider.Today;
         var cfg = TeamListDto.CreateTypeAdapterConfig(today);
 
         return await query

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/TeamsOfTeams/Queries/GetTeamMembershipsQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/TeamsOfTeams/Queries/GetTeamMembershipsQuery.cs
@@ -33,7 +33,6 @@ internal sealed class GetTeamMembershipsQueryHandler : IQueryHandler<GetTeamMemb
 
     public async Task<IReadOnlyList<TeamMembershipDto>> Handle(GetTeamMembershipsQuery request, CancellationToken cancellationToken)
     {
-        var today = _dateTimeProvider.Now.InUtc().Date;
         var query = _organizationDbContext.TeamOfTeams
             .Include(t => t.ParentMemberships)
                 .ThenInclude(m => m.Target)

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/TeamsOfTeams/Queries/GetTeamOfTeamsListQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/TeamsOfTeams/Queries/GetTeamOfTeamsListQuery.cs
@@ -35,7 +35,7 @@ internal sealed class GetTeamOfTeamsListQueryHandler(
 
 
 
-        var today = _dateTimeProvider.Now.InUtc().Date;
+        var today = _dateTimeProvider.Today;
         var cfg = TeamOfTeamsListDto.CreateTypeAdapterConfig(today);
 
         return await query

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/TeamsOfTeams/Queries/GetTeamOfTeamsQuery.cs
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/TeamsOfTeams/Queries/GetTeamOfTeamsQuery.cs
@@ -50,7 +50,7 @@ internal sealed class GetTeamOfTeamsQueryHandler(
             throw exception;
         }
 
-        var today = _dateTimeProvider.Now.InUtc().Date;
+        var today = _dateTimeProvider.Today;
         var cfg = TeamOfTeamsDetailsDto.CreateTypeAdapterConfig(today);
 
         return await query

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetPlanningIntervalPredictabilityQuery.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetPlanningIntervalPredictabilityQuery.cs
@@ -44,7 +44,7 @@ internal sealed class GetPlanningIntervalPredictabilityQueryHandler : IQueryHand
         else if (!planningInterval.Teams.Any())
             return new PlanningIntervalPredictabilityDto(null, []);
 
-        var currentDate = _dateTimeProvider.Now.InUtc().Date;
+        var currentDate = _dateTimeProvider.Today;
 
         // Pre-bucket team objectives once. We need per-team counts of
         // regular/stretch/completed objectives — same data the predictability

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetTeamPlanningIntervalPredictabilityQuery.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetTeamPlanningIntervalPredictabilityQuery.cs
@@ -35,7 +35,7 @@ internal sealed class GetTeamPlanningIntervalPredictabilityQueryHandler(IPlannin
         if (planningInterval is null || planningInterval.Teams.Count == 0)
             return null;
 
-        return planningInterval.CalculatePredictability(_dateTimeProvider.Now.InUtc().Date, request.TeamId);
+        return planningInterval.CalculatePredictability(_dateTimeProvider.Today, request.TeamId);
     }
 }
 


### PR DESCRIPTION
- Refactor to use TimeProvider instead of NodaTime IClock
- Refactor token status checks to use timestamp methods
- Inject TimeProvider for consistent time handling
- Replace Now.InUtc().Date with Today for date consistency
- Inject FixedTimeProvider for deterministic test times