### PR TITLE
Feature/migrate to tanstack table part2

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Application/Identity/PersonalAccessTokens/Dtos/PersonalAccessTokenDto.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/PersonalAccessTokens/Dtos/PersonalAccessTokenDto.cs
@@ -1,4 +1,7 @@
-﻿namespace Wayd.Common.Application.Identity.PersonalAccessTokens.Dtos;
+﻿using System.Linq.Expressions;
+using Wayd.Common.Domain.Identity;
+
+namespace Wayd.Common.Application.Identity.PersonalAccessTokens.Dtos;
 
 /// <summary>
 /// DTO for personal access token information.
@@ -15,4 +18,26 @@ public sealed record PersonalAccessTokenDto
     public bool IsExpired { get; init; }
     public bool IsRevoked { get; init; }
     public string? Scopes { get; init; }
+
+    /// <summary>
+    /// EF-translatable projection from a <see cref="PersonalAccessToken"/> to this DTO,
+    /// computing the time-relative status flags against <paramref name="now"/>.
+    /// The status booleans are not stored, and the domain exposes them as
+    /// timestamp methods (<see cref="PersonalAccessToken.IsExpiredAt"/> /
+    /// <see cref="PersonalAccessToken.IsActiveAt"/>) rather than properties, so the
+    /// projection reproduces that logic inline where it can be translated to SQL.
+    /// </summary>
+    public static Expression<Func<PersonalAccessToken, PersonalAccessTokenDto>> Projection(Instant now) =>
+        token => new PersonalAccessTokenDto
+        {
+            Id = token.Id,
+            Name = token.Name,
+            ExpiresAt = token.ExpiresAt,
+            LastUsedAt = token.LastUsedAt,
+            RevokedAt = token.RevokedAt,
+            IsRevoked = token.RevokedAt.HasValue,
+            IsExpired = token.ExpiresAt <= now,
+            IsActive = !(token.ExpiresAt <= now) && !token.RevokedAt.HasValue,
+            Scopes = token.Scopes,
+        };
 }

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/PersonalAccessTokens/Queries/GetMyPersonalAccessTokensQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/PersonalAccessTokens/Queries/GetMyPersonalAccessTokensQuery.cs
@@ -1,5 +1,4 @@
-﻿using Mapster;
-using Wayd.Common.Application.Identity.PersonalAccessTokens.Dtos;
+﻿using Wayd.Common.Application.Identity.PersonalAccessTokens.Dtos;
 using Wayd.Common.Application.Persistence;
 
 namespace Wayd.Common.Application.Identity.PersonalAccessTokens.Queries;
@@ -9,19 +8,21 @@ namespace Wayd.Common.Application.Identity.PersonalAccessTokens.Queries;
 /// </summary>
 public sealed record GetMyPersonalAccessTokensQuery : IQuery<Result<List<PersonalAccessTokenDto>>>;
 
-internal sealed class GetMyPersonalAccessTokensQueryHandler(IWaydDbContext dbContext, ICurrentUser currentUser) : IQueryHandler<GetMyPersonalAccessTokensQuery, Result<List<PersonalAccessTokenDto>>>
+internal sealed class GetMyPersonalAccessTokensQueryHandler(IWaydDbContext dbContext, ICurrentUser currentUser, IDateTimeProvider dateTimeProvider) : IQueryHandler<GetMyPersonalAccessTokensQuery, Result<List<PersonalAccessTokenDto>>>
 {
     private readonly IWaydDbContext _dbContext = dbContext;
     private readonly ICurrentUser _currentUser = currentUser;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
 
     public async Task<Result<List<PersonalAccessTokenDto>>> Handle(GetMyPersonalAccessTokensQuery request, CancellationToken cancellationToken)
     {
         var userId = _currentUser.GetUserId();
+        var now = _dateTimeProvider.Now;
 
         var tokens = await _dbContext.PersonalAccessTokens
             .Where(t => t.UserId == userId)
             .OrderByDescending(t => t.ExpiresAt)
-            .ProjectToType<PersonalAccessTokenDto>()
+            .Select(PersonalAccessTokenDto.Projection(now))
             .ToListAsync(cancellationToken);
 
         return Result.Success(tokens);

--- a/Wayd.Common/src/Wayd.Common.Application/Identity/PersonalAccessTokens/Queries/GetPersonalAccessTokenQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Identity/PersonalAccessTokens/Queries/GetPersonalAccessTokenQuery.cs
@@ -1,5 +1,4 @@
-﻿using Mapster;
-using Wayd.Common.Application.Identity.PersonalAccessTokens.Dtos;
+﻿using Wayd.Common.Application.Identity.PersonalAccessTokens.Dtos;
 using Wayd.Common.Application.Persistence;
 
 namespace Wayd.Common.Application.Identity.PersonalAccessTokens.Queries;
@@ -18,18 +17,20 @@ public sealed class GetPersonalAccessTokenQueryValidator : CustomValidator<GetPe
     }
 }
 
