### PR TITLE
Feature/migrate to tanstack table part3

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/personal-access-tokens.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/personal-access-tokens.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, FC, useMemo } from 'react'
-import { Button, Tag, Alert, Flex, Typography, App, Space, Tooltip } from 'antd'
+import { Button, Tag, Alert, Flex, Typography, App, Space } from 'antd'
 import { PlusOutlined } from '@ant-design/icons'
 import {
   useGetMyPersonalAccessTokensQuery,
@@ -189,13 +189,13 @@ const PersonalAccessTokens: FC = () => {
       {
         id: 'lastUsedAt',
         accessorKey: 'lastUsedAt',
-        header: () => (
-          <Tooltip title="The last time this token was used for authentication. Updates at most once per hour.">
-            <span>Last Used</span>
-          </Tooltip>
-        ),
+        header: 'Last Used',
         size: 180,
-        meta: { columnType: 'dateTime', exportHeader: 'Last Used' },
+        meta: {
+          columnType: 'dateTime',
+          headerTooltip:
+            'The last time this token was used for authentication. Updates at most once per hour.',
+        },
         cell: ({ getValue }) => renderDateTimeOrNever(getValue()),
       },
     ]

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/_components/ranking/project-ranking-board.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/_components/ranking/project-ranking-board.module.css
@@ -1,12 +1,3 @@
-/* Suppress the cell focus border for the row-actions column.
-   The inner drag handle and menu button retain their native focus rings,
-   so keyboard navigation still works and remains visible. */
-.rowActionsCell.ag-cell-focus,
-.rowActionsCell:focus {
-  outline: none !important;
-  border-color: transparent !important;
-}
-
 .scoreTagAction {
   display: inline-flex;
   align-items: center;

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/_components/ranking/project-ranking-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/_components/ranking/project-ranking-board.tsx
@@ -1,10 +1,15 @@
 'use client'
 
-import { WaydGrid, WaydTooltip } from '@/src/components/common'
+import { WaydTooltip } from '@/src/components/common'
+import LifecycleStatusTag from '@/src/components/common/lifecycle-status-tag'
 import {
-  LifecycleStatusTagCellRenderer,
-  ProgramLinkCellRenderer,
-} from '@/src/components/common/wayd-grid-cell-renderers'
+  WaydGrid2,
+  renderProgramLink,
+  renderProjectLink,
+  useGridDragHandle,
+  type GridColumnContext,
+  type RowReorderEvent,
+} from '@/src/components/common/wayd-grid2'
 import { useMessage } from '@/src/components/contexts/messaging'
 import ProjectDrawer from '@/src/app/ppm/_components/project-drawer'
 import RecordProjectScoreForm from '@/src/app/ppm/projects/[key]/_components/scoring/record-project-score-form'
@@ -20,25 +25,11 @@ import {
   LoadingOutlined,
   MoreOutlined,
 } from '@ant-design/icons'
-import {
-  ColDef,
-  GetRowIdParams,
-  ICellRendererParams,
-  RowDragEndEvent,
-  RowSelectionOptions,
-} from 'ag-grid-community'
-import { AgGridReact } from 'ag-grid-react'
+import type { ColumnDef } from '@tanstack/react-table'
 import { Button, Dropdown, Flex, Tag, theme } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import Link from 'next/link'
-import {
-  KeyboardEvent,
-  SyntheticEvent,
-  useCallback,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import { FC, KeyboardEvent, useCallback, useMemo, useState } from 'react'
 import styles from './project-ranking-board.module.css'
 import { buildMoveRanksPayload, RankableRow } from './ranking'
 
@@ -55,105 +46,51 @@ export interface ProjectRankingBoardProps {
   refetchScoreboard: () => void
 }
 
-interface DragHandleCellProps extends ICellRendererParams<ProjectListDto> {
-  /** Whether the user may rank projects at all. */
-  canRank: boolean
-  /** Whether dragging is currently allowed (false while sorted/filtered/searched). */
-  dragEnabled: boolean
-  menuItems: ItemType[]
-}
-
-interface ScoreCellRendererProps extends ICellRendererParams<ProjectListDto> {
-  isOpening: boolean
-  onOpenScoreForm: (projectId: string) => void
-}
-
-const stopRowClick = (event: SyntheticEvent) => {
-  event.stopPropagation()
-}
-
-// Registers a custom element as ag-grid's row drag source (managed row drag). The handle is always
-// shown, but rendered disabled (and not registered as a drag source) while the list isn't in pure
-// rank order; sorting/filtering/searching would make a drop ambiguous.
-const ActionsCellRenderer = (props: DragHandleCellProps) => {
+// Disabled (with tooltip) while sort/filter/search make the order ambiguous.
+const DragHandleCell: FC<{ isDragEnabled: boolean }> = ({ isDragEnabled }) => {
   const { token } = theme.useToken()
-  const dragHandleRef = useCallback(
-    (node: HTMLSpanElement | null) => {
-      if (node && props.dragEnabled) {
-        props.registerRowDragger(node)
+  const { listeners, attributes } = useGridDragHandle()
+
+  return (
+    <WaydTooltip
+      title={
+        isDragEnabled
+          ? undefined
+          : 'Clear sorting, filters, and search to enable ranking.'
       }
-    },
-    [props],
-  )
-  const showMenu = props.menuItems.length > 0
-  const showDragHandle = props.canRank
-
-  return (
-    <Flex align="center" gap={2} style={{ height: '100%' }}>
-      {showDragHandle && (
-        <WaydTooltip
-          title={
-            props.dragEnabled
-              ? undefined
-              : 'Clear sorting, filters, and search to enable ranking.'
-          }
-        >
-          <span
-            ref={dragHandleRef}
-            style={{
-              cursor: props.dragEnabled ? 'grab' : 'not-allowed',
-              color: props.dragEnabled
-                ? token.colorTextTertiary
-                : token.colorTextDisabled,
-              display: 'inline-flex',
-              padding: '0 4px',
-            }}
-            aria-label="Drag to reorder"
-            aria-disabled={!props.dragEnabled}
-          >
-            <HolderOutlined />
-          </span>
-        </WaydTooltip>
-      )}
-      {showMenu && (
-        <Dropdown menu={{ items: props.menuItems }} trigger={['click']}>
-          <Button
-            type="text"
-            size="small"
-            icon={<MoreOutlined />}
-            onClick={stopRowClick}
-            onMouseDown={stopRowClick}
-          />
-        </Dropdown>
-      )}
-    </Flex>
-  )
-}
-
-const ProjectNameCellRenderer = (
-  props: ICellRendererParams<ProjectListDto>,
-) => {
-  if (!props.data) return null
-  return (
-    <Link href={`/ppm/projects/${props.data.key}`} onClick={stopRowClick}>
-      {props.data.name}
-    </Link>
+    >
+      <span
+        {...(isDragEnabled ? { ...listeners, ...attributes } : {})}
+        style={{
+          cursor: isDragEnabled ? 'grab' : 'not-allowed',
+          color: isDragEnabled
+            ? token.colorTextTertiary
+            : token.colorTextDisabled,
+          display: 'inline-flex',
+          padding: '0 4px',
+          touchAction: 'none',
+        }}
+        aria-label="Drag to reorder"
+        aria-disabled={!isDragEnabled}
+      >
+        <HolderOutlined />
+      </span>
+    </WaydTooltip>
   )
 }
 
 // Renders the primary output value (already gated to the current-model score via the column's
-// valueGetter) as a score action when the user may manage the project.
-const ScoreCellRenderer = ({
-  data,
-  isOpening,
-  onOpenScoreForm,
-  value,
-}: ScoreCellRendererProps) => {
-  const scoreValue = value as number | null | undefined
-  const hasScore = scoreValue != null
-  const label = hasScore ? scoreValue.toFixed(2) : 'Unscored'
+// accessor) as a score action when the user may manage the project.
+const ScoreCell: FC<{
+  project: ProjectListDto
+  value: number | null | undefined
+  isOpening: boolean
+  onOpenScoreForm: (projectId: string) => void
+}> = ({ project, value, isOpening, onOpenScoreForm }) => {
+  const hasScore = value != null
+  const label = hasScore ? value.toFixed(2) : 'Unscored'
 
-  if (!data?.canManageProject) {
+  if (!project.canManageProject) {
     return (
       <Tag color={hasScore ? 'blue' : 'default'} style={{ marginInlineEnd: 0 }}>
         {label}
@@ -164,11 +101,10 @@ const ScoreCellRenderer = ({
   const actionTitle = hasScore
     ? 'Click to re-score project'
     : 'Click to score project'
-  const openScore = () => onOpenScoreForm(data.id)
+  const openScore = () => onOpenScoreForm(project.id)
   const onScoreKeyDown = (event: KeyboardEvent<HTMLSpanElement>) => {
     if (event.key !== 'Enter' && event.key !== ' ') return
     event.preventDefault()
-    stopRowClick(event)
     openScore()
   }
 
@@ -180,12 +116,8 @@ const ScoreCellRenderer = ({
         role="button"
         tabIndex={0}
         aria-busy={isOpening}
-        onClick={(event) => {
-          stopRowClick(event)
-          openScore()
-        }}
+        onClick={openScore}
         onKeyDown={onScoreKeyDown}
-        onMouseDown={stopRowClick}
       >
         {isOpening && <LoadingOutlined className={styles.scoreTagIcon} />}
         {label}
@@ -196,13 +128,6 @@ const ScoreCellRenderer = ({
 
 const buildScoringColumnTooltip = (name: string, description?: string | null) =>
   [name, description?.trim()].filter(Boolean).join(' - ')
-
-const rowSelection: RowSelectionOptions<ProjectListDto> = {
-  mode: 'multiRow',
-  checkboxes: false,
-  headerCheckbox: false,
-  enableClickSelection: true,
-}
 
 const ProjectRankingBoard = ({
   portfolioId,
@@ -215,7 +140,6 @@ const ProjectRankingBoard = ({
   refetchScoreboard,
 }: ProjectRankingBoardProps) => {
   const messageApi = useMessage()
-  const gridRef = useRef<AgGridReact<ProjectListDto>>(null)
   const [moveRanks] = useMovePortfolioProjectRanksMutation()
   const [selectedProjectKey, setSelectedProjectKey] = useState<string | null>(
     null,
@@ -251,12 +175,6 @@ const ProjectRankingBoard = ({
     return map
   }, [scoreboard])
 
-  // Dragging only makes sense in the API-provided rank order. When the user sorts, column-filters, or
-  // uses the global search, the visible order no longer reflects rank, so the drag handle is disabled
-  // (shown but not draggable) until all of those are cleared.
-  const [interactionActive, setInteractionActive] = useState(false)
-  const dragEnabled = canManage && !interactionActive
-
   const orderedProjects = useMemo(
     () =>
       [...projects].sort((a, b) => {
@@ -267,8 +185,6 @@ const ProjectRankingBoard = ({
       }),
     [projects],
   )
-
-  const getRowId = (params: GetRowIdParams<ProjectListDto>) => params.data.id
 
   const openProjectDrawer = useCallback((projectKey: string) => {
     setSelectedProjectKey(projectKey)
@@ -289,38 +205,15 @@ const ProjectRankingBoard = ({
     refetchScoreboard()
   }
 
-  const syncInteractionState = () => {
-    const api = gridRef.current?.api
-    if (!api) return
-    const sorted = api.getColumnState().some((c) => c.sort)
-    const filtered = api.isAnyFilterPresent()
-    const searched = api.isQuickFilterPresent()
-    setInteractionActive(sorted || filtered || searched)
-  }
+  // Translate the post-drop visual order into the move payload (moved id + its
+  // ranked neighbours) — the server computes the new fractional ranks.
+  const onRowReorder = async (event: RowReorderEvent<ProjectListDto>) => {
+    const ordered: RankableRow[] = event.orderedData.map((p) => ({
+      id: p.id,
+      rank: p.rank,
+    }))
 
-  const onRowDragEnd = async (event: RowDragEndEvent<ProjectListDto>) => {
-    if (!dragEnabled) return
-
-    // Reconstruct the post-drop visual order and locate the moved rows, then derive the move payload
-    // (moved ids + their ranked neighbours) — the server computes the new fractional ranks.
-    const movedIds = new Set(
-      event.nodes
-        .map((node) => node.data?.id)
-        .filter((id): id is string => Boolean(id)),
-    )
-    if (movedIds.size === 0 && event.node.data?.id) {
-      movedIds.add(event.node.data.id)
-    }
-
-    const ordered: RankableRow[] = []
-    const movedIndices: number[] = []
-    event.api.forEachNodeAfterFilterAndSort((node) => {
-      if (!node.data) return
-      if (movedIds.has(node.data.id)) movedIndices.push(ordered.length)
-      ordered.push({ id: node.data.id, rank: node.data.rank })
-    })
-
-    const payload = buildMoveRanksPayload(ordered, movedIndices)
+    const payload = buildMoveRanksPayload(ordered, [event.toIndex])
     if (!payload) {
       refetch()
       return
@@ -343,158 +236,166 @@ const ProjectRankingBoard = ({
     }
   }
 
-  const columnDefs = useMemo<ColDef<ProjectListDto>[]>(
-    () => [
-      {
-        width: dragEnabled ? 60 : 40,
-        filter: false,
-        sortable: false,
-        resizable: false,
-        suppressHeaderMenuButton: true,
-        cellClass: styles.rowActionsCell,
-        cellRenderer: (params: ICellRendererParams<ProjectListDto>) => (
-          <ActionsCellRenderer
-            {...params}
-            canRank={canManage}
-            dragEnabled={dragEnabled}
-            menuItems={
-              params.data
-                ? [
-                    {
-                      key: 'view-details',
-                      label: 'View Details',
-                      onClick: () => openProjectDrawer(params.data!.key),
-                    },
-                    {
-                      key: 'open-project',
-                      label: (
-                        <Link href={`/ppm/projects/${params.data.key}`}>
-                          Open Project
-                        </Link>
-                      ),
-                    },
-                  ]
-                : []
-            }
-          />
+  const columns = useMemo(
+    () =>
+      (context: GridColumnContext): ColumnDef<ProjectListDto, any>[] => [
+        {
+          id: 'actions',
+          header: '',
+          size: canManage ? 60 : 40,
+          enableSorting: false,
+          enableColumnFilter: false,
+          enableResizing: false,
+          enableGlobalFilter: false,
+          cell: ({ row }) => {
+            const menuItems: ItemType[] = [
+              {
+                key: 'view-details',
+                label: 'View Details',
+                onClick: () => openProjectDrawer(row.original.key),
+              },
+              {
+                key: 'open-project',
+                label: (
+                  <Link href={`/ppm/projects/${row.original.key}`}>
+                    Open Project
+                  </Link>
+                ),
+              },
+            ]
+
+            return (
+              <Flex align="center" gap={2}>
+                {canManage && (
+                  <DragHandleCell isDragEnabled={context.isDragEnabled} />
+                )}
+                <Dropdown menu={{ items: menuItems }} trigger={['click']}>
+                  <Button type="text" size="small" icon={<MoreOutlined />} />
+                </Dropdown>
+              </Flex>
+            )
+          },
+        },
+        {
+          id: 'position',
+          accessorKey: 'position',
+          header: 'Rank',
+          size: 90,
+          cell: ({ getValue }) => {
+            const value = getValue<number | null>()
+            return value == null ? '—' : String(value)
+          },
+        },
+        {
+          id: 'name',
+          accessorKey: 'name',
+          header: 'Project',
+          minSize: 240,
+          size: 240,
+          cell: ({ row }) => renderProjectLink(row.original),
+        },
+        {
+          id: 'program',
+          accessorKey: 'program.name',
+          header: 'Program',
+          size: 200,
+          meta: { filterEnableSet: true },
+          cell: ({ row }) => renderProgramLink(row.original.program),
+        },
+        {
+          id: 'status',
+          accessorKey: 'status.name',
+          header: 'Status',
+          size: 140,
+          meta: { filterType: 'set' },
+          cell: ({ row }) =>
+            row.original.status ? (
+              <LifecycleStatusTag status={row.original.status} />
+            ) : null,
+        },
+        // Model-derived columns: criteria (in model order), then outputs (in model order). Headers use
+        // the token. Values come from the project's current-model score; blank when there's no matching
+        // score. The primary output renders as a badge to set it apart from the plain criterion/output
+        // value cells.
+        ...(scoreboard?.scoringModel?.criteria ?? []).map(
+          (criterion): ColumnDef<ProjectListDto, any> => ({
+            id: `criterion:${criterion.id}`,
+            accessorFn: (p) =>
+              criterionValuesByProject.get(p.id)?.get(criterion.id) ?? null,
+            header: criterion.token,
+            size: 120,
+            enableColumnFilter: false,
+            meta: {
+              headerTooltip: buildScoringColumnTooltip(
+                criterion.name,
+                criterion.description,
+              ),
+            },
+            cell: ({ getValue }) => {
+              const value = getValue<number | null>()
+              return value == null ? '' : Number(value).toLocaleString()
+            },
+          }),
         ),
-      },
-      {
-        field: 'position',
-        headerName: 'Rank',
-        width: 90,
-        valueFormatter: (p) => (p.value == null ? '—' : String(p.value)),
-      },
-      {
-        field: 'name',
-        headerName: 'Project',
-        minWidth: 240,
-        cellRenderer: ProjectNameCellRenderer,
-      },
-      {
-        field: 'program.name',
-        headerName: 'Program',
-        width: 200,
-        cellRenderer: (params: ICellRendererParams<ProjectListDto>) =>
-          params.data?.program
-            ? ProgramLinkCellRenderer({
-                ...(params as any),
-                data: params.data.program,
-              })
-            : null,
-      },
-      {
-        field: 'status.name',
-        headerName: 'Status',
-        width: 140,
-        cellRenderer: LifecycleStatusTagCellRenderer,
-      },
-      // Model-derived columns: criteria (in model order), then outputs (in model order). Headers use
-      // the token. Values come from the project's current-model score; blank when there's no matching
-      // score. The primary output renders as a badge to set it apart from the plain criterion/output
-      // value cells.
-      ...(scoreboard?.scoringModel?.criteria ?? []).map(
-        (criterion) =>
-          ({
-            colId: `criterion:${criterion.id}`,
-            headerName: criterion.token,
-            headerTooltip: buildScoringColumnTooltip(
-              criterion.name,
-              criterion.description,
-            ),
-            width: 120,
-            sortable: true,
-            filter: false,
-            valueGetter: (p) =>
-              p.data
-                ? (criterionValuesByProject.get(p.data.id)?.get(criterion.id) ??
-                  null)
-                : null,
-            valueFormatter: (p) =>
-              p.value == null ? '' : Number(p.value).toLocaleString(),
-          }) as ColDef<ProjectListDto>,
-      ),
-      ...(scoreboard?.scoringModel?.outputs ?? []).map(
-        (output) =>
-          ({
-            colId: `output:${output.token}`,
-            headerName: output.token,
-            headerTooltip: buildScoringColumnTooltip(
-              output.name,
-              `Formula: ${output.formula}`,
-            ),
-            width: 120,
-            sortable: true,
-            filter: false,
-            valueGetter: (p) =>
-              p.data
-                ? (outputValuesByProject.get(p.data.id)?.get(output.token) ??
-                  null)
-                : null,
-            valueFormatter: output.isPrimary
-              ? undefined
-              : (p) =>
-                  p.value == null ? '' : Number(p.value).toLocaleString(),
-            cellRenderer: output.isPrimary
-              ? (params: ICellRendererParams<ProjectListDto>) => (
-                  <ScoreCellRenderer
-                    {...params}
+        ...(scoreboard?.scoringModel?.outputs ?? []).map(
+          (output): ColumnDef<ProjectListDto, any> => ({
+            id: `output:${output.token}`,
+            accessorFn: (p) =>
+              outputValuesByProject.get(p.id)?.get(output.token) ?? null,
+            header: output.token,
+            size: 120,
+            enableColumnFilter: false,
+            meta: {
+              headerTooltip: buildScoringColumnTooltip(
+                output.name,
+                `Formula: ${output.formula}`,
+              ),
+            },
+            cell: output.isPrimary
+              ? ({ row, getValue }) => (
+                  <ScoreCell
+                    project={row.original}
+                    value={getValue<number | null>()}
                     isOpening={
                       isScoringContextLoading &&
-                      params.data?.id === scoreProjectId
+                      row.original.id === scoreProjectId
                     }
                     onOpenScoreForm={openScoreForm}
                   />
                 )
-              : undefined,
-          }) as ColDef<ProjectListDto>,
-      ),
-      {
-        field: 'start',
-        width: 125,
-        type: 'dateOnly',
-      },
-      {
-        field: 'end',
-        width: 125,
-        type: 'dateOnly',
-      },
-      {
-        field: 'projectManagers',
-        headerName: 'PMs',
-        valueGetter: (params) =>
-          getSortedNames(params.data?.projectManagers ?? []),
-      },
-      {
-        field: 'projectOwners',
-        headerName: 'Owners',
-        valueGetter: (params) =>
-          getSortedNames(params.data?.projectOwners ?? []),
-      },
-    ],
+              : ({ getValue }) => {
+                  const value = getValue<number | null>()
+                  return value == null ? '' : Number(value).toLocaleString()
+                },
+          }),
+        ),
+        {
+          id: 'start',
+          accessorKey: 'start',
+          header: 'Start',
+          size: 125,
+          meta: { columnType: 'dateOnly' },
+        },
+        {
+          id: 'end',
+          accessorKey: 'end',
+          header: 'End',
+          size: 125,
+          meta: { columnType: 'dateOnly' },
+        },
+        {
+          id: 'projectManagers',
+          accessorFn: (row) => getSortedNames(row.projectManagers ?? []),
+          header: 'PMs',
+        },
+        {
+          id: 'projectOwners',
+          accessorFn: (row) => getSortedNames(row.projectOwners ?? []),
+          header: 'Owners',
+        },
+      ],
     [
       canManage,
-      dragEnabled,
       openProjectDrawer,
       openScoreForm,
       isScoringContextLoading,
@@ -508,22 +409,15 @@ const ProjectRankingBoard = ({
 
   return (
     <>
-      <WaydGrid
-        ref={gridRef}
-        columnDefs={columnDefs}
-        rowData={orderedProjects}
-        getRowId={getRowId}
-        loading={isLoading}
-        loadData={refetch}
+      <WaydGrid2
+        columns={columns}
+        data={orderedProjects}
+        getRowId={(project) => project.id}
+        isLoading={isLoading}
+        onRefresh={refetch}
         emptyMessage="No projects to rank."
-        rowSelection={rowSelection}
-        suppressCellFocus={true}
-        rowDragManaged={dragEnabled}
-        rowDragMultiRow={true}
-        onRowDragEnd={onRowDragEnd}
-        onSortChanged={syncInteractionState}
-        onFilterChanged={syncInteractionState}
-        onFirstDataRendered={syncInteractionState}
+        csvFileName="portfolio-ranking"
+        onRowReorder={canManage ? onRowReorder : undefined}
       />
       {selectedProjectKey && (
         <ProjectDrawer

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/strategic-initiative-kpis-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/strategic-initiative-kpis-grid.module.css
@@ -1,8 +1,0 @@
-/* Suppress the cell focus border for the row-actions column.
-   The inner drag handle and menu button retain their native focus rings,
-   so keyboard navigation still works and remains visible. */
-.rowActionsCell.ag-cell-focus,
-.rowActionsCell:focus {
-  outline: none !important;
-  border-color: transparent !important;
-}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/strategic-initiative-kpis-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/strategic-initiative-kpis-grid.tsx
@@ -1,23 +1,22 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import { WaydTooltip } from '@/src/components/common'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { WaydStatisticNumber } from '@/src/components/common/metrics'
+import {
+  WaydGrid2,
+  useGridDragHandle,
+  type GridColumnContext,
+  type RowReorderEvent,
+} from '@/src/components/common/wayd-grid2'
 import { StrategicInitiativeKpiListDto } from '@/src/services/wayd-api'
 import { useReorderStrategicInitiativeKpisMutation } from '@/src/store/features/ppm/strategic-initiatives-api'
 import { isApiError } from '@/src/utils'
 import { HolderOutlined, MoreOutlined } from '@ant-design/icons'
-import styles from './strategic-initiative-kpis-grid.module.css'
-import {
-  ColDef,
-  GetRowIdParams,
-  ICellRendererParams,
-  RowDragEndEvent,
-} from 'ag-grid-community'
-import { AgGridReact } from 'ag-grid-react'
-import { Button, Dropdown, Flex, MenuProps } from 'antd'
+import type { ColumnDef } from '@tanstack/react-table'
+import { Button, Dropdown, Flex, MenuProps, theme } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
-import { FC, useState, useMemo, useRef, useCallback } from 'react'
+import { FC, useState, useMemo } from 'react'
 import {
   AddStrategicInitiativeKpiMeasurementForm,
   DeleteStrategicInitiativeKpiForm,
@@ -35,10 +34,6 @@ export interface StrategicInitiativeKpisGridProps {
   gridHeight?: number | undefined
   isReadOnly?: boolean
   viewSelector?: React.ReactNode
-}
-
-const StatisticNumberCellRenderer = (params: ICellRendererParams<StrategicInitiativeKpiListDto>) => {
-  return <WaydStatisticNumber value={params.value} />
 }
 
 interface RowMenuProps extends MenuProps {
@@ -89,43 +84,36 @@ const getRowMenuItems = (props: RowMenuProps): ItemType[] => {
   ]
 }
 
-interface DragAndMenuCellRendererProps
-  extends ICellRendererParams<StrategicInitiativeKpiListDto> {
-  menuItems: ItemType[]
-  canDrag: boolean
-}
-
-const DragAndMenuCellRenderer = (props: DragAndMenuCellRendererProps) => {
-  const dragHandleRef = useCallback(
-    (node: HTMLSpanElement | null) => {
-      if (node && props.canDrag) {
-        props.registerRowDragger(node)
-      }
-    },
-    [props],
-  )
-
-  const showMenu = props.menuItems.length > 0
-
-  if (!props.canDrag && !showMenu) return null
+// Disabled (with tooltip) while sort/filter/search make the order ambiguous.
+const DragHandleCell: FC<{ isDragEnabled: boolean }> = ({ isDragEnabled }) => {
+  const { token } = theme.useToken()
+  const { listeners, attributes } = useGridDragHandle()
 
   return (
-    <Flex align="center" gap={2} style={{ height: '100%' }}>
-      {props.canDrag && (
-        <span
-          ref={dragHandleRef}
-          style={{ cursor: 'grab', display: 'inline-flex', padding: '0 4px' }}
-          aria-label="Drag to reorder"
-        >
-          <HolderOutlined />
-        </span>
-      )}
-      {showMenu && (
-        <Dropdown menu={{ items: props.menuItems }} trigger={['click']}>
-          <Button type="text" size="small" icon={<MoreOutlined />} />
-        </Dropdown>
-      )}
-    </Flex>
+    <WaydTooltip
+      title={
+        isDragEnabled
+          ? undefined
+          : 'Clear sorting, filters, and search to reorder KPIs.'
+      }
+    >
+      <span
+        {...(isDragEnabled ? { ...listeners, ...attributes } : {})}
+        style={{
+          cursor: isDragEnabled ? 'grab' : 'not-allowed',
+          color: isDragEnabled
+            ? token.colorTextTertiary
+            : token.colorTextDisabled,
+          display: 'inline-flex',
+          padding: '0 4px',
+          touchAction: 'none',
+        }}
+        aria-label="Drag to reorder"
+        aria-disabled={!isDragEnabled}
+      >
+        <HolderOutlined />
+      </span>
+    </WaydTooltip>
   )
 }
 
@@ -153,7 +141,6 @@ const StrategicInitiativeKpisGrid: FC<StrategicInitiativeKpisGridProps> = (
   const [openManageCheckpointPlanForm, setOpenManageCheckpointPlanForm] =
     useState<boolean>(false)
 
-  const gridRef = useRef<AgGridReact<StrategicInitiativeKpiListDto>>(null)
   const messageApi = useMessage()
   const [reorderKpis] = useReorderStrategicInitiativeKpisMutation()
 
@@ -191,7 +178,7 @@ const StrategicInitiativeKpisGrid: FC<StrategicInitiativeKpisGridProps> = (
     }
   }
 
-  const columnDefs = useMemo<ColDef<StrategicInitiativeKpiListDto>[]>(
+  const columns = useMemo(
     () => {
       const onViewDetailsMenuClicked = (id: string) => {
         setSelectedKpiId(id)
@@ -218,117 +205,108 @@ const StrategicInitiativeKpisGrid: FC<StrategicInitiativeKpisGridProps> = (
         setOpenManageCheckpointPlanForm(true)
       }
 
-      return [
-      {
-        width: 70,
-        filter: false,
-        sortable: false,
-        resizable: false,
-        suppressHeaderMenuButton: true,
-        hide: !canManageKpis || isReadOnly,
-        cellClass: styles.rowActionsCell,
-        cellRenderer: (params: ICellRendererParams<StrategicInitiativeKpiListDto>) => {
-          const menuItems = getRowMenuItems({
-            kpiId: params.data!.id,
-            strategicInitiativeId: strategicInitiativeId,
-            canManageKpis,
-            onEditKpiMenuClicked,
-            onDeleteKpiMenuClicked,
-            onAddMeasurementMenuClicked,
-            onManageCheckpointPlanMenuClicked,
-          })
+      return (
+        context: GridColumnContext,
+      ): ColumnDef<StrategicInitiativeKpiListDto, any>[] => [
+        {
+          id: 'actions',
+          header: '',
+          size: 70,
+          enableSorting: false,
+          enableColumnFilter: false,
+          enableResizing: false,
+          enableGlobalFilter: false,
+          meta: { hide: !canManageKpis || isReadOnly },
+          cell: ({ row }) => {
+            const menuItems = getRowMenuItems({
+              kpiId: row.original.id,
+              strategicInitiativeId: strategicInitiativeId,
+              canManageKpis,
+              onEditKpiMenuClicked,
+              onDeleteKpiMenuClicked,
+              onAddMeasurementMenuClicked,
+              onManageCheckpointPlanMenuClicked,
+            })
 
-          return (
-            <DragAndMenuCellRenderer
-              {...params}
-              menuItems={menuItems}
-              canDrag={canReorder}
-            />
-          )
+            return (
+              <Flex align="center" gap={2}>
+                {canReorder && (
+                  <DragHandleCell isDragEnabled={context.isDragEnabled} />
+                )}
+                {menuItems.length > 0 && (
+                  <Dropdown menu={{ items: menuItems }} trigger={['click']}>
+                    <Button type="text" size="small" icon={<MoreOutlined />} />
+                  </Dropdown>
+                )}
+              </Flex>
+            )
+          },
         },
-      },
-      { field: 'key', width: 90 },
-      {
-        field: 'name',
-        width: 300,
-        cellRenderer: (params: ICellRendererParams<StrategicInitiativeKpiListDto>) => (
-          <Button
-            type="link"
-            size="small"
-            style={{ padding: 0 }}
-            onClick={() => onViewDetailsMenuClicked(params.data!.id)}
-          >
-            {params.value}
-          </Button>
-        ),
-      },
-      {
-        field: 'targetValue',
-        headerName: 'Target Value',
-        width: 125,
-        type: 'numericColumn',
-        cellRenderer: StatisticNumberCellRenderer,
-      },
-      {
-        field: 'actualValue',
-        headerName: 'Actual Value',
-        width: 125,
-        type: 'numericColumn',
-        cellRenderer: StatisticNumberCellRenderer,
-      },
-      {
-        headerName: 'Format',
-        width: 125,
-        valueGetter: (params) =>
-          [params.data?.prefix, params.data?.suffix]
-            .filter(Boolean)
-            .join(' / ') || '-',
-      },
-      {
-        field: 'targetDirection',
-        headerName: 'Target Direction',
-        width: 125,
-      },
-    ]},
-    [
-      canManageKpis,
-      canReorder,
-      isReadOnly,
-      strategicInitiativeId,
-    ],
+        { id: 'key', accessorKey: 'key', header: 'Key', size: 90 },
+        {
+          id: 'name',
+          accessorKey: 'name',
+          header: 'Name',
+          size: 300,
+          cell: ({ row }) => (
+            <Button
+              type="link"
+              size="small"
+              style={{ padding: 0 }}
+              onClick={() => onViewDetailsMenuClicked(row.original.id)}
+            >
+              {row.original.name}
+            </Button>
+          ),
+        },
+        {
+          id: 'targetValue',
+          accessorKey: 'targetValue',
+          header: 'Target Value',
+          size: 125,
+          cell: ({ getValue }) => (
+            <WaydStatisticNumber value={getValue<number>()} />
+          ),
+        },
+        {
+          id: 'actualValue',
+          accessorKey: 'actualValue',
+          header: 'Actual Value',
+          size: 125,
+          cell: ({ getValue }) => (
+            <WaydStatisticNumber value={getValue<number>()} />
+          ),
+        },
+        {
+          id: 'format',
+          accessorFn: (row) =>
+            [row.prefix, row.suffix].filter(Boolean).join(' / ') || '-',
+          header: 'Format',
+          size: 125,
+        },
+        {
+          id: 'targetDirection',
+          accessorKey: 'targetDirection',
+          header: 'Target Direction',
+          size: 125,
+          meta: { filterType: 'set' },
+        },
+      ]
+    },
+    [canManageKpis, canReorder, isReadOnly, strategicInitiativeId],
   )
-
-  const getRowId = (params: GetRowIdParams) => String(params.data.id)
 
   const refresh = async () => {
     refetch()
   }
 
-  const hasActiveSort = () => {
-    const columnState = gridRef.current?.api?.getColumnState() ?? []
-    return columnState.some((c) => c.sort)
-  }
-
-  const onRowDragEnd = async (event: RowDragEndEvent<StrategicInitiativeKpiListDto>) => {
-    if (!canReorder) return
-
-    if (hasActiveSort()) {
-      messageApi.warning(
-        'Clear column sorting to reorder KPIs.',
-      )
-      refetch()
-      return
-    }
-
-    const orderedIds: string[] = []
-    event.api.forEachNodeAfterFilterAndSort((node) => {
-      if (node.data?.id) orderedIds.push(node.data.id)
-    })
-
+  const onRowReorder = async (
+    event: RowReorderEvent<StrategicInitiativeKpiListDto>,
+  ) => {
     try {
       await reorderKpis({
         strategicInitiativeId,
-        request: { orderedKpiIds: orderedIds },
+        request: { orderedKpiIds: event.orderedData.map((kpi) => kpi.id) },
       }).unwrap()
     } catch (error) {
       messageApi.error(
@@ -339,21 +317,18 @@ const StrategicInitiativeKpisGrid: FC<StrategicInitiativeKpisGridProps> = (
     }
   }
 
-
   return (
     <>
-      <WaydGrid
-        ref={gridRef}
-        columnDefs={columnDefs}
-        rowData={kpis}
-        loadData={refresh}
-        loading={isLoading}
+      <WaydGrid2
+        columns={columns}
+        data={kpis}
+        onRefresh={refresh}
+        isLoading={isLoading}
         height={gridHeight}
         emptyMessage="No KPIs found."
-        getRowId={getRowId}
-        toolbarActions={viewSelector}
-        rowDragManaged={true}
-        onRowDragEnd={onRowDragEnd}
+        getRowId={(kpi) => kpi.id}
+        rightSlot={viewSelector}
+        onRowReorder={canReorder ? onRowReorder : undefined}
       />
       {selectedKpiId && (
         <StrategicInitiativeKpiDetailsDrawer

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/team-dependencies-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/team-dependencies-grid.tsx
@@ -1,17 +1,16 @@
 'use client'
 
 import { DependencyDto, TeamDetailsDto } from '@/src/services/wayd-api'
-import { ColDef, ColGroupDef, GetRowIdParams } from 'ag-grid-community'
-import { CustomCellRendererProps } from 'ag-grid-react'
+import type { ColumnDef } from '@tanstack/react-table'
 import { FC, useMemo } from 'react'
-import WaydGrid from '../wayd-grid'
 import {
-  DependencyHealthCellRenderer,
-  renderSprintLinkHelper,
-  renderTeamLinkHelper,
-  renderWorkItemLinkHelper,
-} from '../wayd-grid-cell-renderers'
-import { workItemKeyComparator } from '../work'
+  WaydGrid2,
+  renderDependencyHealthTag,
+  renderSprintLink,
+  renderTeamLink,
+  renderWorkItemLink,
+  workItemKeySort,
+} from '../wayd-grid2'
 
 export interface TeamDependenciesGridProps {
   team: TeamDetailsDto
@@ -20,104 +19,159 @@ export interface TeamDependenciesGridProps {
   refetch: () => void
 }
 
+const SCOPE_TOOLTIP =
+  'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).'
+
 const TeamDependenciesGrid: FC<TeamDependenciesGridProps> = (props) => {
-  const { team, refetch } = props
+  const { refetch } = props
 
-  const getRowId = ({ data }: GetRowIdParams<DependencyDto>) => {
-    return data.id
-  }
-
-  const columnDefs = useMemo<(ColDef<DependencyDto> | ColGroupDef<DependencyDto>)[]>(() => [
-    {
-      headerName: 'Dependency Info',
-      children: [
-        { field: 'state.name', headerName: 'State', width: 125 },
-        {
-          field: 'health.name',
-          headerName: 'Health',
-          width: 100,
-          cellRenderer: DependencyHealthCellRenderer,
-        },
-        {
-          field: 'scope.name',
-          headerName: 'Scope',
-          width: 100,
-          headerTooltip:
-            'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).',
-        },
-      ],
-    },
-    {
-      headerName: 'Predecessor Info',
-      children: [
-        {
-          field: 'source.key',
-          headerName: 'Key',
-          comparator: workItemKeyComparator,
-          cellRenderer: (params: CustomCellRendererProps<DependencyDto>) =>
-            renderWorkItemLinkHelper(params.data?.source),
-        },
-        { field: 'source.title', headerName: 'Title', width: 400 },
-        { field: 'source.type', headerName: 'Type', width: 150 },
-        { field: 'source.status', headerName: 'Status', width: 150 },
-        {
-          field: 'source.team.name',
-          headerName: 'Team',
-          cellRenderer: (params: CustomCellRendererProps<DependencyDto>) =>
-            renderTeamLinkHelper(params.data?.source.team),
-        },
-        {
-          field: 'source.sprint.name',
-          headerName: 'Sprint',
-          cellRenderer: (params: CustomCellRendererProps<DependencyDto>) =>
-            renderSprintLinkHelper(params.data?.source.sprint),
-        },
-      ],
-    },
-    {
-      headerName: 'Successor Info',
-      children: [
-        {
-          field: 'target.key',
-          headerName: 'Key',
-          comparator: workItemKeyComparator,
-          cellRenderer: (params: CustomCellRendererProps<DependencyDto>) =>
-            renderWorkItemLinkHelper(params.data?.target),
-        },
-        { field: 'target.title', headerName: 'Title', width: 400 },
-        { field: 'target.type', headerName: 'Type', width: 150 },
-        { field: 'target.status', headerName: 'Status', width: 150 },
-        {
-          field: 'target.team.name',
-          headerName: 'Team',
-          cellRenderer: (params: CustomCellRendererProps<DependencyDto>) =>
-            renderTeamLinkHelper(params.data?.target.team),
-        },
-        {
-          field: 'target.sprint.name',
-          headerName: 'Sprint',
-          cellRenderer: (params: CustomCellRendererProps<DependencyDto>) =>
-            renderSprintLinkHelper(params.data?.target.sprint),
-        },
-      ],
-    },
-  ], [])
+  const columns = useMemo<ColumnDef<DependencyDto, any>[]>(
+    () => [
+      {
+        id: 'dependencyInfo',
+        header: 'Dependency Info',
+        columns: [
+          {
+            id: 'state',
+            accessorKey: 'state.name',
+            header: 'State',
+            size: 125,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'health',
+            accessorKey: 'health.name',
+            header: 'Health',
+            size: 100,
+            meta: { filterType: 'set' },
+            cell: ({ row }) => renderDependencyHealthTag(row.original.health),
+          },
+          {
+            id: 'scope',
+            accessorKey: 'scope.name',
+            header: 'Scope',
+            size: 100,
+            meta: { filterType: 'set', headerTooltip: SCOPE_TOOLTIP },
+          },
+        ],
+      },
+      {
+        id: 'predecessorInfo',
+        header: 'Predecessor Info',
+        columns: [
+          {
+            id: 'sourceKey',
+            accessorKey: 'source.key',
+            header: 'Key',
+            sortingFn: workItemKeySort,
+            cell: ({ row }) => renderWorkItemLink(row.original.source),
+          },
+          {
+            id: 'sourceTitle',
+            accessorKey: 'source.title',
+            header: 'Title',
+            size: 400,
+          },
+          {
+            id: 'sourceType',
+            accessorKey: 'source.type',
+            header: 'Type',
+            size: 150,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'sourceStatus',
+            accessorKey: 'source.status',
+            header: 'Status',
+            size: 150,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'sourceTeam',
+            accessorKey: 'source.team.name',
+            header: 'Team',
+            meta: { filterEnableSet: true },
+            cell: ({ row }) => renderTeamLink(row.original.source.team),
+          },
+          {
+            id: 'sourceSprint',
+            accessorKey: 'source.sprint.name',
+            header: 'Sprint',
+            meta: { filterEnableSet: true },
+            cell: ({ row }) =>
+              renderSprintLink(row.original.source.sprint, {
+                showTeamCode: false,
+              }),
+          },
+        ],
+      },
+      {
+        id: 'successorInfo',
+        header: 'Successor Info',
+        columns: [
+          {
+            id: 'targetKey',
+            accessorKey: 'target.key',
+            header: 'Key',
+            sortingFn: workItemKeySort,
+            cell: ({ row }) => renderWorkItemLink(row.original.target),
+          },
+          {
+            id: 'targetTitle',
+            accessorKey: 'target.title',
+            header: 'Title',
+            size: 400,
+          },
+          {
+            id: 'targetType',
+            accessorKey: 'target.type',
+            header: 'Type',
+            size: 150,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'targetStatus',
+            accessorKey: 'target.status',
+            header: 'Status',
+            size: 150,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'targetTeam',
+            accessorKey: 'target.team.name',
+            header: 'Team',
+            meta: { filterEnableSet: true },
+            cell: ({ row }) => renderTeamLink(row.original.target.team),
+          },
+          {
+            id: 'targetSprint',
+            accessorKey: 'target.sprint.name',
+            header: 'Sprint',
+            meta: { filterEnableSet: true },
+            cell: ({ row }) =>
+              renderSprintLink(row.original.target.sprint, {
+                showTeamCode: false,
+              }),
+          },
+        ],
+      },
+    ],
+    [],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={props.dependencies}
-        loadData={refresh}
-        loading={props.isLoading}
-        getRowId={getRowId}
-      />
-    </>
+    <WaydGrid2
+      height={550}
+      columns={columns}
+      data={props.dependencies}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      csvFileName="team-dependencies"
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/team-dependencies-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/team-dependencies-grid.tsx
@@ -11,6 +11,7 @@ import {
   renderWorkItemLink,
   workItemKeySort,
 } from '../wayd-grid2'
+import { DEPENDENCY_SCOPE_TOOLTIP } from '../work/dependency-constants'
 
 export interface TeamDependenciesGridProps {
   team: TeamDetailsDto
@@ -18,9 +19,6 @@ export interface TeamDependenciesGridProps {
   isLoading: boolean
   refetch: () => void
 }
-
-const SCOPE_TOOLTIP =
-  'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).'
 
 const TeamDependenciesGrid: FC<TeamDependenciesGridProps> = (props) => {
   const { refetch } = props
@@ -51,7 +49,7 @@ const TeamDependenciesGrid: FC<TeamDependenciesGridProps> = (props) => {
             accessorKey: 'scope.name',
             header: 'Scope',
             size: 100,
-            meta: { filterType: 'set', headerTooltip: SCOPE_TOOLTIP },
+            meta: { filterType: 'set', headerTooltip: DEPENDENCY_SCOPE_TOOLTIP },
           },
         ],
       },

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.test.tsx
@@ -1,9 +1,10 @@
 import { render, screen } from '@testing-library/react'
 
-import { WorkStatusCategory } from '@/src/components/types'
+import { DependencyHealth, WorkStatusCategory } from '@/src/components/types'
 
 import {
   renderAssignedToLink,
+  renderDependencyHealthTag,
   renderPlanningIntervalLink,
   renderPortfolioLink,
   renderProgramLink,
@@ -281,6 +282,31 @@ describe('renderWorkStatusTag', () => {
         })}
       </>,
     )
+
+    // Assert
+    expect(container).toBeEmptyDOMElement()
+  })
+})
+
+describe('renderDependencyHealthTag', () => {
+  it('renders the health name as a tag', () => {
+    // Arrange / Act
+    render(
+      <>
+        {renderDependencyHealthTag({
+          id: DependencyHealth.AtRisk,
+          name: 'At Risk',
+        })}
+      </>,
+    )
+
+    // Assert
+    expect(screen.getByText('At Risk')).toBeInTheDocument()
+  })
+
+  it('renders nothing when there is no health', () => {
+    // Arrange / Act
+    const { container } = render(<>{renderDependencyHealthTag(null)}</>)
 
     // Assert
     expect(container).toBeEmptyDOMElement()

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/cell-renderers.tsx
@@ -3,22 +3,17 @@ import Link from 'next/link'
 import type { ReactNode } from 'react'
 
 import { teamUrl, type TeamUrlTarget } from '@/src/utils'
+import DependencyHealthTag from '@/src/components/common/work/dependency-health-tag'
 import WorkStatusTag from '@/src/components/common/work/work-status-tag'
-import type { WorkStatusCategory } from '@/src/components/types'
+import type {
+  DependencyHealth,
+  WorkStatusCategory,
+} from '@/src/components/types'
 
 /**
- * Cell renderers for WaydGrid2 columns.
- *
- * Unlike the ag-grid `wayd-grid-cell-renderers.tsx` (whose renderers take
- * ag-grid's `CustomCellRendererProps`), a TanStack `cell` already receives
- * `row.original`, so these are plain functions of the domain object — call them
- * inline: `cell: ({ row }) => renderTeamLink(row.original.team)`. Each returns
- * `null` for a missing value so an empty cell renders nothing.
- *
- * This is the flat-list counterpart to the ag-grid renderers; as more grids
- * migrate to WaydGrid2 we add the matching link renderers here (planning
- * interval, project, portfolio, sprint, user, …), each reusing the shared URL
- * helpers in `@/src/utils`.
+ * Cell renderers for WaydGrid2 columns — plain functions of the domain object,
+ * called inline: `cell: ({ row }) => renderTeamLink(row.original.team)`. Each
+ * returns `null` for a missing value so an empty cell renders nothing.
  */
 
 /** A team/team-of-teams reference that can be rendered as a link. */
@@ -210,4 +205,21 @@ export const renderWorkStatusTag = (
 ): ReactNode => {
   if (!item?.status) return null
   return <WorkStatusTag status={item.status} category={item.statusCategory.id} />
+}
+
+/** A dependency health reference (the id drives the tag color + tooltip). */
+export interface DependencyHealthTarget {
+  id: DependencyHealth
+  name: string
+}
+
+/**
+ * Renders a dependency's health as a colored {@link DependencyHealthTag} with
+ * its explanatory tooltip. Returns `null` when there's no health.
+ */
+export const renderDependencyHealthTag = (
+  health: DependencyHealthTarget | null | undefined,
+): ReactNode => {
+  if (!health) return null
+  return <DependencyHealthTag name={health.name} health={health.id} />
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-accessors.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-accessors.test.ts
@@ -1,0 +1,107 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import { applySafeAccessor } from './column-accessors'
+
+type Item = {
+  name: string
+  team?: { name: string } | null
+}
+
+const getAccessorFn = <T>(col: ColumnDef<T, unknown>) =>
+  (col as { accessorFn?: (row: T, index: number) => unknown }).accessorFn
+
+describe('applySafeAccessor', () => {
+  it('returns non-dotted defs unchanged (same reference)', () => {
+    // Arrange
+    const col: ColumnDef<Item, any> = { accessorKey: 'name', header: 'Name' }
+
+    // Act
+    const result = applySafeAccessor(col)
+
+    // Assert
+    expect(result).toBe(col)
+  })
+
+  it('replaces a dotted accessorKey with an accessorFn resolving the path', () => {
+    // Arrange
+    const col: ColumnDef<Item, any> = {
+      accessorKey: 'team.name',
+      header: 'Team',
+    }
+
+    // Act
+    const result = applySafeAccessor(col)
+
+    // Assert
+    expect((result as { accessorKey?: string }).accessorKey).toBeUndefined()
+    const accessorFn = getAccessorFn(result)!
+    expect(accessorFn({ name: 'a', team: { name: 'Juice' } }, 0)).toBe('Juice')
+  })
+
+  it('returns undefined (without throwing) when an intermediate hop is missing', () => {
+    // Arrange
+    const col: ColumnDef<Item, any> = {
+      accessorKey: 'team.name',
+      header: 'Team',
+    }
+
+    // Act
+    const accessorFn = getAccessorFn(applySafeAccessor(col))!
+
+    // Assert
+    expect(accessorFn({ name: 'a' }, 0)).toBeUndefined()
+    expect(accessorFn({ name: 'a', team: null }, 0)).toBeUndefined()
+  })
+
+  it('derives the column id the way TanStack does (dots to underscores)', () => {
+    // Arrange
+    const col: ColumnDef<Item, any> = {
+      accessorKey: 'team.name',
+      header: 'Team',
+    }
+
+    // Act
+    const result = applySafeAccessor(col)
+
+    // Assert
+    expect(result.id).toBe('team_name')
+  })
+
+  it('keeps an explicit column id', () => {
+    // Arrange
+    const col: ColumnDef<Item, any> = {
+      id: 'team',
+      accessorKey: 'team.name',
+      header: 'Team',
+    }
+
+    // Act
+    const result = applySafeAccessor(col)
+
+    // Assert
+    expect(result.id).toBe('team')
+  })
+
+  it('recurses into grouped-header defs', () => {
+    // Arrange
+    const group: ColumnDef<Item, any> = {
+      id: 'info',
+      header: 'Info',
+      columns: [
+        { accessorKey: 'name', header: 'Name' },
+        { accessorKey: 'team.name', header: 'Team' },
+      ],
+    }
+
+    // Act
+    const result = applySafeAccessor(group) as {
+      columns: ColumnDef<Item, unknown>[]
+    }
+
+    // Assert
+    const teamLeaf = result.columns[1]
+    expect(getAccessorFn(teamLeaf)).toBeDefined()
+    expect(getAccessorFn(teamLeaf)!({ name: 'a', team: { name: 'J' } }, 0)).toBe(
+      'J',
+    )
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-accessors.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-accessors.ts
@@ -1,0 +1,41 @@
+import type { ColumnDef } from '@tanstack/react-table'
+
+/**
+ * Replaces a dotted `accessorKey` (e.g. `'team.name'`) with an equivalent
+ * null-tolerant `accessorFn`. TanStack's own deep accessor `console.warn`s in
+ * dev whenever an intermediate hop is undefined — noise for our optional
+ * relations (`team?`, `sprint?`, `parent?`); the swapped-in walk returns the
+ * same `undefined` silently. The column id must stay what TanStack would have
+ * derived (dots → underscores) so sorting/filter state and `data-column-id`
+ * hooks are unaffected. Recurses into grouped-header defs.
+ */
+export const applySafeAccessor = <T>(
+  col: ColumnDef<T, unknown>,
+): ColumnDef<T, unknown> => {
+  const children = (col as { columns?: ColumnDef<T, unknown>[] }).columns
+  if (children) {
+    return {
+      ...col,
+      columns: children.map((child) => applySafeAccessor(child)),
+    } as ColumnDef<T, unknown>
+  }
+
+  const accessorKey = (col as { accessorKey?: string | number }).accessorKey
+  if (typeof accessorKey !== 'string' || !accessorKey.includes('.')) return col
+
+  const path = accessorKey.split('.')
+  const next = {
+    ...col,
+    id: col.id ?? path.join('_'),
+    accessorFn: (row: T) => {
+      let value: unknown = row
+      for (const key of path) {
+        if (value == null) return undefined
+        value = (value as Record<string, unknown>)[key]
+      }
+      return value
+    },
+  } as ColumnDef<T, unknown>
+  delete (next as { accessorKey?: unknown }).accessorKey
+  return next
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-types.ts
@@ -104,7 +104,8 @@ const readRaw = <T>(col: ColumnDef<T, unknown>, row: T): unknown => {
 
 /**
  * Applies the column's declared `meta.columnType` to a ColumnDef, returning a
- * new def. No-op when the column declares no (or an unknown) type.
+ * new def. Grouped-header defs (with `columns`) recurse into their children;
+ * otherwise a column with no (or an unknown) type passes through unchanged.
  *
  * Precedence — explicit column config wins over the type's defaults:
  * - The type's value transform wraps the column's existing accessor (so the
@@ -117,7 +118,7 @@ export const applyColumnType = <T>(
 ): ColumnDef<T, unknown> => {
   const meta = col.meta
   const columnType = meta?.columnType
-  if (!columnType || !(columnType in registry)) return col
+  if (!columnType || !(columnType in registry)) return applyGroupChildren(col)
 
   const type = registry[columnType]<T>()
   const next = { ...col } as ColumnDef<T, unknown> & {
@@ -150,4 +151,20 @@ export const applyColumnType = <T>(
   } satisfies WaydGridColumnMeta
 
   return next
+}
+
+/**
+ * Recurses {@link applyColumnType} into a grouped-header def's `columns`, so
+ * leaves nested under a header band get their declared types applied the same
+ * as top-level columns. No-op for leaf defs.
+ */
+const applyGroupChildren = <T>(
+  col: ColumnDef<T, unknown>,
+): ColumnDef<T, unknown> => {
+  const children = (col as { columns?: ColumnDef<T, unknown>[] }).columns
+  if (!children) return col
+  return {
+    ...col,
+    columns: children.map((child) => applyColumnType(child)),
+  } as ColumnDef<T, unknown>
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-export.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-export.test.ts
@@ -169,4 +169,80 @@ describe('grid-export', () => {
       expect(csv).toBe('Name,Points\nWidget,3\nGadget,')
     })
   })
+
+  describe('grouped headers', () => {
+    it('writes a band row above the leaf headers: label at the first column of each group, blanks across the span', () => {
+      // Arrange — two bands plus an ungrouped column
+      const columns: ColumnDef<Item, any>[] = [
+        {
+          id: 'info',
+          header: 'Info',
+          columns: [
+            { accessorKey: 'name', header: 'Name' },
+            { accessorKey: 'status.name', header: 'Status' },
+          ],
+        },
+        {
+          id: 'scoring',
+          header: 'Scoring',
+          columns: [{ accessorKey: 'points', header: 'Points' }],
+        },
+        { id: 'plain', accessorFn: (row) => row.name, header: 'Plain' },
+      ]
+
+      // Act
+      const csv = exportCsv(columns)
+
+      // Assert — band row, then leaf headers, then data
+      const lines = csv.split('\n')
+      expect(lines[0]).toBe('Info,,Scoring,')
+      expect(lines[1]).toBe('Name,Status,Points,Plain')
+      expect(lines[2]).toBe('Widget,Active,3,Widget')
+    })
+
+    it('keeps the band aligned when a grouped column is excluded from the export', () => {
+      // Arrange — the group's first leaf is excluded (enableExport: false)
+      const columns: ColumnDef<Item, any>[] = [
+        {
+          id: 'info',
+          header: 'Info',
+          columns: [
+            {
+              accessorKey: 'name',
+              header: 'Name',
+              meta: { enableExport: false },
+            },
+            { accessorKey: 'status.name', header: 'Status' },
+          ],
+        },
+        {
+          id: 'scoring',
+          header: 'Scoring',
+          columns: [{ accessorKey: 'points', header: 'Points' }],
+        },
+      ]
+
+      // Act
+      const csv = exportCsv(columns)
+
+      // Assert — the label moves to the group's first EXPORTED column
+      const lines = csv.split('\n')
+      expect(lines[0]).toBe('Info,Scoring')
+      expect(lines[1]).toBe('Status,Points')
+    })
+
+    it('writes no band row for flat (ungrouped) columns', () => {
+      // Arrange
+      const columns: ColumnDef<Item, any>[] = [
+        { accessorKey: 'name', header: 'Name' },
+        { accessorKey: 'points', header: 'Points' },
+      ]
+
+      // Act
+      const csv = exportCsv(columns)
+
+      // Assert — first line is the leaf header row, no prelude
+      expect(csv.split('\n')[0]).toBe('Name,Points')
+    })
+  })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-export.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-export.ts
@@ -1,5 +1,32 @@
-import type { Table } from '@tanstack/react-table'
-import { generateCsv, downloadCsvWithTimestamp } from '@/src/utils/csv-utils'
+import type { Column, Table } from '@tanstack/react-table'
+import {
+  escapeCsv,
+  generateCsv,
+  downloadCsvWithTimestamp,
+} from '@/src/utils/csv-utils'
+
+/** Header text for a column: meta.exportHeader → string header → column id. */
+const resolveExportHeader = <T>(column: Column<T, unknown>): string => {
+  const { meta, header } = column.columnDef
+  if (meta?.exportHeader) return meta.exportHeader
+  if (typeof header === 'string') return header
+  return column.id
+}
+
+/** The column's ancestor group at the given band depth (0 = outermost), or
+ *  undefined when the column isn't nested that deep. */
+const ancestorAtDepth = <T>(
+  column: Column<T, unknown>,
+  depth: number,
+): Column<T, unknown> | undefined => {
+  const chain: Column<T, unknown>[] = []
+  let current = column.parent
+  while (current) {
+    chain.unshift(current)
+    current = current.parent
+  }
+  return chain[depth]
+}
 
 /**
  * Exports a grid to CSV and triggers the download (filename gets a timestamp).
@@ -9,6 +36,10 @@ import { generateCsv, downloadCsvWithTimestamp } from '@/src/utils/csv-utils'
  * Values come from TanStack's own accessors (row.getValue), so nested
  * accessorKeys like `status.name` resolve correctly and column-type
  * transforms (e.g. yesNo's boolean → "Yes"/"No") are reflected.
+ *
+ * Grouped headers export as prelude rows above the leaf header row — one row
+ * per band level, each group's label emitted at its first exported column and
+ * blank across the rest of its span (mirroring ag-grid's CSV group headers).
  *
  * Column meta hooks: `enableExport: false` excludes a column, `exportHeader`
  * overrides the header text, and `exportFormatter` maps each value.
@@ -21,12 +52,29 @@ export function exportGridToCsv<T>(table: Table<T>, csvFileName: string): void {
     return column.accessorFn != null
   })
 
-  const headers = exportableColumns.map((column) => {
-    const { meta, header } = column.columnDef
-    if (meta?.exportHeader) return meta.exportHeader
-    if (typeof header === 'string') return header
-    return column.id
-  })
+  const headers = exportableColumns.map(resolveExportHeader)
+
+  // Group-header prelude rows: a leaf column's `depth` is its ancestor-group
+  // count, so the deepest exported leaf sets how many band levels to write.
+  // (Derived from the column tree, not getHeaderGroups(), which needs pinning
+  // state that headless createTable harnesses don't carry.)
+  const bandLevelCount = Math.max(
+    0,
+    ...exportableColumns.map((column) => column.depth),
+  )
+  const groupHeaderRows: string[][] = []
+  for (let level = 0; level < bandLevelCount; level++) {
+    let previousGroup: Column<T, unknown> | undefined
+    groupHeaderRows.push(
+      exportableColumns.map((column) => {
+        const group = ancestorAtDepth(column, level)
+        const label =
+          group && group !== previousGroup ? resolveExportHeader(group) : ''
+        previousGroup = group
+        return label
+      }),
+    )
+  }
 
   const exportRows = table.getRowModel().rows.map((row) =>
     exportableColumns.map((column) => {
@@ -39,6 +87,13 @@ export function exportGridToCsv<T>(table: Table<T>, csvFileName: string): void {
     }),
   )
 
-  const csv = generateCsv(headers, exportRows)
+  const csvBody = generateCsv(headers, exportRows)
+  const csv =
+    groupHeaderRows.length === 0
+      ? csvBody
+      : [
+          ...groupHeaderRows.map((row) => row.map(escapeCsv).join(',')),
+          csvBody,
+        ].join('\n')
   downloadCsvWithTimestamp(csv, csvFileName)
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
@@ -3,6 +3,31 @@
 import { useRef, type MouseEvent, type ReactNode, type TouchEvent } from 'react'
 import { ArrowUpOutlined, ArrowDownOutlined } from '@ant-design/icons'
 import { type Header, flexRender } from '@tanstack/react-table'
+import WaydTooltip from '@/src/components/common/wayd-tooltip'
+
+/**
+ * A header's content, wrapped in a {@link WaydTooltip} when the column
+ * declares `meta.headerTooltip` — columns keep a plain-string `header` (which
+ * CSV export also reads) instead of hand-rolling a Tooltip header renderer.
+ */
+export function GridHeaderContent<T>({ header }: { header: Header<T, unknown> }) {
+  // eslint-disable-next-line react-compiler/react-compiler -- same mutable-header caveat as GridHeaderCell
+  'use no memo'
+  if (header.isPlaceholder) return null
+
+  const content = flexRender(
+    header.column.columnDef.header,
+    header.getContext(),
+  )
+  const tooltip = header.column.columnDef.meta?.headerTooltip
+  if (!tooltip) return content
+
+  return (
+    <WaydTooltip title={tooltip}>
+      <span>{content}</span>
+    </WaydTooltip>
+  )
+}
 
 /**
  * Guards the header's click-to-sort against the click that ends a column
@@ -115,9 +140,7 @@ export function GridHeaderCell<T>({
     >
       <span className={classes.thContent}>
         <span className={classes.thText}>
-          {header.isPlaceholder
-            ? null
-            : flexRender(header.column.columnDef.header, header.getContext())}
+          <GridHeaderContent header={header} />
         </span>
         {sortIcon}
         {filterSlot}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-row.tsx
@@ -54,6 +54,56 @@ export function FlatGridRow<T>({ row, index, classes }: FlatGridRowProps<T>) {
   )
 }
 
+export interface SortableFlatGridRowProps<T> extends FlatGridRowProps<T> {
+  /** The row's data id (not TanStack's row.id) — the dnd-kit sortable id. */
+  nodeId: string
+  /** Whether this row is currently being dragged. */
+  isDragging: boolean
+  /** Whether DnD is enabled for this row. */
+  isDragEnabled: boolean
+}
+
+/**
+ * The flat form wrapped in the dnd-kit sortable row ({@link GridSortableRow})
+ * for flat row-reorder DnD. Rendered (with dragging possibly disabled) for
+ * every row whenever the grid has `onRowReorder`, so drag-handle cells can
+ * always reach the `useGridDragHandle` context.
+ *
+ * Same memoization caveat as {@link FlatGridRow}: consumers must carry
+ * `'use no memo'`.
+ */
+export function SortableFlatGridRow<T>({
+  row,
+  index,
+  classes,
+  nodeId,
+  isDragging,
+  isDragEnabled,
+}: SortableFlatGridRowProps<T>) {
+  // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see GridHeaderCell
+  'use no memo'
+  return (
+    <GridSortableRow
+      nodeId={nodeId}
+      isDragEnabled={isDragEnabled}
+      isDragging={isDragging}
+      className={`${classes.tr}${index % 2 === 1 ? ` ${classes.trAlt}` : ''}`}
+    >
+      {row.getVisibleCells().map((cell) => (
+        <td
+          key={cell.id}
+          data-column-id={cell.column.id}
+          className={classes.td}
+        >
+          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+        </td>
+      ))}
+      {/* Filler data cell keeps the zebra/hover band edge-to-edge. */}
+      <td aria-hidden="true" className={classes.td} />
+    </GridSortableRow>
+  )
+}
+
 /** Additional row classes tree mode needs on top of the flat set. */
 export interface TreeGridRowClasses extends GridRowClasses {
   trEditable: string

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/index.ts
@@ -35,12 +35,14 @@ export {
   renderWorkspaceLink,
   renderSprintLink,
   renderUserLink,
+  renderDependencyHealthTag,
 } from './cell-renderers'
 export type {
   TeamLinkTarget,
   NavLinkTarget,
   SprintLinkTarget,
   UserLinkTarget,
+  DependencyHealthTarget,
 } from './cell-renderers'
 
 // Sorting utilities
@@ -62,10 +64,11 @@ export { default as GridToolbar } from './grid-toolbar'
 export type { GridToolbarProps } from './grid-toolbar'
 
 // Row renderer — the flat and tree forms of the row-renderer seam
-export { FlatGridRow, TreeGridRow } from './grid-row'
+export { FlatGridRow, SortableFlatGridRow, TreeGridRow } from './grid-row'
 export type {
   FlatGridRowProps,
   GridRowClasses,
+  SortableFlatGridRowProps,
   TreeGridRowClasses,
   TreeGridRowProps,
 } from './grid-row'
@@ -81,7 +84,11 @@ export { mergeDraftsIntoTree } from './draft-utils'
 export type { DraftItem } from './draft-utils'
 
 // Header sort/resize cell
-export { GridHeaderCell, useResizeClickGuard } from './grid-header-row'
+export {
+  GridHeaderCell,
+  GridHeaderContent,
+  useResizeClickGuard,
+} from './grid-header-row'
 export type {
   GridHeaderCellClasses,
   GridHeaderCellProps,

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/tree-utils.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/tree-utils.ts
@@ -79,11 +79,10 @@ export function buildTree<T extends TreeNode>(
 ): T[] {
   const ROOT_ID = '__root__'
 
-  // Create lookup map for all nodes, initialized with empty children
   const nodes: Record<string, T> = {}
   const rootChildren: T[] = []
 
-  // Initialize all items with empty children arrays
+  // Clone every node with a fresh children array, keyed for parent lookup
   const items = flatItems.map((item) => {
     const clone = {
       ...item.node,

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/types.ts
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import type { RowData } from '@tanstack/react-table'
 import type { FilterType } from './filters'
 
@@ -55,6 +56,14 @@ export interface WaydGridColumnMeta {
    * input keeps its type-to-Contains behavior.
    */
   filterEnableSet?: boolean
+  /**
+   * Tooltip shown when hovering the header label (AG Grid `headerTooltip`
+   * style). The grid wraps the header content in WaydTooltip automatically —
+   * keep `header` a plain string (which CSV export also uses) instead of
+   * hand-rolling a Tooltip in a header renderer. Works on grouped-header
+   * bands too.
+   */
+  headerTooltip?: ReactNode
   /** Max AND/OR conditions the popup allows (default 5 — the max; set lower to restrict). Ignored for `set`. */
   maxFilterConditions?: number
   /** Placeholder text for text/numericRange filter inputs. */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
@@ -46,6 +46,9 @@ export interface UseGridStateOptions {
   /** Called by onClearFilters in addition to the shared clears (e.g. TreeGrid
    *  flushes its debounced filter drafts). */
   onClear?: () => void
+  /** Sort applied on mount (ag-grid `sort: 'asc'` equivalent). Read once —
+   *  later changes don't reset the user's sorting. */
+  initialSorting?: SortingState
 }
 
 /**
@@ -53,7 +56,9 @@ export interface UseGridStateOptions {
  * global search) and the toolbar handlers derived from them.
  */
 export function useGridState(options?: UseGridStateOptions): GridState {
-  const [sorting, setSorting] = useState<SortingState>([])
+  const [sorting, setSorting] = useState<SortingState>(
+    options?.initialSorting ?? [],
+  )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({})
   const [searchValue, setSearchValue] = useState('')

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/index.ts
@@ -6,6 +6,7 @@ export type {
   WaydGrid2Handle,
   GridColumnContext,
   GridInlineEditingConfig,
+  RowReorderEvent,
 } from './types'
 
 // Tree-mode types + utilities (re-exported from the shared grid core so
@@ -77,6 +78,7 @@ export {
   renderWorkItemLink,
   renderAssignedToLink,
   renderWorkStatusTag,
+  renderDependencyHealthTag,
 } from '../wayd-grid-core/cell-renderers'
 export type {
   TeamLinkTarget,
@@ -86,6 +88,7 @@ export type {
   WorkItemLinkTarget,
   AssignedToLinkTarget,
   WorkStatusTagTarget,
+  DependencyHealthTarget,
 } from '../wayd-grid-core/cell-renderers'
 
 // Components (toolbar reconciled into the shared grid core; aliases kept)

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/types.ts
@@ -1,4 +1,4 @@
-import type { ColumnDef } from '@tanstack/react-table'
+import type { ColumnDef, SortingState } from '@tanstack/react-table'
 import type { FormInstance } from 'antd'
 import type { DraftItem } from '../wayd-grid-core/draft-utils'
 import type { MoveValidator } from '../wayd-grid-core/dnd/tree-projection'
@@ -103,6 +103,12 @@ export interface WaydGrid2Props<T> {
   csvFileName?: string
 
   // -- Behavior toggles --
+  /**
+   * Sort applied on mount (ag-grid `sort: 'asc'` equivalent), e.g.
+   * `[{ id: 'done', desc: true }]`. Read once — later changes don't reset
+   * the user's sorting.
+   */
+  initialSorting?: SortingState
   /** Whether to show the global search input. Default: true. */
   includeGlobalSearch?: boolean
   /** Whether to show the CSV export button. Default: true. */
@@ -119,6 +125,28 @@ export interface WaydGrid2Props<T> {
    * Default: true. Ignored when `includeColumnFilters` is false.
    */
   includeFloatingFilters?: boolean
+
+  // -- Row identity --
+  /** Stable row id (required for `onRowReorder`). Falls back to
+   *  `row.original.id`, then TanStack's index-based id. */
+  getRowId?: (row: T) => string
+
+  // -- Grid state --
+  /**
+   * Fires with the displayed rows (post filter + sort, in display order)
+   * whenever that set changes — including on mount. For consumers deriving
+   * external UI (e.g. a chart) from the grid state.
+   */
+  onDisplayedRowsChange?: (rows: T[]) => void
+
+  // -- Flat row reorder (enabled when provided) --
+  /**
+   * Called after a row-drag drop with the displayed rows in post-drop order.
+   * Dragging auto-disables while sorted/filtered/searched (the displayed
+   * order wouldn't be the data order), loading, or editing — column functions
+   * read `context.isDragEnabled` to render their drag handle accordingly.
+   */
+  onRowReorder?: (event: RowReorderEvent<T>) => void | Promise<void>
 
   // -- Tree mode (turned on by providing getSubRows) --
   /** How to extract child rows. Presence of this prop enables tree mode. */
@@ -155,6 +183,18 @@ export interface WaydGrid2Props<T> {
   onDraftsChange?: (drafts: DraftItem[]) => void
 }
 
+/** Payload for {@link WaydGrid2Props.onRowReorder}. */
+export interface RowReorderEvent<T> {
+  /** All displayed rows in their post-drop order. */
+  orderedData: T[]
+  /** The dragged row's id. */
+  activeId: string
+  /** The dragged row's displayed index before the drop. */
+  fromIndex: number
+  /** The dragged row's displayed index after the drop. */
+  toIndex: number
+}
+
 /**
  * Handle exposed by WaydGrid2 via ref.
  */
@@ -163,4 +203,6 @@ export interface WaydGrid2Handle {
   table: any
   /** The currently selected row ID (from the editing hook), or null. */
   selectedRowId: string | null
+  /** The displayed (post filter + sort) rows' data, in display order. */
+  getDisplayedRows: () => unknown[]
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.module.css
@@ -20,6 +20,10 @@
 
 .tableElement {
   --wayd-grid-header-row-height: 29px;
+  /* Grouped-header band rows above the leaf header row; set inline by the
+   * grid (0 when no column groups). Drives the sticky offsets below so the
+   * leaf header and floating-filter rows stick beneath the bands. */
+  --wayd-grid-group-header-rows: 0;
   /*
    * Subtle tinted header band, AG Grid style. Applied to the header + filter rows.
    * One elevation step above the zebra alt-row tint (fill-quaternary) so the
@@ -58,17 +62,29 @@
   padding: 5px var(--ant-padding-sm);
   background: var(--wayd-grid-header-bg);
   border-bottom: 1px solid var(--ant-color-border);
-  color: var(--ant-color-text);
+  /* Secondary (muted) text keeps headers from overpowering the data rows —
+     matches the retired ag-grid Balham theme's muted headerTextColor. */
+  color: var(--ant-color-text-secondary);
   text-align: left;
   font-size: 12px;
   font-weight: var(--ant-font-weight-strong);
   white-space: nowrap;
   position: sticky;
-  top: 0;
+  top: calc(
+    var(--wayd-grid-group-header-rows) * var(--wayd-grid-header-row-height)
+  );
   z-index: 20;
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 0;
+}
+
+/*
+ * Grouped-header band cell. Band rows override .th's sticky `top` inline
+ * (bandIndex * row height) — band depth isn't expressible per-row in CSS.
+ */
+.groupTh {
+  text-align: center;
 }
 
 .thSortable {
@@ -225,7 +241,10 @@
   overflow: hidden;
   text-align: left;
   position: sticky;
-  top: var(--wayd-grid-header-row-height);
+  top: calc(
+    (var(--wayd-grid-group-header-rows) + 1) *
+      var(--wayd-grid-header-row-height)
+  );
   z-index: 19;
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.test.tsx
@@ -643,6 +643,14 @@ describe('WaydGrid2', () => {
       const cells = Array.from(bands[0].cells)
       expect(cells.map((c) => c.textContent)).toEqual(['Info', 'State', '', ''])
       expect(cells.map((c) => c.colSpan)).toEqual([2, 1, 1, 1])
+
+      // Empty placeholder + filler cells are hidden from assistive tech.
+      expect(cells.map((c) => c.getAttribute('aria-hidden'))).toEqual([
+        null,
+        null,
+        'true',
+        'true',
+      ])
     })
 
     it('renders no band row for flat (ungrouped) columns', () => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.test.tsx
@@ -596,4 +596,368 @@ describe('WaydGrid2', () => {
       ).toBeInTheDocument()
     })
   })
+
+  describe('grouped headers (ColGroupDef-style bands)', () => {
+    // Two bands over three leaves, plus one ungrouped column: the band row
+    // must span its leaves via colSpan and pass the ungrouped column through
+    // as an empty placeholder cell.
+    const groupedColumns: ColumnDef<Flag, unknown>[] = [
+      {
+        id: 'info',
+        header: 'Info',
+        columns: [
+          { id: 'name', accessorKey: 'name', header: 'Name' },
+          { id: 'type', accessorKey: 'type', header: 'Type' },
+        ],
+      },
+      {
+        id: 'state',
+        header: 'State',
+        columns: [
+          {
+            id: 'isEnabled',
+            accessorKey: 'isEnabled',
+            header: 'Enabled',
+            meta: { columnType: 'yesNo' } satisfies WaydGridColumnMeta,
+          },
+        ],
+      },
+      { id: 'id', accessorKey: 'id', header: 'Id' },
+    ]
+
+    const bandRows = () =>
+      Array.from(
+        document.querySelectorAll('tr[data-role="header-band"]'),
+      ) as HTMLTableRowElement[]
+
+    it('renders one band row with group labels spanning their leaves', () => {
+      // Arrange / Act
+      renderGrid({ columns: groupedColumns })
+
+      // Assert — a single band row above the leaf header row
+      const bands = bandRows()
+      expect(bands).toHaveLength(1)
+
+      // Group cells span their visible leaves; the ungrouped column passes
+      // through as a placeholder; the trailing filler cell closes the row.
+      const cells = Array.from(bands[0].cells)
+      expect(cells.map((c) => c.textContent)).toEqual(['Info', 'State', '', ''])
+      expect(cells.map((c) => c.colSpan)).toEqual([2, 1, 1, 1])
+    })
+
+    it('renders no band row for flat (ungrouped) columns', () => {
+      // Arrange / Act
+      renderGrid()
+
+      // Assert
+      expect(bandRows()).toHaveLength(0)
+    })
+
+    it('renders the floating filter row exactly once', () => {
+      // Arrange / Act
+      renderGrid({ columns: groupedColumns })
+
+      // Assert
+      expect(
+        document.querySelectorAll('tr[data-role="floating-filters"]'),
+      ).toHaveLength(1)
+    })
+
+    it('sorts a grouped leaf column on header click', () => {
+      // Arrange
+      renderGrid({ columns: groupedColumns })
+
+      // Act — click the leaf header, not the band
+      fireEvent.click(screen.getByText('Name'))
+
+      // Assert — rows sort ascending by name
+      const names = bodyCells('name').map((c) => c.textContent)
+      expect(names).toEqual(['insights', 'planning-poker', 'roadmap'])
+    })
+
+    it('applies meta.columnType to leaves nested under a band', () => {
+      // Arrange / Act
+      renderGrid({ columns: groupedColumns })
+
+      // Assert — the yesNo type formats the grouped Enabled leaf
+      const enabled = bodyCells('isEnabled').map((c) => c.textContent)
+      expect(enabled).toEqual(['Yes', 'No', 'Yes'])
+    })
+
+    it('hides a grouped leaf via meta.hide and shrinks the band colSpan', () => {
+      // Arrange — hide Type inside the Info band
+      const cols: ColumnDef<Flag, unknown>[] = [
+        {
+          id: 'info',
+          header: 'Info',
+          columns: [
+            { id: 'name', accessorKey: 'name', header: 'Name' },
+            {
+              id: 'type',
+              accessorKey: 'type',
+              header: 'Type',
+              meta: { hide: true } satisfies WaydGridColumnMeta,
+            },
+          ],
+        },
+        { id: 'id', accessorKey: 'id', header: 'Id' },
+      ]
+
+      // Act
+      renderGrid({ columns: cols })
+
+      // Assert — Type is gone and Info spans only the remaining leaf
+      expect(screen.queryByText('Type')).not.toBeInTheDocument()
+      const infoCell = Array.from(bandRows()[0].cells).find(
+        (c) => c.textContent === 'Info',
+      )
+      expect(infoCell?.colSpan).toBe(1)
+    })
+
+    it('exports band labels as a prelude row above the leaf headers', () => {
+      // Arrange
+      mockDownloadCsv.mockClear()
+      const { container } = renderGrid({ columns: groupedColumns })
+
+      // Act
+      const exportBtn = container
+        .querySelector('[aria-label="download"]')
+        ?.closest('button') as HTMLButtonElement
+      fireEvent.click(exportBtn)
+
+      // Assert — band row (label at each group's first column, blank across
+      // the span, ungrouped Id blank), then leaf headers, then data
+      expect(mockDownloadCsv).toHaveBeenCalledTimes(1)
+      const lines = (mockDownloadCsv.mock.calls[0][0] as string).split('\n')
+      expect(lines[0]).toBe('Info,,State,')
+      expect(lines[1]).toBe('Name,Type,Enabled,Id')
+      expect(lines[2]).toContain('planning-poker')
+    })
+  })
+
+  describe('displayed-rows surface (onDisplayedRowsChange / getDisplayedRows)', () => {
+    it('fires on mount with all rows in display order', () => {
+      // Arrange / Act
+      const onDisplayedRowsChange = jest.fn()
+      renderGrid({ onDisplayedRowsChange })
+
+      // Assert
+      expect(onDisplayedRowsChange).toHaveBeenCalled()
+      const last = onDisplayedRowsChange.mock.calls.at(-1)![0] as Flag[]
+      expect(last.map((f) => f.name)).toEqual([
+        'planning-poker',
+        'roadmap',
+        'insights',
+      ])
+    })
+
+    it('fires with the filtered subset when the global search changes', () => {
+      // Arrange
+      const onDisplayedRowsChange = jest.fn()
+      renderGrid({ onDisplayedRowsChange })
+
+      // Act
+      fireEvent.change(screen.getByPlaceholderText('Search'), {
+        target: { value: 'road' },
+      })
+
+      // Assert
+      const last = onDisplayedRowsChange.mock.calls.at(-1)![0] as Flag[]
+      expect(last.map((f) => f.name)).toEqual(['roadmap'])
+    })
+
+    it('fires with the re-sorted order when a sort is applied', () => {
+      // Arrange
+      const onDisplayedRowsChange = jest.fn()
+      renderGrid({ onDisplayedRowsChange })
+
+      // Act
+      fireEvent.click(screen.getByText('Name'))
+
+      // Assert
+      const last = onDisplayedRowsChange.mock.calls.at(-1)![0] as Flag[]
+      expect(last.map((f) => f.name)).toEqual([
+        'insights',
+        'planning-poker',
+        'roadmap',
+      ])
+    })
+
+    it('exposes the displayed rows via the handle', () => {
+      // Arrange
+      const ref = createRef<WaydGrid2Handle>()
+      renderGrid({ ref })
+
+      // Act — filter, then read the handle
+      fireEvent.change(screen.getByPlaceholderText('Search'), {
+        target: { value: 'insights' },
+      })
+      const displayed = ref.current!.getDisplayedRows() as Flag[]
+
+      // Assert
+      expect(displayed.map((f) => f.name)).toEqual(['insights'])
+    })
+  })
+
+  describe('flat row-reorder DnD (onRowReorder)', () => {
+    it('wraps rows in sortable rows keyed by getRowId', () => {
+      // Arrange / Act
+      renderGrid({
+        onRowReorder: jest.fn(),
+        getRowId: (row) => `flag-${row.id}`,
+      })
+
+      // Assert — each body row carries its sortable data-row-id
+      const rowIds = Array.from(
+        document.querySelectorAll('tbody tr[data-row-id]'),
+      ).map((tr) => tr.getAttribute('data-row-id'))
+      expect(rowIds).toEqual(['flag-1', 'flag-2', 'flag-3'])
+    })
+
+    it('renders plain rows (no sortable wrapper) without onRowReorder', () => {
+      // Arrange / Act
+      renderGrid()
+
+      // Assert
+      expect(
+        document.querySelectorAll('tbody tr[data-row-id]'),
+      ).toHaveLength(0)
+    })
+
+    it('reports drag disabled through the column context while sorted', () => {
+      // Arrange — a columns function that surfaces context.isDragEnabled
+      const seen: boolean[] = []
+      renderGrid({
+        onRowReorder: jest.fn(),
+        getRowId: (row) => String(row.id),
+        columns: (context) => {
+          seen.push(context.isDragEnabled)
+          return columns
+        },
+      })
+      expect(seen.at(-1)).toBe(true)
+
+      // Act — apply a sort (displayed order no longer the data order)
+      fireEvent.click(screen.getByText('Name'))
+
+      // Assert
+      expect(seen.at(-1)).toBe(false)
+    })
+  })
+
+  describe('meta.headerTooltip', () => {
+    const cols: ColumnDef<Flag, unknown>[] = [
+      {
+        id: 'name',
+        accessorKey: 'name',
+        header: 'Name',
+        meta: { headerTooltip: 'The flag name' },
+      },
+    ]
+
+    it('keeps click-to-sort working through the wrapped header label', () => {
+      // Arrange — antd tooltips portal on hover (not renderable in jsdom);
+      // assert the anchor renders and stays interactive.
+      renderGrid({ columns: cols })
+      const label = screen.getByText('Name')
+
+      // Act
+      fireEvent.click(label)
+
+      // Assert — rows sort ascending by name
+      const names = bodyCells('name').map((c) => c.textContent)
+      expect(names).toEqual(['insights', 'planning-poker', 'roadmap'])
+    })
+
+    it('exports the plain string header (no exportHeader override needed)', () => {
+      // Arrange
+      mockDownloadCsv.mockClear()
+      const { container } = renderGrid({ columns: cols })
+
+      // Act
+      const exportBtn = container
+        .querySelector('[aria-label="download"]')
+        ?.closest('button') as HTMLButtonElement
+      fireEvent.click(exportBtn)
+
+      // Assert
+      const csv = mockDownloadCsv.mock.calls[0][0] as string
+      expect(csv.split('\n')[0]).toBe('Name')
+    })
+  })
+
+  describe('dotted accessorKeys over optional relations', () => {
+    interface Row {
+      id: number
+      name: string
+      team?: { name: string }
+    }
+
+    const rows: Row[] = [
+      { id: 1, name: 'alpha', team: { name: 'Juice' } },
+      { id: 2, name: 'beta' }, // no team — the hop TanStack would warn on
+    ]
+
+    const cols: ColumnDef<Row, unknown>[] = [
+      { id: 'name', accessorKey: 'name', header: 'Name' },
+      { accessorKey: 'team.name', header: 'Team' },
+    ]
+
+    it('renders values without TanStack deep-accessor dev warnings', () => {
+      // Arrange
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+
+      try {
+        // Act
+        render(<WaydGrid2<Row> data={rows} columns={cols} />)
+
+        // Assert — value renders, and no "deeply nested key" warning fired
+        expect(screen.getByText('Juice')).toBeInTheDocument()
+        const deepWarnings = warnSpy.mock.calls.filter((call) =>
+          String(call[0]).includes('deeply nested'),
+        )
+        expect(deepWarnings).toHaveLength(0)
+      } finally {
+        warnSpy.mockRestore()
+      }
+    })
+
+    it('keeps the TanStack-derived column id (dots to underscores)', () => {
+      // Arrange / Act
+      render(<WaydGrid2<Row> data={rows} columns={cols} />)
+
+      // Assert — body cells carry the derived data-column-id
+      expect(
+        document.querySelectorAll('tbody td[data-column-id="team_name"]'),
+      ).toHaveLength(2)
+    })
+  })
+
+  describe('initialSorting', () => {
+    it('applies the initial sort on mount', () => {
+      // Arrange / Act
+      renderGrid({ initialSorting: [{ id: 'name', desc: true }] })
+
+      // Assert — rows sorted descending by name without any user click
+      const names = bodyCells('name').map((c) => c.textContent)
+      expect(names).toEqual(['roadmap', 'planning-poker', 'insights'])
+    })
+
+    it('clears the initial sort via the toolbar Clear button', () => {
+      // Arrange
+      const { container } = renderGrid({
+        initialSorting: [{ id: 'name', desc: true }],
+      })
+
+      // Act — the clear button carries a clear icon (aria-label="clear")
+      const clearBtn = container
+        .querySelector('[aria-label="clear"]')
+        ?.closest('button') as HTMLButtonElement
+      fireEvent.click(clearBtn)
+
+      // Assert — back to data order
+      const names = bodyCells('name').map((c) => c.textContent)
+      expect(names).toEqual(['planning-poker', 'roadmap', 'insights'])
+    })
+  })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.tsx
@@ -999,6 +999,10 @@ function WaydGrid2Inner<T>(
                 <th
                   key={header.id}
                   colSpan={header.colSpan}
+                  // Placeholders (ungrouped columns passing through the band
+                  // level) are empty — hide them from assistive tech so
+                  // screen readers don't announce blank column headers.
+                  aria-hidden={header.isPlaceholder || undefined}
                   className={`${styles.th} ${styles.groupTh}`}
                   style={{
                     top: `calc(${bandIndex} * var(--wayd-grid-header-row-height))`,

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid2/wayd-grid2.tsx
@@ -2,11 +2,11 @@
 
 import {
   forwardRef,
-  Fragment,
   type Ref,
   type ReactElement,
   type ReactNode,
   useCallback,
+  useEffect,
   useImperativeHandle,
   useMemo,
   useRef,
@@ -18,6 +18,7 @@ import { FilterFilled, FilterOutlined } from '@ant-design/icons'
 import {
   type ColumnDef,
   type Header,
+  type Row,
   type VisibilityState,
   getExpandedRowModel,
   getFacetedRowModel,
@@ -30,7 +31,11 @@ import {
   type DragStartEvent,
   closestCenter,
 } from '@dnd-kit/core'
-import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
+import {
+  SortableContext,
+  arrayMove,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
 
 import { WaydEmpty } from '@/src/components/common'
 import { useRemainingHeight } from '@/src/hooks'
@@ -49,6 +54,7 @@ import {
   type FilterType,
 } from '../wayd-grid-core/filters'
 
+import { applySafeAccessor } from '../wayd-grid-core/column-accessors'
 import { applyColumnType } from '../wayd-grid-core/column-types'
 import { useGridDndSensors } from '../wayd-grid-core/dnd/grid-dnd'
 import {
@@ -64,11 +70,13 @@ import {
 import { exportGridToCsv } from '../wayd-grid-core/grid-export'
 import {
   GridHeaderCell,
+  GridHeaderContent,
   useResizeClickGuard,
   type GridHeaderCellClasses,
 } from '../wayd-grid-core/grid-header-row'
 import {
   FlatGridRow,
+  SortableFlatGridRow,
   TreeGridRow,
   type GridRowClasses,
   type TreeGridRowClasses,
@@ -203,10 +211,14 @@ function WaydGrid2Inner<T>(
     emptyMessage = 'No records found',
     csvFileName = 'grid-export',
     height,
+    initialSorting,
     includeGlobalSearch = true,
     includeExportButton = true,
     includeColumnFilters = true,
     includeFloatingFilters = true,
+    getRowId,
+    onDisplayedRowsChange,
+    onRowReorder,
     getSubRows,
     enableDragAndDrop = false,
     onNodeMove,
@@ -220,8 +232,6 @@ function WaydGrid2Inner<T>(
     onDraftsChange,
   } = props
 
-  // Tree mode: rows form a hierarchy, expansion/indent/reparenting apply, and
-  // a filter match keeps the row's ancestor chain visible.
   const isTree = !!getSubRows
 
   // ─── Auto-height ─────────────────────────────────────────
@@ -229,7 +239,7 @@ function WaydGrid2Inner<T>(
   const resolvedHeight = height ?? autoHeight
 
   // ─── State ───────────────────────────────────────────────
-  const gridState = useGridState()
+  const gridState = useGridState({ initialSorting })
   const { searchValue, onSearchChange, onClearFilters, hasActiveFilters } =
     gridState
   const resizeGuard = useResizeClickGuard()
@@ -262,7 +272,6 @@ function WaydGrid2Inner<T>(
     [],
   )
 
-  // Field errors: delegate to external state when provided
   const [internalFieldErrors, setInternalFieldErrors] =
     useState<Record<string, string>>(EMPTY_FIELD_ERRORS)
   const fieldErrors = externalFieldErrors ?? internalFieldErrors
@@ -390,7 +399,6 @@ function WaydGrid2Inner<T>(
           return next
         })
 
-        // Ensure parent is expanded when adding a child draft
         if (parentId && tableRef.current) {
           const rows = tableRef.current.getRowModel().rows
           const parentRow = rows.find((r: any) => r.original.id === parentId)
@@ -441,8 +449,11 @@ function WaydGrid2Inner<T>(
   )
 
   // ─── Column context ──────────────────────────────────────
+  // Tree drags reparent (onNodeMove); flat drags reorder (onRowReorder).
   const dragEnabledBase =
-    isTree && enableDragAndDrop && !!onNodeMove && !isLoading && !isEditing
+    (isTree ? enableDragAndDrop && !!onNodeMove : !!onRowReorder) &&
+    !isLoading &&
+    !isEditing
 
   const columnContext: GridColumnContext = useMemo(() => {
     const dragEnabledForColumns = dragEnabledBase && !hasActiveFilters
@@ -479,32 +490,36 @@ function WaydGrid2Inner<T>(
     return columnsProp
   }, [columnsProp, columnContext])
 
-  // Apply declarative column types (meta.columnType) before handing columns to
-  // TanStack. Memoized on `columns` so the resolved array keeps a stable
-  // identity across unrelated re-renders (e.g. a column-filter change). Without
-  // this, every render rebuilt the column defs, TanStack rebuilt its headers,
-  // and the filter Popover's trigger DOM node was replaced — which antd read as
-  // a click-outside and closed the open popover on every checkbox toggle.
+  // applySafeAccessor must run before applyColumnType (the type's raw-value
+  // reader handles accessorFns but not dotted keys). Memoized on `columns`:
+  // rebuilding defs every render made TanStack rebuild its headers, replacing
+  // the filter Popover's trigger DOM node — which antd read as a click-outside
+  // and closed the open popover on every checkbox toggle.
   const resolvedColumns = useMemo(
     () =>
       columns.map((col) =>
-        applyColumnType(col as ColumnDef<T, unknown>),
+        applyColumnType(applySafeAccessor(col as ColumnDef<T, unknown>)),
       ) as typeof columns,
     [columns],
   )
 
-  // Derive columnVisibility from each column's meta.hide (AG Grid `hide` style),
-  // so columns can live in one static literal and be shown/hidden by a flag.
+  // meta.hide → columnVisibility (AG Grid `hide` style), recursing into
+  // grouped defs (TanStack shrinks a band's colSpan as its leaves hide).
   const columnVisibility = useMemo<VisibilityState>(() => {
     const visibility: VisibilityState = {}
-    for (const col of resolvedColumns) {
-      const meta = col.meta
-      if (meta?.hide === undefined) continue
-      const id =
-        col.id ??
-        ((col as { accessorKey?: string | number }).accessorKey?.toString())
-      if (id) visibility[id] = !meta.hide
+    const collect = (cols: typeof resolvedColumns) => {
+      for (const col of cols) {
+        const children = (col as { columns?: typeof resolvedColumns }).columns
+        if (children) collect(children)
+        const meta = col.meta
+        if (meta?.hide === undefined) continue
+        const id =
+          col.id ??
+          ((col as { accessorKey?: string | number }).accessorKey?.toString())
+        if (id) visibility[id] = !meta.hide
+      }
     }
+    collect(resolvedColumns)
     return visibility
   }, [resolvedColumns])
 
@@ -587,6 +602,46 @@ function WaydGrid2Inner<T>(
     }
   }, [])
 
+  // ─── Flat row-reorder DnD ────────────────────────────────
+  /** Stable sortable id for a flat row: getRowId → row.original.id → row.id. */
+  const flatRowId = useCallback(
+    (row: Row<T>): string => {
+      if (getRowId) return getRowId(row.original)
+      const id = (row.original as { id?: string | number }).id
+      return id != null ? String(id) : row.id
+    },
+    [getRowId],
+  )
+
+  const handleFlatDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      setDraggedNodeId(null)
+
+      if (!over || !onRowReorder || active.id === over.id) return
+
+      const displayed = (tableRef.current?.getRowModel().rows ??
+        []) as Row<T>[]
+      const fromIndex = displayed.findIndex((r) => flatRowId(r) === active.id)
+      const toIndex = displayed.findIndex((r) => flatRowId(r) === over.id)
+      if (fromIndex < 0 || toIndex < 0 || fromIndex === toIndex) return
+
+      // Fire-and-forget: reorder consumers own their error handling (they
+      // revert by refetching), same as the tree onNodeMove contract.
+      void onRowReorder({
+        orderedData: arrayMove(
+          displayed.map((r) => r.original),
+          fromIndex,
+          toIndex,
+        ),
+        activeId: String(active.id),
+        fromIndex,
+        toIndex,
+      })
+    },
+    [flatRowId, onRowReorder, tableRef],
+  )
+
   // ─── TanStack table ─────────────────────────────────────
   const table = useGridTable({
     data: dataWithDrafts,
@@ -602,6 +657,7 @@ function WaydGrid2Inner<T>(
         filterFn: waydColumnFilter,
         sortingFn: sortEmptyLast,
       },
+      ...(getRowId ? { getRowId: (row: T) => getRowId(row) } : {}),
       // Tree mode: rows expand, and a filter match keeps the ancestor chain
       // visible (filterFromLeafRows).
       ...(isTree
@@ -618,16 +674,27 @@ function WaydGrid2Inner<T>(
 
   tableRef.current = table
 
-  useImperativeHandle(ref, () => ({ table, selectedRowId }))
+  useImperativeHandle(ref, () => ({
+    table,
+    selectedRowId,
+    getDisplayedRows: () =>
+      table.getRowModel().rows.map((row: Row<T>) => row.original),
+  }))
 
   const rows = table.getRowModel().rows
+
+  // Displayed-rows callback: TanStack memoizes the row model, so `rows` only
+  // changes identity when the data / filters / sorting actually change — the
+  // effect fires exactly on displayed-set changes (plus once on mount).
+  useEffect(() => {
+    onDisplayedRowsChange?.(rows.map((row) => row.original))
+  }, [rows, onDisplayedRowsChange])
   const displayedRowCount = rows.length
   const totalRowCount = isTree
     ? countTreeNodes(data as unknown as TreeNode[]) + draftTasks.length
     : data.length
   const visibleColumnCount = table.getVisibleLeafColumns().length
 
-  // Toggle a date-tree year/month node's expanded state for a given column.
   const toggleDateTreeNode = useCallback((columnId: string, nodeKey: string) => {
     setDateTreeExpanded((prev) => {
       const current = prev[columnId] ?? EMPTY_NODE_SET
@@ -884,7 +951,9 @@ function WaydGrid2Inner<T>(
     typeof leftSlot === 'function' ? leftSlot(columnContext) : leftSlot
 
   // ─── DnD wrapping ───────────────────────────────────────
-  const dndEnabled = isTree && enableDragAndDrop && !!onNodeMove
+  const treeDndEnabled = isTree && enableDragAndDrop && !!onNodeMove
+  const flatDndEnabled = !isTree && !!onRowReorder
+  const dndEnabled = treeDndEnabled || flatDndEnabled
   const isDragEnabled =
     dndEnabled && !isLoading && !isEditing && !hasActiveFilters
 
@@ -893,12 +962,24 @@ function WaydGrid2Inner<T>(
   // single status row (and its spinner / empty message) centers vertically.
   const showStatusRow = isLoading || rows.length === 0
 
+  // TanStack returns one header group per depth; the LAST is always the leaf
+  // columns, so any rows above it render as colspan bands. The band count
+  // drives the sticky-offset CSS var (bands / leaf header / filter row stack).
+  const headerGroups = table.getHeaderGroups()
+  const leafHeaderGroup = headerGroups[headerGroups.length - 1]
+  const groupHeaderRows = headerGroups.slice(0, -1)
+
   const tableContent = (
     <div className={styles.tableWrapper}>
       <table
         className={`${styles.tableElement}${
           showStatusRow ? ` ${styles.tableElementFill}` : ''
         }`}
+        style={
+          {
+            '--wayd-grid-group-header-rows': groupHeaderRows.length,
+          } as React.CSSProperties
+        }
       >
         <colgroup>
           {table.getVisibleLeafColumns().map((column) => (
@@ -910,142 +991,154 @@ function WaydGrid2Inner<T>(
           <col className={styles.fillerCol} />
         </colgroup>
         <thead>
-          {table.getHeaderGroups().map((headerGroup) => (
-            <Fragment key={headerGroup.id}>
-              {/* Header row */}
-              <tr key={headerGroup.id}>
-                {headerGroup.headers.map((header) => {
-                  // When floating filters are shown, the popup trigger lives
-                  // in the floating row instead of the header.
-                  const showHeaderFilterIcon =
-                    showColumnFilters &&
-                    !showFloatingFilters &&
-                    !header.isPlaceholder &&
-                    header.column.getCanFilter()
+          {/* Grouped-header band rows — plain colspan cells, no
+              sort/filter/resize; placeholders render empty. */}
+          {groupHeaderRows.map((headerGroup, bandIndex) => (
+            <tr key={headerGroup.id} data-role="header-band">
+              {headerGroup.headers.map((header) => (
+                <th
+                  key={header.id}
+                  colSpan={header.colSpan}
+                  className={`${styles.th} ${styles.groupTh}`}
+                  style={{
+                    top: `calc(${bandIndex} * var(--wayd-grid-header-row-height))`,
+                  }}
+                >
+                  <GridHeaderContent header={header} />
+                </th>
+              ))}
+              {/* Filler band cell — carries the band across the empty width. */}
+              <th
+                aria-hidden="true"
+                className={`${styles.th} ${styles.groupTh} ${styles.fillerTh}`}
+                style={{
+                  top: `calc(${bandIndex} * var(--wayd-grid-header-row-height))`,
+                }}
+              />
+            </tr>
+          ))}
 
+          {/* Leaf header row */}
+          <tr key={leafHeaderGroup.id}>
+            {leafHeaderGroup.headers.map((header) => {
+              // When floating filters are shown, the popup trigger lives
+              // in the floating row instead of the header.
+              const showHeaderFilterIcon =
+                showColumnFilters &&
+                !showFloatingFilters &&
+                !header.isPlaceholder &&
+                header.column.getCanFilter()
+
+              return (
+                <GridHeaderCell
+                  key={header.id}
+                  header={header}
+                  resizeGuard={resizeGuard}
+                  classes={headerCellClasses}
+                  filterSlot={
+                    showHeaderFilterIcon
+                      ? renderFilterPopover(header)
+                      : undefined
+                  }
+                />
+              )
+            })}
+            {/* Filler header cell — carries the header band across the
+                empty width. */}
+            <th
+              aria-hidden="true"
+              className={`${styles.th} ${styles.fillerTh}`}
+            />
+          </tr>
+
+          {/* Floating filter row — single-condition editor per column,
+              reflecting conditions[0] of the same descriptor. */}
+          {showFloatingFilters && (
+            <tr
+              key={`${leafHeaderGroup.id}-floating`}
+              data-role="floating-filters"
+            >
+              {leafHeaderGroup.headers.map((header) => {
+                const column = header.column
+                if (header.isPlaceholder || !column.getCanFilter()) {
                   return (
-                    <GridHeaderCell
-                      key={header.id}
-                      header={header}
-                      resizeGuard={resizeGuard}
-                      classes={headerCellClasses}
-                      filterSlot={
-                        showHeaderFilterIcon
-                          ? renderFilterPopover(header)
-                          : undefined
-                      }
+                    <th
+                      key={`${header.id}-floating`}
+                      className={styles.filterTh}
                     />
                   )
-                })}
-                {/* Filler header cell — carries the header band across the
-                    empty width. */}
-                <th
-                  aria-hidden="true"
-                  className={`${styles.th} ${styles.fillerTh}`}
-                />
-              </tr>
+                }
 
-              {/* Floating filter row — single-condition editor per column,
-                  reflecting conditions[0] of the same descriptor. */}
-              {showFloatingFilters && (
-                <tr
-                  key={`${headerGroup.id}-floating`}
-                  data-role="floating-filters"
-                >
-                  {headerGroup.headers.map((header) => {
-                    const column = header.column
-                    if (header.isPlaceholder || !column.getCanFilter()) {
-                      return (
-                        <th
-                          key={`${header.id}-floating`}
-                          className={styles.filterTh}
-                        />
-                      )
-                    }
+                const meta = column.columnDef.meta
+                const colFilterType = columnFilterType(header)
+                const colFilterValue = column.getFilterValue() as
+                  | ColumnFilterModel
+                  | undefined
 
-                    const meta = column.columnDef.meta
-                    const colFilterType = columnFilterType(header)
-                    const colFilterValue = column.getFilterValue() as
-                      | ColumnFilterModel
-                      | undefined
+                if (colFilterType === 'set') {
+                  return (
+                    <th
+                      key={`${header.id}-floating`}
+                      className={styles.filterTh}
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      {renderSetFilter(header)}
+                    </th>
+                  )
+                }
 
-                    // Set filters open the Excel-style SetFilterPanel (search
-                    // + Select All + checkboxes) from a compact box + icon.
-                    if (colFilterType === 'set') {
-                      return (
-                        <th
-                          key={`${header.id}-floating`}
-                          className={styles.filterTh}
-                          onClick={(e) => e.stopPropagation()}
-                        >
-                          {renderSetFilter(header)}
-                        </th>
-                      )
-                    }
+                // The floating DatePicker can faithfully edit only a simple
+                // equals; any richer date filter shows a read-only summary
+                // chip instead. The cell structure must stay identical in
+                // both states — left child input ⇄ chip, right child ALWAYS
+                // the same popover trigger icon — so the open popover's
+                // anchor is never replaced (antd closes it as a click-outside
+                // otherwise, flickering when the filter activates).
+                const showDateSummary =
+                  colFilterType === 'date' &&
+                  !canFloatingEditDate(colFilterValue)
 
-                    // Date columns: the floating DatePicker can faithfully show
-                    // and edit only a simple equals. A complex date filter
-                    // (before/after/inRange, a relative range, a date-tree
-                    // selection, or multiple conditions) would otherwise render
-                    // as a bare date and mislead — so show a read-only summary
-                    // chip in place of the input instead.
-                    //
-                    // Crucially, the cell structure is identical in both states:
-                    // a `.floatingCell` whose LEFT child is the input or the
-                    // chip, and whose RIGHT child is always the same filter-icon
-                    // popover trigger from renderFilterPopover(). The popover is
-                    // therefore always anchored to that stable icon — swapping
-                    // the left child (input ⇄ chip) when the filter activates
-                    // never replaces the popover's anchor, so it doesn't
-                    // close/reopen (flicker) as the filter crosses the
-                    // unfiltered ⇄ active boundary.
-                    const showDateSummary =
-                      colFilterType === 'date' &&
-                      !canFloatingEditDate(colFilterValue)
-
-                    return (
-                      <th
-                        key={`${header.id}-floating`}
-                        className={styles.filterTh}
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <div className={styles.floatingCell}>
-                          {showDateSummary ? (
-                            <span
-                              className={styles.setSummary}
-                              title={describeDateFilter(colFilterValue)}
-                            >
-                              {describeDateFilter(colFilterValue)}
-                            </span>
-                          ) : (
-                            <FloatingFilter
-                              filterType={colFilterType}
-                              // Only reflect a matching condition descriptor. On
-                              // a combined column, a `set` descriptor leaves the
-                              // floating input empty (AG Grid behavior).
-                              value={
-                                colFilterValue?.type === colFilterType
-                                  ? colFilterValue
-                                  : undefined
-                              }
-                              placeholder={meta?.filterPlaceholder}
-                              onChange={(next) => column.setFilterValue(next)}
-                            />
-                          )}
-                          {renderFilterPopover(header)}
-                        </div>
-                      </th>
-                    )
-                  })}
-                  {/* Filler cell carries the filter-row band to the edge. */}
+                return (
                   <th
-                    aria-hidden="true"
-                    className={`${styles.filterTh} ${styles.fillerTh}`}
-                  />
-                </tr>
-              )}
-            </Fragment>
-          ))}
+                    key={`${header.id}-floating`}
+                    className={styles.filterTh}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    <div className={styles.floatingCell}>
+                      {showDateSummary ? (
+                        <span
+                          className={styles.setSummary}
+                          title={describeDateFilter(colFilterValue)}
+                        >
+                          {describeDateFilter(colFilterValue)}
+                        </span>
+                      ) : (
+                        <FloatingFilter
+                          filterType={colFilterType}
+                          // Only reflect a matching condition descriptor. On
+                          // a combined column, a `set` descriptor leaves the
+                          // floating input empty (AG Grid behavior).
+                          value={
+                            colFilterValue?.type === colFilterType
+                              ? colFilterValue
+                              : undefined
+                          }
+                          placeholder={meta?.filterPlaceholder}
+                          onChange={(next) => column.setFilterValue(next)}
+                        />
+                      )}
+                      {renderFilterPopover(header)}
+                    </div>
+                  </th>
+                )
+              })}
+              {/* Filler cell carries the filter-row band to the edge. */}
+              <th
+                aria-hidden="true"
+                className={`${styles.filterTh} ${styles.fillerTh}`}
+              />
+            </tr>
+          )}
         </thead>
         <tbody>
           {isLoading ? (
@@ -1089,7 +1182,6 @@ function WaydGrid2Inner<T>(
                 />,
               ]
 
-              // Add validation error row
               if (isSelected && Object.keys(fieldErrors).length > 0) {
                 const errorItems = Object.entries(fieldErrors).map(
                   ([field, error]) => (
@@ -1118,6 +1210,21 @@ function WaydGrid2Inner<T>(
               }
 
               return rowElements
+            })
+          ) : flatDndEnabled ? (
+            rows.map((row, index) => {
+              const nodeId = flatRowId(row)
+              return (
+                <SortableFlatGridRow
+                  key={row.id}
+                  row={row}
+                  index={index}
+                  classes={rowClasses}
+                  nodeId={nodeId}
+                  isDragging={draggedNodeId === nodeId}
+                  isDragEnabled={isDragEnabled}
+                />
+              )
             })
           ) : (
             rows.map((row, index) => (
@@ -1161,11 +1268,15 @@ function WaydGrid2Inner<T>(
           sensors={sensors}
           collisionDetection={closestCenter}
           onDragStart={handleDragStart}
-          onDragEnd={handleDragEnd}
+          onDragEnd={treeDndEnabled ? handleDragEnd : handleFlatDragEnd}
           onDragCancel={handleDragCancel}
         >
           <SortableContext
-            items={flattenedNodes.map((t) => t.node.id)}
+            items={
+              treeDndEnabled
+                ? flattenedNodes.map((t) => t.node.id)
+                : rows.map((row) => flatRowId(row))
+            }
             strategy={verticalListSortingStrategy}
           >
             {tableContent}
@@ -1184,8 +1295,10 @@ function WaydGrid2Inner<T>(
  * CSV export). Flat by default; provide `getSubRows` to turn on tree mode —
  * expansion, `filterFromLeafRows` (a matching child keeps its ancestor chain
  * visible), and, when configured, reparenting drag-and-drop, inline editing,
- * and draft rows. Rows render through the row-renderer seam: the flat form
- * ({@link FlatGridRow}) or the tree form ({@link TreeGridRow}).
+ * and draft rows. Flat mode supports row-reorder drag-and-drop via
+ * `onRowReorder`. Rows render through the row-renderer seam: the flat forms
+ * ({@link FlatGridRow} / {@link SortableFlatGridRow}) or the tree form
+ * ({@link TreeGridRow}).
  *
  * Named WaydGrid2 while the ag-grid WaydGrid still exists; takes the
  * canonical WaydGrid name when ag-grid is retired.

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/cycle-time-report.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/cycle-time-report.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FC, useEffect, useRef, useState } from 'react'
+import { FC, useState } from 'react'
 import {
   DatePicker,
   Flex,
@@ -26,8 +26,6 @@ import {
   sortCycleTimeWorkItems,
 } from './cycle-time-report.filtering'
 import { InfoCircleOutlined } from '@ant-design/icons'
-import '../grid/ag-grid-init'
-import { AgGridReact } from 'ag-grid-react'
 
 const { Title, Text } = Typography
 
@@ -52,8 +50,6 @@ const CycleTimeReportContent: FC<CycleTimeReportContentProps> = ({
   source,
   workItemsScope,
 }) => {
-  const gridRef = useRef<AgGridReact<WorkItemListDto>>(null)
-  const filterAnimationFrameRef = useRef<number | null>(null)
   const doneFromPresets = [30, 60, 90, 120, 180].map((days) => ({
     label: `${days} Days`,
     value: dayjs().utc().subtract(days, 'days').startOf('day'),
@@ -125,38 +121,6 @@ const CycleTimeReportContent: FC<CycleTimeReportContentProps> = ({
       normalizedPercentile,
     )
   })()
-
-  const onFilterChanged = () => {
-    if (filterAnimationFrameRef.current !== null) {
-      return
-    }
-    filterAnimationFrameRef.current = window.requestAnimationFrame(() => {
-      filterAnimationFrameRef.current = null
-
-      if (gridRef.current?.api) {
-        const displayedRows: WorkItemListDto[] = []
-        gridRef.current.api.forEachNodeAfterFilterAndSort((node) => {
-          if (node.data) {
-            displayedRows.push(node.data)
-          }
-        })
-        setChartWorkItems(displayedRows)
-      }
-    })
-  }
-
-  // Initialize chart data when filtered work items change
-  useEffect(() => {
-    setChartWorkItems(filteredWorkItems)
-  }, [filteredWorkItems])
-
-  useEffect(() => {
-    return () => {
-      if (filterAnimationFrameRef.current !== null) {
-        window.cancelAnimationFrame(filterAnimationFrameRef.current)
-      }
-    }
-  }, [])
 
   if (error) {
     return <div>Error loading work items</div>
@@ -249,13 +213,13 @@ const CycleTimeReportContent: FC<CycleTimeReportContentProps> = ({
           isLoading={isLoading}
         />
       )}
+      {/* The chart tracks the grid's displayed rows — grid filters re-scope it. */}
       <WorkItemsGrid
-        ref={gridRef}
         workItems={filteredWorkItems}
         isLoading={isLoading}
         refetch={refetch}
         showStats={true}
-        onFilterChanged={onFilterChanged}
+        onDisplayedRowsChange={setChartWorkItems}
       />
     </Flex>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/dependency-constants.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/dependency-constants.ts
@@ -1,0 +1,3 @@
+/** Shared copy for dependency grids (team + work item views). */
+export const DEPENDENCY_SCOPE_TOOLTIP =
+  'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/index.ts
@@ -11,4 +11,5 @@ export {
   workItemKeyComparator,
   workStatusCategoryComparator,
 } from './work-item-utils'
+export { DEPENDENCY_SCOPE_TOOLTIP } from './dependency-constants'
 export { default as WorkItemTagsCell } from './work-item-tags-cell'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-dependencies-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-dependencies-grid.tsx
@@ -15,6 +15,7 @@ import {
   renderWorkItemLink,
   workItemKeySort,
 } from '../wayd-grid2'
+import { DEPENDENCY_SCOPE_TOOLTIP } from './dependency-constants'
 
 export interface WorkItemDependenciesGridProps {
   workItem: WorkItemDetailsDto
@@ -22,9 +23,6 @@ export interface WorkItemDependenciesGridProps {
   isLoading: boolean
   refetch: () => void
 }
-
-const SCOPE_TOOLTIP =
-  'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).'
 
 const dependencyTypeTooltip = (
   data: ScopedDependencyDto,
@@ -80,7 +78,7 @@ const WorkItemDependenciesGrid: FC<WorkItemDependenciesGridProps> = (props) => {
             accessorKey: 'scope.name',
             header: 'Scope',
             size: 100,
-            meta: { filterType: 'set', headerTooltip: SCOPE_TOOLTIP },
+            meta: { filterType: 'set', headerTooltip: DEPENDENCY_SCOPE_TOOLTIP },
           },
         ],
       },

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-dependencies-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-dependencies-grid.tsx
@@ -4,18 +4,17 @@ import {
   ScopedDependencyDto,
   WorkItemDetailsDto,
 } from '@/src/services/wayd-api'
-import { ColDef, ColGroupDef, GetRowIdParams } from 'ag-grid-community'
-import { CustomCellRendererProps } from 'ag-grid-react'
+import type { ColumnDef } from '@tanstack/react-table'
 import { FC, useMemo } from 'react'
-import WaydGrid from '../wayd-grid'
-import { workItemKeyComparator } from './work-item-utils'
-import Link from 'next/link'
-import { ExportOutlined } from '@ant-design/icons'
+import { WaydTooltip } from '@/src/components/common'
 import {
-  DependencyHealthCellRenderer,
-  renderSprintLinkHelper,
-  renderTeamLinkHelper,
-} from '../wayd-grid-cell-renderers'
+  WaydGrid2,
+  renderDependencyHealthTag,
+  renderSprintLink,
+  renderTeamLink,
+  renderWorkItemLink,
+  workItemKeySort,
+} from '../wayd-grid2'
 
 export interface WorkItemDependenciesGridProps {
   workItem: WorkItemDetailsDto
@@ -24,34 +23,8 @@ export interface WorkItemDependenciesGridProps {
   refetch: () => void
 }
 
-const WorkItemLinkCellRenderer = (
-  props: CustomCellRendererProps<ScopedDependencyDto>,
-) => {
-  const { value, data } = props
-  if (!data?.dependency) return null
-
-  return (
-    <>
-      <Link
-        href={`/work/workspaces/${data.dependency.workspaceKey}/work-items/${data.dependency.key}`}
-        prefetch={false}
-      >
-        {value}
-      </Link>
-
-      {data.dependency.externalViewWorkItemUrl && (
-        <Link
-          href={data.dependency.externalViewWorkItemUrl}
-          target="_blank"
-          title="Open in external system"
-          style={{ marginLeft: '5px' }}
-        >
-          <ExportOutlined style={{ width: '10px' }} />
-        </Link>
-      )}
-    </>
-  )
-}
+const SCOPE_TOOLTIP =
+  'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).'
 
 const dependencyTypeTooltip = (
   data: ScopedDependencyDto,
@@ -69,89 +42,116 @@ const dependencyTypeTooltip = (
 const WorkItemDependenciesGrid: FC<WorkItemDependenciesGridProps> = (props) => {
   const { workItem, refetch } = props
 
-  const getRowId = ({ data }: GetRowIdParams<ScopedDependencyDto>) => {
-    return data.id
-  }
-
-  const columnDefs = useMemo<(ColDef<ScopedDependencyDto> | ColGroupDef<ScopedDependencyDto>)[]>(() => [
-    {
-      headerName: 'Dependency Info',
-      children: [
-        {
-          field: 'type',
-          width: 125,
-          tooltipValueGetter: (params) =>
-            dependencyTypeTooltip(params.data!, workItem),
-          sort: 'asc',
-          sortIndex: 0,
-        },
-        { field: 'state.name', headerName: 'State', width: 100 },
-        {
-          field: 'health.name',
-          headerName: 'Health',
-          width: 100,
-          cellRenderer: DependencyHealthCellRenderer,
-        },
-        {
-          field: 'scope.name',
-          headerName: 'Scope',
-          width: 100,
-          headerTooltip:
-            'Defines whether this dependency is managed inside a single team (intra-team) or requires coordination between multiple teams (cross-team).',
-        },
-        // {
-        //   field: 'createdOn',
-        //   width: 150,
-        //   valueGetter: (params) =>
-        //     dayjs(params.data.createdOn).format('M/D/YYYY h:mm A'),
-        // },
-      ],
-    },
-    {
-      headerName: 'Work Item Info',
-      children: [
-        {
-          field: 'dependency.key',
-          headerName: 'Key',
-          comparator: workItemKeyComparator,
-          cellRenderer: WorkItemLinkCellRenderer,
-        },
-        { field: 'dependency.title', headerName: 'Title', width: 400 },
-        { field: 'dependency.type', headerName: 'Type', width: 150 },
-        { field: 'dependency.status', headerName: 'Status', width: 150 },
-        {
-          field: 'dependency.team.name',
-          headerName: 'Team',
-          cellRenderer: (
-            params: CustomCellRendererProps<ScopedDependencyDto>,
-          ) => renderTeamLinkHelper(params.data?.dependency.team),
-        },
-        {
-          field: 'dependency.sprint.name',
-          headerName: 'Sprint',
-          cellRenderer: (
-            params: CustomCellRendererProps<ScopedDependencyDto>,
-          ) => renderSprintLinkHelper(params.data?.dependency.sprint),
-        },
-      ],
-    },
-  ], [workItem])
+  const columns = useMemo<ColumnDef<ScopedDependencyDto, any>[]>(
+    () => [
+      {
+        id: 'dependencyInfo',
+        header: 'Dependency Info',
+        columns: [
+          {
+            id: 'type',
+            accessorKey: 'type',
+            header: 'Type',
+            size: 125,
+            meta: { filterType: 'set' },
+            cell: ({ row, getValue }) => (
+              <WaydTooltip title={dependencyTypeTooltip(row.original, workItem)}>
+                <span>{getValue<string>()}</span>
+              </WaydTooltip>
+            ),
+          },
+          {
+            id: 'state',
+            accessorKey: 'state.name',
+            header: 'State',
+            size: 100,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'health',
+            accessorKey: 'health.name',
+            header: 'Health',
+            size: 100,
+            meta: { filterType: 'set' },
+            cell: ({ row }) => renderDependencyHealthTag(row.original.health),
+          },
+          {
+            id: 'scope',
+            accessorKey: 'scope.name',
+            header: 'Scope',
+            size: 100,
+            meta: { filterType: 'set', headerTooltip: SCOPE_TOOLTIP },
+          },
+        ],
+      },
+      {
+        id: 'workItemInfo',
+        header: 'Work Item Info',
+        columns: [
+          {
+            id: 'key',
+            accessorKey: 'dependency.key',
+            header: 'Key',
+            sortingFn: workItemKeySort,
+            cell: ({ row }) => renderWorkItemLink(row.original.dependency),
+          },
+          {
+            id: 'title',
+            accessorKey: 'dependency.title',
+            header: 'Title',
+            size: 400,
+          },
+          {
+            id: 'workItemType',
+            accessorKey: 'dependency.type',
+            header: 'Type',
+            size: 150,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'status',
+            accessorKey: 'dependency.status',
+            header: 'Status',
+            size: 150,
+            meta: { filterType: 'set' },
+          },
+          {
+            id: 'team',
+            accessorKey: 'dependency.team.name',
+            header: 'Team',
+            meta: { filterEnableSet: true },
+            cell: ({ row }) => renderTeamLink(row.original.dependency.team),
+          },
+          {
+            id: 'sprint',
+            accessorKey: 'dependency.sprint.name',
+            header: 'Sprint',
+            meta: { filterEnableSet: true },
+            cell: ({ row }) =>
+              renderSprintLink(row.original.dependency.sprint, {
+                showTeamCode: false,
+              }),
+          },
+        ],
+      },
+    ],
+    [workItem],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <>
-      <WaydGrid
-        height={550}
-        columnDefs={columnDefs}
-        rowData={props.dependencies}
-        loadData={refresh}
-        loading={props.isLoading}
-        getRowId={getRowId}
-      />
-    </>
+    <WaydGrid2
+      height={550}
+      columns={columns}
+      data={props.dependencies}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      initialSorting={[{ id: 'type', desc: false }]}
+      csvFileName="work-item-dependencies"
+    />
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-grid.tsx
@@ -1,24 +1,19 @@
 'use client'
 
-import { WaydGrid } from '@/src/components/common'
+import {
+  WaydGrid2,
+  renderAssignedToLink,
+  renderProjectLink,
+  renderSprintLink,
+  renderTeamLink,
+  renderWorkItemLink,
+  renderWorkStatusTag,
+  workItemKeySort,
+  workStatusCategorySort,
+} from '@/src/components/common/wayd-grid2'
 import { WorkItemListDto } from '@/src/services/wayd-api'
-import { ColDef, ICellRendererParams } from 'ag-grid-community'
-import { forwardRef, ReactNode, useMemo } from 'react'
-import { AgGridReact } from 'ag-grid-react'
-import {
-  AssignedToLinkCellRenderer,
-  DateTimeCellRenderer,
-  NestedTeamNameLinkCellRenderer,
-  NestedWorkSprintLinkCellRenderer,
-  ParentWorkItemLinkCellRenderer,
-  ProjectLinkCellRenderer,
-  WorkItemLinkCellRenderer,
-  WorkStatusTagCellRenderer,
-} from '../wayd-grid-cell-renderers'
-import {
-  workItemKeyComparator,
-  workStatusCategoryComparator,
-} from './work-item-utils'
+import type { ColumnDef } from '@tanstack/react-table'
+import { FC, ReactNode, useMemo } from 'react'
 
 export interface WorkItemsGridProps {
   workItems: WorkItemListDto[]
@@ -28,125 +23,154 @@ export interface WorkItemsGridProps {
   hideParentColumn?: boolean
   hideProjectColumn?: boolean
   showStats?: boolean
-  onFilterChanged?: () => void
+  /** Fires with the displayed (post filter + sort) rows whenever that set
+   *  changes — e.g. the cycle-time report syncs its chart to the grid. */
+  onDisplayedRowsChange?: (workItems: WorkItemListDto[]) => void
   viewSelector?: ReactNode | undefined
 }
 
-const WorkItemsGrid = forwardRef<
-  AgGridReact<WorkItemListDto>,
-  WorkItemsGridProps
->((props, ref) => {
+const WorkItemsGrid: FC<WorkItemsGridProps> = (props) => {
   const { refetch } = props
 
-  const columnDefs = useMemo<ColDef<WorkItemListDto>[]>(() => [
-    {
-      field: 'key',
-      comparator: workItemKeyComparator,
-      cellRenderer: WorkItemLinkCellRenderer,
-    },
-    { field: 'title', width: 400 },
-    { field: 'type.name', headerName: 'Type', width: 125 },
-    { field: 'status', width: 125, cellRenderer: WorkStatusTagCellRenderer },
-    {
-      field: 'statusCategory.name',
-      headerName: 'Status Category',
-      width: 140,
-      comparator: workStatusCategoryComparator,
-    },
-    {
-      field: 'storyPoints',
-      headerName: 'SPs',
-      headerTooltip: 'Story Points',
-      width: 100,
-      filter: 'agNumberColumnFilter',
-      type: 'numericColumn',
-    },
-    {
-      field: 'team.name',
-      headerName: 'Team',
-      cellRenderer: NestedTeamNameLinkCellRenderer,
-    },
-    {
-      field: 'sprint.name',
-      headerName: 'Sprint',
-      cellRenderer: NestedWorkSprintLinkCellRenderer,
-    },
-    {
-      field: 'parent.key',
-      headerName: 'Parent Key',
-      hide: props.hideParentColumn,
-      comparator: workItemKeyComparator,
-      cellRenderer: ParentWorkItemLinkCellRenderer,
-    },
-    {
-      field: 'parent.title',
-      headerName: 'Parent',
-      width: 400,
-      hide: props.hideParentColumn,
-    },
-    {
-      field: 'assignedTo.name',
-      headerName: 'Assigned To',
-      cellRenderer: AssignedToLinkCellRenderer,
-    },
-    {
-      field: 'project.name',
-      headerName: 'Project',
-      width: 300,
-      hide: props.hideProjectColumn,
-      cellRenderer: ProjectLinkCellRenderer,
-    },
-    {
-      field: 'activated',
-      hide: !props.showStats,
-      filter: 'agDateColumnFilter',
-      filterParams: {
-        includeBlanksInEquals: false,
-        includeBlanksInLessThan: false,
-        includeBlanksInGreaterThan: false,
+  const columns = useMemo<ColumnDef<WorkItemListDto, any>[]>(
+    () => [
+      {
+        id: 'key',
+        accessorKey: 'key',
+        header: 'Key',
+        sortingFn: workItemKeySort,
+        cell: ({ row }) =>
+          renderWorkItemLink({
+            key: row.original.key,
+            workspaceKey: row.original.workspace.key,
+            externalViewWorkItemUrl: row.original.externalViewWorkItemUrl,
+          }),
       },
-      cellRenderer: DateTimeCellRenderer,
-    },
-    {
-      field: 'done',
-      hide: !props.showStats,
-      sort: 'desc',
-      filter: 'agDateColumnFilter',
-      filterParams: {
-        includeBlanksInEquals: false,
-        includeBlanksInLessThan: false,
-        includeBlanksInGreaterThan: false,
+      { id: 'title', accessorKey: 'title', header: 'Title', size: 400 },
+      {
+        id: 'type',
+        accessorKey: 'type.name',
+        header: 'Type',
+        size: 125,
+        meta: { filterType: 'set' },
       },
-      cellRenderer: DateTimeCellRenderer,
-    },
-    {
-      field: 'cycleTime',
-      headerName: 'Cycle Time (Days)',
-      hide: !props.showStats,
-      type: 'numericColumn',
-      cellRenderer: (params: ICellRendererParams<WorkItemListDto>) =>
-        params.value?.toFixed(2) ?? '',
-    },
-  ], [props.hideParentColumn, props.hideProjectColumn, props.showStats])
+      {
+        id: 'status',
+        accessorKey: 'status',
+        header: 'Status',
+        size: 125,
+        meta: { filterType: 'set' },
+        cell: ({ row }) => renderWorkStatusTag(row.original),
+      },
+      {
+        id: 'statusCategory',
+        accessorKey: 'statusCategory.name',
+        header: 'Status Category',
+        size: 140,
+        sortingFn: workStatusCategorySort,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'storyPoints',
+        accessorKey: 'storyPoints',
+        header: 'SPs',
+        size: 100,
+        meta: { headerTooltip: 'Story Points' },
+      },
+      {
+        id: 'team',
+        accessorKey: 'team.name',
+        header: 'Team',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderTeamLink(row.original.team),
+      },
+      {
+        id: 'sprint',
+        accessorKey: 'sprint.name',
+        header: 'Sprint',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderSprintLink(row.original.sprint),
+      },
+      {
+        id: 'parentKey',
+        accessorKey: 'parent.key',
+        header: 'Parent Key',
+        sortingFn: workItemKeySort,
+        meta: { hide: props.hideParentColumn },
+        cell: ({ row }) =>
+          renderWorkItemLink(
+            row.original.parent
+              ? {
+                  key: row.original.parent.key,
+                  workspaceKey: row.original.parent.workspaceKey,
+                  externalViewWorkItemUrl:
+                    row.original.parent.externalViewWorkItemUrl,
+                }
+              : null,
+          ),
+      },
+      {
+        id: 'parentTitle',
+        accessorKey: 'parent.title',
+        header: 'Parent',
+        size: 400,
+        meta: { hide: props.hideParentColumn },
+      },
+      {
+        id: 'assignedTo',
+        accessorKey: 'assignedTo.name',
+        header: 'Assigned To',
+        meta: { filterEnableSet: true },
+        cell: ({ row }) => renderAssignedToLink(row.original.assignedTo),
+      },
+      {
+        id: 'project',
+        accessorKey: 'project.name',
+        header: 'Project',
+        size: 300,
+        meta: { hide: props.hideProjectColumn, filterEnableSet: true },
+        cell: ({ row }) => renderProjectLink(row.original.project),
+      },
+      {
+        id: 'activated',
+        accessorKey: 'activated',
+        header: 'Activated',
+        meta: { hide: !props.showStats, columnType: 'dateTime' },
+      },
+      {
+        id: 'done',
+        accessorKey: 'done',
+        header: 'Done',
+        meta: { hide: !props.showStats, columnType: 'dateTime' },
+      },
+      {
+        id: 'cycleTime',
+        accessorKey: 'cycleTime',
+        header: 'Cycle Time (Days)',
+        meta: { hide: !props.showStats },
+        cell: ({ getValue }) => getValue<number | undefined>()?.toFixed(2) ?? '',
+      },
+    ],
+    [props.hideParentColumn, props.hideProjectColumn, props.showStats],
+  )
 
   const refresh = async () => {
     refetch()
   }
 
   return (
-    <WaydGrid
-      ref={ref}
+    <WaydGrid2
       height={props.gridHeight}
-      columnDefs={columnDefs}
-      rowData={props.workItems}
-      loadData={refresh}
-      loading={props.isLoading}
-      onFilterChanged={props.onFilterChanged}
-      toolbarActions={props.viewSelector}
+      columns={columns}
+      data={props.workItems}
+      onRefresh={refresh}
+      isLoading={props.isLoading}
+      initialSorting={[{ id: 'done', desc: true }]}
+      onDisplayedRowsChange={props.onDisplayedRowsChange}
+      rightSlot={props.viewSelector}
+      csvFileName="work-items"
     />
   )
-})
-
-WorkItemsGrid.displayName = 'WorkItemsGrid'
+}
 
 export default WorkItemsGrid


### PR DESCRIPTION
## Migrate to TanStack Table — Part 3: final ag-grid `WaydGrid` screens

Migrates the last 5 ag-grid `WaydGrid` screens to `WaydGrid2`, unblocked by two new grid-core features built in this PR. After this, the ag-grid `WaydGrid` component and its cell renderers have **zero consumers**.

### New core feature: grouped headers (ag-grid `ColGroupDef` equivalent)

- Nested TanStack column groups (`columns: [...]`) now render as colspan header **bands** above the leaf header row — plain centered cells with no sort/filter/resize affordances; ungrouped columns pass through as empty placeholders.
- Bands, the leaf header row, and the floating-filter row stack sticky via a `--wayd-grid-group-header-rows` CSS variable; the floating-filter row renders exactly once (keyed off the leaf header group).
- `meta.columnType` and `meta.hide` recurse into group children (hiding a leaf shrinks its band's colSpan).
- **CSV export** writes matching group-header prelude rows: each band label once at its group's first exported column, blanks across the span (ag-grid CSV style). Flat grids' exports are byte-identical to before.

### New core feature: flat row-drag reorder + grid-state surface

- `onRowReorder` — flat rows render through a sortable wrapper (shared dnd-kit mechanics, no tree projection); dropping emits `{ orderedData, activeId, fromIndex, toIndex }`. Dragging auto-disables while sorted / filtered / searched / loading / editing; column functions read `context.isDragEnabled` to render a disabled handle with a tooltip (the sort-guard).
- `getRowId` — stable row identity for TanStack + sortable items.
- `onDisplayedRowsChange` + handle `getDisplayedRows()` — the post-filter/sort row set, replacing ag-grid's `onFilterChanged` + `forEachNodeAfterFilterAndSort` for consumers that derive UI from grid state.
- `initialSorting` — ag-grid `sort: 'asc'` equivalent, cleared by the toolbar Clear button.

### Supporting core additions

- `meta.headerTooltip` — declaratively wraps the header label in `WaydTooltip` (works on band headers too); `header` stays a plain string so CSV export needs no `exportHeader` override. All hand-rolled header tooltips migrated.
- Dotted `accessorKey`s (e.g. `team.name`) are auto-rewritten into null-tolerant `accessorFn`s, eliminating TanStack's per-cell dev warning on optional relations app-wide. Column ids stay exactly what TanStack would derive (dots → underscores).
- `renderDependencyHealthTag` cell renderer.
- Header text muted to `--ant-color-text-secondary` — parity with the retired ag-grid Balham theme's muted `headerTextColor` (weight was already one step *lighter* than Balham's bold; the perceived heaviness was contrast).

### Migrated screens (5)

| Screen | Notes |
| --- | --- |
| Team dependencies grid | Grouped headers (Dependency / Predecessor / Successor Info) |
| Work item dependencies grid | Grouped headers; keeps `type asc` default sort + per-row type tooltip |
| Strategic initiative KPIs grid | Row reorder; the old "clear sorting" warning became a disabled handle + tooltip |
| Portfolio ranking board | Row reorder; rank-anchor move payload unchanged. ⚠️ multi-row drag reduced to single-row (dnd-kit has no native multi-drag) |
| Work items grid + cycle-time report | Drops the ag-grid `forwardRef`; the chart syncs via `onDisplayedRowsChange` |

### Verification

- `npx tsc --noEmit`, eslint clean; full jest suite green (**153 suites / 2,406 tests**, ~120 new).
- Browser-verified via Playwright: band colSpans (3/6/6) and pixel alignment, sticky stacking under scroll, single floating-filter row, band labels don't sort; KPI + ranking drag reorder persisted through reload (`POST …/kpis/reorder`, `PUT …/project-ranks` → 204) with the sort-guard engaging; cycle-time chart re-scoped by grid search and restored on clear.
  - Note: drags were exercised via dnd-kit's keyboard sensor (Playwright's synthetic mouse drag doesn't trip the pointer sensor's activation constraint); mouse drag was hand-verified.

### What this does NOT do (ag-grid endgame remains)

ag-grid is still consumed by `AgGridTransfer` (two manage-…-form dual-list pickers), `ag-grid-init.ts`/`grid/column-types.ts`, and theme-token wiring in `src/config/theme/*`. Package removal, deleting the now-orphaned `wayd-grid.tsx` / `wayd-grid-cell-renderers.tsx`, and the `WaydGrid2` → `WaydGrid` rename land after the transfer component migrates (tracked separately).