-internal sealed class GetPersonalAccessTokenQueryHandler(IWaydDbContext dbContext, ICurrentUser currentUser) : IQueryHandler<GetPersonalAccessTokenQuery, Result<PersonalAccessTokenDto>>
+internal sealed class GetPersonalAccessTokenQueryHandler(IWaydDbContext dbContext, ICurrentUser currentUser, IDateTimeProvider dateTimeProvider) : IQueryHandler<GetPersonalAccessTokenQuery, Result<PersonalAccessTokenDto>>
 {
     private readonly IWaydDbContext _dbContext = dbContext;
     private readonly ICurrentUser _currentUser = currentUser;
+    private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
 
     public async Task<Result<PersonalAccessTokenDto>> Handle(GetPersonalAccessTokenQuery request, CancellationToken cancellationToken)
     {
         var userId = _currentUser.GetUserId();
+        var now = _dateTimeProvider.Now;
 
         var token = await _dbContext.PersonalAccessTokens
             .Where(t => t.Id == request.TokenId && t.UserId == userId)
-            .ProjectToType<PersonalAccessTokenDto>()
+            .Select(PersonalAccessTokenDto.Projection(now))
             .FirstOrDefaultAsync(cancellationToken);
 
         if (token == null)

--- a/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Identity/PersonalAccessTokens/Queries/GetMyPersonalAccessTokensQueryHandlerTests.cs
+++ b/Wayd.Common/tests/Wayd.Common.Application.Tests/Sut/Identity/PersonalAccessTokens/Queries/GetMyPersonalAccessTokensQueryHandlerTests.cs
@@ -1,0 +1,127 @@
+﻿using FluentAssertions;
+using NodaTime;
+using Wayd.Common.Application.Identity.PersonalAccessTokens.Queries;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Tests.Infrastructure;
+using Wayd.Tests.Shared;
+using Wayd.Tests.Shared.Data;
+
+namespace Wayd.Common.Application.Tests.Sut.Identity.PersonalAccessTokens.Queries;
+
+public class GetMyPersonalAccessTokensQueryHandlerTests
+{
+    private const string UserId = "user-1";
+
+    private static readonly Instant Now =
+        Instant.FromUtc(2026, 7, 2, 12, 0, 0);
+
+    private readonly FakeWaydDbContext _dbContext = new();
+    private readonly TestingDateTimeProvider _dateTimeProvider = new(Now.ToDateTimeUtc());
+    private readonly Mock<ICurrentUser> _currentUser = new();
+
+    public GetMyPersonalAccessTokensQueryHandlerTests()
+    {
+        _currentUser.Setup(x => x.GetUserId()).Returns(UserId);
+    }
+
+    private GetMyPersonalAccessTokensQueryHandler CreateHandler() =>
+        new(_dbContext, _currentUser.Object, _dateTimeProvider);
+
+    private void SeedActiveToken() =>
+        _dbContext.PersonalAccessTokens.Add(
+            new PersonalAccessTokenFaker(Now)
+                .WithUserId(UserId)
+                .WithExpiresAt(Now.Plus(Duration.FromDays(30)))
+                .Generate());
+
+    private void SeedExpiredToken() =>
+        _dbContext.PersonalAccessTokens.Add(
+            new PersonalAccessTokenFaker(Now)
+                .WithUserId(UserId)
+                .WithExpiresAt(Now.Minus(Duration.FromDays(1)))
+                .Generate());
+
+    private void SeedRevokedToken() =>
+        _dbContext.PersonalAccessTokens.Add(
+            new PersonalAccessTokenFaker(Now)
+                .WithUserId(UserId)
+                .WithExpiresAt(Now.Plus(Duration.FromDays(30)))
+                .AsRevoked(revokedAt: Now.Minus(Duration.FromDays(1)))
+                .Generate());
+
+    [Fact]
+    public async Task Handle_ShouldMarkNonExpiredNonRevokedToken_AsActive()
+    {
+        // Arrange
+        SeedActiveToken();
+
+        // Act
+        var result = await CreateHandler().Handle(
+            new GetMyPersonalAccessTokensQuery(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        var token = result.Value.Should().ContainSingle().Subject;
+        token.IsActive.Should().BeTrue();
+        token.IsExpired.Should().BeFalse();
+        token.IsRevoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldMarkTokenPastExpiry_AsExpiredAndNotActive()
+    {
+        // Arrange
+        SeedExpiredToken();
+
+        // Act
+        var result = await CreateHandler().Handle(
+            new GetMyPersonalAccessTokensQuery(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        var token = result.Value.Should().ContainSingle().Subject;
+        token.IsExpired.Should().BeTrue();
+        token.IsActive.Should().BeFalse();
+        token.IsRevoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldMarkRevokedToken_AsRevokedAndNotActive()
+    {
+        // Arrange
+        SeedRevokedToken();
+
+        // Act
+        var result = await CreateHandler().Handle(
+            new GetMyPersonalAccessTokensQuery(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        var token = result.Value.Should().ContainSingle().Subject;
+        token.IsRevoked.Should().BeTrue();
+        token.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_ShouldOnlyReturnTokensForTheCurrentUser()
+    {
+        // Arrange
+        SeedActiveToken();
+        _dbContext.PersonalAccessTokens.Add(
+            new PersonalAccessTokenFaker(Now)
+                .WithUserId("someone-else")
+                .Generate());
+
+        // Act
+        var result = await CreateHandler().Handle(
+            new GetMyPersonalAccessTokensQuery(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+        result.Value.Should().ContainSingle();
+    }
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/claims-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/claims-grid.tsx
@@ -1,17 +1,26 @@
 import { useMemo } from 'react'
-import WaydGrid from '../../../components/common/wayd-grid'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
+import type { ColumnDef } from '@tanstack/react-table'
 import useAuth, { Claim } from '../../../components/contexts/auth'
-import { ColDef } from 'ag-grid-community'
 
 const ClaimsGrid = () => {
   const { user } = useAuth()
 
-  const columnDefs = useMemo<ColDef<Claim>[]>(
-    () => [{ field: 'type' }, { field: 'value', width: 500 }],
+  const columns = useMemo<ColumnDef<Claim, any>[]>(
+    () => [
+      { id: 'type', accessorKey: 'type', header: 'Type', size: 400 },
+      { id: 'value', accessorKey: 'value', header: 'Value', size: 400 },
+    ],
     [],
   )
 
-  return <WaydGrid columnDefs={columnDefs} rowData={user?.claims} />
+  return (
+    <WaydGrid2
+      columns={columns}
+      data={user?.claims ?? []}
+      csvFileName="claims"
+    />
+  )
 }
 
 export default ClaimsGrid

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/personal-access-tokens.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/personal-access-tokens.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, FC, useMemo } from 'react'
-import { Button, Tag, Alert, Flex, Typography, App, Space } from 'antd'
+import { Button, Tag, Alert, Flex, Typography, App, Space, Tooltip } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import {
   useGetMyPersonalAccessTokensQuery,
@@ -9,104 +9,38 @@ import {
   useDeletePersonalAccessTokenMutation,
 } from '@/src/store/features/user-management/personal-access-tokens-api'
 import { PersonalAccessTokenDto } from '@/src/services/wayd-api'
-import dayjs from 'dayjs'
-import WaydGrid from '@/src/components/common/wayd-grid'
-import { CustomCellRendererProps } from 'ag-grid-react'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import {
+  WaydGrid2,
+  createActionsColumn,
+  formatDateTime,
+} from '@/src/components/common/wayd-grid2'
+import type { ColumnDef } from '@tanstack/react-table'
 import {
   CreatePersonalAccessTokenForm,
   EditPersonalAccessTokenForm,
   PersonalAccessTokenCreatedModal,
 } from './_components'
 import { useMessage } from '@/src/components/contexts/messaging'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
 import { ItemType } from 'antd/es/menu/interface'
-import { MenuProps } from 'antd'
 
 const { Text } = Typography
 
-// Custom cell renderers
-const StatusCellRenderer = (
-  props: CustomCellRendererProps<PersonalAccessTokenDto>,
-) => {
-  const { data } = props
-  if (!data) return null
-
-  if (data.isRevoked) {
-    return <Tag color="error">Revoked</Tag>
-  }
-  if (data.isExpired) {
-    return <Tag color="warning">Expired</Tag>
-  }
-  if (data.isActive) {
-    return <Tag color="success">Active</Tag>
-  }
-  return <Tag>Unknown</Tag>
+const tokenStatus = (token: PersonalAccessTokenDto): string => {
+  if (token.isRevoked) return 'Revoked'
+  if (token.isExpired) return 'Expired'
+  if (token.isActive) return 'Active'
+  return 'Unknown'
 }
 
-const DateTimeCellRenderer = (props: CustomCellRendererProps) => {
-  const { value } = props
-  if (!value) return 'Never'
-  return dayjs(value).format('YYYY-MM-DD h:mm A')
+const statusTagColor: Record<string, string | undefined> = {
+  Revoked: 'error',
+  Expired: 'warning',
+  Active: 'success',
 }
 
-interface RowMenuProps extends MenuProps {
-  tokenId: string
-  tokenName: string
-  isActive: boolean
-  token: PersonalAccessTokenDto
-  modal: ReturnType<typeof App.useApp>['modal']
-  onEditTokenMenuClicked: (token: PersonalAccessTokenDto) => void
-  onRevokeTokenMenuClicked: (id: string, name: string) => void
-  onDeleteTokenMenuClicked: (id: string, name: string) => void
-}
-
-const getRowMenuItems = (props: RowMenuProps) => {
-  if (!props.tokenId) return null
-
-  const items: ItemType[] = []
-
-  if (props.isActive) {
-    items.push({
-      key: 'editToken',
-      label: 'Edit',
-      onClick: () => props.onEditTokenMenuClicked(props.token),
-    })
-    items.push({
-      key: 'revokeToken',
-      label: 'Revoke',
-      onClick: () => {
-        props.modal.confirm({
-          title: `Revoke Token - ${props.tokenName}`,
-          content:
-            'Are you sure you want to revoke this token? It will no longer work.',
-          okText: 'Revoke',
-          okType: 'danger',
-          onOk: () =>
-            props.onRevokeTokenMenuClicked(props.tokenId, props.tokenName),
-        })
-      },
-    })
-  }
-
-  items.push({
-    key: 'deleteToken',
-    label: 'Delete',
-    onClick: () => {
-      props.modal.confirm({
-        title: `Delete Token - ${props.tokenName}`,
-        content:
-          'Are you sure you want to permanently delete this token? This cannot be undone.',
-        okText: 'Delete',
-        okType: 'danger',
-        onOk: () =>
-          props.onDeleteTokenMenuClicked(props.tokenId, props.tokenName),
-      })
-    },
-  })
-
-  return items
-}
+/** Renders a dateTime cell in the grid's standard format, or "Never" when unset. */
+const renderDateTimeOrNever = (value: unknown) =>
+  value ? formatDateTime(value) : 'Never'
 
 const PersonalAccessTokens: FC = () => {
   const [isCreateFormVisible, setIsCreateFormVisible] = useState(false)
@@ -153,81 +87,119 @@ const PersonalAccessTokens: FC = () => {
     refetch()
   }
 
-  const columnDefs = useMemo<ColDef<PersonalAccessTokenDto>[]>(
-    () => {
-      const handleEdit = (token: PersonalAccessTokenDto) => {
-        setEditingToken(token)
-        setIsEditFormVisible(true)
-      }
+  const columns = useMemo<ColumnDef<PersonalAccessTokenDto, any>[]>(() => {
+    const handleEdit = (token: PersonalAccessTokenDto) => {
+      setEditingToken(token)
+      setIsEditFormVisible(true)
+    }
 
-      const handleRevoke = async (id: string, name: string) => {
-        try {
-          await revokeToken(id).unwrap()
-          messageApi.success(`Token "${name}" revoked successfully`)
-        } catch (error) {
-          console.error('Failed to revoke token:', error)
-          messageApi.error('Failed to revoke token')
-        }
+    const handleRevoke = async (id: string, name: string) => {
+      try {
+        await revokeToken(id).unwrap()
+        messageApi.success(`Token "${name}" revoked successfully`)
+      } catch (error) {
+        console.error('Failed to revoke token:', error)
+        messageApi.error('Failed to revoke token')
       }
+    }
 
-      const handleDelete = async (id: string, name: string) => {
-        try {
-          await deleteToken(id).unwrap()
-          messageApi.success(`Token "${name}" deleted successfully`)
-        } catch (error) {
-          console.error('Failed to delete token:', error)
-          messageApi.error('Failed to delete token')
-        }
+    const handleDelete = async (id: string, name: string) => {
+      try {
+        await deleteToken(id).unwrap()
+        messageApi.success(`Token "${name}" deleted successfully`)
+      } catch (error) {
+        console.error('Failed to delete token:', error)
+        messageApi.error('Failed to delete token')
       }
+    }
 
-      return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
-        cellRenderer: (params: ICellRendererParams<PersonalAccessTokenDto>) => {
-          const menuItems = getRowMenuItems({
-            tokenId: params.data?.id ?? '',
-            tokenName: params.data?.name ?? '',
-            isActive: params.data?.isActive ?? false,
-            token: params.data!,
-            modal,
-            onEditTokenMenuClicked: handleEdit,
-            onRevokeTokenMenuClicked: handleRevoke,
-            onDeleteTokenMenuClicked: handleDelete,
+    return [
+      createActionsColumn<PersonalAccessTokenDto>({
+        ariaLabel: 'Token actions',
+        getItems: (token) => {
+          if (!token.id) return []
+
+          const items: ItemType[] = []
+
+          if (token.isActive) {
+            items.push({
+              key: 'editToken',
+              label: 'Edit',
+              onClick: () => handleEdit(token),
+            })
+            items.push({
+              key: 'revokeToken',
+              label: 'Revoke',
+              onClick: () => {
+                modal.confirm({
+                  title: `Revoke Token - ${token.name}`,
+                  content:
+                    'Are you sure you want to revoke this token? It will no longer work.',
+                  okText: 'Revoke',
+                  okType: 'danger',
+                  onOk: () => handleRevoke(token.id, token.name),
+                })
+              },
+            })
+          }
+
+          items.push({
+            key: 'deleteToken',
+            label: 'Delete',
+            onClick: () => {
+              modal.confirm({
+                title: `Delete Token - ${token.name}`,
+                content:
+                  'Are you sure you want to permanently delete this token? This cannot be undone.',
+                okText: 'Delete',
+                okType: 'danger',
+                onOk: () => handleDelete(token.id, token.name),
+              })
+            },
           })
-          return RowMenuCellRenderer({ ...params, menuItems: menuItems ?? [] })
+
+          return items
+        },
+      }),
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+      },
+      {
+        id: 'status',
+        accessorFn: (row) => tokenStatus(row),
+        header: 'Status',
+        size: 120,
+        meta: { filterType: 'set' },
+        cell: ({ getValue }) => {
+          const status = getValue() as string
+          return <Tag color={statusTagColor[status]}>{status}</Tag>
         },
       },
       {
-        field: 'name',
-        headerName: 'Name',
-        flex: 1,
-        minWidth: 200,
+        id: 'expiresAt',
+        accessorKey: 'expiresAt',
+        header: 'Expires',
+        size: 180,
+        meta: { columnType: 'dateTime' },
+        cell: ({ getValue }) => renderDateTimeOrNever(getValue()),
       },
       {
-        headerName: 'Status',
-        cellRenderer: StatusCellRenderer,
-        width: 120,
+        id: 'lastUsedAt',
+        accessorKey: 'lastUsedAt',
+        header: () => (
+          <Tooltip title="The last time this token was used for authentication. Updates at most once per hour.">
+            <span>Last Used</span>
+          </Tooltip>
+        ),
+        size: 180,
+        meta: { columnType: 'dateTime', exportHeader: 'Last Used' },
+        cell: ({ getValue }) => renderDateTimeOrNever(getValue()),
       },
-      {
-        field: 'expiresAt',
-        headerName: 'Expires',
-        cellRenderer: DateTimeCellRenderer,
-        width: 180,
-      },
-      {
-        field: 'lastUsedAt',
-        headerName: 'Last Used',
-        cellRenderer: DateTimeCellRenderer,
-        width: 180,
-        headerTooltip:
-          'The last time this token was used for authentication. Updates at most once per hour.',
-      },
-    ]},
-    [modal, revokeToken, deleteToken, messageApi],
-  )
+    ]
+  }, [modal, revokeToken, deleteToken, messageApi])
 
   if (error) {
     return (
@@ -263,12 +235,13 @@ const PersonalAccessTokens: FC = () => {
         </Button>
       </Space>
 
-      <WaydGrid
+      <WaydGrid2
         height={500}
-        columnDefs={columnDefs}
-        rowData={tokens}
-        loadData={refresh}
-        loading={isLoading}
+        columns={columns}
+        data={tokens ?? []}
+        isLoading={isLoading}
+        onRefresh={refresh}
+        csvFileName="personal-access-tokens"
         emptyMessage="No PATs found."
       />
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/_components/team-memberships-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/_components/team-memberships-grid.tsx
@@ -1,20 +1,18 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import WaydGrid from '../../../components/common/wayd-grid'
-import { TeamMembershipDto } from '@/src/services/wayd-api'
-import dayjs from 'dayjs'
 import {
-  RowMenuCellRenderer,
-  renderTeamLinkHelper,
-} from '../../../components/common/wayd-grid-cell-renderers'
+  WaydGrid2,
+  createActionsColumn,
+  renderTeamLink,
+} from '../../../components/common/wayd-grid2'
+import { TeamMembershipDto } from '@/src/services/wayd-api'
 import useAuth from '../../../components/contexts/auth'
-import { MenuProps } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import EditTeamMembershipForm from './edit-team-membership-form'
 import { TeamTypeName } from '../types'
 import DeleteTeamMembershipForm from './delete-team-membership-form'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 
 export interface TeamMembershipsGridProps {
   teamId: string
@@ -22,40 +20,6 @@ export interface TeamMembershipsGridProps {
   isLoading: boolean
   refetch: () => void
   teamType: TeamTypeName
-}
-
-const LocalChildTeamNameLinkCellRenderer = ({ data }: ICellRendererParams<TeamMembershipDto>) => {
-  return renderTeamLinkHelper(data?.child)
-}
-
-const LocalParentTeamNameLinkCellRenderer = ({ data }: ICellRendererParams<TeamMembershipDto>) => {
-  return renderTeamLinkHelper(data?.parent)
-}
-
-interface RowMenuProps extends MenuProps {
-  membership: TeamMembershipDto
-  canManageTeamMemberships: boolean
-  onEditTeamMembershipMenuClicked: (membership: TeamMembershipDto) => void
-  onDeleteTeamMembershipMenuClicked: (membership: TeamMembershipDto) => void
-}
-
-const getRowMenuItems = (props: RowMenuProps) => {
-  if (!props.membership) return null
-
-  return [
-    {
-      key: 'edit-team-membership',
-      label: 'Edit Team Membership',
-      disabled: !props.canManageTeamMemberships,
-      onClick: () => props.onEditTeamMembershipMenuClicked(props.membership),
-    },
-    {
-      key: 'delete-team-membership',
-      label: 'Delete Team Membership',
-      disabled: !props.canManageTeamMemberships,
-      onClick: () => props.onDeleteTeamMembershipMenuClicked(props.membership),
-    },
-  ] as ItemType[]
 }
 
 const TeamMembershipsGrid = ({
@@ -82,67 +46,79 @@ const TeamMembershipsGrid = ({
     refetch()
   }
 
-  const columnDefs = useMemo<ColDef<TeamMembershipDto>[]>(
-    () => {
-      const onEditTeamMembershipMenuClicked = (membership: TeamMembershipDto) => {
-        setSelectedTeamMembership(membership)
-        setOpenEditTeamMembershipForm(true)
-      }
+  const columns = useMemo<ColumnDef<TeamMembershipDto, any>[]>(() => {
+    const onEditTeamMembershipMenuClicked = (membership: TeamMembershipDto) => {
+      setSelectedTeamMembership(membership)
+      setOpenEditTeamMembershipForm(true)
+    }
 
-      const onDeleteTeamMembershipMenuClicked = (membership: TeamMembershipDto) => {
-        setSelectedTeamMembership(membership)
-        setOpenDeleteTeamMembershipForm(true)
-      }
+    const onDeleteTeamMembershipMenuClicked = (
+      membership: TeamMembershipDto,
+    ) => {
+      setSelectedTeamMembership(membership)
+      setOpenDeleteTeamMembershipForm(true)
+    }
 
-      return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
+    return [
+      createActionsColumn<TeamMembershipDto>({
         hide: !showRowActions,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<TeamMembershipDto>) => {
-          // only allow editing memberships for current team
-          if (teamId != params.data!.child.id) return null
+        ariaLabel: 'Team membership actions',
+        getItems: (membership): ItemType[] => {
+          // only allow editing memberships for the current team
+          if (teamId != membership.child.id) return []
 
-          const menuItems = getRowMenuItems({
-            id: params.data!.id,
-            membership: params.data!,
-            canManageTeamMemberships,
-            onEditTeamMembershipMenuClicked,
-            onDeleteTeamMembershipMenuClicked,
-          })
-
-          return RowMenuCellRenderer({ ...params, menuItems: menuItems ?? [] })
+          return [
+            {
+              key: 'edit-team-membership',
+              label: 'Edit Team Membership',
+              disabled: !canManageTeamMemberships,
+              onClick: () => onEditTeamMembershipMenuClicked(membership),
+            },
+            {
+              key: 'delete-team-membership',
+              label: 'Delete Team Membership',
+              disabled: !canManageTeamMemberships,
+              onClick: () => onDeleteTeamMembershipMenuClicked(membership),
+            },
+          ]
         },
+      }),
+      {
+        id: 'child',
+        accessorKey: 'child.name',
+        header: 'Child Team',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.child),
       },
       {
-        field: 'child.name',
-        headerName: 'Child Team',
-        cellRenderer: LocalChildTeamNameLinkCellRenderer,
+        id: 'parent',
+        accessorKey: 'parent.name',
+        header: 'Parent Team',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.parent),
       },
       {
-        field: 'parent.name',
-        headerName: 'Parent Team',
-        cellRenderer: LocalParentTeamNameLinkCellRenderer,
-      },
-      { field: 'state' },
-      {
-        field: 'start',
-        valueGetter: (params) => params.data?.start ? dayjs(params.data.start).format('M/D/YYYY') : null,
+        id: 'state',
+        accessorKey: 'state',
+        header: 'State',
+        meta: { filterType: 'set' },
       },
       {
-        field: 'end',
-        valueGetter: (params) =>
-          params.data?.end ? dayjs(params.data.end).format('M/D/YYYY') : null,
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start',
+        meta: { columnType: 'dateOnly' },
       },
-    ]},
-    [
-      showRowActions,
-      teamId,
-      canManageTeamMemberships,
-    ],
-  )
+      {
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End',
+        meta: { columnType: 'dateOnly' },
+      },
+    ]
+  }, [showRowActions, teamId, canManageTeamMemberships])
 
   const onEditTeamMembershipFormClosed = (wasCreated: boolean) => {
     setOpenEditTeamMembershipForm(false)
@@ -161,12 +137,12 @@ const TeamMembershipsGrid = ({
   }
   return (
     <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={teamMemberships}
-        loading={isLoading}
-        loadData={refresh}
+      <WaydGrid2
+        columns={columns}
+        data={teamMemberships ?? []}
+        isLoading={isLoading}
+        onRefresh={refresh}
+        csvFileName="team-memberships"
       />
       {openEditTeamMembershipForm && selectedTeamMembership && (
         <EditTeamMembershipForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/_components/employee-teams-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/_components/employee-teams-grid.tsx
@@ -1,10 +1,13 @@
 'use client'
 
 import { useMemo } from 'react'
-import WaydGrid from '@/src/components/common/wayd-grid'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import {
+  WaydGrid2,
+  renderTeamLink,
+  createMultiValueSetFilter,
+} from '@/src/components/common/wayd-grid2'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Flex, Tag, Tooltip } from 'antd'
-import Link from 'next/link'
 import {
   TeamMemberDto,
   useGetEmployeeTeamMembershipsQuery,
@@ -15,13 +18,12 @@ interface Props {
   employeeId: string
 }
 
-const TeamLinkCellRenderer = ({ data }: ICellRendererParams<TeamMemberDto>) => {
-  if (!data) return null
-  const segment = data.team.type === 'Team of Teams' ? 'team-of-teams' : 'teams'
-  return (
-    <Link href={`/organizations/${segment}/${data.team.key}`}>{data.team.name}</Link>
-  )
-}
+/** Membership roles as their display names (the multi-value source for the cell,
+ *  the Roles set filter, and CSV export). */
+const roleNames = (member: TeamMemberDto): string[] =>
+  member.roles.map((r) => r.name)
+
+const rolesFilter = createMultiValueSetFilter<TeamMemberDto>(roleNames)
 
 const EmployeeTeamsGrid = ({ employeeId }: Props) => {
   const {
@@ -37,52 +39,67 @@ const EmployeeTeamsGrid = ({ employeeId }: Props) => {
     return map
   }, [allRoles])
 
-  const columnDefs = useMemo<ColDef<TeamMemberDto>[]>(
+  // Distinct role names present in this employee's memberships, for the set
+  // filter's checkbox list (individual roles, not whole combinations).
+  const roleFilterOptions = useMemo(() => {
+    const names = new Set<string>()
+    memberships?.forEach((m) => m.roles.forEach((r) => names.add(r.name)))
+    return Array.from(names)
+      .sort()
+      .map((name) => ({ label: name, value: name }))
+  }, [memberships])
+
+  const columns = useMemo<ColumnDef<TeamMemberDto, any>[]>(
     () => [
       {
-        field: 'team.name',
-        headerName: 'Team',
-        cellRenderer: TeamLinkCellRenderer,
-        flex: 1,
+        id: 'team',
+        accessorKey: 'team.name',
+        header: 'Team',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.team),
       },
-      { field: 'team.type', headerName: 'Type', width: 150 },
       {
-        colId: 'roles',
-        headerName: 'Roles',
-        cellRenderer: ({ data }: ICellRendererParams<TeamMemberDto>) => {
-          if (!data) return null
-          return (
-            <Flex wrap gap={4}>
-              {data.roles.map((role) => (
-                <Tooltip
-                  key={role.id}
-                  title={roleDescriptionById.get(role.id)}
-                  placement="top"
-                >
-                  <Tag variant="filled">{role.name}</Tag>
-                </Tooltip>
-              ))}
-            </Flex>
-          )
-        },
-        valueGetter: (params) =>
-          params.data?.roles.map((r) => r.name).join(', '),
-        cellStyle: { display: 'flex', alignItems: 'center' },
-        flex: 1,
+        id: 'type',
+        accessorKey: 'team.type',
+        header: 'Type',
+        size: 150,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'roles',
+        accessorFn: (row) => roleNames(row).join(', '),
+        header: 'Roles',
+        size: 250,
+        filterFn: rolesFilter,
+        meta: { filterEnableSet: true, filterOptions: roleFilterOptions },
+        cell: ({ row }) => (
+          <Flex wrap gap={4}>
+            {row.original.roles.map((role) => (
+              <Tooltip
+                key={role.id}
+                title={roleDescriptionById.get(role.id)}
+                placement="top"
+              >
+                <Tag variant="filled">{role.name}</Tag>
+              </Tooltip>
+            ))}
+          </Flex>
+        ),
       },
     ],
-    [roleDescriptionById],
+    [roleDescriptionById, roleFilterOptions],
   )
 
   return (
-    <WaydGrid
-      height={500}
-      columnDefs={columnDefs}
-      rowData={memberships}
-      loading={isLoading}
-      loadData={() => {
+    <WaydGrid2
+      columns={columns}
+      data={memberships ?? []}
+      isLoading={isLoading}
+      onRefresh={() => {
         refetch()
       }}
+      csvFileName="employee-teams"
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/employee-details.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/employee-details.tsx
@@ -21,9 +21,11 @@ const EmployeeDetails = ({ employee }: EmployeeDetailsProps) => {
         <Item label="Job Title">{employee.jobTitle}</Item>
         <Item label="Department">{employee.department}</Item>
         <Item label="Manager">
-          <Link href={`/organizations/employees/${employee.manager?.key}`}>
-            {employee.manager?.name}
-          </Link>
+          {employee.manager && (
+            <Link href={`/organizations/employees/${employee.manager.key}`}>
+              {employee.manager.name}
+            </Link>
+          )}
         </Item>
         <Item label="Office Location">{employee.officeLocation}</Item>
         <Item label="Hire Date">

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/page.tsx
@@ -1,34 +1,20 @@
 'use client'
 
 import PageTitle from '@/src/components/common/page-title'
-import WaydGrid from '../../../components/common/wayd-grid'
+import { WaydGrid2 } from '../../../components/common/wayd-grid2'
 import { useEffect, useState, useMemo } from 'react'
 import { ItemType } from 'antd/es/menu/interface'
 import Link from 'next/link'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useDocumentTitle } from '../../../hooks/use-document-title'
-import { ControlItemSwitch } from '../../../components/common/control-items-menu'
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '../../../components/common/control-items-menu'
 import { authorizePage } from '../../../components/hoc'
 import { useGetEmployeesQuery } from '@/src/store/features/organizations/employee-api'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { EmployeeListDto } from '@/src/services/wayd-api'
-import { ICellRendererParams } from 'ag-grid-community'
-
-const EmployeeLinkCellRenderer = ({
-  value,
-  data,
-}: ICellRendererParams<EmployeeListDto>) => {
-  return <Link href={`/organizations/employees/${data!.key}`}>{value}</Link>
-}
-
-const ManagerLinkCellRenderer = ({
-  value,
-  data,
-}: ICellRendererParams<EmployeeListDto>) => {
-  if (!data?.manager?.key) return value ?? null
-  return (
-    <Link href={`/organizations/employees/${data.manager.key}`}>{value}</Link>
-  )
-}
 
 const EmployeeListPage = () => {
   useDocumentTitle('Employees')
@@ -50,26 +36,68 @@ const EmployeeListPage = () => {
     }
   }, [error, messageApi])
 
-  const columnDefs = useMemo(
+  const columns = useMemo<ColumnDef<EmployeeListDto, any>[]>(
     () => [
-      { field: 'key', width: 90 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'displayName',
-        headerName: 'Name',
-        cellRenderer: EmployeeLinkCellRenderer,
+        id: 'displayName',
+        accessorKey: 'displayName',
+        header: 'Name',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => (
+          <Link href={`/organizations/employees/${row.original.key}`}>
+            {row.original.displayName}
+          </Link>
+        ),
       },
-      { field: 'email' },
-      { field: 'employeeNumber', headerName: 'Employee Number' },
-      { field: 'employeeType', headerName: 'Employee Type' },
-      { field: 'jobTitle' },
-      { field: 'department' },
+      { id: 'email', accessorKey: 'email', header: 'Email' },
       {
-        field: 'manager.name',
-        headerName: 'Manager',
-        cellRenderer: ManagerLinkCellRenderer,
+        id: 'employeeNumber',
+        accessorKey: 'employeeNumber',
+        header: 'Employee Number',
       },
-      { field: 'officeLocation' },
-      { field: 'isActive' }, // TODO: convert to yes/no
+      {
+        id: 'employeeType',
+        accessorKey: 'employeeType',
+        header: 'Employee Type',
+        meta: { filterType: 'set' },
+      },
+      { id: 'jobTitle', accessorKey: 'jobTitle', header: 'Job Title' },
+      {
+        id: 'department',
+        accessorKey: 'department',
+        header: 'Department',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'manager',
+        accessorKey: 'manager.name',
+        header: 'Manager',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => {
+          const manager = row.original.manager
+          if (!manager?.key) return manager?.name ?? null
+          return (
+            <Link href={`/organizations/employees/${manager.key}`}>
+              {manager.name}
+            </Link>
+          )
+        },
+      },
+      {
+        id: 'officeLocation',
+        accessorKey: 'officeLocation',
+        header: 'Office Location',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
     ],
     [],
   )
@@ -99,12 +127,13 @@ const EmployeeListPage = () => {
   return (
     <>
       <PageTitle title="Employees" />
-      <WaydGrid
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={employeesData}
-        loading={isLoading}
-        loadData={refresh}
+      <WaydGrid2
+        columns={columns}
+        data={employeesData ?? []}
+        isLoading={isLoading}
+        onRefresh={refresh}
+        csvFileName="employees"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
     </>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -164,7 +164,7 @@ const TeamOfTeamsDetailsPage = (props: {
         return <TeamOfTeamsDetails team={team!} />
       case TeamOfTeamsTabs.RiskManagement:
         return createElement(RisksGrid, {
-          risks: risksQuery.data,
+          risks: risksQuery.data ?? [],
           updateIncludeClosed: onIncludeClosedRisksChanged,
           isLoadingRisks: risksQuery.isLoading,
           refreshRisks: risksQuery.refetch,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -321,7 +321,7 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
         return <TeamDependencyManagement team={team!} />
       case TeamTabs.RiskManagement:
         return createElement(RisksGrid, {
-          risks: risksQuery.data,
+          risks: risksQuery.data ?? [],
           updateIncludeClosed: onIncludeClosedRisksChanged,
           isLoadingRisks: risksQuery.isLoading,
           refreshRisks: risksQuery.refetch,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-members-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-members-grid.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import WaydGrid from '@/src/components/common/wayd-grid'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import {
+  WaydGrid2,
+  createActionsColumn,
+  createMultiValueSetFilter,
+} from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { ItemType } from 'antd/es/menu/interface'
 import { Flex, Tag, Tooltip } from 'antd'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
 import {
   TeamMemberDto,
@@ -22,14 +25,12 @@ interface TeamMembersGridProps {
   teamType: 'Team' | 'TeamOfTeams'
 }
 
-const NameCellRenderer = ({ data }: ICellRendererParams<TeamMemberDto>) => {
-  if (!data) return null
-  return (
-    <Link href={`/organizations/employees/${data.employee.key}`}>
-      {data.employee.name}
-    </Link>
-  )
-}
+/** A member's roles as their display names (source for the cell, the Roles set
+ *  filter, and CSV export). */
+const roleNames = (member: TeamMemberDto): string[] =>
+  member.roles.map((r) => r.name)
+
+const rolesFilter = createMultiValueSetFilter<TeamMemberDto>(roleNames)
 
 const TeamMembersGrid = ({ teamId, teamType }: TeamMembersGridProps) => {
   const [editingMember, setEditingMember] = useState<TeamMemberDto | null>(null)
@@ -68,88 +69,96 @@ const TeamMembersGrid = ({ teamId, teamType }: TeamMembersGridProps) => {
   const isLoading = teamType === 'Team' ? teamLoading : totLoading
   const refetch = teamType === 'Team' ? refetchTeam : refetchTot
 
-  const columnDefs = useMemo<ColDef<TeamMemberDto>[]>(() => {
-    const getRowMenuItems = (member: TeamMemberDto): ItemType[] => {
-      if (!canUpdate) return []
-      return [
-        { key: 'edit', label: 'Edit', onClick: () => setEditingMember(member) },
-        {
-          key: 'remove',
-          label: 'Remove',
-          danger: true,
-          onClick: () => setRemovingMember(member),
-        },
-      ]
-    }
+  // Distinct role names across the visible members, for the set filter's
+  // checkbox list (individual roles, not whole combinations).
+  const roleFilterOptions = useMemo(() => {
+    const names = new Set<string>()
+    members?.forEach((m) => m.roles.forEach((r) => names.add(r.name)))
+    return Array.from(names)
+      .sort()
+      .map((name) => ({ label: name, value: name }))
+  }, [members])
 
+  const columns = useMemo<ColumnDef<TeamMemberDto, any>[]>(() => {
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
+      createActionsColumn<TeamMemberDto>({
         hide: !canUpdate,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<TeamMemberDto>) => {
-          if (!params.data) return null
-          return RowMenuCellRenderer({
-            ...params,
-            menuItems: getRowMenuItems(params.data),
-          })
+        ariaLabel: 'Team member actions',
+        getItems: (member): ItemType[] => {
+          if (!canUpdate) return []
+          return [
+            {
+              key: 'edit',
+              label: 'Edit',
+              onClick: () => setEditingMember(member),
+            },
+            {
+              key: 'remove',
+              label: 'Remove',
+              danger: true,
+              onClick: () => setRemovingMember(member),
+            },
+          ]
         },
+      }),
+      {
+        id: 'name',
+        accessorKey: 'employee.name',
+        header: 'Name',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => (
+          <Link href={`/organizations/employees/${row.original.employee.key}`}>
+            {row.original.employee.name}
+          </Link>
+        ),
       },
       {
-        field: 'employee.name',
-        headerName: 'Name',
-        cellRenderer: NameCellRenderer,
-        width: 250,
+        id: 'jobTitle',
+        accessorKey: 'employee.jobTitle',
+        header: 'Title',
+        size: 300,
       },
       {
-        field: 'employee.jobTitle',
-        headerName: 'Title',
-        width: 300,
+        id: 'email',
+        accessorKey: 'employee.email',
+        header: 'Email',
+        size: 300,
       },
       {
-        field: 'employee.email',
-        headerName: 'Email',
-        width: 300,
-      },
-      {
-        colId: 'roles',
-        headerName: 'Roles',
-        cellRenderer: ({ data }: ICellRendererParams<TeamMemberDto>) => {
-          if (!data) return null
-          return (
-            <Flex wrap gap={4}>
-              {data.roles.map((role) => (
-                <Tooltip
-                  key={role.id}
-                  title={roleDescriptionById.get(role.id)}
-                  placement="top"
-                >
-                  <Tag variant="filled">{role.name}</Tag>
-                </Tooltip>
-              ))}
-            </Flex>
-          )
-        },
-        valueGetter: (params) =>
-          params.data?.roles.map((r) => r.name).join(', '),
-        cellStyle: { display: 'flex', alignItems: 'center' },
-        width: 400,
+        id: 'roles',
+        accessorFn: (row) => roleNames(row).join(', '),
+        header: 'Roles',
+        size: 400,
+        filterFn: rolesFilter,
+        meta: { filterEnableSet: true, filterOptions: roleFilterOptions },
+        cell: ({ row }) => (
+          <Flex wrap gap={4}>
+            {row.original.roles.map((role) => (
+              <Tooltip
+                key={role.id}
+                title={roleDescriptionById.get(role.id)}
+                placement="top"
+              >
+                <Tag variant="filled">{role.name}</Tag>
+              </Tooltip>
+            ))}
+          </Flex>
+        ),
       },
     ]
-  }, [canUpdate, roleDescriptionById])
+  }, [canUpdate, roleDescriptionById, roleFilterOptions])
 
   return (
     <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={members}
-        loading={isLoading}
-        loadData={() => {
+      <WaydGrid2
+        columns={columns}
+        data={members ?? []}
+        isLoading={isLoading}
+        onRefresh={() => {
           refetch()
         }}
+        csvFileName="team-members"
       />
       {editingMember && (
         <EditTeamMemberForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-operating-models-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-operating-models-grid.tsx
@@ -1,7 +1,10 @@
 'use client'
 
 import { useState, useMemo } from 'react'
-import WaydGrid from '@/src/components/common/wayd-grid'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import {
   useDeleteTeamOperatingModelMutation,
   useGetTeamOperatingModelsQuery,
@@ -11,11 +14,10 @@ import {
   TeamOperatingModelDetailsDto,
 } from '@/src/services/wayd-api'
 import { useMessage } from '@/src/components/contexts/messaging'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
 import { Tag } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import EditTeamOperatingModelForm from './edit-team-operating-model-form'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 
 interface TeamOperatingModelsGridProps {
   teamId: string
@@ -106,7 +108,9 @@ const TeamOperatingModelsGrid = ({
 
   const totalModelsCount = operatingModelsData?.length ?? 0
 
-  const columnDefs = useMemo<ColDef<TeamOperatingModelDetailsDto>[]>(() => {
+  const columns = useMemo<
+    ColumnDef<TeamOperatingModelDetailsDto, any>[]
+  >(() => {
     const handleEdit = (model: TeamOperatingModelDetailsDto) => {
       setSelectedModelId(model.id)
       setShowUpdateForm(true)
@@ -129,65 +133,63 @@ const TeamOperatingModelsGrid = ({
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
+      createActionsColumn<TeamOperatingModelDetailsDto>({
         hide: !canUpdate,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (
-          params: ICellRendererParams<TeamOperatingModelDetailsDto>,
-        ) => {
-          const menuItems = getRowMenuItems({
-            operatingModel: params.data!,
+        ariaLabel: 'Operating model actions',
+        getItems: (operatingModel) =>
+          getRowMenuItems({
+            operatingModel,
             canUpdate,
             totalModelsCount,
             onEditClicked: handleEdit,
             onDeleteClicked: handleDelete,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
+          }),
+      }),
+      {
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start Date',
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'start',
-        headerName: 'Start Date',
-        type: 'dateOnly',
-        sort: 'desc',
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End Date',
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'end',
-        headerName: 'End Date',
-        type: 'dateOnly',
+        id: 'methodology',
+        accessorKey: 'methodology',
+        header: 'Methodology',
+        meta: { filterType: 'set' },
       },
       {
-        field: 'methodology',
-        headerName: 'Methodology',
-      },
-      {
-        field: 'sizingMethod',
-        headerName: 'Sizing Method',
-        valueGetter: (params) =>
-          params.data?.sizingMethod
-            ? getSizingMethodDisplayName(params.data.sizingMethod)
+        id: 'sizingMethod',
+        accessorFn: (row) =>
+          row.sizingMethod
+            ? getSizingMethodDisplayName(row.sizingMethod)
             : null,
+        header: 'Sizing Method',
+        meta: { filterType: 'set' },
       },
       {
-        field: 'isCurrent',
-        headerName: 'Status',
-        cellRenderer: StatusCellRenderer,
+        id: 'isCurrent',
+        accessorFn: (row) => (row.isCurrent ? 'Current' : 'Historical'),
+        header: 'Status',
+        meta: { filterType: 'set' },
+        cell: ({ row }) => <StatusCellRenderer data={row.original} />,
       },
     ]
   }, [canUpdate, totalModelsCount, teamId, deleteOperatingModel, messageApi])
 
   return (
     <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={operatingModelsData}
-        loading={isLoading}
-        loadData={refresh}
+      <WaydGrid2
+        columns={columns}
+        data={operatingModelsData ?? []}
+        isLoading={isLoading}
+        onRefresh={refresh}
+        csvFileName="team-operating-models"
       />
 
       {showUpdateForm && selectedModelId && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/page.tsx
@@ -1,23 +1,25 @@
 'use client'
 
 import PageTitle from '@/src/components/common/page-title'
-import WaydGrid from '../../../components/common/wayd-grid'
+import {
+  WaydGrid2,
+  renderTeamLink,
+} from '../../../components/common/wayd-grid2'
 import { useMemo, useState } from 'react'
 import { ItemType } from 'antd/es/menu/interface'
 import { Button } from 'antd'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useDocumentTitle } from '../../../hooks/use-document-title'
 import useAuth from '../../../components/contexts/auth'
 import { useAppSelector, useAppDispatch } from '../../../hooks'
 import { setIncludeInactive } from '../../../store/features/organizations/team-slice'
 import { useGetTeamsQuery } from '../../../store/features/organizations/team-api'
 import { ModalCreateTeamForm } from '../_components/create-team-form'
-import {
-  NestedTeamOfTeamsNameLinkCellRenderer,
-  TeamNameLinkCellRenderer,
-} from '../../../components/common/wayd-grid-cell-renderers'
 import { TeamListItem } from '../types'
-import { ColDef } from 'ag-grid-community'
-import { ControlItemSwitch } from '../../../components/common/control-items-menu'
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '../../../components/common/control-items-menu'
 import { authorizePage } from '../../../components/hoc'
 
 const TeamListPage = () => {
@@ -31,33 +33,38 @@ const TeamListPage = () => {
   } = useGetTeamsQuery(includeInactive)
   const [isCreateOpen, setIsCreateOpen] = useState(false)
 
-  const columnDefs = useMemo<ColDef<TeamListItem>[]>(
+  const columns = useMemo<ColumnDef<TeamListItem, any>[]>(
     () => [
-      { field: 'key', width: 90 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'name',
-        cellRenderer: TeamNameLinkCellRenderer,
-        width: 250,
-        comparator: (valueA, valueB) => {
-          return valueA.toLowerCase().localeCompare(valueB.toLowerCase())
-        },
-        initialSort: 'asc',
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original),
       },
-      { field: 'code', width: 125 },
-      { field: 'type' },
+      { id: 'code', accessorKey: 'code', header: 'Code', size: 125 },
       {
-        field: 'teamOfTeams.name',
-        headerName: 'Team of Teams',
-        cellRenderer: NestedTeamOfTeamsNameLinkCellRenderer,
-        width: 250,
-        comparator: (valueA, valueB) => {
-          if (!valueA && !valueB) return 0
-          if (!valueA) return 1
-          if (!valueB) return -1
-          return valueA.toLowerCase().localeCompare(valueB.toLowerCase())
-        },
+        id: 'type',
+        accessorKey: 'type',
+        header: 'Type',
+        meta: { filterType: 'set' },
       },
-      { field: 'isActive' }, // TODO: convert to yes/no
+      {
+        id: 'teamOfTeams',
+        accessorKey: 'teamOfTeams.name',
+        header: 'Team of Teams',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.teamOfTeams),
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
     ],
     [],
   )
@@ -102,14 +109,15 @@ const TeamListPage = () => {
   return (
     <>
       <PageTitle title="Teams" actions={actions()} />
-      <WaydGrid
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={teams}
-        loadData={() => {
+      <WaydGrid2
+        columns={columns}
+        data={teams ?? []}
+        onRefresh={() => {
           refetch()
         }}
-        loading={isLoading}
+        isLoading={isLoading}
+        csvFileName="teams"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
       {isCreateOpen && (
         <ModalCreateTeamForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/health-report/health-report-page.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/health-report/health-report-page.module.css
@@ -1,0 +1,21 @@
+/* Tightens markdown spacing so a health-check note sits cleanly inside a grid
+ * cell (first/last paragraph flush, compact lists). */
+.markdown p {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.markdown > p:first-child {
+  margin-top: 0;
+}
+
+.markdown > p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/health-report/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/health-report/page.tsx
@@ -5,41 +5,18 @@ import { use, useMemo } from 'react'
 import { useDocumentTitle } from '@/src/hooks/use-document-title'
 import { authorizePage } from '@/src/components/hoc'
 import { notFound } from 'next/navigation'
+import Link from 'next/link'
 import {
-  MarkdownCellRenderer,
-  PlanningIntervalObjectiveLinkCellRenderer,
-  NestedTeamNameLinkCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
+  WaydGrid2,
+  renderTeamLink,
+} from '@/src/components/common/wayd-grid2'
+import { MarkdownRenderer } from '@/src/components/common/markdown'
 import PiObjectiveHealthCheckTag from '@/src/app/planning/planning-intervals/_components/pi-objective-health-check-tag'
-import { WaydGrid } from '@/src/components/common'
 import { Progress } from 'antd'
 import { useGetPlanningIntervalObjectivesHealthReportQuery } from '@/src/store/features/planning/planning-interval-api'
 import { PlanningIntervalObjectiveHealthCheckDto } from '@/src/services/wayd-api'
-import { ICellRendererParams } from 'ag-grid-community'
-
-const LocalHealthCheckCellRenderer = (params: ICellRendererParams<PlanningIntervalObjectiveHealthCheckDto>) => {
-  if (!params.data?.healthCheckId) return null
-  return (
-    <PiObjectiveHealthCheckTag
-      healthCheck={{
-        id: params.data.healthCheckId,
-        status: params.data.healthStatus!,
-        reportedOn: params.data.reportedOn,
-        expiration: params.data.expiration,
-        note: params.data.note,
-      }}
-      planningIntervalId={params.data.planningInterval?.id}
-      objectiveId={params.data.id}
-    />
-  )
-}
-
-const ProgressCellRenderer = ({ value, data }: ICellRendererParams<PlanningIntervalObjectiveHealthCheckDto>) => {
-  const progressStatus = ['Canceled', 'Missed'].includes(data!.status?.name)
-    ? 'exception'
-    : undefined
-  return <Progress percent={value} size="small" status={progressStatus} />
-}
+import type { ColumnDef } from '@tanstack/react-table'
+import styles from './health-report-page.module.css'
 
 const ObjectiveHealthReportPage = (props: {
   params: Promise<{ key: string }>
@@ -57,49 +34,115 @@ const ObjectiveHealthReportPage = (props: {
     planningIntervalKey: piKey,
   })
 
-  const columnDefs = useMemo(
+  const columns = useMemo<
+    ColumnDef<PlanningIntervalObjectiveHealthCheckDto, any>[]
+  >(
     () => [
-      { field: 'id', hide: true },
-      { field: 'key', width: 90 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'name',
-        width: 400,
-        cellRenderer: PlanningIntervalObjectiveLinkCellRenderer,
-      },
-      { field: 'isStretch', width: 100 },
-      {
-        field: 'status.name',
-        headerName: 'Status',
-        width: 125,
-      },
-      {
-        field: 'team.name',
-        headerName: 'Team',
-        cellRenderer: NestedTeamNameLinkCellRenderer,
-        hide: false,
-      },
-      { field: 'progress', width: 250, cellRenderer: ProgressCellRenderer },
-      { field: 'healthCheckId', hide: true },
-      {
-        field: 'healthStatus.name',
-        headerName: 'Health',
-        width: 115,
-        cellRenderer: LocalHealthCheckCellRenderer,
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 400,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => (
+          <Link
+            href={`/planning/planning-intervals/${row.original.planningInterval?.key}/objectives/${row.original.key}`}
+          >
+            {row.original.name}
+          </Link>
+        ),
       },
       {
-        field: 'note',
-        width: 400,
-        autoHeight: true,
-        wrapText: true,
-        cellRenderer: MarkdownCellRenderer,
+        id: 'isStretch',
+        accessorKey: 'isStretch',
+        header: 'Stretch',
+        meta: { columnType: 'yesNo' },
       },
       {
-        field: 'reportedOn',
-        type: 'dateTime',
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
       },
       {
-        field: 'expiration',
-        type: 'dateTime',
+        id: 'team',
+        accessorKey: 'team.name',
+        header: 'Team',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.team),
+      },
+      {
+        id: 'progress',
+        accessorKey: 'progress',
+        header: 'Progress',
+        size: 250,
+        enableColumnFilter: false,
+        cell: ({ row }) => {
+          const status = ['Canceled', 'Missed'].includes(
+            row.original.status?.name,
+          )
+            ? 'exception'
+            : undefined
+          return (
+            <Progress
+              percent={row.original.progress}
+              size="small"
+              status={status}
+            />
+          )
+        },
+      },
+      {
+        id: 'health',
+        accessorFn: (row) => row.healthStatus?.name ?? '',
+        header: 'Health',
+        size: 115,
+        cell: ({ row }) => {
+          const item = row.original
+          if (!item.healthCheckId) return null
+          return (
+            <PiObjectiveHealthCheckTag
+              healthCheck={{
+                id: item.healthCheckId,
+                status: item.healthStatus!,
+                reportedOn: item.reportedOn,
+                expiration: item.expiration,
+                note: item.note,
+              }}
+              planningIntervalId={item.planningInterval?.id}
+              objectiveId={item.id}
+            />
+          )
+        },
+      },
+      {
+        id: 'note',
+        accessorKey: 'note',
+        header: 'Note',
+        size: 400,
+        cell: ({ getValue }) => {
+          const note = getValue() as string | null | undefined
+          if (!note) return null
+          return (
+            <div className={styles.markdown}>
+              <MarkdownRenderer markdown={note} />
+            </div>
+          )
+        },
+      },
+      {
+        id: 'reportedOn',
+        accessorKey: 'reportedOn',
+        header: 'Reported On',
+        meta: { columnType: 'dateTime' },
+      },
+      {
+        id: 'expiration',
+        accessorKey: 'expiration',
+        header: 'Expiration',
+        meta: { columnType: 'dateTime' },
       },
     ],
     [],
@@ -116,12 +159,12 @@ const ObjectiveHealthReportPage = (props: {
   return (
     <>
       <PageTitle title="PI Objectives Health Report" />
-      {/* TODO:  setup dynamic height */}
-      <WaydGrid
-        columnDefs={columnDefs}
-        rowData={healthReport}
-        loading={isLoading}
-        loadData={refresh}
+      <WaydGrid2
+        columns={columns}
+        data={healthReport ?? []}
+        isLoading={isLoading}
+        onRefresh={refresh}
+        csvFileName="pi-objectives-health-report"
       />
     </>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.module.css
@@ -1,0 +1,21 @@
+/* Tightens markdown spacing so a health-check note sits cleanly inside a grid
+ * cell (first/last paragraph flush, compact lists). */
+.markdown p {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.markdown > p:first-child {
+  margin-top: 0;
+}
+
+.markdown > p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.tsx
@@ -61,11 +61,14 @@ const PiObjectiveHealthReportGrid = (
         id: 'reportedBy',
         accessorKey: 'reportedBy.name',
         header: 'Reported By',
-        cell: ({ row }) => (
-          <Link href={`/organizations/employees/${row.original.reportedBy?.key}`}>
-            {row.original.reportedBy?.name}
-          </Link>
-        ),
+        cell: ({ row }) =>
+          row.original.reportedBy ? (
+            <Link
+              href={`/organizations/employees/${row.original.reportedBy.key}`}
+            >
+              {row.original.reportedBy.name}
+            </Link>
+          ) : null,
       },
       {
         id: 'reportedOn',

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.tsx
@@ -1,27 +1,18 @@
 'use client'
 
-import React, { useMemo } from 'react'
-import WaydGrid from '../../../../components/common/wayd-grid'
+import { useMemo } from 'react'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import Link from 'next/link'
-import {
-  PiObjectiveHealthCheckStatusCellRenderer,
-  MarkdownCellRenderer,
-} from '../../../../components/common/wayd-grid-cell-renderers'
+import PiObjectiveHealthCheckTag from './pi-objective-health-check-tag'
+import { MarkdownRenderer } from '@/src/components/common/markdown'
 import { PlanningIntervalObjectiveHealthCheckDetailsDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useGetObjectiveHealthChecksQuery } from '@/src/store/features/planning/pi-objective-health-checks-api'
+import styles from './pi-objective-health-report-grid.module.css'
 
 interface PiObjectiveHealthReportGridProps {
   planningIntervalId: string
   objectiveId: string
-}
-
-const ReportedByLinkCellRenderer = ({ value, data }: ICellRendererParams<PlanningIntervalObjectiveHealthCheckDetailsDto>) => {
-  return (
-    <Link href={`/organizations/employees/${data!.reportedBy?.key}`}>
-      {value}
-    </Link>
-  )
 }
 
 const PiObjectiveHealthReportGrid = (
@@ -30,8 +21,6 @@ const PiObjectiveHealthReportGrid = (
   const {
     data: healthReportData,
     isLoading,
-    isFetching,
-    error,
     refetch,
   } = useGetObjectiveHealthChecksQuery(
     {
@@ -41,36 +30,54 @@ const PiObjectiveHealthReportGrid = (
     { skip: !props.planningIntervalId || !props.objectiveId },
   )
 
-  const columnDefs = useMemo<
-    ColDef<PlanningIntervalObjectiveHealthCheckDetailsDto>[]
+  const columns = useMemo<
+    ColumnDef<PlanningIntervalObjectiveHealthCheckDetailsDto, any>[]
   >(
     () => [
-      { field: 'id', hide: true },
       {
-        field: 'status.name',
-        headerName: 'Health',
-        width: 115,
-        cellRenderer: PiObjectiveHealthCheckStatusCellRenderer,
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Health',
+        size: 115,
+        meta: { filterType: 'set' },
+        cell: ({ row }) => <PiObjectiveHealthCheckTag healthCheck={row.original} />,
       },
       {
-        field: 'note',
-        width: 400,
-        autoHeight: true,
-        wrapText: true,
-        cellRenderer: MarkdownCellRenderer,
+        id: 'note',
+        accessorKey: 'note',
+        header: 'Note',
+        size: 400,
+        cell: ({ getValue }) => {
+          const note = getValue() as string | null | undefined
+          if (!note) return null
+          return (
+            <div className={styles.markdown}>
+              <MarkdownRenderer markdown={note} />
+            </div>
+          )
+        },
       },
       {
-        field: 'reportedBy.name',
-        headerName: 'Reported By',
-        cellRenderer: ReportedByLinkCellRenderer,
+        id: 'reportedBy',
+        accessorKey: 'reportedBy.name',
+        header: 'Reported By',
+        cell: ({ row }) => (
+          <Link href={`/organizations/employees/${row.original.reportedBy?.key}`}>
+            {row.original.reportedBy?.name}
+          </Link>
+        ),
       },
       {
-        field: 'reportedOn',
-        type: 'dateTime',
+        id: 'reportedOn',
+        accessorKey: 'reportedOn',
+        header: 'Reported On',
+        meta: { columnType: 'dateTime' },
       },
       {
-        field: 'expiration',
-        type: 'dateTime',
+        id: 'expiration',
+        accessorKey: 'expiration',
+        header: 'Expiration',
+        meta: { columnType: 'dateTime' },
       },
     ],
     [],
@@ -81,15 +88,14 @@ const PiObjectiveHealthReportGrid = (
   }
 
   return (
-    <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={healthReportData}
-        loadData={refresh}
-        loading={isLoading}
-      />
-    </>
+    <WaydGrid2
+      height={550}
+      columns={columns}
+      data={healthReportData ?? []}
+      onRefresh={refresh}
+      isLoading={isLoading}
+      csvFileName="pi-objective-health-report"
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/page.tsx
@@ -1,8 +1,10 @@
 'use client'
 
-import WaydGrid from '@/src/components/common/wayd-grid'
+import {
+  WaydGrid2,
+  renderPlanningIntervalLink,
+} from '@/src/components/common/wayd-grid2'
 import PageTitle from '@/src/components/common/page-title'
-import Link from 'next/link'
 import { useState, useMemo } from 'react'
 import { useDocumentTitle } from '../../../hooks/use-document-title'
 import dayjs from 'dayjs'
@@ -12,14 +14,7 @@ import { Button } from 'antd'
 import { authorizePage } from '../../../components/hoc'
 import { useGetPlanningIntervalsQuery } from '@/src/store/features/planning/planning-interval-api'
 import { PlanningIntervalListDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
-
-const PlanningIntervalLinkCellRenderer = ({
-  value,
-  data,
-}: ICellRendererParams<PlanningIntervalListDto>) => {
-  return <Link href={`/planning/planning-intervals/${data!.key}`}>{value}</Link>
-}
+import type { ColumnDef } from '@tanstack/react-table'
 
 const stateOrder = ['Active', 'Future', 'Completed']
 
@@ -49,21 +44,34 @@ const PlanningIntervalListPage = () => {
         }
       })
 
-  const columnDefs = useMemo<ColDef<PlanningIntervalListDto>[]>(
+  const columns = useMemo<ColumnDef<PlanningIntervalListDto, any>[]>(
     () => [
-      { field: 'key', width: 90 },
-      { field: 'name', cellRenderer: PlanningIntervalLinkCellRenderer },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'state.name',
-        width: 125,
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderPlanningIntervalLink(row.original),
       },
       {
-        field: 'start',
-        type: 'dateOnly',
+        id: 'state',
+        accessorKey: 'state.name',
+        header: 'State',
+        size: 125,
+        meta: { filterType: 'set' },
       },
       {
-        field: 'end',
-        type: 'dateOnly',
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start',
+        meta: { columnType: 'dateOnly' },
+      },
+      {
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End',
+        meta: { columnType: 'dateOnly' },
       },
     ],
     [],
@@ -99,11 +107,12 @@ const PlanningIntervalListPage = () => {
         title="Planning Intervals"
         actions={showActions && actions()}
       />
-      <WaydGrid
-        columnDefs={columnDefs}
-        rowData={data}
-        loading={isLoading}
-        loadData={refresh}
+      <WaydGrid2
+        columns={columns}
+        data={data}
+        isLoading={isLoading}
+        onRefresh={refresh}
+        csvFileName="planning-intervals"
       />
       {openCreatePlanningIntervalForm && (
         <CreatePlanningIntervalForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/poker-sessions/_components/poker-sessions-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/poker-sessions/_components/poker-sessions-grid.tsx
@@ -1,9 +1,12 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
+import { ControlItemsMenu } from '@/src/components/common/control-items-menu'
 import { PokerSessionListDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { ItemType } from 'antd/es/menu/interface'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
@@ -59,17 +62,6 @@ const getRowMenuItems = (props: RowMenuProps): ItemType[] => {
   return items
 }
 
-const sessionLinkCellRenderer = (
-  params: ICellRendererParams<PokerSessionListDto>,
-) => {
-  if (!params.data) return null
-  return (
-    <Link href={`/planning/poker-sessions/${params.data.key}`}>
-      {params.value}
-    </Link>
-  )
-}
-
 const PokerSessionsGrid: FC<PokerSessionsGridProps> = ({
   sessions = [],
   isLoading,
@@ -83,34 +75,53 @@ const PokerSessionsGrid: FC<PokerSessionsGridProps> = ({
 }) => {
   const showRowMenu = canUpdate || canDelete
 
-  const columnDefs = useMemo<ColDef<PokerSessionListDto>[]>(
+  const columns = useMemo<ColumnDef<PokerSessionListDto, any>[]>(
     () => [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<PokerSessionListDto>({
         hide: !showRowMenu,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<PokerSessionListDto>) => {
-          if (!params.data) return null
-          const menuItems = getRowMenuItems({
-            session: params.data,
+        ariaLabel: 'Poker session actions',
+        getItems: (session) =>
+          getRowMenuItems({
+            session,
             canUpdate,
             canDelete,
             onEditClicked,
             onCompleteClicked,
             onDeleteClicked,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
+          }),
+      }),
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => (
+          <Link href={`/planning/poker-sessions/${row.original.key}`}>
+            {row.original.name}
+          </Link>
+        ),
       },
-      { field: 'key', width: 90 },
-      { field: 'name', width: 300, cellRenderer: sessionLinkCellRenderer },
-      { field: 'status', width: 125 },
-      { field: 'facilitator.name', headerName: 'Facilitator', width: 200 },
-      { field: 'roundCount', headerName: 'Rounds', width: 110 },
+      {
+        id: 'status',
+        accessorKey: 'status',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'facilitator',
+        accessorKey: 'facilitator.name',
+        header: 'Facilitator',
+        size: 200,
+      },
+      {
+        id: 'roundCount',
+        accessorKey: 'roundCount',
+        header: 'Rounds',
+        size: 110,
+      },
     ],
     [
       showRowMenu,
@@ -123,14 +134,19 @@ const PokerSessionsGrid: FC<PokerSessionsGridProps> = ({
   )
 
   return (
-    <WaydGrid
-      columnDefs={columnDefs}
-      gridControlMenuItems={gridControlMenuItems}
-      rowData={sessions}
-      loadData={refetch}
-      loading={isLoading}
+    <WaydGrid2
+      columns={columns}
+      data={sessions}
+      onRefresh={refetch}
+      isLoading={isLoading}
       height={650}
+      csvFileName="poker-sessions"
       emptyMessage="No poker sessions found."
+      rightSlot={
+        gridControlMenuItems ? (
+          <ControlItemsMenu items={gridControlMenuItems} />
+        ) : undefined
+      }
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmaps-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmaps-grid.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { RoadmapListDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import { getSortedNames } from '@/src/utils'
+import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
 import { FC, ReactNode, useMemo } from 'react'
 
@@ -15,64 +16,68 @@ export interface RoadmapsGridProps {
   parentRoadmapId?: string | undefined
 }
 
-type RoadmapGridRow = RoadmapListDto & {
-  roadmapManagersDisplay: string
-}
-
-const RoadmapCellRenderer = ({ value, data }: ICellRendererParams<RoadmapGridRow>) => {
-  return <Link href={`/planning/roadmaps/${data!.key}`}>{value}</Link>
-}
-
 const RoadmapsGrid: FC<RoadmapsGridProps> = (props: RoadmapsGridProps) => {
-  const rowData: RoadmapGridRow[] = props.roadmapsData.map((roadmap) => ({
-    ...roadmap,
-    roadmapManagersDisplay: roadmap.roadmapManagers
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((m) => m.name)
-      .join(', '),
-  }))
-
-  const columnDefs = useMemo<ColDef<RoadmapGridRow>[]>(
+  const columns = useMemo<ColumnDef<RoadmapListDto, any>[]>(
     () => [
-      { field: 'key', width: 90 },
-      { field: 'name', width: 300, cellRenderer: RoadmapCellRenderer },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'start',
-        width: 150,
-        type: 'dateOnly',
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => (
+          <Link href={`/planning/roadmaps/${row.original.key}`}>
+            {row.original.name}
+          </Link>
+        ),
       },
       {
-        field: 'end',
-        width: 150,
-        type: 'dateOnly',
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start',
+        size: 150,
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'roadmapManagersDisplay',
-        headerName: 'Roadmap Managers',
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End',
+        size: 150,
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'visibility.name',
-        headerName: 'Visibility',
-        width: 125,
+        id: 'roadmapManagers',
+        accessorFn: (row) => getSortedNames(row.roadmapManagers ?? []),
+        header: 'Roadmap Managers',
       },
       {
-        field: 'state.name',
-        headerName: 'State',
-        width: 120,
+        id: 'visibility',
+        accessorKey: 'visibility.name',
+        header: 'Visibility',
+        size: 125,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'state',
+        accessorKey: 'state.name',
+        header: 'State',
+        size: 120,
+        meta: { filterType: 'set' },
       },
     ],
     [],
   )
 
   return (
-    <WaydGrid
+    <WaydGrid2
       height={props.gridHeight ?? 650}
-      columnDefs={columnDefs}
-      rowData={rowData}
-      loadData={props.refreshRoadmaps}
-      loading={props.roadmapsLoading}
-      toolbarActions={props.viewSelector}
+      columns={columns}
+      data={props.roadmapsData}
+      onRefresh={props.refreshRoadmaps}
+      isLoading={props.roadmapsLoading}
+      csvFileName="roadmaps"
+      rightSlot={props.viewSelector}
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-grid.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
 import {
-  LifecycleStatusTagCellRenderer,
-  PortfolioLinkCellRenderer,
-  ProgramLinkCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
+  WaydGrid2,
+  renderPortfolioLink,
+  renderProgramLink,
+} from '@/src/components/common/wayd-grid2'
+import LifecycleStatusTag from '@/src/components/common/lifecycle-status-tag'
 import { ProgramListDto } from '@/src/services/wayd-api'
 import { getSortedNames } from '@/src/utils'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { FC, useMemo } from 'react'
 
 export interface ProgramsGridProps {
@@ -23,60 +23,69 @@ export interface ProgramsGridProps {
 const ProgramsGrid: FC<ProgramsGridProps> = (props: ProgramsGridProps) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<ProgramListDto>[]>(
+  const columns = useMemo<ColumnDef<ProgramListDto, any>[]>(
     () => [
-      { field: 'key', width: 90 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'name',
-        cellRenderer: ProgramLinkCellRenderer,
-        width: 300,
-        initialSort: 'asc',
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderProgramLink(row.original),
       },
       {
-        field: 'status.name',
-        headerName: 'Status',
-        width: 125,
-        cellRenderer: LifecycleStatusTagCellRenderer,
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+        cell: ({ row }) =>
+          row.original.status ? (
+            <LifecycleStatusTag status={row.original.status} />
+          ) : null,
       },
       {
-        field: 'portfolio.name',
-        headerName: 'Portfolio',
-        width: 200,
-        hide: props.hidePortfolio,
-        cellRenderer: (params: ICellRendererParams<ProgramListDto>) => {
-          if (!params.data) return null
-          return PortfolioLinkCellRenderer({ ...(params as any), data: params.data.portfolio })
-        },
+        id: 'portfolio',
+        accessorKey: 'portfolio.name',
+        header: 'Portfolio',
+        size: 200,
+        meta: { hide: props.hidePortfolio, filterEnableSet: true },
+        cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
       },
       {
-        field: 'start',
-        width: 125,
-        type: 'dateOnly',
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start',
+        size: 125,
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'end',
-        width: 125,
-        type: 'dateOnly',
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End',
+        size: 125,
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'programManagers',
-        headerName: 'PMs',
-        valueGetter: (params) => getSortedNames(params.data?.programManagers ?? []),
+        id: 'programManagers',
+        accessorFn: (row) => getSortedNames(row.programManagers ?? []),
+        header: 'PMs',
       },
       {
-        field: 'programOwners',
-        headerName: 'Owners',
-        valueGetter: (params) => getSortedNames(params.data?.programOwners ?? []),
+        id: 'programOwners',
+        accessorFn: (row) => getSortedNames(row.programOwners ?? []),
+        header: 'Owners',
       },
       {
-        field: 'programSponsors',
-        headerName: 'Sponsors',
-        valueGetter: (params) => getSortedNames(params.data?.programSponsors ?? []),
+        id: 'programSponsors',
+        accessorFn: (row) => getSortedNames(row.programSponsors ?? []),
+        header: 'Sponsors',
       },
       {
-        field: 'strategicThemes',
-        headerName: 'Strategic Themes',
-        valueGetter: (params) => getSortedNames(params.data?.strategicThemes ?? []),
+        id: 'strategicThemes',
+        accessorFn: (row) => getSortedNames(row.strategicThemes ?? []),
+        header: 'Strategic Themes',
       },
     ],
     [props.hidePortfolio],
@@ -87,17 +96,16 @@ const ProgramsGrid: FC<ProgramsGridProps> = (props: ProgramsGridProps) => {
   }
 
   return (
-    <>
-      <WaydGrid
-        columnDefs={columnDefs}
-        rowData={props.programs}
-        loadData={refresh}
-        loading={props.isLoading}
-        toolbarActions={props.viewSelector}
-        height={props.gridHeight}
-        emptyMessage="No programs found."
-      />
-    </>
+    <WaydGrid2
+      columns={columns}
+      data={props.programs}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="programs"
+      rightSlot={props.viewSelector}
+      height={props.gridHeight}
+      emptyMessage="No programs found."
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-grid.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
 import {
-  LifecycleStatusTagCellRenderer,
-  PortfolioLinkCellRenderer,
-  ProgramLinkCellRenderer,
-  NestedProjectHealthCheckStatusCellRenderer,
-  ProjectLinkCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
+  WaydGrid2,
+  renderPortfolioLink,
+  renderProgramLink,
+  renderProjectLink,
+} from '@/src/components/common/wayd-grid2'
+import LifecycleStatusTag from '@/src/components/common/lifecycle-status-tag'
+import ProjectHealthCheckTag from '@/src/app/ppm/projects/_components/project-health-check-tag'
 import { ProjectListDto } from '@/src/services/wayd-api'
 import { getSortedNames } from '@/src/utils'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { FC, ReactNode, useMemo } from 'react'
 
 export interface ProjectsGridProps {
@@ -26,99 +26,110 @@ export interface ProjectsGridProps {
 const ProjectsGrid: FC<ProjectsGridProps> = (props: ProjectsGridProps) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<ProjectListDto>[]>(
+  const columns = useMemo<ColumnDef<ProjectListDto, any>[]>(
     () => [
       {
-        field: 'position',
-        headerName: 'Rank',
-        headerTooltip:
-          "Rank based on the project's portfolio and the current context.",
-        width: 90,
-        valueFormatter: (params) =>
-          params.value == null ? '—' : String(params.value),
+        id: 'position',
+        accessorKey: 'position',
+        header: 'Rank',
+        size: 90,
+        enableColumnFilter: false,
+        cell: ({ getValue }) => {
+          const value = getValue() as number | null | undefined
+          return value == null ? '—' : String(value)
+        },
       },
-      { field: 'key', width: 125 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 125 },
       {
-        field: 'name',
-        cellRenderer: ProjectLinkCellRenderer,
-        width: 300,
-        initialSort: 'asc',
-      },
-      {
-        field: 'status.name',
-        headerName: 'Status',
-        width: 125,
-        cellRenderer: LifecycleStatusTagCellRenderer,
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderProjectLink(row.original),
       },
       {
-        field: 'healthCheck.status.name',
-        headerName: 'Health',
-        width: 125,
-        cellRenderer: NestedProjectHealthCheckStatusCellRenderer,
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+        cell: ({ row }) =>
+          row.original.status ? (
+            <LifecycleStatusTag status={row.original.status} />
+          ) : null,
       },
       {
-        field: 'portfolio.name',
-        headerName: 'Portfolio',
-        width: 200,
-        hide: props.hidePortfolio,
-        cellRenderer: (params: ICellRendererParams<ProjectListDto>) => {
-          if (!params.data) return null
-          return PortfolioLinkCellRenderer({
-            ...(params as any),
-            data: params.data.portfolio,
-          })
+        id: 'health',
+        accessorFn: (row) => row.healthCheck?.status?.name ?? '',
+        header: 'Health',
+        size: 125,
+        cell: ({ row }) => {
+          const project = row.original
+          if (!project.healthCheck) return null
+          return (
+            <ProjectHealthCheckTag
+              healthCheck={project.healthCheck}
+              projectId={project.id}
+            />
+          )
         },
       },
       {
-        field: 'program.name',
-        headerName: 'Program',
-        width: 200,
-        hide: props.hideProgram,
-        cellRenderer: (params: ICellRendererParams<ProjectListDto>) =>
-          params.data?.program
-            ? ProgramLinkCellRenderer({
-                ...(params as any),
-                data: params.data.program,
-              })
-            : null,
+        id: 'portfolio',
+        accessorKey: 'portfolio.name',
+        header: 'Portfolio',
+        size: 200,
+        meta: { hide: props.hidePortfolio, filterEnableSet: true },
+        cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
       },
       {
-        field: 'start',
-        width: 125,
-        type: 'dateOnly',
+        id: 'program',
+        accessorKey: 'program.name',
+        header: 'Program',
+        size: 200,
+        meta: { hide: props.hideProgram, filterEnableSet: true },
+        cell: ({ row }) => renderProgramLink(row.original.program),
       },
       {
-        field: 'end',
-        width: 125,
-        type: 'dateOnly',
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start',
+        size: 125,
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'projectManagers',
-        headerName: 'PMs',
-        valueGetter: (params) =>
-          getSortedNames(params.data?.projectManagers ?? []),
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End',
+        size: 125,
+        meta: { columnType: 'dateOnly' },
       },
       {
-        field: 'projectOwners',
-        headerName: 'Owners',
-        valueGetter: (params) =>
-          getSortedNames(params.data?.projectOwners ?? []),
+        id: 'projectManagers',
+        accessorFn: (row) => getSortedNames(row.projectManagers ?? []),
+        header: 'PMs',
       },
       {
-        field: 'projectSponsors',
-        headerName: 'Sponsors',
-        valueGetter: (params) =>
-          getSortedNames(params.data?.projectSponsors ?? []),
+        id: 'projectOwners',
+        accessorFn: (row) => getSortedNames(row.projectOwners ?? []),
+        header: 'Owners',
       },
       {
-        field: 'strategicThemes',
-        headerName: 'Strategic Themes',
-        valueGetter: (params) =>
-          getSortedNames(params.data?.strategicThemes ?? []),
+        id: 'projectSponsors',
+        accessorFn: (row) => getSortedNames(row.projectSponsors ?? []),
+        header: 'Sponsors',
       },
       {
-        field: 'projectLifecycle.name',
-        headerName: 'Lifecycle',
+        id: 'strategicThemes',
+        accessorFn: (row) => getSortedNames(row.strategicThemes ?? []),
+        header: 'Strategic Themes',
+      },
+      {
+        id: 'projectLifecycle',
+        accessorKey: 'projectLifecycle.name',
+        header: 'Lifecycle',
+        meta: { filterType: 'set' },
       },
     ],
     [props.hidePortfolio, props.hideProgram],
@@ -129,17 +140,16 @@ const ProjectsGrid: FC<ProjectsGridProps> = (props: ProjectsGridProps) => {
   }
 
   return (
-    <>
-      <WaydGrid
-        columnDefs={columnDefs}
-        rowData={props.projects}
-        loadData={refresh}
-        loading={props.isLoading}
-        toolbarActions={props.viewSelector}
-        height={props.gridHeight}
-        emptyMessage="No projects found."
-      />
-    </>
+    <WaydGrid2
+      columns={columns}
+      data={props.projects}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="projects"
+      rightSlot={props.viewSelector}
+      height={props.gridHeight}
+      emptyMessage="No projects found."
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-grid.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
 import {
-  LifecycleStatusTagCellRenderer,
-  PortfolioLinkCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
+  WaydGrid2,
+  renderPortfolioLink,
+} from '@/src/components/common/wayd-grid2'
+import LifecycleStatusTag from '@/src/components/common/lifecycle-status-tag'
 import {
   NavigationDto,
   StrategicInitiativeListDto,
 } from '@/src/services/wayd-api'
 import { getSortedNames } from '@/src/utils'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
 import { FC, useMemo } from 'react'
 
@@ -23,15 +23,15 @@ export interface StrategicInitiativesGridProps {
   viewSelector?: React.ReactNode | undefined
 }
 
-export interface NavigationLinkCellRendererProps {
-  data: NavigationDto
-}
-export const StrategicInitiativeLinkCellRenderer = ({
-  data,
-}: NavigationLinkCellRendererProps) => {
-  if (!data) return null
+/** Renders a strategic initiative as a link to its page. */
+export const renderStrategicInitiativeLink = (
+  initiative: NavigationDto | null | undefined,
+) => {
+  if (!initiative) return null
   return (
-    <Link href={`/ppm/strategic-initiatives/${data.key}`}>{data.name}</Link>
+    <Link href={`/ppm/strategic-initiatives/${initiative.key}`}>
+      {initiative.name}
+    </Link>
   )
 }
 
@@ -40,64 +40,78 @@ const StrategicInitiativesGrid: FC<StrategicInitiativesGridProps> = (
 ) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<StrategicInitiativeListDto>[]>(() => [
-    { field: 'key', width: 90 },
-    {
-      field: 'name',
-      cellRenderer: StrategicInitiativeLinkCellRenderer,
-      width: 300,
-    },
-    {
-      field: 'status.name',
-      headerName: 'Status',
-      width: 125,
-      cellRenderer: LifecycleStatusTagCellRenderer,
-    },
-    {
-      field: 'portfolio.name',
-      headerName: 'Portfolio',
-      width: 200,
-      hide: props.hidePortfolio,
-      cellRenderer: (params: ICellRendererParams<StrategicInitiativeListDto>) => {
-        if (!params.data) return null
-        return PortfolioLinkCellRenderer({ ...(params as any), data: params.data.portfolio })
+  const columns = useMemo<ColumnDef<StrategicInitiativeListDto, any>[]>(
+    () => [
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderStrategicInitiativeLink(row.original),
       },
-    },
-    {
-      field: 'start',
-      width: 125,
-      type: 'dateOnly',
-    },
-    {
-      field: 'end',
-      width: 125,
-      type: 'dateOnly',
-    },
-    {
-      field: 'strategicInitiativeSponsors',
-      headerName: 'Sponsors',
-      valueGetter: (params) =>
-        getSortedNames(params.data?.strategicInitiativeSponsors ?? []),
-    },
-    {
-      field: 'strategicInitiativeOwners',
-      headerName: 'Owners',
-      valueGetter: (params) =>
-        getSortedNames(params.data?.strategicInitiativeOwners ?? []),
-    },
-  ], [props.hidePortfolio])
+      {
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+        cell: ({ row }) =>
+          row.original.status ? (
+            <LifecycleStatusTag status={row.original.status} />
+          ) : null,
+      },
+      {
+        id: 'portfolio',
+        accessorKey: 'portfolio.name',
+        header: 'Portfolio',
+        size: 200,
+        meta: { hide: props.hidePortfolio, filterEnableSet: true },
+        cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
+      },
+      {
+        id: 'start',
+        accessorKey: 'start',
+        header: 'Start',
+        size: 125,
+        meta: { columnType: 'dateOnly' },
+      },
+      {
+        id: 'end',
+        accessorKey: 'end',
+        header: 'End',
+        size: 125,
+        meta: { columnType: 'dateOnly' },
+      },
+      {
+        id: 'strategicInitiativeSponsors',
+        accessorFn: (row) =>
+          getSortedNames(row.strategicInitiativeSponsors ?? []),
+        header: 'Sponsors',
+      },
+      {
+        id: 'strategicInitiativeOwners',
+        accessorFn: (row) =>
+          getSortedNames(row.strategicInitiativeOwners ?? []),
+        header: 'Owners',
+      },
+    ],
+    [props.hidePortfolio],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <WaydGrid
-      columnDefs={columnDefs}
-      rowData={props.strategicInitiatives}
-      loadData={refresh}
-      loading={props.isLoading}
-      toolbarActions={props.viewSelector}
+    <WaydGrid2
+      columns={columns}
+      data={props.strategicInitiatives}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="strategic-initiatives"
+      rightSlot={props.viewSelector}
       height={props.gridHeight}
       emptyMessage="No strategic initiatives found."
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/_components/portfolios-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/_components/portfolios-grid.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { PortfolioLinkCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { WaydGrid2, renderPortfolioLink } from '@/src/components/common/wayd-grid2'
 import { ProjectPortfolioListDto } from '@/src/services/wayd-api'
 import { getSortedNames } from '@/src/utils'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { ReactElement, useMemo } from 'react'
 
 export interface PortfoliosGridProps {
@@ -19,30 +18,37 @@ const PortfoliosGrid: React.FC<PortfoliosGridProps> = (
 ) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<ProjectPortfolioListDto>[]>(
+  const columns = useMemo<ColumnDef<ProjectPortfolioListDto, any>[]>(
     () => [
-      { field: 'key', width: 90 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
       {
-        field: 'name',
-        cellRenderer: PortfolioLinkCellRenderer,
-        width: 200,
-        initialSort: 'asc',
-      },
-      { field: 'status.name', headerName: 'Status' },
-      {
-        field: 'portfolioManagers',
-        headerName: 'PMs',
-        valueGetter: (params) => getSortedNames(params.data?.portfolioManagers ?? []),
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderPortfolioLink(row.original),
       },
       {
-        field: 'portfolioOwners',
-        headerName: 'Owners',
-        valueGetter: (params) => getSortedNames(params.data?.portfolioOwners ?? []),
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Status',
+        meta: { filterType: 'set' },
       },
       {
-        field: 'portfolioSponsors',
-        headerName: 'Sponsors',
-        valueGetter: (params) => getSortedNames(params.data?.portfolioSponsors ?? []),
+        id: 'portfolioManagers',
+        accessorFn: (row) => getSortedNames(row.portfolioManagers ?? []),
+        header: 'PMs',
+      },
+      {
+        id: 'portfolioOwners',
+        accessorFn: (row) => getSortedNames(row.portfolioOwners ?? []),
+        header: 'Owners',
+      },
+      {
+        id: 'portfolioSponsors',
+        accessorFn: (row) => getSortedNames(row.portfolioSponsors ?? []),
+        header: 'Sponsors',
       },
     ],
     [],
@@ -53,16 +59,15 @@ const PortfoliosGrid: React.FC<PortfoliosGridProps> = (
   }
 
   return (
-    <>
-      <WaydGrid
-        columnDefs={columnDefs}
-        rowData={props.portfolios}
-        loadData={refresh}
-        loading={props.isLoading}
-        toolbarActions={props.viewSelector}
-        emptyMessage="No portolios found."
-      />
-    </>
+    <WaydGrid2
+      columns={columns}
+      data={props.portfolios}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="portfolios"
+      rightSlot={props.viewSelector}
+      emptyMessage="No portfolios found."
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.module.css
@@ -1,0 +1,21 @@
+/* Tightens markdown spacing so a health-check note sits cleanly inside a grid
+ * cell (first/last paragraph flush, compact lists). */
+.markdown p {
+  margin-top: 12px;
+  margin-bottom: 12px;
+  word-break: break-word;
+  white-space: normal;
+}
+
+.markdown > p:first-child {
+  margin-top: 0;
+}
+
+.markdown > p:last-child {
+  margin-bottom: 0;
+}
+
+.markdown ul {
+  margin-top: 0;
+  margin-bottom: 0;
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.tsx
@@ -1,14 +1,13 @@
 'use client'
 
 import { useMemo } from 'react'
-import WaydGrid from '@/src/components/common/wayd-grid'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import Link from 'next/link'
-import {
-  ProjectHealthCheckStatusCellRenderer,
-  MarkdownCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
+import ProjectHealthCheckTag from '@/src/app/ppm/projects/_components/project-health-check-tag'
+import { MarkdownRenderer } from '@/src/components/common/markdown'
 import { ProjectHealthCheckDetailsDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
+import styles from './project-health-report-grid.module.css'
 
 interface ProjectHealthReportGridProps {
   data?: ProjectHealthCheckDetailsDto[]
@@ -16,64 +15,76 @@ interface ProjectHealthReportGridProps {
   refetch: () => void
 }
 
-const ReportedByLinkCellRenderer = ({
-  value,
-  data,
-}: ICellRendererParams<ProjectHealthCheckDetailsDto>) => (
-  <Link href={`/organizations/employees/${data?.reportedBy?.key}`}>{value}</Link>
-)
-
 const ProjectHealthReportGrid = ({
   data,
   isLoading,
   refetch,
 }: ProjectHealthReportGridProps) => {
-  const columnDefs = useMemo<ColDef<ProjectHealthCheckDetailsDto>[]>(
+  const columns = useMemo<ColumnDef<ProjectHealthCheckDetailsDto, any>[]>(
     () => [
-      { field: 'id', hide: true },
       {
-        field: 'status.name',
-        headerName: 'Health',
-        width: 115,
-        cellRenderer: ProjectHealthCheckStatusCellRenderer,
+        id: 'status',
+        accessorKey: 'status.name',
+        header: 'Health',
+        size: 115,
+        meta: { filterType: 'set' },
+        cell: ({ row }) => <ProjectHealthCheckTag healthCheck={row.original} />,
       },
       {
-        field: 'note',
-        width: 400,
-        autoHeight: true,
-        wrapText: true,
-        cellRenderer: MarkdownCellRenderer,
+        id: 'note',
+        accessorKey: 'note',
+        header: 'Note',
+        size: 400,
+        cell: ({ getValue }) => {
+          const note = getValue() as string | null | undefined
+          if (!note) return null
+          return (
+            <div className={styles.markdown}>
+              <MarkdownRenderer markdown={note} />
+            </div>
+          )
+        },
       },
       {
-        field: 'reportedBy.name',
-        headerName: 'Reported By',
-        cellRenderer: ReportedByLinkCellRenderer,
+        id: 'reportedBy',
+        accessorKey: 'reportedBy.name',
+        header: 'Reported By',
+        cell: ({ row }) => (
+          <Link
+            href={`/organizations/employees/${row.original.reportedBy?.key}`}
+          >
+            {row.original.reportedBy?.name}
+          </Link>
+        ),
       },
       {
-        field: 'reportedOn',
-        type: 'dateTime',
+        id: 'reportedOn',
+        accessorKey: 'reportedOn',
+        header: 'Reported On',
+        meta: { columnType: 'dateTime' },
       },
       {
-        field: 'expiration',
-        type: 'dateTime',
+        id: 'expiration',
+        accessorKey: 'expiration',
+        header: 'Expiration',
+        meta: { columnType: 'dateTime' },
       },
     ],
     [],
   )
 
   return (
-    <WaydGrid
-      height={550}
-      columnDefs={columnDefs}
-      rowData={data}
-      loadData={() => {
+    <WaydGrid2
+      columns={columns}
+      data={data ?? []}
+      onRefresh={() => {
         refetch()
       }}
-      loading={isLoading}
+      isLoading={isLoading}
+      csvFileName="project-health-report"
       emptyMessage="No health checks found."
     />
   )
 }
 
 export default ProjectHealthReportGrid
-

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.tsx
@@ -49,13 +49,14 @@ const ProjectHealthReportGrid = ({
         id: 'reportedBy',
         accessorKey: 'reportedBy.name',
         header: 'Reported By',
-        cell: ({ row }) => (
-          <Link
-            href={`/organizations/employees/${row.original.reportedBy?.key}`}
-          >
-            {row.original.reportedBy?.name}
-          </Link>
-        ),
+        cell: ({ row }) =>
+          row.original.reportedBy ? (
+            <Link
+              href={`/organizations/employees/${row.original.reportedBy.key}`}
+            >
+              {row.original.reportedBy.name}
+            </Link>
+          ) : null,
       },
       {
         id: 'reportedOn',

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-team-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-team-grid.tsx
@@ -1,53 +1,44 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { ProjectTeamMemberDto } from '@/src/services/wayd-api'
 import { useGetProjectTeamQuery } from '@/src/store/features/ppm/projects-api'
-import { ColDef } from 'ag-grid-community'
-import { CustomCellRendererProps } from 'ag-grid-react'
+import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
 import { FC } from 'react'
 
-const PersonLinkCellRenderer = (
-  props: CustomCellRendererProps<ProjectTeamMemberDto>,
-) => {
-  if (!props.data) return null
-  return (
-    <Link
-      href={`/organizations/employees/${props.data.employee.key}`}
-      prefetch={false}
-    >
-      {props.data.employee.name}
-    </Link>
-  )
-}
-
-const columnDefs: ColDef<ProjectTeamMemberDto>[] = [
+const columns: ColumnDef<ProjectTeamMemberDto, any>[] = [
   {
-    field: 'employee.name',
-    headerName: 'Person',
-    cellRenderer: PersonLinkCellRenderer,
-    minWidth: 200,
-    flex: 1,
+    id: 'person',
+    accessorKey: 'employee.name',
+    header: 'Person',
+    size: 250,
+    cell: ({ row }) => (
+      <Link
+        href={`/organizations/employees/${row.original.employee.key}`}
+        prefetch={false}
+      >
+        {row.original.employee.name}
+      </Link>
+    ),
   },
   {
-    field: 'roles',
-    headerName: 'Roles',
-    minWidth: 200,
-    flex: 1,
-    valueGetter: (params) => params.data?.roles?.join(', '),
+    id: 'roles',
+    accessorFn: (row) => row.roles?.join(', ') ?? '',
+    header: 'Roles',
+    size: 250,
   },
   {
-    field: 'assignedPhases',
-    headerName: 'Assigned Phases',
-    minWidth: 200,
-    flex: 1,
-    valueGetter: (params) => params.data?.assignedPhases?.join(', ') || null,
+    id: 'assignedPhases',
+    accessorFn: (row) => row.assignedPhases?.join(', ') || '',
+    header: 'Assigned Phases',
+    size: 250,
   },
   {
-    field: 'activeWorkItemCount',
-    headerName: 'Active Tasks',
-    width: 130,
+    id: 'activeWorkItemCount',
+    accessorKey: 'activeWorkItemCount',
+    header: 'Active Tasks',
+    size: 130,
   },
 ]
 
@@ -67,11 +58,12 @@ const ProjectTeamGrid: FC<ProjectTeamGridProps> = ({ projectIdOrKey }) => {
   }
 
   return (
-    <WaydGrid
-      columnDefs={columnDefs}
-      rowData={teamData}
-      loadData={refresh}
-      loading={isLoading}
+    <WaydGrid2
+      columns={columns}
+      data={teamData ?? []}
+      onRefresh={refresh}
+      isLoading={isLoading}
+      csvFileName="project-team"
       emptyMessage="No team members assigned."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/active-tenant-migrations.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/active-tenant-migrations.tsx
@@ -1,55 +1,51 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import { WaydGrid2, formatDateTime } from '@/src/components/common/wayd-grid2'
 import { PendingTenantMigrationDto } from '@/src/services/wayd-api'
 import { useGetPendingTenantMigrationsQuery } from '@/src/store/features/user-management/oidc-providers-api'
-import {
-  ColDef,
-  ICellRendererParams,
-  ValueFormatterParams,
-} from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
-import dayjs from 'dayjs'
 
-const formatDate = (
-  params: ValueFormatterParams<PendingTenantMigrationDto, Date | undefined>,
-) => (params.value ? dayjs(params.value).format('MMM D, YYYY h:mm A') : '—')
+/** Formats a value with a dash fallback when empty. */
+const orDash = (value: unknown) => (value ? String(value) : '—')
 
-const columnDefs: ColDef<PendingTenantMigrationDto>[] = [
-  { field: 'userId', hide: true },
+const columns: ColumnDef<PendingTenantMigrationDto, any>[] = [
   {
-    field: 'userName',
-    headerName: 'User',
-    cellRenderer: (params: ICellRendererParams<PendingTenantMigrationDto>) => {
-      if (!params.data) return null
-      return (
-        <Link href={`/settings/user-management/users/${params.data.userId}`}>
-          {params.data.userName}
-        </Link>
-      )
-    },
+    id: 'userName',
+    accessorKey: 'userName',
+    header: 'User',
+    cell: ({ row }) => (
+      <Link href={`/settings/user-management/users/${row.original.userId}`}>
+        {row.original.userName}
+      </Link>
+    ),
   },
   {
-    field: 'email',
-    headerName: 'Email',
-    width: 175,
-    valueFormatter: (params) => params.value ?? '—',
+    id: 'email',
+    accessorKey: 'email',
+    header: 'Email',
+    size: 175,
+    cell: ({ getValue }) => orDash(getValue()),
   },
   {
-    field: 'sourceTenantId',
-    headerName: 'Source tenant',
-    width: 175,
-    valueFormatter: (params) => params.value ?? '—',
+    id: 'sourceTenantId',
+    accessorKey: 'sourceTenantId',
+    header: 'Source tenant',
+    size: 175,
+    cell: ({ getValue }) => orDash(getValue()),
   },
   {
-    field: 'targetTenantId',
-    headerName: 'Target tenant',
-    width: 175,
+    id: 'targetTenantId',
+    accessorKey: 'targetTenantId',
+    header: 'Target tenant',
+    size: 175,
   },
   {
-    field: 'stagedAt',
-    headerName: 'Staged',
-    valueFormatter: formatDate,
+    id: 'stagedAt',
+    accessorKey: 'stagedAt',
+    header: 'Staged',
+    meta: { columnType: 'dateTime' },
+    cell: ({ getValue }) => (getValue() ? formatDateTime(getValue()) : '—'),
   },
 ]
 
@@ -64,14 +60,14 @@ const ActiveTenantMigrations = ({
     useGetPendingTenantMigrationsQuery(providerId)
 
   return (
-    <WaydGrid
-      height={500}
-      columnDefs={columnDefs}
-      rowData={data}
-      loading={isLoading}
-      loadData={() => {
+    <WaydGrid2
+      columns={columns}
+      data={data ?? []}
+      isLoading={isLoading}
+      onRefresh={() => {
         refetch()
       }}
+      csvFileName="tenant-migrations"
       emptyMessage="No tenant migrations are currently in progress."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/page.tsx
@@ -1,12 +1,18 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { PageTitle } from '@/src/components/common'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { authorizePage } from '@/src/components/hoc'
 import { useDocumentTitle } from '@/src/hooks'
-import { OidcProviderListItemDto, OidcProviderType } from '@/src/services/wayd-api'
+import {
+  OidcProviderListItemDto,
+  OidcProviderType,
+} from '@/src/services/wayd-api'
 import {
   useGetOidcProvidersQuery,
   useTestOidcProviderDiscoveryMutation,
@@ -17,7 +23,7 @@ import {
   CloseCircleOutlined,
   LoadingOutlined,
 } from '@ant-design/icons'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button, Space, Tag, Tooltip, Typography } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import Link from 'next/link'
@@ -133,7 +139,12 @@ const OidcProvidersPage = () => {
   const [testStates, setTestStates] = useState<Record<string, TestState>>({})
 
   const messageApi = useMessage()
-  const { data: providers, isLoading, error, refetch } = useGetOidcProvidersQuery()
+  const {
+    data: providers,
+    isLoading,
+    error,
+    refetch,
+  } = useGetOidcProvidersQuery()
   const [testDiscovery] = useTestOidcProviderDiscoveryMutation()
 
   const { hasPermissionClaim } = useAuth()
@@ -185,83 +196,86 @@ const OidcProvidersPage = () => {
   const handleDelete = (provider: OidcProviderListItemDto) =>
     setDeleteProvider(provider)
 
-  const columnDefs: ColDef<OidcProviderListItemDto>[] = [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
-        hide: !showRowMenu,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<OidcProviderListItemDto>) => {
-          const menuItems = getRowMenuItems({
-            provider: params.data!,
-            canUpdate,
-            canDelete,
-            onEditClicked: handleEdit,
-            onDeleteClicked: handleDelete,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
+  const columns: ColumnDef<OidcProviderListItemDto, any>[] = [
+    createActionsColumn<OidcProviderListItemDto>({
+      hide: !showRowMenu,
+      ariaLabel: 'Identity provider actions',
+      getItems: (provider) =>
+        getRowMenuItems({
+          provider,
+          canUpdate,
+          canDelete,
+          onEditClicked: handleEdit,
+          onDeleteClicked: handleDelete,
+        }),
+    }),
+    {
+      id: 'name',
+      accessorKey: 'name',
+      header: 'Name',
+      size: 200,
+      cell: ({ row }) => (
+        <Link href={`/settings/auth/providers/${row.original.id}`}>
+          {row.original.name}
+        </Link>
+      ),
+    },
+    {
+      id: 'displayName',
+      accessorKey: 'displayName',
+      header: 'Display Name',
+      size: 200,
+    },
+    {
+      id: 'providerType',
+      accessorFn: (row) => providerTypeLabel(row.providerType ?? ''),
+      header: 'Type',
+      size: 180,
+      meta: { filterType: 'set' },
+    },
+    {
+      id: 'authority',
+      accessorKey: 'authority',
+      header: 'Authority',
+      size: 300,
+    },
+    {
+      id: 'isEnabled',
+      accessorFn: (row) => (row.isEnabled ? 'Enabled' : 'Disabled'),
+      header: 'Enabled',
+      size: 100,
+      meta: { filterType: 'set' },
+      cell: ({ row }) =>
+        row.original.isEnabled ? (
+          <Tag color="success">Enabled</Tag>
+        ) : (
+          <Tag color="default">Disabled</Tag>
+        ),
+    },
+    {
+      id: 'discovery',
+      header: 'Discovery',
+      size: 120,
+      enableSorting: false,
+      enableColumnFilter: false,
+      enableGlobalFilter: false,
+      cell: ({ row }) => {
+        const provider = row.original
+        const testState = testStates[provider.id] ?? { status: 'idle' }
+        return (
+          <DiscoveryTestCell
+            provider={provider}
+            testState={testState}
+            onTest={handleTest}
+          />
+        )
       },
-      { field: 'id', hide: true },
-      {
-        field: 'name',
-        headerName: 'Name',
-        flex: 1,
-        cellRenderer: (params: ICellRendererParams<OidcProviderListItemDto>) => {
-          if (!params.data) return null
-          return (
-            <Link href={`/settings/auth/providers/${params.data.id}`}>
-              {params.data.name}
-            </Link>
-          )
-        },
-      },
-      { field: 'displayName', headerName: 'Display Name', flex: 1 },
-      {
-        field: 'providerType',
-        headerName: 'Type',
-        width: 180,
-        valueGetter: (params) => providerTypeLabel(params.data?.providerType ?? ''),
-      },
-      {
-        field: 'authority',
-        headerName: 'Authority',
-        flex: 2,
-      },
-      {
-        field: 'isEnabled',
-        headerName: 'Enabled',
-        width: 100,
-        cellRenderer: (params: ICellRendererParams<OidcProviderListItemDto>) =>
-          params.value ? (
-            <Tag color="success">Enabled</Tag>
-          ) : (
-            <Tag color="default">Disabled</Tag>
-          ),
-      },
-      {
-        headerName: 'Discovery',
-        width: 120,
-        filter: false,
-        sortable: false,
-        cellRenderer: (params: ICellRendererParams<OidcProviderListItemDto>) => {
-          const provider = params.data!
-          const testState = testStates[provider.id] ?? { status: 'idle' }
-          return (
-            <DiscoveryTestCell
-              provider={provider}
-              testState={testState}
-              onTest={handleTest}
-            />
-          )
-        },
-      },
+    },
   ]
 
-  const refresh = () => { refetch() }
+  const refresh = () => {
+    refetch()
+  }
 
   const actions = !canCreate ? null : (
     <Button onClick={() => setOpenCreateForm(true)}>
@@ -288,12 +302,12 @@ const OidcProvidersPage = () => {
     <>
       <PageTitle title="Identity Providers" actions={actions} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={providers}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={providers ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="identity-providers"
       />
 
       {openCreateForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/background-jobs/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/background-jobs/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import PageTitle from '@/src/components/common/page-title'
-import WaydGrid from '../../../components/common/wayd-grid'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { useMemo, useState } from 'react'
 import { BackgroundJobDto } from '@/src/services/wayd-api'
 import { getBackgroundJobsClient } from '@/src/services/clients'
@@ -14,7 +14,7 @@ import { useDocumentTitle } from '../../../hooks'
 import { PageActions } from '../../../components/common'
 import { useGetJobTypesQuery } from '@/src/store/features/admin/background-jobs-api'
 import CreateRecurringJobForm from './create-recurring-job-form'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 
 const BackgroundJobsListPage = () => {
   useDocumentTitle('Background Jobs')
@@ -29,14 +29,27 @@ const BackgroundJobsListPage = () => {
     'Permissions.BackgroundJobs.Create',
   )
 
-  const columnDefs = useMemo<ColDef<BackgroundJobDto>[]>(() => [
-      { field: 'id' },
-      { field: 'action' },
-      { field: 'status' },
-      { field: 'type' },
-      { field: 'namespace' },
-      { field: 'startedAt', headerName: 'Start (UTC)' },
-    ], [])
+  const columns = useMemo<ColumnDef<BackgroundJobDto, any>[]>(
+    () => [
+      { id: 'id', accessorKey: 'id', header: 'Id' },
+      { id: 'action', accessorKey: 'action', header: 'Action' },
+      {
+        id: 'status',
+        accessorKey: 'status',
+        header: 'Status',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'type',
+        accessorKey: 'type',
+        header: 'Type',
+        meta: { filterType: 'set' },
+      },
+      { id: 'namespace', accessorKey: 'namespace', header: 'Namespace' },
+      { id: 'startedAt', accessorKey: 'startedAt', header: 'Start (UTC)' },
+    ],
+    [],
+  )
 
   const { data: jobTypeData = [] } = useGetJobTypesQuery()
 
@@ -141,11 +154,11 @@ const BackgroundJobsListPage = () => {
         actions={<PageActions actionItems={actionsMenuItems} />}
       />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={backgroundJobs}
-        loadData={getRunningJobs}
+      <WaydGrid2
+        columns={columns}
+        data={backgroundJobs}
+        onRefresh={getRunningJobs}
+        csvFileName="background-jobs"
       />
       {openCreateRecurringJobForm && (
         <CreateRecurringJobForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/connections/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/connections/page.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import { useMemo, useState } from 'react'
-import { WaydGrid, PageActions, PageTitle } from '../../../components/common'
+import { PageActions, PageTitle } from '../../../components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { authorizePage } from '../../../components/hoc'
 import { useDocumentTitle } from '../../../hooks'
 import useAuth from '../../../components/contexts/auth'
@@ -9,17 +10,13 @@ import CreateConnectionForm from './_components/create-connection-form'
 import Link from 'next/link'
 import { ConnectionListDto } from '@/src/services/wayd-api'
 import { getCapabilityNames } from '@/src/types/connectors'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { ItemType } from 'antd/es/menu/interface'
 import { useGetConnectionsQuery } from '@/src/store/features/app-integration/connections-api'
-import { ControlItemSwitch } from '../../../components/common/control-items-menu'
-
-const ConnectionLinkCellRenderer = ({
-  value,
-  data,
-}: ICellRendererParams<ConnectionListDto>) => {
-  return <Link href={`/settings/connections/${data!.id}`}>{value}</Link>
-}
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '../../../components/common/control-items-menu'
 
 const ConnectionsPage = () => {
   useDocumentTitle('Connections')
@@ -38,18 +35,46 @@ const ConnectionsPage = () => {
     'Permissions.Connections.Create',
   )
 
-  const columnDefs = useMemo<ColDef<ConnectionListDto>[]>(
+  const columns = useMemo<ColumnDef<ConnectionListDto, any>[]>(
     () => [
-      { field: 'id', hide: true },
-      { field: 'name', cellRenderer: ConnectionLinkCellRenderer, width: 250 },
-      { field: 'connector.name', headerName: 'Connector', width: 150 },
       {
-        headerName: 'Capabilities',
-        valueGetter: ({ data }) => getCapabilityNames(data),
-        width: 180,
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 250,
+        cell: ({ row }) => (
+          <Link href={`/settings/connections/${row.original.id}`}>
+            {row.original.name}
+          </Link>
+        ),
       },
-      { field: 'isActive', width: 125 },
-      { field: 'isValidConfiguration', width: 150 },
+      {
+        id: 'connector',
+        accessorKey: 'connector.name',
+        header: 'Connector',
+        size: 150,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'capabilities',
+        accessorFn: (row) => getCapabilityNames(row),
+        header: 'Capabilities',
+        size: 180,
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        size: 125,
+        meta: { columnType: 'yesNo' },
+      },
+      {
+        id: 'isValidConfiguration',
+        accessorKey: 'isValidConfiguration',
+        header: 'Valid Configuration',
+        size: 160,
+        meta: { columnType: 'yesNo' },
+      },
     ],
     [],
   )
@@ -95,13 +120,13 @@ const ConnectionsPage = () => {
         actions={<PageActions actionItems={actionsMenuItems} />}
       />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={connectionsData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={connectionsData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="connections"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
 
       {openCreateConnectionForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/organization/team-member-roles/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/organization/team-member-roles/page.tsx
@@ -1,7 +1,10 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { PageTitle } from '@/src/components/common'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { authorizePage } from '@/src/components/hoc'
 import { useDocumentTitle } from '@/src/hooks'
@@ -11,10 +14,13 @@ import {
   useActivateTeamMemberRoleMutation,
   useDeactivateTeamMemberRoleMutation,
 } from '@/src/store/features/organization/team-member-roles-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from 'antd'
 import { useEffect, useMemo, useState } from 'react'
-import { ControlItemSwitch } from '@/src/components/common/control-items-menu'
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '@/src/components/common/control-items-menu'
 import { ItemType } from 'antd/es/menu/interface'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { isApiError } from '@/src/utils'
@@ -28,7 +34,9 @@ const TeamMemberRolesPage = () => {
   const [includeInactive, setIncludeInactive] = useState(false)
   const [openCreateForm, setOpenCreateForm] = useState(false)
   const [editingRole, setEditingRole] = useState<TeamMemberRoleDto | null>(null)
-  const [deletingRole, setDeletingRole] = useState<TeamMemberRoleDto | null>(null)
+  const [deletingRole, setDeletingRole] = useState<TeamMemberRoleDto | null>(
+    null,
+  )
 
   const messageApi = useMessage()
   const { hasPermissionClaim } = useAuth()
@@ -37,7 +45,12 @@ const TeamMemberRolesPage = () => {
   const canUpdate = hasPermissionClaim('Permissions.TeamMemberRoles.Update')
   const canDelete = hasPermissionClaim('Permissions.TeamMemberRoles.Delete')
 
-  const { data: roles, isLoading, error, refetch } = useGetTeamMemberRolesQuery(includeInactive)
+  const {
+    data: roles,
+    isLoading,
+    error,
+    refetch,
+  } = useGetTeamMemberRolesQuery(includeInactive)
   const [activateRole] = useActivateTeamMemberRoleMutation()
   const [deactivateRole] = useDeactivateTeamMemberRoleMutation()
 
@@ -51,11 +64,15 @@ const TeamMemberRolesPage = () => {
     }
   }, [error, messageApi])
 
-  const columnDefs = useMemo<ColDef<TeamMemberRoleDto>[]>(() => {
+  const columns = useMemo<ColumnDef<TeamMemberRoleDto, any>[]>(() => {
     const getRowMenuItems = (role: TeamMemberRoleDto): ItemType[] => {
       const items: ItemType[] = []
       if (canUpdate) {
-        items.push({ key: 'edit', label: 'Edit', onClick: () => setEditingRole(role) })
+        items.push({
+          key: 'edit',
+          label: 'Edit',
+          onClick: () => setEditingRole(role),
+        })
         if (role.isActive) {
           items.push({
             key: 'deactivate',
@@ -64,8 +81,9 @@ const TeamMemberRolesPage = () => {
               const response = await deactivateRole(role.id)
               if (response.error) {
                 messageApi.error(
-                  (isApiError(response.error) ? response.error.detail : undefined) ??
-                    'Failed to deactivate role.',
+                  (isApiError(response.error)
+                    ? response.error.detail
+                    : undefined) ?? 'Failed to deactivate role.',
                 )
               } else {
                 messageApi.success(`"${role.name}" deactivated.`)
@@ -80,8 +98,9 @@ const TeamMemberRolesPage = () => {
               const response = await activateRole(role.id)
               if (response.error) {
                 messageApi.error(
-                  (isApiError(response.error) ? response.error.detail : undefined) ??
-                    'Failed to activate role.',
+                  (isApiError(response.error)
+                    ? response.error.detail
+                    : undefined) ?? 'Failed to activate role.',
                 )
               } else {
                 messageApi.success(`"${role.name}" activated.`)
@@ -91,27 +110,36 @@ const TeamMemberRolesPage = () => {
         }
       }
       if (canDelete) {
-        items.push({ key: 'delete', label: 'Delete', danger: true, onClick: () => setDeletingRole(role) })
+        items.push({
+          key: 'delete',
+          label: 'Delete',
+          danger: true,
+          onClick: () => setDeletingRole(role),
+        })
       }
       return items
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
+      createActionsColumn<TeamMemberRoleDto>({
         hide: !canUpdate && !canDelete,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<TeamMemberRoleDto>) => {
-          if (!params.data) return null
-          return RowMenuCellRenderer({ ...params, menuItems: getRowMenuItems(params.data) })
-        },
+        ariaLabel: 'Team member role actions',
+        getItems: (role) => getRowMenuItems(role),
+      }),
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      { id: 'name', accessorKey: 'name', header: 'Name', size: 250 },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 400,
       },
-      { field: 'key', width: 90 },
-      { field: 'name', flex: 1 },
-      { field: 'description', flex: 2 },
-      { field: 'isActive', headerName: 'Active', width: 90 },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
     ]
   }, [canUpdate, canDelete, activateRole, deactivateRole, messageApi])
 
@@ -130,39 +158,52 @@ const TeamMemberRolesPage = () => {
   ]
 
   const actions = canCreate ? (
-    <Button onClick={() => setOpenCreateForm(true)}>Create Team Member Role</Button>
+    <Button onClick={() => setOpenCreateForm(true)}>
+      Create Team Member Role
+    </Button>
   ) : null
 
   return (
     <>
       <PageTitle title="Team Member Roles" actions={actions} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={roles}
-        loadData={() => { refetch() }}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={roles ?? []}
+        onRefresh={() => {
+          refetch()
+        }}
+        isLoading={isLoading}
+        csvFileName="team-member-roles"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
 
       {openCreateForm && (
         <CreateTeamMemberRoleForm
-          onFormComplete={() => { setOpenCreateForm(false); refetch() }}
+          onFormComplete={() => {
+            setOpenCreateForm(false)
+            refetch()
+          }}
           onFormCancel={() => setOpenCreateForm(false)}
         />
       )}
       {editingRole && (
         <EditTeamMemberRoleForm
           role={editingRole}
-          onFormComplete={() => { setEditingRole(null); refetch() }}
+          onFormComplete={() => {
+            setEditingRole(null)
+            refetch()
+          }}
           onFormCancel={() => setEditingRole(null)}
         />
       )}
       {deletingRole && (
         <DeleteTeamMemberRoleForm
           role={deletingRole}
-          onFormComplete={() => { setDeletingRole(null); refetch() }}
+          onFormComplete={() => {
+            setDeletingRole(null)
+            refetch()
+          }}
           onFormCancel={() => setDeletingRole(null)}
         />
       )}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/planning/estimation-scales/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/planning/estimation-scales/page.tsx
@@ -1,7 +1,10 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { PageTitle } from '@/src/components/common'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { authorizePage, requireFeatureFlag } from '@/src/components/hoc'
 import { useDocumentTitle } from '@/src/hooks'
@@ -10,7 +13,7 @@ import {
   useGetEstimationScalesQuery,
   useSetEstimationScaleActiveStatusMutation,
 } from '@/src/store/features/planning/estimation-scales-api'
-import { ColDef, ICellRendererParams, ValueGetterParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import Link from 'next/link'
@@ -22,10 +25,6 @@ import {
 } from './_components'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { isApiError } from '@/src/utils'
-
-const EstimationScaleCellRenderer = ({ value, data }: ICellRendererParams<EstimationScaleDto>) => {
-  return <Link href={`./estimation-scales/${data!.id}`}>{value}</Link>
-}
 
 interface RowMenuProps {
   scale: EstimationScaleDto
@@ -70,8 +69,9 @@ const EstimationScalesPage = () => {
   useDocumentTitle('Planning - Estimation Scales')
   const [openCreateForm, setOpenCreateForm] = useState<boolean>(false)
   const [editScaleId, setEditScaleId] = useState<number | null>(null)
-  const [deleteScale, setDeleteScale] =
-    useState<EstimationScaleDto | null>(null)
+  const [deleteScale, setDeleteScale] = useState<EstimationScaleDto | null>(
+    null,
+  )
 
   const messageApi = useMessage()
 
@@ -98,13 +98,14 @@ const EstimationScalesPage = () => {
   useEffect(() => {
     if (error) {
       messageApi.error(
-        (isApiError(error) ? error.detail : undefined) ?? 'An error occurred while loading estimation scales',
+        (isApiError(error) ? error.detail : undefined) ??
+          'An error occurred while loading estimation scales',
       )
       console.error(error)
     }
   }, [error, messageApi])
 
-  const columnDefs = useMemo<ColDef<EstimationScaleDto>[]>(() => {
+  const columns = useMemo<ColumnDef<EstimationScaleDto, any>[]>(() => {
     const handleEdit = (id: number) => {
       setEditScaleId(id)
     }
@@ -134,51 +135,61 @@ const EstimationScalesPage = () => {
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<EstimationScaleDto>({
         hide: !showRowMenu,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<EstimationScaleDto>) => {
-          const menuItems = getRowMenuItems({
-            scale: params.data!,
+        ariaLabel: 'Estimation scale actions',
+        getItems: (scale) =>
+          getRowMenuItems({
+            scale,
             canUpdate: canUpdateEstimationScale,
             canDelete: canDeleteEstimationScale,
             onEditClicked: handleEdit,
             onToggleActiveClicked: handleToggleActive,
             onDeleteClicked: handleDelete,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
-      },
-      { field: 'id', hide: true },
-      { field: 'name', cellRenderer: EstimationScaleCellRenderer },
+          }),
+      }),
       {
-        field: 'isActive',
-        headerName: 'Active',
-        width: 100,
-        cellRenderer: (params: ICellRendererParams<EstimationScaleDto>) => (params.value ? 'Yes' : 'No'),
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <Link href={`./estimation-scales/${row.original.id}`}>
+            {row.original.name}
+          </Link>
+        ),
       },
       {
-        field: 'values',
-        headerName: 'Values',
-        width: 100,
-        valueGetter: (params: ValueGetterParams<EstimationScaleDto>) => params.data?.values?.length ?? 0,
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        size: 100,
+        meta: { columnType: 'yesNo' },
       },
-    ]}, [showRowMenu, canUpdateEstimationScale, canDeleteEstimationScale, setActiveStatus, messageApi])
+      {
+        id: 'values',
+        accessorFn: (row) => row.values?.length ?? 0,
+        header: 'Values',
+        size: 100,
+        enableColumnFilter: false,
+      },
+    ]
+  }, [
+    showRowMenu,
+    canUpdateEstimationScale,
+    canDeleteEstimationScale,
+    setActiveStatus,
+    messageApi,
+  ])
 
   const refresh = async () => {
     refetch()
   }
 
   const actions = !canCreateEstimationScale ? null : (
-      <Button onClick={() => setOpenCreateForm(true)}>
-        Create Estimation Scale
-      </Button>
-    )
+    <Button onClick={() => setOpenCreateForm(true)}>
+      Create Estimation Scale
+    </Button>
+  )
 
   const onCreateFormClosed = (wasCreated: boolean) => {
     setOpenCreateForm(false)
@@ -205,12 +216,12 @@ const EstimationScalesPage = () => {
     <>
       <PageTitle title="Estimation Scales" actions={actions} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={scaleData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={scaleData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="estimation-scales"
       />
       {openCreateForm && (
         <CreateEstimationScaleForm
@@ -237,7 +248,11 @@ const EstimationScalesPage = () => {
 }
 
 const EstimationScalesPageWithAuthorization = requireFeatureFlag(
-  authorizePage(EstimationScalesPage, 'Permission', 'Permissions.EstimationScales.View'),
+  authorizePage(
+    EstimationScalesPage,
+    'Permission',
+    'Permissions.EstimationScales.View',
+  ),
   'planning-poker',
 )
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/expenditure-categories/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/expenditure-categories/page.tsx
@@ -1,22 +1,19 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
+import { PageTitle } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { authorizePage } from '@/src/components/hoc'
 import { useDocumentTitle } from '@/src/hooks'
 import { ExpenditureCategoryListDto } from '@/src/services/wayd-api'
 import { useGetExpenditureCategoriesQuery } from '@/src/store/features/ppm/expenditure-categories-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from 'antd'
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import { CreateExpenditureCategoryForm } from './_components'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { isApiError } from '@/src/utils'
-
-const ExpenditureCategoryCellRenderer = ({ value, data }: ICellRendererParams<ExpenditureCategoryListDto>) => {
-  return <Link href={`./expenditure-categories/${data!.id}`}>{value}</Link>
-}
 
 const ExpenditureCategoriesPage = () => {
   useDocumentTitle('PPM - Expenditure Categories')
@@ -50,36 +47,62 @@ const ExpenditureCategoriesPage = () => {
     }
   }, [error, messageApi])
 
-  const columnDefs = useMemo<ColDef<ExpenditureCategoryListDto>[]>(() => [
-      { field: 'id', hide: true },
-      { field: 'name', cellRenderer: ExpenditureCategoryCellRenderer },
-      { field: 'state.name', headerName: 'State', width: 100 },
+  const columns = useMemo<ColumnDef<ExpenditureCategoryListDto, any>[]>(
+    () => [
       {
-        field: 'isCapitalizable',
-        headerName: 'Capitalizable',
-        width: 100,
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <Link href={`./expenditure-categories/${row.original.id}`}>
+            {row.original.name}
+          </Link>
+        ),
       },
       {
-        field: 'requiresDepreciation',
-        headerName: 'Requires Depreciation',
-        width: 150,
+        id: 'state',
+        accessorKey: 'state.name',
+        header: 'State',
+        size: 100,
+        meta: { filterType: 'set' },
       },
-      { field: 'accountingCode', headerName: 'Accounting Code', width: 150 },
-    ], [])
+      {
+        id: 'isCapitalizable',
+        accessorKey: 'isCapitalizable',
+        header: 'Capitalizable',
+        size: 120,
+        meta: { columnType: 'yesNo' },
+      },
+      {
+        id: 'requiresDepreciation',
+        accessorKey: 'requiresDepreciation',
+        header: 'Requires Depreciation',
+        size: 170,
+        meta: { columnType: 'yesNo' },
+      },
+      {
+        id: 'accountingCode',
+        accessorKey: 'accountingCode',
+        header: 'Accounting Code',
+        size: 150,
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   const actions = !showActions ? null : (
-      <>
-        {canCreateExpenditureCategory && (
-          <Button onClick={() => setOpenCreateExpenditureCategoryForm(true)}>
-            Create Expenditure Category
-          </Button>
-        )}
-      </>
-    )
+    <>
+      {canCreateExpenditureCategory && (
+        <Button onClick={() => setOpenCreateExpenditureCategoryForm(true)}>
+          Create Expenditure Category
+        </Button>
+      )}
+    </>
+  )
 
   const onCreateExpenditureCategoryFormClosed = (wasCreated: boolean) => {
     setOpenCreateExpenditureCategoryForm(false)
@@ -92,12 +115,12 @@ const ExpenditureCategoriesPage = () => {
     <>
       <PageTitle title="Expenditure Categories" actions={actions} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={categoryData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={categoryData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="expenditure-categories"
       />
       {openCreateExpenditureCategoryForm && (
         <CreateExpenditureCategoryForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/_components/project-lifecycle-phases-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/_components/project-lifecycle-phases-list.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import { useMessage } from '@/src/components/contexts/messaging'
 import {
   ProjectLifecycleDetailsDto,
@@ -13,7 +15,7 @@ import {
 } from '@/src/store/features/ppm/project-lifecycles-api'
 import { App, Button } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import AddProjectLifecyclePhaseForm from './add-project-lifecycle-phase-form'
 import EditProjectLifecyclePhaseForm from './edit-project-lifecycle-phase-form'
@@ -101,7 +103,7 @@ const ProjectLifecyclePhasesList = ({
     [lifecycle?.phases],
   )
 
-  const columnDefs = useMemo<ColDef<ProjectLifecyclePhaseDto>[]>(() => {
+  const columns = useMemo<ColumnDef<ProjectLifecyclePhaseDto, any>[]>(() => {
     const handleEdit = (phase: ProjectLifecyclePhaseDto) => {
       setEditingPhase(phase)
     }
@@ -162,28 +164,32 @@ const ProjectLifecyclePhasesList = ({
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<ProjectLifecyclePhaseDto>({
         hide: !canManagePhases,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<ProjectLifecyclePhaseDto>) => {
-          const menuItems = getRowMenuItems({
-            phase: params.data!,
+        ariaLabel: 'Phase actions',
+        getItems: (phase) =>
+          getRowMenuItems({
+            phase,
             sortedPhases,
             onEditClicked: handleEdit,
             onDeleteClicked: handleDeletePhase,
             onMoveClicked: handleMove,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
+          }),
+      }),
+      {
+        id: 'order',
+        accessorKey: 'order',
+        header: 'Order',
+        size: 90,
+        enableColumnFilter: false,
       },
-      { field: 'order', headerName: 'Order', width: 90, sort: 'asc' as const },
-      { field: 'name', headerName: 'Name', width: 200 },
-      { field: 'description', headerName: 'Description', flex: 1 },
+      { id: 'name', accessorKey: 'name', header: 'Name', size: 200 },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 400,
+      },
     ]}, [canManagePhases, sortedPhases, modal, removeProjectLifecyclePhase, reorderPhases, lifecycle.id, messageApi])
 
   const actions = canManagePhases ? (
@@ -194,12 +200,13 @@ const ProjectLifecyclePhasesList = ({
 
   return (
     <>
-      <WaydGrid
+      <WaydGrid2
         height={300}
-        columnDefs={columnDefs}
-        rowData={sortedPhases}
-        actions={actions}
-        loadData={loadData}
+        columns={columns}
+        data={sortedPhases}
+        leftSlot={actions}
+        onRefresh={loadData}
+        csvFileName="project-lifecycle-phases"
       />
       {openAddPhaseForm && (
         <AddProjectLifecyclePhaseForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/page.tsx
@@ -1,22 +1,19 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
+import { PageTitle } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { authorizePage } from '@/src/components/hoc'
 import { useDocumentTitle } from '@/src/hooks'
 import { ProjectLifecycleListDto } from '@/src/services/wayd-api'
 import { useGetProjectLifecyclesQuery } from '@/src/store/features/ppm/project-lifecycles-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from 'antd'
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import CreateProjectLifecycleForm from './_components/create-project-lifecycle-form'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { isApiError } from '@/src/utils'
-
-const ProjectLifecycleCellRenderer = ({ value, data }: ICellRendererParams<ProjectLifecycleListDto>) => {
-  return <Link href={`./project-lifecycles/${data!.key}`}>{value}</Link>
-}
 
 const ProjectLifecyclesPage = () => {
   useDocumentTitle('PPM - Project Lifecycles')
@@ -47,27 +44,49 @@ const ProjectLifecyclesPage = () => {
     }
   }, [error, messageApi])
 
-  const columnDefs = useMemo<ColDef<ProjectLifecycleListDto>[]>(() => [
-      { field: 'id', hide: true },
-      { field: 'key', width: 90 },
-      { field: 'name', cellRenderer: ProjectLifecycleCellRenderer, sort: 'asc' },
-      { field: 'state.name', headerName: 'State', width: 100 },
-      { field: 'phaseCount', headerName: 'Phase Count', width: 120 },
-    ], [])
+  const columns = useMemo<ColumnDef<ProjectLifecycleListDto, any>[]>(
+    () => [
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <Link href={`./project-lifecycles/${row.original.key}`}>
+            {row.original.name}
+          </Link>
+        ),
+      },
+      {
+        id: 'state',
+        accessorKey: 'state.name',
+        header: 'State',
+        size: 100,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'phaseCount',
+        accessorKey: 'phaseCount',
+        header: 'Phase Count',
+        size: 120,
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   const actions = !showActions ? null : (
-      <>
-        {canCreateProjectLifecycle && (
-          <Button onClick={() => setOpenCreateForm(true)}>
-            Create Project Lifecycle
-          </Button>
-        )}
-      </>
-    )
+    <>
+      {canCreateProjectLifecycle && (
+        <Button onClick={() => setOpenCreateForm(true)}>
+          Create Project Lifecycle
+        </Button>
+      )}
+    </>
+  )
 
   const onCreateFormClosed = (wasCreated: boolean) => {
     setOpenCreateForm(false)
@@ -80,12 +99,12 @@ const ProjectLifecyclesPage = () => {
     <>
       <PageTitle title="Project Lifecycles" actions={actions} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={lifecycleData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={lifecycleData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="project-lifecycles"
       />
       {openCreateForm && (
         <CreateProjectLifecycleForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-criteria-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-criteria-list.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import { useMessage } from '@/src/components/contexts/messaging'
 import {
   ScoringModelCriterionDto,
@@ -13,7 +15,7 @@ import {
 } from '@/src/store/features/scoring/scoring-models-api'
 import { App, Button, Space, Tag, Typography } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import AddScoringModelCriterionForm from './add-scoring-model-criterion-form'
 import EditScoringModelCriterionForm from './edit-scoring-model-criterion-form'
@@ -117,7 +119,7 @@ const ScoringModelCriteriaList = ({
     [sortedCriteria],
   )
 
-  const columnDefs = useMemo<ColDef<ScoringModelCriterionDto>[]>(() => {
+  const columns = useMemo<ColumnDef<ScoringModelCriterionDto, any>[]>(() => {
     const handleEdit = (criterion: ScoringModelCriterionDto) => {
       setEditingCriterion(criterion)
     }
@@ -183,45 +185,52 @@ const ScoringModelCriteriaList = ({
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<ScoringModelCriterionDto>({
         hide: !canManage,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (
-          params: ICellRendererParams<ScoringModelCriterionDto>,
-        ) => {
-          const menuItems = getRowMenuItems({
-            criterion: params.data!,
+        ariaLabel: 'Criterion actions',
+        getItems: (criterion) =>
+          getRowMenuItems({
+            criterion,
             sortedCriteria,
             onEditClicked: handleEdit,
             onDeleteClicked: handleDelete,
             onMoveClicked: handleMove,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
-      },
-      { field: 'order', headerName: 'Order', width: 80, sort: 'asc' as const },
-      { field: 'name', headerName: 'Name', width: 250 },
-      { field: 'token', headerName: 'Token', width: 110 },
+          }),
+      }),
       {
-        headerName: 'Scale',
-        valueGetter: (p) => {
-          const scaleId = p.data?.scaleId
+        id: 'order',
+        accessorKey: 'order',
+        header: 'Order',
+        size: 80,
+        enableColumnFilter: false,
+      },
+      { id: 'name', accessorKey: 'name', header: 'Name', size: 250 },
+      { id: 'token', accessorKey: 'token', header: 'Token', size: 110 },
+      {
+        id: 'scale',
+        accessorFn: (row) => {
+          const scaleId = row.scaleId
           if (!scaleId) return 'Free entry'
           return scoringModel.scales?.find((s) => s.id === scaleId)?.name ?? '—'
         },
+        header: 'Scale',
       },
       {
-        field: 'weight',
-        headerName: 'Weight (%)',
-        width: 120,
-        valueFormatter: (p) => (p.value != null ? `${p.value}%` : ''),
+        id: 'weight',
+        accessorKey: 'weight',
+        header: 'Weight (%)',
+        size: 120,
+        cell: ({ getValue }) => {
+          const value = getValue() as number | null | undefined
+          return value != null ? `${value}%` : ''
+        },
       },
-      { field: 'description', headerName: 'Description', width: 300 },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 300,
+      },
     ]
   }, [
     canManage,
@@ -262,12 +271,13 @@ const ScoringModelCriteriaList = ({
 
   return (
     <>
-      <WaydGrid
+      <WaydGrid2
         height={300}
-        columnDefs={columnDefs}
-        rowData={sortedCriteria}
-        actions={actions}
-        loadData={loadData}
+        columns={columns}
+        data={sortedCriteria}
+        leftSlot={actions}
+        onRefresh={loadData}
+        csvFileName="scoring-criteria"
       />
       {openAddForm && (
         <AddScoringModelCriterionForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-outputs-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-outputs-list.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import { useMessage } from '@/src/components/contexts/messaging'
 import {
   ScoringModelDetailsDto,
@@ -13,7 +15,7 @@ import {
 } from '@/src/store/features/scoring/scoring-models-api'
 import { App, Button, Space, Tag } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import AddScoringModelOutputForm from './add-scoring-model-output-form'
 import EditScoringModelOutputForm from './edit-scoring-model-output-form'
@@ -116,7 +118,7 @@ const ScoringModelOutputsList = ({
     [scoringModel?.criteria, scoringModel?.outputs],
   )
 
-  const columnDefs = useMemo<ColDef<ScoringModelOutputDto>[]>(() => {
+  const columns = useMemo<ColumnDef<ScoringModelOutputDto, any>[]>(() => {
     const handleEdit = (output: ScoringModelOutputDto) => {
       setEditingOutput(output)
     }
@@ -182,35 +184,36 @@ const ScoringModelOutputsList = ({
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<ScoringModelOutputDto>({
         hide: !canManage,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<ScoringModelOutputDto>) => {
-          const menuItems = getRowMenuItems({
-            output: params.data!,
+        ariaLabel: 'Output actions',
+        getItems: (output) =>
+          getRowMenuItems({
+            output,
             sortedOutputs,
             onEditClicked: handleEdit,
             onDeleteClicked: handleDelete,
             onMoveClicked: handleMove,
-          })
-          if (menuItems.length === 0) return null
-          return RowMenuCellRenderer({ ...params, menuItems })
-        },
-      },
-      { field: 'order', width: 80, sort: 'asc' as const },
-      { field: 'name', width: 200 },
-      { field: 'token', width: 110 },
-      { field: 'formula', flex: 1 },
+          }),
+      }),
       {
-        field: 'isPrimary',
-        headerName: 'Primary',
-        width: 110,
-        cellRenderer: (params: ICellRendererParams<ScoringModelOutputDto>) =>
-          params.value ? <Tag color="blue">Primary</Tag> : null,
+        id: 'order',
+        accessorKey: 'order',
+        header: 'Order',
+        size: 80,
+        enableColumnFilter: false,
+      },
+      { id: 'name', accessorKey: 'name', header: 'Name', size: 200 },
+      { id: 'token', accessorKey: 'token', header: 'Token', size: 110 },
+      { id: 'formula', accessorKey: 'formula', header: 'Formula', size: 300 },
+      {
+        id: 'isPrimary',
+        accessorFn: (row) => (row.isPrimary ? 'Yes' : 'No'),
+        header: 'Primary',
+        size: 110,
+        meta: { filterType: 'set' },
+        cell: ({ row }) =>
+          row.original.isPrimary ? <Tag color="blue">Primary</Tag> : null,
       },
     ]
   }, [
@@ -279,12 +282,13 @@ const ScoringModelOutputsList = ({
 
   return (
     <>
-      <WaydGrid
+      <WaydGrid2
         height={300}
-        columnDefs={columnDefs}
-        rowData={sortedOutputs}
-        actions={actions}
-        loadData={loadData}
+        columns={columns}
+        data={sortedOutputs}
+        leftSlot={actions}
+        onRefresh={loadData}
+        csvFileName="scoring-outputs"
       />
       {openAddForm && (
         <AddScoringModelOutputForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-scales-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-scales-list.tsx
@@ -1,7 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { RowMenuCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import { useMessage } from '@/src/components/contexts/messaging'
 import {
   ScoringModelDetailsDto,
@@ -15,7 +17,7 @@ import {
 } from '@/src/store/features/scoring/scoring-models-api'
 import { App, Button, Collapse, Empty, Space, Typography } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useMemo, useState } from 'react'
 import AddScoringScaleForm from './add-scoring-scale-form'
 import EditScoringScaleForm from './edit-scoring-scale-form'
@@ -86,10 +88,10 @@ const ScoringScalesList = ({
     })
   }
 
-  const makeLevelColumnDefs = (
+  const makeLevelColumns = (
     scale: ScoringScaleDto,
     sortedLevels: ScoringRatingLevelDto[],
-  ): ColDef<ScoringRatingLevelDto>[] => {
+  ): ColumnDef<ScoringRatingLevelDto, any>[] => {
     const handleDeleteLevel = (level: ScoringRatingLevelDto) => {
       modal.confirm({
         title: 'Delete this rating level?',
@@ -185,22 +187,20 @@ const ScoringScalesList = ({
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<ScoringRatingLevelDto>({
         hide: !canManage,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<ScoringRatingLevelDto>) =>
-          RowMenuCellRenderer({
-            ...params,
-            menuItems: getRowMenuItems(params.data!),
-          }),
+        ariaLabel: 'Rating level actions',
+        getItems: (level) => getRowMenuItems(level),
+      }),
+      {
+        id: 'order',
+        accessorKey: 'order',
+        header: 'Order',
+        size: 90,
+        enableColumnFilter: false,
       },
-      { field: 'order', headerName: 'Order', width: 90, sort: 'asc' as const },
-      { field: 'label', headerName: 'Label', width: 200 },
-      { field: 'value', headerName: 'Value', flex: 1 },
+      { id: 'label', accessorKey: 'label', header: 'Label', size: 200 },
+      { id: 'value', accessorKey: 'value', header: 'Value', size: 150 },
     ]
   }
 
@@ -230,11 +230,12 @@ const ScoringScalesList = ({
         </Space>
       ) : undefined,
       children: (
-        <WaydGrid
+        <WaydGrid2
           height={220}
-          columnDefs={makeLevelColumnDefs(scale, sortedLevels)}
-          rowData={sortedLevels}
-          loadData={loadData}
+          columns={makeLevelColumns(scale, sortedLevels)}
+          data={sortedLevels}
+          onRefresh={loadData}
+          csvFileName="scoring-scale-levels"
         />
       ),
     }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/page.tsx
@@ -1,25 +1,19 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
+import { PageTitle } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import useAuth from '@/src/components/contexts/auth'
 import { authorizePage } from '@/src/components/hoc'
 import { useDocumentTitle } from '@/src/hooks'
 import { ScoringModelListDto } from '@/src/services/wayd-api'
 import { useGetScoringModelsQuery } from '@/src/store/features/scoring/scoring-models-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button } from 'antd'
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
 import CreateScoringModelForm from './_components/create-scoring-model-form'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { isApiError } from '@/src/utils'
-
-const ScoringModelCellRenderer = ({
-  value,
-  data,
-}: ICellRendererParams<ScoringModelListDto>) => {
-  return <Link href={`./scoring-models/${data!.key}`}>{value}</Link>
-}
 
 const ScoringModelsPage = () => {
   useDocumentTitle('Settings - Scoring Models')
@@ -50,15 +44,44 @@ const ScoringModelsPage = () => {
     }
   }, [error, messageApi])
 
-  const columnDefs = useMemo<ColDef<ScoringModelListDto>[]>(
+  const columns = useMemo<ColumnDef<ScoringModelListDto, any>[]>(
     () => [
-      { field: 'id', hide: true },
-      { field: 'key', width: 90 },
-      { field: 'name', cellRenderer: ScoringModelCellRenderer, sort: 'asc' },
-      { field: 'state.name', headerName: 'State', width: 100 },
-      { field: 'criterionCount', headerName: 'Criteria', width: 110 },
-      { field: 'scaleCount', headerName: 'Scales', width: 110 },
-      { field: 'outputCount', headerName: 'Outputs', width: 110 },
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <Link href={`./scoring-models/${row.original.key}`}>
+            {row.original.name}
+          </Link>
+        ),
+      },
+      {
+        id: 'state',
+        accessorKey: 'state.name',
+        header: 'State',
+        size: 100,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'criterionCount',
+        accessorKey: 'criterionCount',
+        header: 'Criteria',
+        size: 110,
+      },
+      {
+        id: 'scaleCount',
+        accessorKey: 'scaleCount',
+        header: 'Scales',
+        size: 110,
+      },
+      {
+        id: 'outputCount',
+        accessorKey: 'outputCount',
+        header: 'Outputs',
+        size: 110,
+      },
     ],
     [],
   )
@@ -88,12 +111,12 @@ const ScoringModelsPage = () => {
     <>
       <PageTitle title="Scoring Models" actions={actions} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={scoringModelData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={scoringModelData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="scoring-models"
       />
       {openCreateForm && (
         <CreateScoringModelForm
@@ -112,4 +135,3 @@ const ScoringModelsPageWithAuthorization = authorizePage(
 )
 
 export default ScoringModelsPageWithAuthorization
-

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/_components/role-users-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/_components/role-users-grid.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { UserLinkCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
-import { RoleListDto, UserDetailsDto } from '@/src/services/wayd-api'
+import { WaydGrid2, renderUserLink } from '@/src/components/common/wayd-grid2'
+import { UserDetailsDto } from '@/src/services/wayd-api'
 import { useGetRoleUsersQuery } from '@/src/store/features/user-management/roles-api'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { FC, useMemo } from 'react'
 
 export interface RoleUsersGridProps {
@@ -18,33 +17,46 @@ const RoleUsersGrid: FC<RoleUsersGridProps> = (props: RoleUsersGridProps) => {
     refetch,
   } = useGetRoleUsersQuery(props.roleId)
 
-  const columnDefs = useMemo<ColDef<UserDetailsDto>[]>(() => [
-      { field: 'id', hide: true },
-      { field: 'userName', cellRenderer: UserLinkCellRenderer },
-      { field: 'firstName' },
-      { field: 'lastName' },
+  const columns = useMemo<ColumnDef<UserDetailsDto, any>[]>(
+    () => [
       {
-        field: 'roles',
-        valueFormatter: (params) =>
-          params.value
-            ?.map((r: RoleListDto) => r.name)
+        id: 'userName',
+        accessorKey: 'userName',
+        header: 'User Name',
+        cell: ({ row }) => renderUserLink(row.original),
+      },
+      { id: 'firstName', accessorKey: 'firstName', header: 'First Name' },
+      { id: 'lastName', accessorKey: 'lastName', header: 'Last Name' },
+      {
+        id: 'roles',
+        accessorFn: (row) =>
+          row.roles
+            ?.map((r) => r.name)
             .sort()
             .join(', ') ?? '',
+        header: 'Roles',
       },
-      { field: 'isActive' }, // TODO: convert to yes/no
-    ], [])
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <WaydGrid
-      height={550}
-      columnDefs={columnDefs}
-      rowData={usersData}
-      loadData={refresh}
-      loading={isLoading}
+    <WaydGrid2
+      columns={columns}
+      data={usersData ?? []}
+      onRefresh={refresh}
+      isLoading={isLoading}
+      csvFileName="role-users"
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/page.tsx
@@ -2,7 +2,7 @@
 
 import PageTitle from '@/src/components/common/page-title'
 import { useEffect, useMemo, useState } from 'react'
-import WaydGrid from '@/src/components/common/wayd-grid'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { authorizePage } from '@/src/components/hoc'
 import Link from 'next/link'
 import { Button } from 'antd'
@@ -12,11 +12,7 @@ import { useDocumentTitle } from '@/src/hooks'
 import { useGetRolesQuery } from '@/src/store/features/user-management/roles-api'
 import { CreateRoleForm } from './_components'
 import { RoleListDto } from '@/src/services/wayd-api'
-import { ICellRendererParams } from 'ag-grid-community'
-
-const LinkCellRenderer = ({ value, data }: ICellRendererParams<RoleListDto>) => {
-  return <Link href={`roles/${data!.id}`}>{value}</Link>
-}
+import type { ColumnDef } from '@tanstack/react-table'
 
 const RoleListPage = () => {
   useDocumentTitle('Roles')
@@ -28,10 +24,25 @@ const RoleListPage = () => {
   const { hasClaim } = useAuth()
   const canCreateRole = hasClaim('Permission', 'Permissions.Roles.Create')
 
-  const columnDefs = useMemo(() => [
-      { field: 'name', cellRenderer: LinkCellRenderer },
-      { field: 'description', width: 300 },
-    ], [])
+  const columns = useMemo<ColumnDef<RoleListDto, any>[]>(
+    () => [
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        cell: ({ row }) => (
+          <Link href={`roles/${row.original.id}`}>{row.original.name}</Link>
+        ),
+      },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 300,
+      },
+    ],
+    [],
+  )
 
   useEffect(() => {
     error && console.error(error)
@@ -57,12 +68,12 @@ const RoleListPage = () => {
     <>
       <PageTitle title="Roles" actions={actions()} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={roleData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={roleData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="roles"
       />
 
       {openCreateRoleForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/users/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/users/page.tsx
@@ -2,7 +2,12 @@
 
 import PageTitle from '@/src/components/common/page-title'
 import { useEffect, useMemo, useState } from 'react'
-import WaydGrid from '@/src/components/common/wayd-grid'
+import {
+  WaydGrid2,
+  createActionsColumn,
+  renderUserLink,
+  formatDateTime,
+} from '@/src/components/common/wayd-grid2'
 import { authorizePage } from '@/src/components/hoc'
 import Link from 'next/link'
 import { Button, Tag } from 'antd'
@@ -10,13 +15,9 @@ import { WaydTooltip } from '@/src/components/common'
 import useAuth from '@/src/components/contexts/auth'
 import { useDocumentTitle } from '@/src/hooks'
 import { useGetUsersQuery } from '@/src/store/features/user-management/users-api'
-import { RoleListDto, UserDetailsDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams, ValueFormatterParams } from 'ag-grid-community'
+import { UserDetailsDto } from '@/src/services/wayd-api'
+import type { ColumnDef } from '@tanstack/react-table'
 import dayjs from 'dayjs'
-import {
-  RowMenuCellRenderer,
-  UserLinkCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
 import {
   CreateUserForm,
   EditUserForm,
@@ -25,16 +26,6 @@ import {
   useUserAccountActions,
 } from './_components'
 import { ItemType } from 'antd/es/menu/interface'
-
-const EmployeeLinkCellRenderer = ({ value, data }: ICellRendererParams<UserDetailsDto>) => {
-  return (
-    <Link href={`/organizations/employees/${data!.employee?.key}`}>{value}</Link>
-  )
-}
-
-const dateTimeValueFormatter = (
-  params: ValueFormatterParams<UserDetailsDto>,
-) => (params.value ? dayjs(params.value).format('YYYY-MM-DD h:mm A') : '')
 
 const UsersListPage = () => {
   useDocumentTitle('Users')
@@ -58,112 +49,137 @@ const UsersListPage = () => {
   const { getAccountActionMenuItems } = useUserAccountActions()
   const { data: usersData, isLoading, error, refetch } = useGetUsersQuery()
 
-  const columnDefs = useMemo<ColDef<UserDetailsDto>[]>(() => [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
+  const columns = useMemo<ColumnDef<UserDetailsDto, any>[]>(
+    () => [
+      createActionsColumn<UserDetailsDto>({
         hide: !showRowActions,
-        suppressHeaderMenuButton: true,
-        cellRenderer: (params: ICellRendererParams<UserDetailsDto>) => {
+        ariaLabel: 'User actions',
+        getItems: (user) => {
           const menuItems: ItemType[] = []
           if (canUpdateUser) {
             menuItems.push({
               key: 'edit',
               label: 'Edit',
-              onClick: () => setEditingUser(params.data ?? null),
+              onClick: () => setEditingUser(user),
             })
             menuItems.push(
               ...getAccountActionMenuItems({
-                id: params.data!.id,
-                userName: params.data!.userName!,
-                firstName: params.data!.firstName!,
-                lastName: params.data!.lastName!,
-                isActive: params.data!.isActive,
+                id: user.id,
+                userName: user.userName!,
+                firstName: user.firstName!,
+                lastName: user.lastName!,
+                isActive: user.isActive,
                 isLockedOut:
-                  !!params.data!.lockoutEnd &&
-                  new Date(params.data!.lockoutEnd) > new Date(),
+                  !!user.lockoutEnd && new Date(user.lockoutEnd) > new Date(),
               }),
             )
           }
           const secondaryItems: ItemType[] = []
-          if (canUpdateUser && params.data!.loginProvider === 'Wayd') {
+          if (canUpdateUser && user.loginProvider === 'Wayd') {
             secondaryItems.push({
               key: 'reset-password',
               label: 'Reset Password',
-              onClick: () => setResettingPasswordUser(params.data ?? null),
+              onClick: () => setResettingPasswordUser(user),
             })
           }
           if (canUpdateUserRoles) {
             secondaryItems.push({
               key: 'manage-roles',
               label: 'Manage Roles',
-              onClick: () => setManagingRolesUserId(params.data!.id),
+              onClick: () => setManagingRolesUserId(user.id),
             })
           }
           if (secondaryItems.length > 0 && menuItems.length > 0) {
             menuItems.push({ key: 'divider', type: 'divider' })
           }
           menuItems.push(...secondaryItems)
-          return <RowMenuCellRenderer {...params} menuItems={menuItems} />
+          return menuItems
         },
-      },
-      { field: 'id', hide: true },
-      { field: 'userName', cellRenderer: UserLinkCellRenderer },
-      { field: 'firstName' },
-      { field: 'lastName' },
-      { field: 'email' },
+      }),
       {
-        field: 'loginProvider',
-        headerName: 'Login Provider',
-        valueFormatter: (params) =>
-          params.value === 'MicrosoftEntraId'
+        id: 'userName',
+        accessorKey: 'userName',
+        header: 'User Name',
+        cell: ({ row }) => renderUserLink(row.original),
+      },
+      { id: 'firstName', accessorKey: 'firstName', header: 'First Name' },
+      { id: 'lastName', accessorKey: 'lastName', header: 'Last Name' },
+      { id: 'email', accessorKey: 'email', header: 'Email' },
+      {
+        id: 'loginProvider',
+        accessorFn: (row) =>
+          row.loginProvider === 'MicrosoftEntraId'
             ? 'Microsoft Entra ID'
-            : (params.value ?? ''),
+            : (row.loginProvider ?? ''),
+        header: 'Login Provider',
+        meta: { filterType: 'set' },
       },
       {
-        field: 'employee.name',
-        headerName: 'Employee',
-        cellRenderer: EmployeeLinkCellRenderer,
-      },
-      {
-        field: 'roles',
-        valueFormatter: (params) =>
-          params.value
-            ?.map((r: RoleListDto) => r.name)
-            .sort()
-            .join(', ') ?? '',
-      },
-      {
-        field: 'lockoutEnd',
-        headerName: 'Locked Out',
-        width: 120,
-        cellRenderer: (params: { value: Date | undefined }) =>
-          params.value && new Date(params.value) > new Date() ? (
-            <WaydTooltip
-              title={`Locked until ${dayjs(params.value).format('MMM D, YYYY h:mm A')}`}
+        id: 'employee',
+        accessorKey: 'employee.name',
+        header: 'Employee',
+        cell: ({ row }) =>
+          row.original.employee ? (
+            <Link
+              href={`/organizations/employees/${row.original.employee.key}`}
             >
-              <Tag color="error">Locked</Tag>
-            </WaydTooltip>
+              {row.original.employee.name}
+            </Link>
           ) : null,
       },
       {
-        field: 'lastActivityAt',
-        headerName: 'Last Activity',
-        valueFormatter: dateTimeValueFormatter,
+        id: 'roles',
+        accessorFn: (row) =>
+          row.roles
+            ?.map((r) => r.name)
+            .sort()
+            .join(', ') ?? '',
+        header: 'Roles',
       },
       {
-        field: 'isActive',
-        headerName: 'Active',
-        width: 100,
-        cellRenderer: (params: { value: boolean | undefined }) =>
-          params.value ? (
+        id: 'lockoutEnd',
+        accessorKey: 'lockoutEnd',
+        header: 'Locked Out',
+        size: 120,
+        cell: ({ getValue }) => {
+          const value = getValue() as Date | undefined
+          return value && new Date(value) > new Date() ? (
+            <WaydTooltip
+              title={`Locked until ${dayjs(value).format('MMM D, YYYY h:mm A')}`}
+            >
+              <Tag color="error">Locked</Tag>
+            </WaydTooltip>
+          ) : null
+        },
+      },
+      {
+        id: 'lastActivityAt',
+        accessorKey: 'lastActivityAt',
+        header: 'Last Activity',
+        meta: { columnType: 'dateTime' },
+        cell: ({ getValue }) => (getValue() ? formatDateTime(getValue()) : ''),
+      },
+      {
+        id: 'isActive',
+        accessorFn: (row) => (row.isActive ? 'Active' : 'Inactive'),
+        header: 'Active',
+        size: 100,
+        meta: { filterType: 'set' },
+        cell: ({ row }) =>
+          row.original.isActive ? (
             <Tag color="success">Active</Tag>
           ) : (
             <Tag color="error">Inactive</Tag>
           ),
       },
-    ], [showRowActions, canUpdateUser, canUpdateUserRoles, getAccountActionMenuItems, setEditingUser, setResettingPasswordUser, setManagingRolesUserId])
+    ],
+    [
+      showRowActions,
+      canUpdateUser,
+      canUpdateUserRoles,
+      getAccountActionMenuItems,
+    ],
+  )
 
   useEffect(() => {
     error && console.error(error)
@@ -189,12 +205,12 @@ const UsersListPage = () => {
     <>
       <PageTitle title="Users" actions={actions()} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        rowData={usersData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={usersData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="users"
       />
 
       {openCreateUserForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-processes/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-processes/page.tsx
@@ -1,20 +1,20 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
-import { ControlItemSwitch } from '@/src/components/common/control-items-menu'
+import { PageTitle } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '@/src/components/common/control-items-menu'
 import { authorizePage } from '@/src/components/hoc'
 import { useAppDispatch, useAppSelector, useDocumentTitle } from '@/src/hooks'
 import { WorkProcessListDto } from '@/src/services/wayd-api'
 import { useGetWorkProcessesQuery } from '@/src/store/features/work-management/work-process-api'
 import { setIncludeInactive } from '@/src/store/features/work-management/work-process-slice'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { ItemType } from 'antd/es/menu/interface'
 import Link from 'next/link'
 import { useEffect, useMemo } from 'react'
-
-const WorkProcessLinkCellRenderer = ({ value, data }: ICellRendererParams<WorkProcessListDto>) => {
-  return <Link href={`./work-processes/${data!.key}`}>{value}</Link>
-}
 
 const WorkProcessesPage: React.FC = () => {
   useDocumentTitle('Work Management - Work Processes')
@@ -29,13 +29,35 @@ const WorkProcessesPage: React.FC = () => {
   } = useGetWorkProcessesQuery(includeInactive)
   const dispatch = useAppDispatch()
 
-  const columnDefs = useMemo<ColDef<WorkProcessListDto>[]>(() => [
-      { field: 'id', hide: true },
-      { field: 'key', width: 80 },
-      { field: 'name', width: 300, cellRenderer: WorkProcessLinkCellRenderer },
-      { field: 'ownership.name', headerName: 'Ownership' },
-      { field: 'isActive', width: 100 }, // TODO: convert to yes/no
-    ], [])
+  const columns = useMemo<ColumnDef<WorkProcessListDto, any>[]>(
+    () => [
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 80 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 300,
+        cell: ({ row }) => (
+          <Link href={`./work-processes/${row.original.key}`}>
+            {row.original.name}
+          </Link>
+        ),
+      },
+      {
+        id: 'ownership',
+        accessorKey: 'ownership.name',
+        header: 'Ownership',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
+    ],
+    [],
+  )
 
   useEffect(() => {
     error && console.error(error)
@@ -67,13 +89,13 @@ const WorkProcessesPage: React.FC = () => {
     <>
       <PageTitle title="Work Processes" />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={workProcessesData}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={workProcessesData ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="work-processes"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
     </>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-statuses/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-statuses/page.tsx
@@ -1,14 +1,18 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
+import { PageTitle } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { useAppDispatch, useAppSelector, useDocumentTitle } from '@/src/hooks'
 import { WorkStatusDto } from '@/src/services/wayd-api'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useEffect, useMemo } from 'react'
 import { setIncludeInactive } from '../../../../store/features/work-management/work-status-slice'
 import { authorizePage } from '@/src/components/hoc'
 import { useGetWorkStatusesQuery } from '@/src/store/features/work-management/work-status-api'
-import { ControlItemSwitch } from '@/src/components/common/control-items-menu'
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '@/src/components/common/control-items-menu'
 import { ItemType } from 'antd/es/menu/interface'
 
 const WorkStatusesPage = () => {
@@ -28,12 +32,24 @@ const WorkStatusesPage = () => {
     error && console.error(error)
   }, [error])
 
-  const columnDefs = useMemo<ColDef<WorkStatusDto>[]>(() => [
-      { field: 'id', hide: true },
-      { field: 'name' },
-      { field: 'description', width: 300 },
-      { field: 'isActive', width: 100 }, // TODO: convert to yes/no
-    ], [])
+  const columns = useMemo<ColumnDef<WorkStatusDto, any>[]>(
+    () => [
+      { id: 'name', accessorKey: 'name', header: 'Name' },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 300,
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
@@ -62,13 +78,13 @@ const WorkStatusesPage = () => {
     <>
       <PageTitle title="Work Statuses" />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={workStatuses}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={workStatuses ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="work-statuses"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
     </>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-types/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-types/page.tsx
@@ -1,26 +1,33 @@
 'use client'
 
-import { WaydGrid, PageTitle } from '@/src/components/common'
+import { PageTitle } from '@/src/components/common'
+import {
+  WaydGrid2,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid2'
 import { useAppDispatch, useAppSelector, useDocumentTitle } from '@/src/hooks'
 import { WorkTypeDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
-import { Button } from 'antd'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useEffect, useMemo, useState } from 'react'
 import { setIncludeInactive } from '../../../../store/features/work-management/work-type-slice'
 import { authorizePage } from '@/src/components/hoc'
 import { useGetWorkTypesQuery } from '@/src/store/features/work-management/work-type-api'
 import useAuth from '@/src/components/contexts/auth'
-import { EditOutlined } from '@ant-design/icons'
 import EditWorkTypeForm from './_components/edit-work-type-form'
 import Link from 'next/link'
 import { ItemType } from 'antd/es/menu/interface'
-import { ControlItemSwitch } from '@/src/components/common/control-items-menu'
+import {
+  ControlItemsMenu,
+  ControlItemSwitch,
+} from '@/src/components/common/control-items-menu'
 
 const WorkTypesPage = () => {
   useDocumentTitle('Work Management - Work Types')
   const [openUpdateWorkTypeForm, setOpenUpdateWorkTypeForm] =
     useState<boolean>(false)
-  const [editWorkTypeId, setEditWorkTypeId] = useState<number | undefined>(undefined)
+  const [editWorkTypeId, setEditWorkTypeId] = useState<number | undefined>(
+    undefined,
+  )
 
   const { includeInactive } = useAppSelector((state) => state.workType)
 
@@ -46,38 +53,48 @@ const WorkTypesPage = () => {
     error && console.error(error)
   }, [error])
 
-  const columnDefs = useMemo<ColDef<WorkTypeDto>[]>(() => {
+  const columns = useMemo<ColumnDef<WorkTypeDto, any>[]>(() => {
     const editWorkTypeButtonClicked = (id: number) => {
       setEditWorkTypeId(id)
       setOpenUpdateWorkTypeForm(true)
     }
 
     return [
-      {
-        width: 50,
-        filter: false,
-        sortable: false,
-        resizable: false,
+      createActionsColumn<WorkTypeDto>({
         hide: !canUpdateWorkTypes,
-        cellRenderer: (params: ICellRendererParams<WorkTypeDto>) => {
-          return (
-            canUpdateWorkTypes && (
-              <Button
-                type="text"
-                size="small"
-                icon={<EditOutlined />}
-                onClick={() => editWorkTypeButtonClicked(params.data!.id)}
-              />
-            )
-          )
-        },
+        ariaLabel: 'Work type actions',
+        getItems: (workType): ItemType[] =>
+          canUpdateWorkTypes
+            ? [
+                {
+                  key: 'edit',
+                  label: 'Edit',
+                  onClick: () => editWorkTypeButtonClicked(workType.id),
+                },
+              ]
+            : [],
+      }),
+      { id: 'name', accessorKey: 'name', header: 'Name' },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 300,
       },
-      { field: 'id', hide: true },
-      { field: 'name' },
-      { field: 'description', width: 300 },
-      { field: 'level.name', headerName: 'Level' },
-      { field: 'isActive', width: 100 }, // TODO: convert to yes/no
-    ]}, [canUpdateWorkTypes])
+      {
+        id: 'level',
+        accessorKey: 'level.name',
+        header: 'Level',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
+    ]
+  }, [canUpdateWorkTypes])
 
   const refresh = async () => {
     refetch()
@@ -126,13 +143,13 @@ const WorkTypesPage = () => {
     <>
       <PageTitle title="Work Types" actions={actions()} />
 
-      <WaydGrid
-        height={600}
-        columnDefs={columnDefs}
-        gridControlMenuItems={controlItems}
-        rowData={workTypes}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={workTypes ?? []}
+        onRefresh={refresh}
+        isLoading={isLoading}
+        csvFileName="work-types"
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
       {openUpdateWorkTypeForm && (
         <EditWorkTypeForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/strategic-management/strategic-themes/_components/strategic-themes-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/strategic-management/strategic-themes/_components/strategic-themes-grid.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import { WaydGrid2 } from '@/src/components/common/wayd-grid2'
 import { StrategicThemeListDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import Link from 'next/link'
 import { useMemo } from 'react'
 
@@ -13,34 +13,44 @@ export interface StrategicThemesGridProps {
   gridHeight?: number | undefined
 }
 
-const StrategicThemeCellRenderer = ({ value, data }: ICellRendererParams<StrategicThemeListDto>) => {
-  return (
-    <Link href={`/strategic-management/strategic-themes/${data!.key}`}>
-      {value}
-    </Link>
-  )
-}
-
 const StrategicThemesGrid: React.FC<StrategicThemesGridProps> = (
   props: StrategicThemesGridProps,
 ) => {
-  const columnDefs = useMemo<ColDef<StrategicThemeListDto>[]>(() => [
-    { field: 'key', width: 90 },
-    { field: 'name', width: 350, cellRenderer: StrategicThemeCellRenderer },
-    {
-      field: 'state.name',
-      headerName: 'State',
-      width: 125,
-    },
-  ], [])
+  const columns = useMemo<ColumnDef<StrategicThemeListDto, any>[]>(
+    () => [
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 350,
+        cell: ({ row }) => (
+          <Link
+            href={`/strategic-management/strategic-themes/${row.original.key}`}
+          >
+            {row.original.name}
+          </Link>
+        ),
+      },
+      {
+        id: 'state',
+        accessorKey: 'state.name',
+        header: 'State',
+        size: 125,
+        meta: { filterType: 'set' },
+      },
+    ],
+    [],
+  )
 
   return (
-    <WaydGrid
+    <WaydGrid2
       height={props.gridHeight}
-      columnDefs={columnDefs}
-      rowData={props.strategicThemesData}
-      loadData={props.refreshStrategicThemes}
-      loading={props.strategicThemesLoading}
+      columns={columns}
+      data={props.strategicThemesData}
+      isLoading={props.strategicThemesLoading}
+      onRefresh={props.refreshStrategicThemes}
+      csvFileName="strategic-themes"
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/_components/workspaces-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/_components/workspaces-grid.tsx
@@ -1,9 +1,8 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { WorkspaceLinkCellRenderer } from '@/src/components/common/wayd-grid-cell-renderers'
+import { WaydGrid2, renderWorkspaceLink } from '@/src/components/common/wayd-grid2'
 import { WorkspaceListDto } from '@/src/services/wayd-api'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { ReactElement, useMemo } from 'react'
 
 export interface WorkspacesGridProps {
@@ -16,28 +15,51 @@ export interface WorkspacesGridProps {
 const WorkspacesGrid = (props: WorkspacesGridProps) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<WorkspaceListDto>[]>(() => [
-    { field: 'key', width: 90 },
-    { field: 'name', cellRenderer: WorkspaceLinkCellRenderer },
-    { field: 'description', width: 300 },
-    { field: 'ownership.name', headerName: 'Ownership' },
-    { field: 'isActive' },
-  ], [])
+  const columns = useMemo<ColumnDef<WorkspaceListDto, any>[]>(
+    () => [
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderWorkspaceLink(row.original),
+      },
+      {
+        id: 'description',
+        accessorKey: 'description',
+        header: 'Description',
+        size: 300,
+      },
+      {
+        id: 'ownership',
+        accessorKey: 'ownership.name',
+        header: 'Ownership',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <>
-      <WaydGrid
-        columnDefs={columnDefs}
-        rowData={props.workspaces}
-        loadData={refresh}
-        loading={props.isLoading}
-        toolbarActions={props.viewSelector}
-      />
-    </>
+    <WaydGrid2
+      columns={columns}
+      data={props.workspaces ?? []}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="workspaces"
+      rightSlot={props.viewSelector}
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/teams-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/teams-grid.tsx
@@ -1,11 +1,7 @@
 import { FC, useMemo } from 'react'
-import WaydGrid from '../wayd-grid'
+import { WaydGrid2, renderTeamLink } from '../wayd-grid2'
 import { PlanningIntervalTeamResponse } from '@/src/services/wayd-api'
-import {
-  NestedTeamOfTeamsNameLinkCellRenderer,
-  TeamNameLinkCellRenderer,
-} from '../wayd-grid-cell-renderers'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 
 export interface TeamsGridProps {
   teams: PlanningIntervalTeamResponse[]
@@ -16,37 +12,54 @@ export interface TeamsGridProps {
 const TeamsGrid: FC<TeamsGridProps> = (props) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<PlanningIntervalTeamResponse>[]>(() => [
-    { field: 'key', width: 90 },
-    {
-      field: 'name',
-      cellRenderer: TeamNameLinkCellRenderer,
-    },
-    { field: 'code', width: 125 },
-    { field: 'type' },
-    {
-      field: 'teamOfTeams.name',
-      headerName: 'Team of Teams',
-      cellRenderer: NestedTeamOfTeamsNameLinkCellRenderer,
-    },
-    { field: 'isActive' }, // TODO: convert to yes/no
-  ], [])
+  const columns = useMemo<ColumnDef<PlanningIntervalTeamResponse, any>[]>(
+    () => [
+      { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original),
+      },
+      { id: 'code', accessorKey: 'code', header: 'Code', size: 125 },
+      {
+        id: 'type',
+        accessorKey: 'type',
+        header: 'Type',
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'teamOfTeams',
+        accessorKey: 'teamOfTeams.name',
+        header: 'Team of Teams',
+        size: 200,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.teamOfTeams),
+      },
+      {
+        id: 'isActive',
+        accessorKey: 'isActive',
+        header: 'Active',
+        meta: { columnType: 'yesNo' },
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <>
-      {/* TODO:  setup dynamic height */}
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={props.teams}
-        loadData={refresh}
-        loading={props.isLoading}
-      />
-    </>
+    <WaydGrid2
+      columns={columns}
+      data={props.teams}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="teams"
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/risks-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/risks-grid.tsx
@@ -1,16 +1,18 @@
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
-import WaydGrid from '../wayd-grid'
+import {
+  WaydGrid2,
+  createActionsColumn,
+  renderTeamLink,
+} from '../wayd-grid2'
 import { RiskListDto } from '@/src/services/wayd-api'
 import { ItemType } from 'antd/es/menu/interface'
 import { Button } from 'antd'
 import useAuth from '../../contexts/auth'
 import CreateRiskForm from './create-risk-form'
-import { EditOutlined } from '@ant-design/icons'
 import EditRiskForm from './edit-risk-form'
-import { NestedTeamNameLinkCellRenderer } from '../wayd-grid-cell-renderers'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
-import { ControlItemSwitch } from '../control-items-menu'
+import type { ColumnDef } from '@tanstack/react-table'
+import { ControlItemsMenu, ControlItemSwitch } from '../control-items-menu'
 
 export interface RisksGridProps {
   risks: RiskListDto[]
@@ -21,16 +23,6 @@ export interface RisksGridProps {
   newRisksAllowed?: boolean
   hideTeamColumn?: boolean
   gridHeight?: number
-}
-
-const RiskLinkCellRenderer = ({ value, data }: ICellRendererParams<RiskListDto>) => {
-  return <Link href={`/planning/risks/${data!.key}`}>{value}</Link>
-}
-
-const AssigneeLinkCellRenderer = ({ value, data }: ICellRendererParams<RiskListDto>) => {
-  return (
-    <Link href={`/organizations/employees/${data!.assignee?.key}`}>{value}</Link>
-  )
 }
 
 const RisksGrid = ({
@@ -115,72 +107,106 @@ const RisksGrid = ({
     },
   ]
 
-  // TODO: dates are formatted correctly and filter, but the filter is string based, not date based
-  const columnDefs = useMemo<ColDef<RiskListDto>[]>(() => {
+  const columns = useMemo<ColumnDef<RiskListDto, any>[]>(() => {
     const editRiskButtonClicked = (key: number) => {
       setEditRiskKey(key)
       setOpenUpdateRiskForm(true)
     }
 
     return [
-    {
-      width: 50,
-      filter: false,
-      sortable: false,
-      resizable: false,
+    createActionsColumn<RiskListDto>({
       hide: !canUpdateRisks,
-      cellRenderer: (params: ICellRendererParams<RiskListDto>) => {
-        if (!params.data) return null
-        return (
-          canUpdateRisks && (
-            <Button
-              type="text"
-              size="small"
-              icon={<EditOutlined />}
-              onClick={() => editRiskButtonClicked(params.data!.key)}
-            />
-          )
-        )
-      },
-    },
-    { field: 'id', hide: true },
-    { field: 'key', width: 90 },
-    { field: 'summary', width: 300, cellRenderer: RiskLinkCellRenderer },
+      ariaLabel: 'Risk actions',
+      getItems: (risk): ItemType[] =>
+        canUpdateRisks
+          ? [
+              {
+                key: 'edit',
+                label: 'Edit',
+                onClick: () => editRiskButtonClicked(risk.key),
+              },
+            ]
+          : [],
+    }),
+    { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
     {
-      field: 'team.name',
-      headerName: 'Team',
-      cellRenderer: NestedTeamNameLinkCellRenderer,
-      hide: hideTeam,
-    },
-    { field: 'status', width: 125, hide: includeClosed === false },
-    { field: 'category', width: 125 },
-    { field: 'exposure', width: 125 },
-    {
-      field: 'followUpDate',
-      type: 'dateOnly',
+      id: 'summary',
+      accessorKey: 'summary',
+      header: 'Summary',
+      size: 300,
+      meta: { filterEnableSet: true },
+      cell: ({ row }) => (
+        <Link href={`/planning/risks/${row.original.key}`}>
+          {row.original.summary}
+        </Link>
+      ),
     },
     {
-      field: 'assignee.name',
-      headerName: 'Assignee',
-      cellRenderer: AssigneeLinkCellRenderer,
+      id: 'team',
+      accessorKey: 'team.name',
+      header: 'Team',
+      meta: { hide: hideTeam, filterEnableSet: true },
+      cell: ({ row }) => renderTeamLink(row.original.team),
     },
     {
-      field: 'reportedOn',
-      type: 'dateOnly',
+      id: 'status',
+      accessorKey: 'status',
+      header: 'Status',
+      size: 125,
+      meta: { hide: includeClosed === false, filterType: 'set' },
+    },
+    {
+      id: 'category',
+      accessorKey: 'category',
+      header: 'Category',
+      size: 125,
+      meta: { filterType: 'set' },
+    },
+    {
+      id: 'exposure',
+      accessorKey: 'exposure',
+      header: 'Exposure',
+      size: 125,
+      meta: { filterType: 'set' },
+    },
+    {
+      id: 'followUpDate',
+      accessorKey: 'followUpDate',
+      header: 'Follow Up Date',
+      meta: { columnType: 'dateOnly' },
+    },
+    {
+      id: 'assignee',
+      accessorKey: 'assignee.name',
+      header: 'Assignee',
+      cell: ({ row }) =>
+        row.original.assignee ? (
+          <Link
+            href={`/organizations/employees/${row.original.assignee.key}`}
+          >
+            {row.original.assignee.name}
+          </Link>
+        ) : null,
+    },
+    {
+      id: 'reportedOn',
+      accessorKey: 'reportedOn',
+      header: 'Reported On',
+      meta: { columnType: 'dateOnly' },
     },
   ]}, [canUpdateRisks, hideTeam, includeClosed])
 
   return (
     <>
-      {/* TODO:  setup dynamic height */}
-      <WaydGrid
+      <WaydGrid2
         height={gridHeight}
-        columnDefs={columnDefs}
-        rowData={risks}
-        loading={isLoadingRisks}
-        loadData={refreshRisks}
-        actions={showActions && actions()}
-        gridControlMenuItems={controlItems}
+        columns={columns}
+        data={risks ?? []}
+        isLoading={isLoadingRisks}
+        onRefresh={refreshRisks}
+        csvFileName="risks"
+        leftSlot={showActions ? actions() : undefined}
+        rightSlot={<ControlItemsMenu items={controlItems} />}
       />
       {openCreateRiskForm && (
         <CreateRiskForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprint-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprint-backlog-grid.tsx
@@ -1,24 +1,20 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import {
+  WaydGrid2,
+  renderAssignedToLink,
+  renderProjectLink,
+  renderSprintLink,
+  renderTeamLink,
+  renderWorkItemLink,
+  renderWorkStatusTag,
+  workItemKeySort,
+  workStatusCategorySort,
+} from '@/src/components/common/wayd-grid2'
 import { SprintBacklogItemDto } from '@/src/services/wayd-api'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useMemo } from 'react'
-import { CustomCellRendererProps } from 'ag-grid-react'
 import { WorkItemTagsCell } from '@/src/components/common/work'
-import {
-  workItemKeyComparator,
-  workStatusCategoryComparator,
-} from '@/src/components/common/work'
-import {
-  AssignedToLinkCellRenderer,
-  NestedTeamNameLinkCellRenderer,
-  NestedWorkSprintLinkCellRenderer,
-  ParentWorkItemLinkCellRenderer,
-  ProjectLinkCellRenderer,
-  WorkItemLinkCellRenderer,
-  WorkStatusTagCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
 
 export interface SprintBacklogGridProps {
   workItems: SprintBacklogItemDto[]
@@ -39,85 +35,133 @@ const SprintBacklogGrid = (props: SprintBacklogGridProps) => {
     gridHeight = -1,
   } = props
 
-  const columnDefs = useMemo<ColDef<SprintBacklogItemDto>[]>(() => [
-    { field: 'rank', width: 50, filter: false },
-    {
-      field: 'key',
-      comparator: workItemKeyComparator,
-      cellRenderer: WorkItemLinkCellRenderer,
-    },
-    { field: 'type', width: 125 },
-    { field: 'title', width: 400 },
-    {
-      field: 'storyPoints',
-      headerName: 'SPs',
-      headerTooltip: 'Story Points',
-      width: 80,
-    },
-    { field: 'status', width: 125, cellRenderer: WorkStatusTagCellRenderer },
-    {
-      field: 'statusCategory.name',
-      headerName: 'Status Category',
-      width: 120,
-      comparator: workStatusCategoryComparator,
-    },
-    {
-      field: 'team.name',
-      headerName: 'Team',
-      cellRenderer: NestedTeamNameLinkCellRenderer,
-      hide: hideTeamColumn,
-    },
-    {
-      field: 'sprint.name',
-      headerName: 'Sprint',
-      cellRenderer: NestedWorkSprintLinkCellRenderer,
-      cellRendererParams: { showTeamCode: false },
-      hide: hideSprintColumn,
-    },
-    {
-      field: 'parent.key',
-      headerName: 'Parent Key',
-      comparator: workItemKeyComparator,
-      cellRenderer: ParentWorkItemLinkCellRenderer,
-    },
-    {
-      field: 'parent.title',
-      headerName: 'Parent',
-      width: 400,
-    },
-    {
-      field: 'assignedTo.name',
-      headerName: 'Assigned To',
-      cellRenderer: AssignedToLinkCellRenderer,
-    },
-    {
-      field: 'project.name',
-      headerName: 'Project',
-      width: 300,
-      cellRenderer: ProjectLinkCellRenderer,
-    },
-    {
-      field: 'tags',
-      headerName: 'Tags',
-      width: 200,
-      valueGetter: (params) => params.data?.tags?.join(', ') ?? '',
-      cellRenderer: (params: CustomCellRendererProps<SprintBacklogItemDto>) => (
-        <WorkItemTagsCell tags={params.data?.tags} />
-      ),
-    },
-  ], [hideTeamColumn, hideSprintColumn])
+  const columns = useMemo<ColumnDef<SprintBacklogItemDto, any>[]>(
+    () => [
+      {
+        id: 'rank',
+        accessorKey: 'rank',
+        header: 'Rank',
+        size: 50,
+        enableColumnFilter: false,
+      },
+      {
+        id: 'key',
+        accessorKey: 'key',
+        header: 'Key',
+        sortingFn: workItemKeySort,
+        cell: ({ row }) =>
+          renderWorkItemLink({
+            key: row.original.key,
+            workspaceKey: row.original.workspace.key,
+            externalViewWorkItemUrl: row.original.externalViewWorkItemUrl,
+          }),
+      },
+      {
+        id: 'type',
+        accessorKey: 'type',
+        header: 'Type',
+        size: 125,
+        meta: { filterType: 'set' },
+      },
+      { id: 'title', accessorKey: 'title', header: 'Title', size: 400 },
+      {
+        id: 'storyPoints',
+        accessorKey: 'storyPoints',
+        header: 'SPs',
+        size: 80,
+      },
+      {
+        id: 'status',
+        accessorKey: 'status',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+        cell: ({ row }) => renderWorkStatusTag(row.original),
+      },
+      {
+        id: 'statusCategory',
+        accessorKey: 'statusCategory.name',
+        header: 'Status Category',
+        size: 120,
+        sortingFn: workStatusCategorySort,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'team',
+        accessorKey: 'team.name',
+        header: 'Team',
+        meta: { hide: hideTeamColumn, filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.team),
+      },
+      {
+        id: 'sprint',
+        accessorKey: 'sprint.name',
+        header: 'Sprint',
+        meta: { hide: hideSprintColumn, filterEnableSet: true },
+        cell: ({ row }) =>
+          renderSprintLink(row.original.sprint, { showTeamCode: false }),
+      },
+      {
+        id: 'parentKey',
+        accessorKey: 'parent.key',
+        header: 'Parent Key',
+        sortingFn: workItemKeySort,
+        cell: ({ row }) =>
+          renderWorkItemLink(
+            row.original.parent
+              ? {
+                  key: row.original.parent.key,
+                  workspaceKey: row.original.parent.workspaceKey,
+                  externalViewWorkItemUrl:
+                    row.original.parent.externalViewWorkItemUrl,
+                }
+              : null,
+          ),
+      },
+      {
+        id: 'parentTitle',
+        accessorKey: 'parent.title',
+        header: 'Parent',
+        size: 400,
+      },
+      {
+        id: 'assignedTo',
+        accessorKey: 'assignedTo.name',
+        header: 'Assigned To',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderAssignedToLink(row.original.assignedTo),
+      },
+      {
+        id: 'project',
+        accessorKey: 'project.name',
+        header: 'Project',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderProjectLink(row.original.project),
+      },
+      {
+        id: 'tags',
+        accessorFn: (row) => row.tags?.join(', ') ?? '',
+        header: 'Tags',
+        size: 200,
+        cell: ({ row }) => <WorkItemTagsCell tags={row.original.tags} />,
+      },
+    ],
+    [hideTeamColumn, hideSprintColumn],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <WaydGrid
+    <WaydGrid2
       height={gridHeight}
-      columnDefs={columnDefs}
-      rowData={workItems}
-      loadData={refresh}
-      loading={props.isLoading}
+      columns={columns}
+      data={workItems ?? []}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="sprint-backlog"
       emptyMessage="No planned work items"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.test.tsx
@@ -1,37 +1,32 @@
-import React from 'react'
 import { render, screen } from '@testing-library/react'
 
-// Mock the WaydGrid component
-jest.mock('../index', () => ({
-  WaydGrid: jest.fn(
-    ({ columnDefs, rowData, loadData, loading, height, emptyMessage }) => (
+// Mock WaydGrid2 with a light stand-in that exposes the props under test.
+jest.mock('../wayd-grid2', () => ({
+  WaydGrid2: jest.fn(
+    ({ data, isLoading, height, emptyMessage, columns, onRefresh }) => (
       <div data-testid="wayd-grid">
-        <div data-testid="row-count">{rowData?.length ?? 0}</div>
-        <div data-testid="loading">{loading ? 'loading' : 'not-loading'}</div>
+        <div data-testid="row-count">{data?.length ?? 0}</div>
+        <div data-testid="loading">{isLoading ? 'loading' : 'not-loading'}</div>
         <div data-testid="height">{height}</div>
         <div data-testid="empty-message">{emptyMessage}</div>
-        <div data-testid="column-count">{columnDefs?.length ?? 0}</div>
-        {loadData && (
-          <button type="button" onClick={loadData} data-testid="load-data">
+        <div data-testid="column-count">{columns?.length ?? 0}</div>
+        {onRefresh && (
+          <button type="button" onClick={onRefresh} data-testid="load-data">
             Refresh
           </button>
         )}
       </div>
     ),
   ),
-}))
-
-// Mock the TeamNameLinkCellRenderer
-jest.mock('../wayd-grid-cell-renderers', () => ({
-  TeamNameLinkCellRenderer: jest.fn(({ data }) => (
-    <div data-testid="team-link">{data?.name}</div>
-  )),
+  // Link renderers are exercised elsewhere; stub them so the grid stays simple.
+  renderSprintLink: jest.fn(() => null),
+  renderTeamLink: jest.fn(() => null),
 }))
 
 // Note: useTheme and dayjs are mocked globally in jest.setup.ts
 
 import SprintsGrid from './sprints-grid'
-import * as ModaGridModule from '../index'
+import * as WaydGrid2Module from '../wayd-grid2'
 import { SprintListDto } from '@/src/services/wayd-api'
 
 describe('SprintsGrid', () => {
@@ -62,7 +57,8 @@ describe('SprintsGrid', () => {
     jest.clearAllMocks()
   })
 
-  it('renders the WaydGrid component', () => {
+  it('renders the grid', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -71,10 +67,12 @@ describe('SprintsGrid', () => {
       />,
     )
 
+    // Assert
     expect(screen.getByTestId('wayd-grid')).toBeInTheDocument()
   })
 
-  it('passes sprint data to WaydGrid', () => {
+  it('passes sprint data to the grid', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -83,40 +81,30 @@ describe('SprintsGrid', () => {
       />,
     )
 
+    // Assert
     expect(screen.getByTestId('row-count')).toHaveTextContent('2')
   })
 
-  it('passes loading state to WaydGrid', () => {
+  it('passes the loading state through', () => {
+    // Arrange / Act
     render(
-      <SprintsGrid
-        sprints={mockSprints}
-        isLoading={true}
-        refetch={mockRefetch}
-      />,
+      <SprintsGrid sprints={mockSprints} isLoading={true} refetch={mockRefetch} />,
     )
 
+    // Assert
     expect(screen.getByTestId('loading')).toHaveTextContent('loading')
   })
 
-  it('passes not loading state to WaydGrid', () => {
-    render(
-      <SprintsGrid
-        sprints={mockSprints}
-        isLoading={false}
-        refetch={mockRefetch}
-      />,
-    )
-
-    expect(screen.getByTestId('loading')).toHaveTextContent('not-loading')
-  })
-
-  it('renders with empty sprints array', () => {
+  it('renders with an empty sprints array', () => {
+    // Arrange / Act
     render(<SprintsGrid sprints={[]} isLoading={false} refetch={mockRefetch} />)
 
+    // Assert
     expect(screen.getByTestId('row-count')).toHaveTextContent('0')
   })
 
-  it('uses default grid height when not specified', () => {
+  it('uses the default grid height when not specified', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -125,10 +113,12 @@ describe('SprintsGrid', () => {
       />,
     )
 
+    // Assert
     expect(screen.getByTestId('height')).toHaveTextContent('650')
   })
 
-  it('uses custom grid height when specified', () => {
+  it('uses a custom grid height when specified', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -138,18 +128,22 @@ describe('SprintsGrid', () => {
       />,
     )
 
+    // Assert
     expect(screen.getByTestId('height')).toHaveTextContent('500')
   })
 
-  it('displays correct empty message', () => {
+  it('displays the empty message', () => {
+    // Arrange / Act
     render(<SprintsGrid sprints={[]} isLoading={false} refetch={mockRefetch} />)
 
+    // Assert
     expect(screen.getByTestId('empty-message')).toHaveTextContent(
       'No sprints found.',
     )
   })
 
-  it('creates correct number of columns', () => {
+  it('defines the expected columns', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -158,11 +152,17 @@ describe('SprintsGrid', () => {
       />,
     )
 
-    // Should have 6 columns: key, name, state, start, end, team
-    expect(screen.getByTestId('column-count')).toHaveTextContent('6')
+    // Assert — key, name, team, state, start, end
+    const call = (WaydGrid2Module.WaydGrid2 as unknown as jest.Mock).mock
+      .calls[0][0]
+    const ids = call.columns.map((c: { id: string }) => c.id)
+    expect(ids).toEqual(
+      expect.arrayContaining(['key', 'name', 'team', 'state', 'start', 'end']),
+    )
   })
 
-  it('calls refetch when refresh button is clicked', () => {
+  it('calls refetch when the refresh action fires', () => {
+    // Arrange
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -171,40 +171,15 @@ describe('SprintsGrid', () => {
       />,
     )
 
-    const refreshButton = screen.getByTestId('load-data')
-    refreshButton.click()
+    // Act
+    screen.getByTestId('load-data').click()
 
+    // Assert
     expect(mockRefetch).toHaveBeenCalledTimes(1)
   })
 
-  it('memoizes refresh callback based on refetch dependency', () => {
-    const { rerender } = render(
-      <SprintsGrid
-        sprints={mockSprints}
-        isLoading={false}
-        refetch={mockRefetch}
-      />,
-    )
-
-    // Rerender with same refetch function
-    rerender(
-      <SprintsGrid
-        sprints={mockSprints}
-        isLoading={false}
-        refetch={mockRefetch}
-      />,
-    )
-
-    const secondRefreshButton = screen.getByTestId('load-data')
-
-    // The button should still work
-    secondRefreshButton.click()
-    expect(mockRefetch).toHaveBeenCalledTimes(1)
-  })
-
-  it('respects hideTeam prop when provided', () => {
-    const WaydGrid = ModaGridModule.WaydGrid as unknown as jest.Mock
-
+  it('hides the team column via meta.hide when hideTeam is set', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -214,19 +189,17 @@ describe('SprintsGrid', () => {
       />,
     )
 
-    // Check that WaydGrid was called with column definitions
-    const mockCall = WaydGrid.mock.calls[0][0]
-    const teamColumn = mockCall.columnDefs.find(
-      (col: any) => col.field === 'team.name',
+    // Assert
+    const call = (WaydGrid2Module.WaydGrid2 as unknown as jest.Mock).mock
+      .calls[0][0]
+    const teamColumn = call.columns.find(
+      (c: { id: string }) => c.id === 'team',
     )
-
-    expect(teamColumn).toBeDefined()
-    expect(teamColumn.hide).toBe(true)
+    expect(teamColumn.meta.hide).toBe(true)
   })
 
-  it('does not hide team column by default', () => {
-    const WaydGrid = ModaGridModule.WaydGrid as unknown as jest.Mock
-
+  it('does not hide the team column by default', () => {
+    // Arrange / Act
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -235,35 +208,12 @@ describe('SprintsGrid', () => {
       />,
     )
 
-    // Check that WaydGrid was called with column definitions
-    const mockCall = WaydGrid.mock.calls[0][0]
-    const teamColumn = mockCall.columnDefs.find(
-      (col: any) => col.field === 'team.name',
+    // Assert
+    const call = (WaydGrid2Module.WaydGrid2 as unknown as jest.Mock).mock
+      .calls[0][0]
+    const teamColumn = call.columns.find(
+      (c: { id: string }) => c.id === 'team',
     )
-
-    expect(teamColumn).toBeDefined()
-    expect(teamColumn.hide).toBeUndefined()
-  })
-
-  it('defines all expected columns with correct fields', () => {
-    const WaydGrid = ModaGridModule.WaydGrid as unknown as jest.Mock
-
-    render(
-      <SprintsGrid
-        sprints={mockSprints}
-        isLoading={false}
-        refetch={mockRefetch}
-      />,
-    )
-
-    const mockCall = WaydGrid.mock.calls[0][0]
-    const columnFields = mockCall.columnDefs.map((col: any) => col.field)
-
-    expect(columnFields).toContain('key')
-    expect(columnFields).toContain('name')
-    expect(columnFields).toContain('state.name')
-    expect(columnFields).toContain('start')
-    expect(columnFields).toContain('end')
-    expect(columnFields).toContain('team.name')
+    expect(teamColumn.meta.hide).toBeUndefined()
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.tsx
@@ -1,16 +1,14 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
-import { renderTeamLinkHelper } from '@/src/components/common/wayd-grid-cell-renderers'
-import { SprintListDto } from '@/src/services/wayd-api'
 import {
-  ColDef,
-  ICellRendererParams,
-  ValueFormatterParams,
-} from 'ag-grid-community'
+  WaydGrid2,
+  renderSprintLink,
+  renderTeamLink,
+} from '@/src/components/common/wayd-grid2'
+import { SprintListDto } from '@/src/services/wayd-api'
+import type { ColumnDef } from '@tanstack/react-table'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import Link from 'next/link'
 import { FC, useMemo } from 'react'
 
 dayjs.extend(utc)
@@ -23,67 +21,69 @@ export interface SprintsGridProps {
   gridHeight?: number | undefined
 }
 
-const sprintLinkCellRenderer = (params: ICellRendererParams<SprintListDto>) => {
-  if (!params.data) return null
-  return <Link href={`/planning/sprints/${params.data.key}`}>{params.value}</Link>
-}
-
-const teamCellRenderer = (params: ICellRendererParams<SprintListDto>) =>
-  renderTeamLinkHelper(params.data?.team)
-
+/**
+ * Sprint start/end are stored as UTC calendar dates; formatting them with the
+ * local-timezone `dateOnly` column type would shift them by a day. Render via
+ * `dayjs.utc` so the calendar date is preserved. The raw value still flows to
+ * the date filter/sort via `meta.columnType: 'dateOnly'`.
+ */
 const formatUtcCalendarDate = (value: unknown) =>
   value ? dayjs.utc(value as Date).format('MMM D, YYYY') : ''
-
-const utcAsCalendarDateValueFormatter = (
-  params: ValueFormatterParams<SprintListDto>,
-) => formatUtcCalendarDate(params.value)
 
 const SprintsGrid: FC<SprintsGridProps> = (props: SprintsGridProps) => {
   const { refetch, sprints = [] } = props
 
-  const columnDefs = useMemo<ColDef<SprintListDto>[]>(() => [
-    { field: 'key', width: 90 },
-    { field: 'name', width: 250, cellRenderer: sprintLinkCellRenderer },
+  const columns = useMemo<ColumnDef<SprintListDto, any>[]>(() => [
+    { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
     {
-      field: 'team.name',
-      headerName: 'Team',
-      width: 200,
-      hide: props.hideTeam,
-      cellRenderer: teamCellRenderer,
-    },
-    { field: 'state.name', headerName: 'State', width: 125 },
-    {
-      field: 'start',
-      headerName: 'Start',
-      width: 150,
-      sort: 'desc',
-      cellDataType: 'date',
-      filterParams: {
-        includeTime: false,
-      },
-      valueFormatter: utcAsCalendarDateValueFormatter,
-      getQuickFilterText: (params) => formatUtcCalendarDate(params.value),
+      id: 'name',
+      accessorKey: 'name',
+      header: 'Name',
+      size: 250,
+      meta: { filterEnableSet: true },
+      cell: ({ row }) => renderSprintLink(row.original, { showTeamCode: false }),
     },
     {
-      field: 'end',
-      headerName: 'End',
-      width: 150,
-      cellDataType: 'date',
-      filterParams: {
-        includeTime: false,
-      },
-      valueFormatter: utcAsCalendarDateValueFormatter,
-      getQuickFilterText: (params) => formatUtcCalendarDate(params.value),
+      id: 'team',
+      accessorKey: 'team.name',
+      header: 'Team',
+      size: 200,
+      meta: { hide: props.hideTeam, filterEnableSet: true },
+      cell: ({ row }) => renderTeamLink(row.original.team),
+    },
+    {
+      id: 'state',
+      accessorKey: 'state.name',
+      header: 'State',
+      size: 125,
+      meta: { filterType: 'set' },
+    },
+    {
+      id: 'start',
+      accessorKey: 'start',
+      header: 'Start',
+      size: 150,
+      meta: { columnType: 'dateOnly' },
+      cell: ({ getValue }) => formatUtcCalendarDate(getValue()),
+    },
+    {
+      id: 'end',
+      accessorKey: 'end',
+      header: 'End',
+      size: 150,
+      meta: { columnType: 'dateOnly' },
+      cell: ({ getValue }) => formatUtcCalendarDate(getValue()),
     },
   ], [props.hideTeam])
 
   return (
-    <WaydGrid
-      columnDefs={columnDefs}
-      rowData={sprints}
-      loadData={refetch}
-      loading={props.isLoading}
+    <WaydGrid2
+      columns={columns}
+      data={sprints}
+      onRefresh={refetch}
+      isLoading={props.isLoading}
       height={props.gridHeight ?? 650}
+      csvFileName="sprints"
       emptyMessage="No sprints found."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen } from '@testing-library/react'
 
+import { WorkStatusCategory } from '@/src/components/types'
+
 import {
+  renderAssignedToLink,
   renderPlanningIntervalLink,
   renderPortfolioLink,
   renderProgramLink,
@@ -8,6 +11,8 @@ import {
   renderSprintLink,
   renderTeamLink,
   renderUserLink,
+  renderWorkItemLink,
+  renderWorkStatusTag,
   renderWorkspaceLink,
 } from './cell-renderers'
 
@@ -162,6 +167,120 @@ describe('renderUserLink', () => {
   it('renders nothing for a missing user', () => {
     // Arrange / Act
     const { container } = render(<>{renderUserLink(null)}</>)
+
+    // Assert
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('renderWorkItemLink', () => {
+  it('links a work item within its workspace, labeled by key', () => {
+    // Arrange / Act
+    render(
+      <>{renderWorkItemLink({ key: 'WEB-42', workspaceKey: 'WEB' })}</>,
+    )
+
+    // Assert
+    const link = screen.getByRole('link', { name: 'WEB-42' })
+    expect(link).toHaveAttribute(
+      'href',
+      '/work/workspaces/WEB/work-items/WEB-42',
+    )
+  })
+
+  it('uses a custom label when provided (e.g. a parent title)', () => {
+    // Arrange / Act
+    render(
+      <>
+        {renderWorkItemLink({
+          key: 'WEB-42',
+          workspaceKey: 'WEB',
+          label: 'Parent title',
+        })}
+      </>,
+    )
+
+    // Assert
+    expect(
+      screen.getByRole('link', { name: 'Parent title' }),
+    ).toBeInTheDocument()
+  })
+
+  it('adds an external-system link when a URL is present', () => {
+    // Arrange / Act
+    render(
+      <>
+        {renderWorkItemLink({
+          key: 'WEB-42',
+          workspaceKey: 'WEB',
+          externalViewWorkItemUrl: 'https://example.com/WEB-42',
+        })}
+      </>,
+    )
+
+    // Assert — the primary link plus the external one
+    expect(
+      screen.getByRole('link', { name: 'WEB-42' }),
+    ).toBeInTheDocument()
+    const external = screen.getByTitle('Open in external system')
+    expect(external).toHaveAttribute('href', 'https://example.com/WEB-42')
+    expect(external).toHaveAttribute('target', '_blank')
+  })
+
+  it('renders nothing for a missing work item', () => {
+    // Arrange / Act
+    const { container } = render(<>{renderWorkItemLink(null)}</>)
+
+    // Assert
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('renderAssignedToLink', () => {
+  it('links an assignee to their organization page by key', () => {
+    // Arrange / Act
+    render(<>{renderAssignedToLink({ key: 13, name: 'Ada Lovelace' })}</>)
+
+    // Assert
+    const link = screen.getByRole('link', { name: 'Ada Lovelace' })
+    expect(link).toHaveAttribute('href', '/organizations/employees/13')
+  })
+
+  it('renders nothing when unassigned', () => {
+    // Arrange / Act
+    const { container } = render(<>{renderAssignedToLink(null)}</>)
+
+    // Assert
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('renderWorkStatusTag', () => {
+  it('renders the status text as a tag', () => {
+    // Arrange / Act
+    render(
+      <>
+        {renderWorkStatusTag({
+          status: 'In Progress',
+          statusCategory: { id: WorkStatusCategory.Active },
+        })}
+      </>,
+    )
+
+    // Assert
+    expect(screen.getByText('In Progress')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no status', () => {
+    // Arrange / Act
+    const { container } = render(
+      <>
+        {renderWorkStatusTag({
+          status: '',
+          statusCategory: { id: WorkStatusCategory.Proposed },
+        })}
+      </>,
+    )
 
     // Assert
     expect(container).toBeEmptyDOMElement()

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.tsx
@@ -162,6 +162,7 @@ export const renderWorkItemLink = (
         <Link
           href={workItem.externalViewWorkItemUrl}
           target="_blank"
+          rel="noopener noreferrer"
           title="Open in external system"
           style={{ marginLeft: '5px' }}
         >

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.tsx
@@ -1,7 +1,10 @@
+import { ExportOutlined } from '@ant-design/icons'
 import Link from 'next/link'
 import type { ReactNode } from 'react'
 
 import { teamUrl, type TeamUrlTarget } from '@/src/utils'
+import WorkStatusTag from '@/src/components/common/work/work-status-tag'
+import type { WorkStatusCategory } from '@/src/components/types'
 
 /**
  * Cell renderers for WaydGrid2 columns.
@@ -122,4 +125,88 @@ export const renderUserLink = (
       {user.userName || user.id}
     </Link>
   )
+}
+
+/**
+ * A work item reference: keyed within its workspace, optionally carrying an
+ * external-system URL. Both the primary and parent work-item renderers share
+ * this shape (the parent nav DTO uses `workspaceKey` directly rather than a
+ * nested `workspace`).
+ */
+export interface WorkItemLinkTarget {
+  key: string
+  workspaceKey: string
+  externalViewWorkItemUrl?: string | null
+  /** Optional label; defaults to the key. */
+  label?: string | null
+}
+
+/**
+ * Renders a work item as a link to its detail page, with an optional
+ * external-system link icon when `externalViewWorkItemUrl` is set. Returns
+ * `null` when absent. The label defaults to the work item's key.
+ */
+export const renderWorkItemLink = (
+  workItem: WorkItemLinkTarget | null | undefined,
+): ReactNode => {
+  if (!workItem) return null
+  return (
+    <>
+      <Link
+        href={`/work/workspaces/${workItem.workspaceKey}/work-items/${workItem.key}`}
+        prefetch={false}
+      >
+        {workItem.label ?? workItem.key}
+      </Link>
+      {workItem.externalViewWorkItemUrl && (
+        <Link
+          href={workItem.externalViewWorkItemUrl}
+          target="_blank"
+          title="Open in external system"
+          style={{ marginLeft: '5px' }}
+        >
+          <ExportOutlined style={{ width: '10px' }} />
+        </Link>
+      )}
+    </>
+  )
+}
+
+/** An assignable employee reference: keyed, labeled by name. */
+export interface AssignedToLinkTarget {
+  key: number | string
+  name?: string | null
+}
+
+/**
+ * Renders an assigned employee as a link to their organization page. Returns
+ * `null` when unassigned. (Employees route by `key` here, unlike the user-
+ * management {@link renderUserLink}, which routes by `id`.)
+ */
+export const renderAssignedToLink = (
+  assignedTo: AssignedToLinkTarget | null | undefined,
+): ReactNode => {
+  if (!assignedTo) return null
+  return (
+    <Link href={`/organizations/employees/${assignedTo.key}`} prefetch={false}>
+      {assignedTo.name}
+    </Link>
+  )
+}
+
+/** A work status paired with its category (drives the tag color). */
+export interface WorkStatusTagTarget {
+  status: string
+  statusCategory: { id: WorkStatusCategory }
+}
+
+/**
+ * Renders a work item's status as a colored {@link WorkStatusTag}, keyed off the
+ * status category. Returns `null` when there's no status.
+ */
+export const renderWorkStatusTag = (
+  item: WorkStatusTagTarget | null | undefined,
+): ReactNode => {
+  if (!item?.status) return null
+  return <WorkStatusTag status={item.status} category={item.statusCategory.id} />
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-types.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-types.test.ts
@@ -1,6 +1,17 @@
+// The global jest.setup dayjs mock returns raw values; the formatter tests
+// below need the real library (same opt-in as the filter suites).
+jest.mock('dayjs', () => jest.requireActual('dayjs'))
+
 import type { ColumnDef } from '@tanstack/react-table'
 
-import { applyColumnType, YES, NO, YES_NO_COLUMN_SIZE } from './column-types'
+import {
+  applyColumnType,
+  formatDateOnly,
+  formatDateTime,
+  YES,
+  NO,
+  YES_NO_COLUMN_SIZE,
+} from './column-types'
 import type { WaydGridColumnMeta } from './types'
 
 interface Row {
@@ -98,6 +109,19 @@ describe('applyColumnType', () => {
 
       // Assert
       expect((resolved.meta as WaydGridColumnMeta).filterType).toBe('dateTime')
+    })
+
+    it('exposes the standard display formatters for custom cells', () => {
+      // Arrange
+      const when = '2026-07-02T13:05:00Z'
+
+      // Act / Assert — same formats the dateOnly/dateTime cells use
+      expect(formatDateOnly(when)).toBe(formatDateOnly(new Date(when)))
+      expect(formatDateTime(when)).toMatch(
+        /^[A-Z][a-z]{2} \d{1,2}, \d{4} \d{2}:\d{2} [AP]M$/,
+      )
+      expect(formatDateOnly(null)).toBe('')
+      expect(formatDateTime(undefined)).toBe('')
     })
   })
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-types.ts
@@ -15,10 +15,14 @@ import type { WaydColumnType, WaydGridColumnMeta } from './types'
 const DATE_ONLY_FORMAT = 'MMM D, YYYY'
 const DATE_TIME_FORMAT = 'MMM D, YYYY hh:mm A'
 
-const formatDateOnly = (value: unknown): string =>
+/** Formats a date-ish value with the grid's dateOnly display format ('' when empty). */
+export const formatDateOnly = (value: unknown): string =>
   value ? dayjs(value as Date | string).format(DATE_ONLY_FORMAT) : ''
 
-const formatDateTime = (value: unknown): string =>
+/** Formats a date-ish value with the grid's dateTime display format ('' when empty).
+ * Exported for columns that need the standard format inside a custom cell
+ * (e.g. an empty-value fallback like "Never"). */
+export const formatDateTime = (value: unknown): string =>
   value ? dayjs(value as Date | string).format(DATE_TIME_FORMAT) : ''
 
 /** Display/filter strings for the yes-no type. */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/filters/filter-engine.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/filters/filter-engine.test.ts
@@ -3,8 +3,15 @@
 // needs real date math, so restore the actual dayjs for these tests.
 jest.mock('dayjs', () => jest.requireActual('dayjs'))
 
-import { evaluateFilterModel, toDayKey } from './filter-engine'
+import type { Row } from '@tanstack/react-table'
+
+import {
+  createMultiValueSetFilter,
+  evaluateFilterModel,
+  toDayKey,
+} from './filter-engine'
 import type {
+  ColumnFilterModel,
   DateFilterModel,
   DateSetFilterModel,
   DateTimeFilterModel,
@@ -288,6 +295,69 @@ describe('filter-engine', () => {
       // Act / Assert
       expect(evaluateFilterModel(m, null)).toBe(false)
       expect(evaluateFilterModel(m, 'not-a-date')).toBe(false)
+    })
+  })
+
+  describe('createMultiValueSetFilter', () => {
+    interface RoleRow {
+      roles: string[]
+    }
+
+    // Minimal Row stand-in: the filter only reads `.original` and `.getValue()`.
+    const fakeRow = (roles: string[]): Row<RoleRow> =>
+      ({
+        original: { roles },
+        getValue: () => roles.join(', '),
+      }) as unknown as Row<RoleRow>
+
+    const filter = createMultiValueSetFilter<RoleRow>((row) => row.roles)
+    const run = (roles: string[], model: ColumnFilterModel | undefined) =>
+      filter(fakeRow(roles), 'roles', model, () => {})
+
+    const set = (values: string[]): SetFilterModel => ({ type: 'set', values })
+    const text = (value: string): TextFilterModel => ({
+      type: 'text',
+      conditions: [{ op: 'contains', value }],
+      join: 'AND',
+    })
+
+    it('passes every row when there is no filter', () => {
+      // Arrange / Act / Assert
+      expect(run(['Owner'], undefined)).toBe(true)
+    })
+
+    it('passes every row when the set has no selected values', () => {
+      // Arrange / Act / Assert
+      expect(run(['Owner'], set([]))).toBe(true)
+    })
+
+    it('matches when the row shares ANY selected value (not the whole combo)', () => {
+      // Arrange
+      const m = set(['Owner'])
+
+      // Act / Assert — a row with multiple roles still matches on one of them,
+      // unlike matching the joined "Owner, Engineer" string exactly.
+      expect(run(['Owner', 'Engineer'], m)).toBe(true)
+      expect(run(['Engineer'], m)).toBe(false)
+      expect(run([], m)).toBe(false)
+    })
+
+    it('matches when any of several selected values is present', () => {
+      // Arrange
+      const m = set(['Owner', 'Scrum Master'])
+
+      // Act / Assert
+      expect(run(['Engineer', 'Scrum Master'], m)).toBe(true)
+      expect(run(['Engineer'], m)).toBe(false)
+    })
+
+    it('delegates non-set descriptors to the joined value (Text Filter)', () => {
+      // Arrange — "contains eng" over the joined "Owner, Engineer"
+      const m = text('eng')
+
+      // Act / Assert
+      expect(run(['Owner', 'Engineer'], m)).toBe(true)
+      expect(run(['Owner'], m)).toBe(false)
     })
   })
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/filters/filter-engine.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/filters/filter-engine.ts
@@ -252,3 +252,36 @@ export const waydColumnFilter: FilterFn<any> = (
   const model = filterValue as ColumnFilterModel
   return evaluateFilterModel(model, row.getValue(columnId))
 }
+
+/**
+ * Builds a {@link FilterFn} for a **multi-value** column — one whose cell holds
+ * several discrete values (e.g. a Roles column rendered as a list of tags, whose
+ * accessor is the comma-joined names). The default {@link waydColumnFilter}
+ * matches a `set` descriptor against the *whole* joined string, so it would list
+ * and match each combination ("A, B") as one value — rarely what you want.
+ *
+ * This factory instead:
+ * - **set** descriptor → passes when the row shares **any** selected value with
+ *   its own list (`getValues(row)`), so the set panel lists and matches
+ *   *individual* values. Pair it with `meta.filterOptions` = the distinct values
+ *   so the checkbox list shows them.
+ * - **any other** descriptor (text conditions, blank/notBlank, …) → delegates to
+ *   {@link evaluateFilterModel} against the column's joined accessor value, so the
+ *   Text Filter still behaves as a normal contains/equals over the label.
+ *
+ * @param getValues extracts the row's individual string values from `row.original`.
+ */
+export const createMultiValueSetFilter =
+  <T>(getValues: (row: T) => string[]): FilterFn<T> =>
+  (row, columnId, filterValue) => {
+    if (!filterValue || typeof filterValue !== 'object') return true
+    const model = filterValue as ColumnFilterModel
+
+    if (model.type === 'set') {
+      if (model.values.length === 0) return true
+      const selected = new Set(model.values)
+      return getValues(row.original).some((v) => selected.has(v))
+    }
+
+    return evaluateFilterModel(model, row.getValue(columnId))
+  }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/filters/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/filters/index.ts
@@ -33,7 +33,12 @@ export {
 } from './filter-model'
 
 // Filter engine
-export { evaluateFilterModel, toDayKey, waydColumnFilter } from './filter-engine'
+export {
+  createMultiValueSetFilter,
+  evaluateFilterModel,
+  toDayKey,
+  waydColumnFilter,
+} from './filter-engine'
 
 // Floating-row filter summaries (read-only chip for complex date filters)
 export { canFloatingEditDate, describeDateFilter } from './filter-summary'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.test.ts
@@ -1,4 +1,9 @@
-import { dateSortBy, sortEmptyLast } from './grid-sorting'
+import {
+  dateSortBy,
+  sortEmptyLast,
+  workItemKeySort,
+  workStatusCategorySort,
+} from './grid-sorting'
 import type { Row } from '@tanstack/react-table'
 
 describe('grid-sorting', () => {
@@ -126,6 +131,71 @@ describe('grid-sorting', () => {
             .every((v) => v === null || v === undefined || v === ''),
         ).toBe(true)
       })
+    })
+  })
+
+  describe('workItemKeySort', () => {
+    const row = (value: unknown) =>
+      ({ getValue: () => value }) as unknown as Row<any>
+    const cmp = (a: unknown, b: unknown) => workItemKeySort(row(a), row(b), 'x')
+
+    it('sorts by numeric suffix within a prefix (WEB-9 before WEB-10)', () => {
+      // Act / Assert — a plain string sort would put WEB-10 before WEB-9
+      expect(cmp('WEB-9', 'WEB-10')).toBeLessThan(0)
+      expect(cmp('WEB-10', 'WEB-9')).toBeGreaterThan(0)
+      expect(cmp('WEB-5', 'WEB-5')).toBe(0)
+    })
+
+    it('sorts by prefix alphabetically first', () => {
+      // Act / Assert
+      expect(cmp('API-100', 'WEB-1')).toBeLessThan(0)
+      expect(cmp('WEB-1', 'API-100')).toBeGreaterThan(0)
+    })
+
+    it('sorts empty keys to the end (ascending)', () => {
+      // Act / Assert
+      expect(cmp('', 'WEB-1')).toBe(1)
+      expect(cmp('WEB-1', '')).toBe(-1)
+      expect(cmp(null, undefined)).toBe(0)
+    })
+
+    it('orders a mixed list correctly end-to-end', () => {
+      // Arrange
+      const keys = ['WEB-10', 'API-2', 'WEB-2', '', 'API-10']
+
+      // Act
+      const sorted = [...keys].sort((a, b) => cmp(a, b))
+
+      // Assert — API before WEB, numeric within prefix, empty last
+      expect(sorted).toEqual(['API-2', 'API-10', 'WEB-2', 'WEB-10', ''])
+    })
+  })
+
+  describe('workStatusCategorySort', () => {
+    const row = (value: unknown) =>
+      ({ getValue: () => value }) as unknown as Row<any>
+    const cmp = (a: unknown, b: unknown) =>
+      workStatusCategorySort(row(a), row(b), 'x')
+
+    it('orders by workflow position, not alphabetically', () => {
+      // Act / Assert — Proposed < Active < Done < Removed
+      expect(cmp('Proposed', 'Active')).toBeLessThan(0)
+      expect(cmp('Active', 'Done')).toBeLessThan(0)
+      expect(cmp('Done', 'Removed')).toBeLessThan(0)
+      // Alphabetically 'Active' < 'Done' < 'Proposed' < 'Removed' — the workflow
+      // order deliberately differs.
+      expect(cmp('Removed', 'Active')).toBeGreaterThan(0)
+    })
+
+    it('sorts a mixed list into workflow order', () => {
+      // Arrange
+      const categories = ['Done', 'Proposed', 'Removed', 'Active']
+
+      // Act
+      const sorted = [...categories].sort((a, b) => cmp(a, b))
+
+      // Assert
+      expect(sorted).toEqual(['Proposed', 'Active', 'Done', 'Removed'])
     })
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.test.ts
@@ -169,6 +169,14 @@ describe('grid-sorting', () => {
       // Assert — API before WEB, numeric within prefix, empty last
       expect(sorted).toEqual(['API-2', 'API-10', 'WEB-2', 'WEB-10', ''])
     })
+
+    it('falls back to a string compare for a malformed suffix (no NaN)', () => {
+      // Arrange / Act / Assert — a non-numeric suffix must not produce NaN,
+      // which would make the comparator return an unstable value.
+      expect(cmp('WEB-abc', 'WEB-def')).toBeLessThan(0)
+      expect(cmp('WEB-abc', 'WEB-abc')).toBe(0)
+      expect(Number.isNaN(cmp('WEB-x', 'WEB-1'))).toBe(false)
+    })
   })
 
   describe('workStatusCategorySort', () => {
@@ -196,6 +204,20 @@ describe('grid-sorting', () => {
 
       // Assert
       expect(sorted).toEqual(['Proposed', 'Active', 'Done', 'Removed'])
+    })
+
+    it('sorts unknown/blank categories last, not first', () => {
+      // Arrange — a raw indexOf would give unknowns -1 and float them to the top
+      const categories = ['Done', 'Mystery', 'Proposed', '', 'Active']
+
+      // Act
+      const sorted = [...categories].sort((a, b) => cmp(a, b))
+
+      // Assert — known categories in workflow order, unknowns trailing
+      expect(sorted.slice(0, 3)).toEqual(['Proposed', 'Active', 'Done'])
+      expect(sorted.slice(3).every((c) => c === 'Mystery' || c === '')).toBe(
+        true,
+      )
     })
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.ts
@@ -95,3 +95,51 @@ export const sortEmptyLast: SortingFn<any> = (
 
   return compareNonEmpty(a, b)
 }
+
+/**
+ * Sorts work-item keys of the form `PREFIX-NUMBER` (e.g. `WEB-42`) by prefix
+ * first (alphabetically) then by the numeric suffix — so `WEB-9` sorts before
+ * `WEB-10`, unlike a plain string sort. Empty keys sort to the end (ascending).
+ * A TanStack `sortingFn` mirroring the old AG Grid `workItemKeyComparator`.
+ */
+export const workItemKeySort: SortingFn<any> = (
+  rowA: Row<any>,
+  rowB: Row<any>,
+  columnId: string,
+): number => {
+  const a = rowA.getValue(columnId) as string | null | undefined
+  const b = rowB.getValue(columnId) as string | null | undefined
+
+  if (!a && !b) return 0
+  if (!a) return 1 // empty keys sort to the end
+  if (!b) return -1
+
+  const [prefixA, numA] = a.split('-')
+  const [prefixB, numB] = b.split('-')
+
+  if (prefixA < prefixB) return -1
+  if (prefixA > prefixB) return 1
+
+  return parseInt(numA) - parseInt(numB)
+}
+
+/** Work status categories in workflow order; drives {@link workStatusCategorySort}. */
+const WORK_STATUS_CATEGORY_ORDER = ['Proposed', 'Active', 'Done', 'Removed']
+
+/**
+ * Sorts a work status category column by its position in the workflow
+ * (Proposed → Active → Done → Removed) rather than alphabetically. A TanStack
+ * `sortingFn` mirroring the old AG Grid `workStatusCategoryComparator`.
+ */
+export const workStatusCategorySort: SortingFn<any> = (
+  rowA: Row<any>,
+  rowB: Row<any>,
+  columnId: string,
+): number => {
+  const a = rowA.getValue(columnId) as string
+  const b = rowB.getValue(columnId) as string
+  return (
+    WORK_STATUS_CATEGORY_ORDER.indexOf(a) -
+    WORK_STATUS_CATEGORY_ORDER.indexOf(b)
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-sorting.ts
@@ -120,7 +120,14 @@ export const workItemKeySort: SortingFn<any> = (
   if (prefixA < prefixB) return -1
   if (prefixA > prefixB) return 1
 
-  return parseInt(numA) - parseInt(numB)
+  // Same prefix: compare the numeric suffix. Guard against malformed keys
+  // (missing/non-numeric suffix) — fall back to a plain string compare so a
+  // NaN subtraction can't destabilize the sort.
+  const nA = parseInt(numA, 10)
+  const nB = parseInt(numB, 10)
+  if (Number.isNaN(nA) || Number.isNaN(nB)) return a.localeCompare(b)
+
+  return nA - nB
 }
 
 /** Work status categories in workflow order; drives {@link workStatusCategorySort}. */
@@ -138,8 +145,11 @@ export const workStatusCategorySort: SortingFn<any> = (
 ): number => {
   const a = rowA.getValue(columnId) as string
   const b = rowB.getValue(columnId) as string
-  return (
-    WORK_STATUS_CATEGORY_ORDER.indexOf(a) -
-    WORK_STATUS_CATEGORY_ORDER.indexOf(b)
-  )
+  // Unknown/blank categories aren't in the workflow list; sort them last
+  // (ascending) instead of first, which is what a raw indexOf of -1 would do.
+  const rank = (value: string): number => {
+    const index = WORK_STATUS_CATEGORY_ORDER.indexOf(value)
+    return index === -1 ? WORK_STATUS_CATEGORY_ORDER.length : index
+  }
+  return rank(a) - rank(b)
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/index.ts
@@ -35,11 +35,26 @@ export {
 } from '../wayd-grid-core/grid-filters'
 
 // Sorting utilities
-export { dateSortBy, sortEmptyLast } from '../wayd-grid-core/grid-sorting'
+export {
+  dateSortBy,
+  sortEmptyLast,
+  workItemKeySort,
+  workStatusCategorySort,
+} from '../wayd-grid-core/grid-sorting'
+
+// Multi-value set filter (set panel over individual values, e.g. a Roles column
+// whose accessor is the comma-joined names). Pair with meta.filterOptions.
+export { createMultiValueSetFilter } from '../wayd-grid-core/filters'
 
 // Column types (declarative via meta.columnType) + helpers — moved to the
 // shared grid core; re-exported so consumers keep a single import surface
-export { applyColumnType, YES, NO } from '../wayd-grid-core/column-types'
+export {
+  applyColumnType,
+  formatDateOnly,
+  formatDateTime,
+  YES,
+  NO,
+} from '../wayd-grid-core/column-types'
 export type { WaydColumnType } from './types'
 
 // Reusable row-actions column (⋯ dropdown, per-row getItems)
@@ -59,12 +74,18 @@ export {
   renderWorkspaceLink,
   renderSprintLink,
   renderUserLink,
+  renderWorkItemLink,
+  renderAssignedToLink,
+  renderWorkStatusTag,
 } from '../wayd-grid-core/cell-renderers'
 export type {
   TeamLinkTarget,
   NavLinkTarget,
   SprintLinkTarget,
   UserLinkTarget,
+  WorkItemLinkTarget,
+  AssignedToLinkTarget,
+  WorkStatusTagTarget,
 } from '../wayd-grid-core/cell-renderers'
 
 // Components (toolbar reconciled into the shared grid core; aliases kept)

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.module.css
@@ -26,8 +26,18 @@
    * header stays distinct from both plain and zebra rows. Theme-safe: fill
    * tokens resolve to the correct subtle overlay per theme (darker in light
    * themes, lighter in dark themes).
+   *
+   * The fill token is semi-transparent, so the sticky header/filter rows MUST
+   * composite it over an OPAQUE base — otherwise rows scrolling underneath show
+   * through the header (it's sticky, they aren't). We layer the tint over the
+   * container background as a flat gradient so the result is fully opaque.
    */
-  --wayd-grid-header-bg: var(--ant-color-fill-tertiary);
+  --wayd-grid-header-tint: var(--ant-color-fill-tertiary);
+  --wayd-grid-header-bg: linear-gradient(
+      var(--wayd-grid-header-tint),
+      var(--wayd-grid-header-tint)
+    )
+    var(--ant-color-bg-container);
   /*
    * Fill the wrapper so the header band and borders paint edge-to-edge (AG Grid
    * style). Real columns keep their declared sizes via <col> widths; a trailing
@@ -46,7 +56,7 @@
 
 .th {
   padding: 5px var(--ant-padding-sm);
-  background-color: var(--wayd-grid-header-bg);
+  background: var(--wayd-grid-header-bg);
   border-bottom: 1px solid var(--ant-color-border);
   color: var(--ant-color-text);
   text-align: left;
@@ -208,7 +218,7 @@
 
 .filterTh {
   padding: 4px 4px;
-  background-color: var(--wayd-grid-header-bg);
+  background: var(--wayd-grid-header-bg);
   border-bottom: 1px solid var(--ant-color-border);
   color: var(--ant-color-text);
   font-weight: normal;

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
@@ -1,23 +1,19 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import {
+  WaydGrid2,
+  renderAssignedToLink,
+  renderProjectLink,
+  renderSprintLink,
+  renderTeamLink,
+  renderWorkItemLink,
+  renderWorkStatusTag,
+  workItemKeySort,
+  workStatusCategorySort,
+} from '@/src/components/common/wayd-grid2'
 import { WorkItemBacklogItemDto } from '@/src/services/wayd-api'
-import { ColDef } from 'ag-grid-community'
+import type { ColumnDef } from '@tanstack/react-table'
 import { useMemo } from 'react'
-import {
-  AssignedToLinkCellRenderer,
-  NestedTeamNameLinkCellRenderer,
-  NestedWorkSprintLinkCellRenderer,
-  ParentWorkItemLinkCellRenderer,
-  ProjectLinkCellRenderer,
-  WorkItemLinkCellRenderer,
-  WorkStatusTagCellRenderer,
-} from '../wayd-grid-cell-renderers'
-import {
-  workItemKeyComparator,
-  workStatusCategoryComparator,
-} from './work-item-utils'
-import { CustomCellRendererProps } from 'ag-grid-react'
 import WorkItemTagsCell from './work-item-tags-cell'
 
 export interface WorkItemsBacklogGridProps {
@@ -30,70 +26,109 @@ export interface WorkItemsBacklogGridProps {
 const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<WorkItemBacklogItemDto>[]>(
+  const columns = useMemo<ColumnDef<WorkItemBacklogItemDto, any>[]>(
     () => [
-      { field: 'rank', width: 125 },
+      { id: 'rank', accessorKey: 'rank', header: 'Rank', size: 125 },
       {
-        field: 'key',
-        comparator: workItemKeyComparator,
-        cellRenderer: WorkItemLinkCellRenderer,
+        id: 'key',
+        accessorKey: 'key',
+        header: 'Key',
+        sortingFn: workItemKeySort,
+        cell: ({ row }) =>
+          renderWorkItemLink({
+            key: row.original.key,
+            workspaceKey: row.original.workspace.key,
+            externalViewWorkItemUrl: row.original.externalViewWorkItemUrl,
+          }),
       },
-      { field: 'title', width: 400 },
-      { field: 'type', width: 125 },
+      { id: 'title', accessorKey: 'title', header: 'Title', size: 400 },
       {
-        field: 'storyPoints',
-        headerName: 'SPs',
-        headerTooltip: 'Story Points',
-        width: 80,
-      },
-      { field: 'status', width: 125, cellRenderer: WorkStatusTagCellRenderer },
-      {
-        field: 'statusCategory.name',
-        headerName: 'Status Category',
-        width: 140,
-        comparator: workStatusCategoryComparator,
-      },
-      {
-        field: 'team.name',
-        headerName: 'Team',
-        cellRenderer: NestedTeamNameLinkCellRenderer,
-        hide: props.hideTeamColumn,
+        id: 'type',
+        accessorKey: 'type',
+        header: 'Type',
+        size: 125,
+        meta: { filterType: 'set' },
       },
       {
-        field: 'sprint.name',
-        headerName: 'Sprint',
-        cellRenderer: NestedWorkSprintLinkCellRenderer,
+        id: 'storyPoints',
+        accessorKey: 'storyPoints',
+        header: 'SPs',
+        size: 80,
       },
       {
-        field: 'parent.key',
-        headerName: 'Parent Key',
-        comparator: workItemKeyComparator,
-        cellRenderer: ParentWorkItemLinkCellRenderer,
+        id: 'status',
+        accessorKey: 'status',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+        cell: ({ row }) => renderWorkStatusTag(row.original),
       },
       {
-        field: 'parent.title',
-        headerName: 'Parent',
-        width: 400,
+        id: 'statusCategory',
+        accessorKey: 'statusCategory.name',
+        header: 'Status Category',
+        size: 140,
+        sortingFn: workStatusCategorySort,
+        meta: { filterType: 'set' },
       },
       {
-        field: 'assignedTo.name',
-        headerName: 'Assigned To',
-        cellRenderer: AssignedToLinkCellRenderer,
+        id: 'team',
+        accessorKey: 'team.name',
+        header: 'Team',
+        meta: { hide: props.hideTeamColumn, filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.team),
       },
       {
-        field: 'project.name',
-        headerName: 'Project',
-        width: 300,
-        cellRenderer: ProjectLinkCellRenderer,
+        id: 'sprint',
+        accessorKey: 'sprint.name',
+        header: 'Sprint',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderSprintLink(row.original.sprint),
       },
       {
-        field: 'tags',
-        headerName: 'Tags',
-        width: 200,
-        valueGetter: (params) => params.data?.tags?.join(', ') ?? '',
-        cellRenderer: (
-          params: CustomCellRendererProps<WorkItemBacklogItemDto>,
-        ) => <WorkItemTagsCell tags={params.data?.tags} />,
+        id: 'parentKey',
+        accessorKey: 'parent.key',
+        header: 'Parent Key',
+        sortingFn: workItemKeySort,
+        cell: ({ row }) =>
+          renderWorkItemLink(
+            row.original.parent
+              ? {
+                  key: row.original.parent.key,
+                  workspaceKey: row.original.parent.workspaceKey,
+                  externalViewWorkItemUrl:
+                    row.original.parent.externalViewWorkItemUrl,
+                }
+              : null,
+          ),
+      },
+      {
+        id: 'parentTitle',
+        accessorKey: 'parent.title',
+        header: 'Parent',
+        size: 400,
+      },
+      {
+        id: 'assignedTo',
+        accessorKey: 'assignedTo.name',
+        header: 'Assigned To',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderAssignedToLink(row.original.assignedTo),
+      },
+      {
+        id: 'project',
+        accessorKey: 'project.name',
+        header: 'Project',
+        size: 300,
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderProjectLink(row.original.project),
+      },
+      {
+        id: 'tags',
+        accessorFn: (row) => row.tags?.join(', ') ?? '',
+        header: 'Tags',
+        size: 200,
+        cell: ({ row }) => <WorkItemTagsCell tags={row.original.tags} />,
       },
     ],
     [props.hideTeamColumn],
@@ -104,15 +139,14 @@ const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
   }
 
   return (
-    <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={props.workItems}
-        loadData={refresh}
-        loading={props.isLoading}
-      />
-    </>
+    <WaydGrid2
+      height={550}
+      columns={columns}
+      data={props.workItems ?? []}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="work-items-backlog"
+    />
   )
 }
 


### PR DESCRIPTION
# Migrate to TanStack Table (Part 2): retire ag-grid across ~37 screens

Continues the grid consolidation ([assessment](docs/contributing/specs/grid-consolidation-assessment.md) · [implementation plan](docs/contributing/specs/grid-core-implementation-plan.md)) by migrating the bulk of the remaining ag-grid `WaydGrid` screens onto the TanStack-based `WaydGrid2` and its shared core. It also fixes a backend regression surfaced during verification.

**67 files changed** across 10 reviewable, area-scoped commits. Every migrated screen was type-checked, linted, unit-tested, and browser-verified.

## What changed

### Grid core enhancements (built once, shared)
- **Cell renderers:** `renderWorkItemLink` (with external-system icon), `renderAssignedToLink`, `renderWorkStatusTag`; exposed `formatDateOnly` / `formatDateTime` for custom cells.
- **Sorts:** `workItemKeySort` (prefix-then-numeric so `WEB-9` < `WEB-10`) and `workStatusCategorySort` (workflow order, not alphabetical) — TanStack `sortingFn` versions of the old ag-grid comparators.
- **Filtering:** `createMultiValueSetFilter` for comma-joined multi-value columns (e.g. Roles) so the set panel lists individual values and matches by membership.
- **Fix:** sticky header/filter rows were semi-transparent and bled through scrolled rows; now composited over an opaque background. This fixes every WaydGrid2 screen at once.

### Screens migrated (~37)
| Area | Grids |
| --- | --- |
| Account / misc | Claims, PATs, Strategic Themes |
| Organizations | Teams (list + page), Team Members, Operating Models, Team Memberships, Employees, Employee Teams |
| Settings CRUD | Work Types / Processes / Statuses, Expenditure Categories, Project Lifecycles (+ Phases), Estimation Scales, Team Member Roles, Connections, Background Jobs |
| User & auth | Users, Roles, Role Users, Identity Providers, Tenant Migrations |
| Scoring | Scoring Models (+ Criteria, Outputs, Scales) |
| PPM | Projects, Programs, Portfolios, Strategic Initiatives, Project Team, Project Health Report |
| Planning | Planning Intervals, Poker Sessions, Roadmaps, Sprints, Risks, PI-Objective Health Reports (×2) |
| Work | Workspaces, Work Items Backlog, Sprint Backlog |

Consistent conventions applied throughout: ag-grid `ColDef[]` → TanStack `ColumnDef[]`; row menus / edit buttons → `createActionsColumn`; booleans → `yesNo` column type; date columns → `dateOnly` / `dateTime` column types; `valueGetter` → `accessorFn`; low-cardinality columns → set filters; toolbar view selectors / control menus → `rightSlot` / `leftSlot`.

### Backend fix (separate commit)
**Personal access token status flags always returned false** ("Unknown" for every token). The domain refactor that replaced `IsActive`/`IsExpired` properties with `IsActiveAt(timestamp)` / `IsExpiredAt(timestamp)` methods left Mapster's name-based projection with no source members to map. Replaced with an explicit, EF-translatable `PersonalAccessTokenDto.Projection(now)` computing the flags against the injected `IDateTimeProvider`, applied in both query handlers. Added handler tests.

### Incidental fixes (folded into the batch where found)
- Employee details **Manager** field rendered an empty link to `/employees/undefined` when there was no manager.
- Team / team-of-teams pages passed `undefined` risks data straight into the grid (crash); guarded with `?? []` at the call sites.
- Sprints grid preserves **UTC calendar dates** (`dayjs.utc`) so they don't shift a day under the local-timezone `dateOnly` type.
- Fixed the "portolios" empty-message typo.

## Testing
- `tsc --noEmit`, `eslint`, and the grid jest suites are green (**293 tests**). Added unit tests for the new core renderers, sorts, multi-value filter, and date formatters; rewrote the ag-grid-coupled `sprints-grid` test against the WaydGrid2 shape.
- Every migrated screen was browser-verified: correct columns, links, tags, date formatting, filters, and **zero ag-grid DOM artifacts** on each page.

## Not in scope (deferred — blocked on core features)
Five grids remain on ag-grid, each needing a WaydGrid2 core feature first:
- **Flat row-drag reorder** (3): main Work Items grid (also needs a grid-state / filter-change callback for its cycle-time chart), Strategic Initiative KPIs, Project Ranking Board.
- **Grouped headers** (2): Team Dependencies, Work Item Dependencies (ag-grid `ColGroupDef` header bands).

The **endgame** — deleting `wayd-grid.tsx` + `wayd-grid-cell-renderers.tsx`, removing the ag-grid packages/theme wiring, and renaming `WaydGrid2` → `WaydGrid` — only happens once those last five are migrated, so ag-grid is intentionally still present after this PR.
