### PR TITLE
Feature/add virtualization to waydgrid

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/package-lock.json
+++ b/Wayd.Web/src/wayd.web.reactclient/package-lock.json
@@ -24,6 +24,7 @@
         "@reduxjs/toolkit": "2.12.0",
         "@swc/core": "1.15.41",
         "@tanstack/react-table": "^8.21.3",
+        "@tanstack/react-virtual": "^3.14.5",
         "@uiw/react-md-editor": "^4.1.1",
         "antd": "6.4.4",
         "antd-style": "^4.1.0",
@@ -6781,6 +6782,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.14.5",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.14.5.tgz",
+      "integrity": "sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.17.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
@@ -6789,6 +6807,16 @@
       "engines": {
         "node": ">=12"
       },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.17.3",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.17.3.tgz",
+      "integrity": "sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==",
+      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"

--- a/Wayd.Web/src/wayd.web.reactclient/package.json
+++ b/Wayd.Web/src/wayd.web.reactclient/package.json
@@ -57,6 +57,7 @@
     "@reduxjs/toolkit": "2.12.0",
     "@swc/core": "1.15.41",
     "@tanstack/react-table": "^8.21.3",
+    "@tanstack/react-virtual": "^3.14.5",
     "@uiw/react-md-editor": "^4.1.1",
     "antd": "6.4.4",
     "antd-style": "^4.1.0",

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
@@ -395,6 +395,17 @@
   padding: 0;
 }
 
+/*
+ * Virtual-offset spacer cell (row virtualization). Height is set inline from
+ * the virtualizer's offsets. Zero padding and border so the spacer's height
+ * is exactly the inline value and it contributes no width — any width the
+ * body table gains over the header table desyncs their max horizontal scroll.
+ */
+.virtualSpacer {
+  padding: 0;
+  border: 0;
+}
+
 .tr {
   cursor: default;
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
@@ -66,6 +66,18 @@
   border-bottom: 1px solid var(--ant-color-border);
 }
 
+/* Fills the area under the header: the scrolling wrapper plus the status
+   overlay's positioning context. The overlay must NOT live inside the
+   scrolling wrapper — absolutely-positioned children of a scroll container
+   ride along with its scroll offsets. */
+.bodyArea {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
 /* The body viewport — the grid's one scrolling element (draft/editing
    scroll-into-view helpers target this class). */
 .tableWrapper {
@@ -419,28 +431,19 @@
 }
 
 /*
- * Loading/empty status band. The classes go on a DIV inside the spanning
- * <td> (display:flex directly on a td breaks table-cell rendering), and
- * .tableElementFill stretches the table while the band is shown so the
- * single status row fills the wrapper and centers its content vertically
- * (the td is vertical-align: middle).
+ * Loading/empty status overlay: centered on the VISIBLE body viewport (via
+ * .bodyArea), not on the table — a wide table in a narrow window centers a
+ * spanning status <td> at half the scroll width, pushing it off-screen.
+ * pointer-events: none keeps the scrollbars beneath it usable.
  */
-.tableElementFill {
-  height: 100%;
-}
-
-.empty {
-  padding: var(--ant-padding-lg);
+.statusOverlay {
+  position: absolute;
+  inset: 0;
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.loading {
   padding: var(--ant-padding-lg);
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  pointer-events: none;
 }
 
 /* ─── Tree mode: inline editing ─────────────────────────── */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
@@ -998,6 +998,97 @@ describe('WaydGrid', () => {
     })
   })
 
+  describe('row virtualization', () => {
+    // jsdom has no layout; jest.setup.ts mocks the body viewport's rect to
+    // 800×600 (see data-grid-body-viewport). These tests pin the resulting
+    // window plus the spacer geometry standing in for the unrendered rows.
+    const ROW_ESTIMATE = 28
+    // 600px viewport ÷ 28px rows → indexes 0-21 visible, +10 overscan = 32.
+    const WINDOW_SIZE = 32
+
+    const BIG_DATA: Flag[] = Array.from({ length: 200 }, (_, i) => ({
+      id: i + 1,
+      name: `flag-${String(i + 1).padStart(3, '0')}`,
+      isEnabled: i % 2 === 0,
+      type: i % 3 === 0 ? 'System' : 'User',
+    }))
+
+    /** The scrolling body viewport (parent of the body table, tables[1]). */
+    const bodyViewport = (container: HTMLElement) =>
+      container.querySelectorAll('table')[1].parentElement as HTMLElement
+
+    /** Spacer rows (aria-hidden <tr>s) with their pixel heights. */
+    const spacerHeights = () =>
+      Array.from(
+        document.querySelectorAll('tbody tr[aria-hidden="true"] td'),
+      ).map((td) => (td as HTMLElement).style.height)
+
+    it('renders only the virtual window of a large dataset, keeping the row model complete', () => {
+      // Arrange / Act
+      renderGrid({ data: BIG_DATA })
+
+      // Assert — the toolbar count (row model) sees all rows…
+      expect(screen.getByText('200 of 200')).toBeInTheDocument()
+
+      // …but the DOM holds only the window, from the top of the list
+      const names = bodyCells('name').map((c) => c.textContent)
+      expect(names).toHaveLength(WINDOW_SIZE)
+      expect(names[0]).toBe('flag-001')
+      expect(names[WINDOW_SIZE - 1]).toBe(`flag-0${WINDOW_SIZE}`)
+
+      // A single bottom spacer holds the unrendered remainder's height so
+      // scroll geometry matches the full dataset
+      expect(spacerHeights()).toEqual([
+        `${(BIG_DATA.length - WINDOW_SIZE) * ROW_ESTIMATE}px`,
+      ])
+    })
+
+    it('moves the window (and adds a top spacer) when the body viewport scrolls', () => {
+      // Arrange
+      const { container } = renderGrid({ data: BIG_DATA })
+      const viewport = bodyViewport(container)
+
+      // Act — scroll to row index 50
+      viewport.scrollTop = 50 * ROW_ESTIMATE
+      fireEvent.scroll(viewport)
+
+      // Assert — the window re-anchors around index 50 (± overscan): rows
+      // before index 40 are unmounted, replaced by a top spacer of their
+      // exact height
+      const names = bodyCells('name').map((c) => c.textContent)
+      expect(names[0]).toBe('flag-041')
+      expect(names).not.toContain('flag-001')
+      expect(spacerHeights()[0]).toBe(`${40 * ROW_ESTIMATE}px`)
+    })
+
+    it('exports ALL rows to CSV, not just the rendered window', () => {
+      // Arrange
+      mockDownloadCsv.mockClear()
+      const { container } = renderGrid({ data: BIG_DATA })
+
+      // Act
+      const exportBtn = container
+        .querySelector('[aria-label="download"]')
+        ?.closest('button') as HTMLButtonElement
+      fireEvent.click(exportBtn)
+
+      // Assert — header row + one line per data row, including unrendered ones
+      const csv = mockDownloadCsv.mock.calls[0][0] as string
+      expect(csv.split('\n')).toHaveLength(BIG_DATA.length + 1)
+      expect(csv).toContain('flag-200')
+    })
+
+    it('reports ALL displayed rows through onDisplayedRowsChange, not just the window', () => {
+      // Arrange / Act
+      const onDisplayedRowsChange = jest.fn()
+      renderGrid({ data: BIG_DATA, onDisplayedRowsChange })
+
+      // Assert
+      const last = onDisplayedRowsChange.mock.calls.at(-1)![0] as Flag[]
+      expect(last).toHaveLength(BIG_DATA.length)
+    })
+  })
+
   describe('initialSorting', () => {
     it('applies the initial sort on mount', () => {
       // Arrange / Act

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -298,47 +298,29 @@ function GridBody<T>({
     if (index >= 0) rowVirtualizer.scrollToIndex(index)
   }, [selectedRowId, rows, rowVirtualizer])
 
-  // While loading/empty, the table stretches to fill the wrapper so the
-  // single status row (and its spinner / empty message) centers vertically.
-  const showStatusRow = isLoading || rows.length === 0
+  // While loading (or with no rows) the rows are replaced by a status
+  // overlay. The overlay is a sibling of the scrolling wrapper — anchored to
+  // the VISIBLE body viewport, not the table: a wide table in a narrow window
+  // centers a spanning status <td> at half the scroll width, which can sit
+  // entirely off-screen.
+  const showStatusOverlay = isLoading || rows.length === 0
 
   return (
-    <div
-      className={styles.tableWrapper}
-      ref={bodyViewportRef}
-      onScroll={onBodyScroll}
-      // Measurement hook for jsdom tests: layoutless environments report a
-      // 0×0 rect here, which makes the row virtualizer render nothing —
-      // jest.setup.ts returns a fixed rect for this attribute instead.
-      data-grid-body-viewport=""
-    >
-      <table
-        className={`${styles.tableElement}${
-          showStatusRow ? ` ${styles.tableElementFill}` : ''
-        }`}
+    <div className={styles.bodyArea}>
+      <div
+        className={styles.tableWrapper}
+        ref={bodyViewportRef}
+        onScroll={onBodyScroll}
+        // Measurement hook for jsdom tests: layoutless environments report a
+        // 0×0 rect here, which makes the row virtualizer render nothing —
+        // jest.setup.ts returns a fixed rect for this attribute instead.
+        data-grid-body-viewport=""
       >
-        {colGroup}
-        <tbody>
-          {isLoading ? (
-            <tr>
-              {/* Centering lives on the inner div — `display: flex` directly
-                  on a <td> breaks table-cell rendering in browsers. */}
-              <td colSpan={visibleColumnCount + 1} className={styles.td}>
-                <div className={styles.loading}>
-                  <Spin size="large" />
-                </div>
-              </td>
-            </tr>
-          ) : rows.length === 0 ? (
-            <tr>
-              <td colSpan={visibleColumnCount + 1} className={styles.td}>
-                <div className={styles.empty}>
-                  <WaydEmpty message={emptyMessage} />
-                </div>
-              </td>
-            </tr>
-          ) : (
-            <>
+        <table className={styles.tableElement}>
+          {colGroup}
+          <tbody>
+            {!showStatusOverlay && (
+              <>
               {/* Virtual offset spacers: real table rows standing in for the
                   unrendered rows above/below the window. Zero padding/border
                   so they add no width — header/body scrollWidth must match. */}
@@ -445,10 +427,20 @@ function GridBody<T>({
                   />
                 </tr>
               )}
-            </>
+              </>
+            )}
+          </tbody>
+        </table>
+      </div>
+      {showStatusOverlay && (
+        <div className={styles.statusOverlay}>
+          {isLoading ? (
+            <Spin size="large" />
+          ) : (
+            <WaydEmpty message={emptyMessage} />
           )}
-        </tbody>
-      </table>
+        </div>
+      )}
     </div>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -25,6 +25,7 @@ import {
   getFacetedRowModel,
   getFacetedUniqueValues,
 } from '@tanstack/react-table'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   DndContext,
   type DragCancelEvent,
@@ -109,6 +110,16 @@ const EMPTY_NODE_SET: Set<string> = new Set<string>()
 const EMPTY_DATA: never[] = []
 const EMPTY_FIELD_ERRORS: Record<string, string> = {}
 const DRAFT_SCROLL_MARGIN = 8
+
+/** Fixed row-height estimate for the virtualizer. Rows are uniform in
+ * practice (.td: 4px padding + 1px border + one no-wrap text line), so a
+ * fixed estimate avoids per-row measurement; positions stay self-consistent
+ * because the spacer rows use the same estimates. */
+const ROW_HEIGHT_ESTIMATE = 28
+/** Rows rendered beyond the visible window on each side. Also what keeps
+ * jsdom tests rendering rows at all: with no layout the viewport measures
+ * 0px, so the virtualizer renders indexes 0..overscan. */
+const ROW_OVERSCAN = 10
 
 const NOOP_FORM = {
   validateFields: async () => ({}),
@@ -195,6 +206,251 @@ const treeRowClasses: TreeGridRowClasses = {
   trEditable: styles.trEditable,
   trSelected: styles.trSelected,
   editableCell: styles.editableCell,
+}
+
+interface GridBodyProps<T> {
+  rows: Row<T>[]
+  /** The scrolling viewport ref — owned by the grid (scrollbar-width
+   *  measurement) but attached here. */
+  bodyViewportRef: React.RefObject<HTMLDivElement | null>
+  /** Mirrors scrollLeft into the header viewport. */
+  onBodyScroll: (e: React.UIEvent<HTMLDivElement>) => void
+  /** The shared colgroup element (same instance the header table renders).
+   *  Stable across scrolls, so React skips reconciling it. */
+  colGroup: ReactNode
+  isLoading: boolean
+  emptyMessage: string
+  visibleColumnCount: number
+  isTree: boolean
+  flatDndEnabled: boolean
+  isDragEnabled: boolean
+  canEdit: boolean
+  editableColumns: string[]
+  draftPrefix: string
+  selectedRowId: string | null
+  draggedNodeId: string | null
+  fieldErrors: Record<string, string>
+  flatRowId: (row: Row<T>) => string
+  onRowClick: (e: React.MouseEvent, rowId: string) => void
+  onCellClick: (e: React.MouseEvent) => void
+}
+
+/**
+ * The scrolling body viewport, split from the grid so it alone owns the row
+ * virtualizer: every overscan-window shift re-renders whichever component
+ * holds the virtualizer, and when that was the whole grid the header's antd
+ * controls (filter popovers, floating-filter inputs) re-rendered per shift —
+ * visible as scroll stutter. Confined here, a shift re-renders only the
+ * ~viewport of body rows; the header, toolbar, and filters stay untouched.
+ */
+function GridBody<T>({
+  rows,
+  bodyViewportRef,
+  onBodyScroll,
+  colGroup,
+  isLoading,
+  emptyMessage,
+  visibleColumnCount,
+  isTree,
+  flatDndEnabled,
+  isDragEnabled,
+  canEdit,
+  editableColumns,
+  draftPrefix,
+  selectedRowId,
+  draggedNodeId,
+  fieldErrors,
+  flatRowId,
+  onRowClick,
+  onCellClick,
+}: GridBodyProps<T>) {
+  // Owns virtualizer + TanStack row JSX — same staleness hazard as the grid.
+  'use no memo'
+
+  // ─── Row virtualization ──────────────────────────────────
+  // Only the visible window of rows (plus overscan) is mounted, ag-grid
+  // style. The virtualizer windows the already-flattened row model, so tree
+  // expand/collapse flows through naturally as a count change. Offsets render
+  // as spacer rows (real <tr>s) so the body stays a genuine table — colgroup
+  // column alignment with the header table is untouched.
+  // eslint-disable-next-line react-hooks/incompatible-library -- the warning is about compiler memoization, which 'use no memo' above already opts out of
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => bodyViewportRef.current,
+    estimateSize: () => ROW_HEIGHT_ESTIMATE,
+    overscan: ROW_OVERSCAN,
+  })
+  const virtualRows = rowVirtualizer.getVirtualItems()
+  const spacerTop = virtualRows.length > 0 ? virtualRows[0].start : 0
+  const spacerBottom =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() - virtualRows[virtualRows.length - 1].end
+      : 0
+
+  // Virtualized rows unmount when scrolled out, but the editing machinery
+  // (focusCellById, keyboard nav, draft scroll-into-view) targets rendered
+  // DOM — make sure the selected row's index is mounted before they run.
+  useEffect(() => {
+    if (!selectedRowId) return
+    const index = rows.findIndex(
+      (row) => (row.original as { id?: string }).id === selectedRowId,
+    )
+    if (index >= 0) rowVirtualizer.scrollToIndex(index)
+  }, [selectedRowId, rows, rowVirtualizer])
+
+  // While loading/empty, the table stretches to fill the wrapper so the
+  // single status row (and its spinner / empty message) centers vertically.
+  const showStatusRow = isLoading || rows.length === 0
+
+  return (
+    <div
+      className={styles.tableWrapper}
+      ref={bodyViewportRef}
+      onScroll={onBodyScroll}
+      // Measurement hook for jsdom tests: layoutless environments report a
+      // 0×0 rect here, which makes the row virtualizer render nothing —
+      // jest.setup.ts returns a fixed rect for this attribute instead.
+      data-grid-body-viewport=""
+    >
+      <table
+        className={`${styles.tableElement}${
+          showStatusRow ? ` ${styles.tableElementFill}` : ''
+        }`}
+      >
+        {colGroup}
+        <tbody>
+          {isLoading ? (
+            <tr>
+              {/* Centering lives on the inner div — `display: flex` directly
+                  on a <td> breaks table-cell rendering in browsers. */}
+              <td colSpan={visibleColumnCount + 1} className={styles.td}>
+                <div className={styles.loading}>
+                  <Spin size="large" />
+                </div>
+              </td>
+            </tr>
+          ) : rows.length === 0 ? (
+            <tr>
+              <td colSpan={visibleColumnCount + 1} className={styles.td}>
+                <div className={styles.empty}>
+                  <WaydEmpty message={emptyMessage} />
+                </div>
+              </td>
+            </tr>
+          ) : (
+            <>
+              {/* Virtual offset spacers: real table rows standing in for the
+                  unrendered rows above/below the window. Zero padding/border
+                  so they add no width — header/body scrollWidth must match. */}
+              {spacerTop > 0 && (
+                <tr aria-hidden="true">
+                  <td
+                    className={styles.virtualSpacer}
+                    colSpan={visibleColumnCount + 1}
+                    style={{ height: spacerTop }}
+                  />
+                </tr>
+              )}
+              {virtualRows.map((virtualRow) => {
+                const row = rows[virtualRow.index]
+                // Zebra striping keys off the absolute display index so
+                // stripes don't shift as the window moves.
+                const index = virtualRow.index
+
+                if (isTree) {
+                  const nodeId = (row.original as { id: string }).id
+                  const isSelected = selectedRowId === nodeId
+                  const isRowDragging = draggedNodeId === nodeId
+                  const isDraftRow = nodeId.startsWith(draftPrefix)
+                  const rowElements = [
+                    <TreeGridRow
+                      key={row.id}
+                      row={row}
+                      index={index}
+                      classes={treeRowClasses}
+                      nodeId={nodeId}
+                      isSelected={isSelected}
+                      isDragging={isRowDragging}
+                      isDragEnabled={isDragEnabled && !isDraftRow}
+                      canEdit={canEdit}
+                      editableColumns={editableColumns}
+                      onRowClick={onRowClick}
+                      onCellClick={onCellClick}
+                    />,
+                  ]
+
+                  if (isSelected && Object.keys(fieldErrors).length > 0) {
+                    const errorItems = Object.entries(fieldErrors).map(
+                      ([field, error]) => (
+                        <div
+                          key={field}
+                          className={styles.validationErrorItem}
+                        >
+                          <span className={styles.validationErrorField}>
+                            {field}:
+                          </span>{' '}
+                          {error}
+                        </div>
+                      ),
+                    )
+
+                    rowElements.push(
+                      <tr
+                        key={`${row.id}-errors`}
+                        className={`${styles.tr} ${styles.validationErrorRow}`}
+                      >
+                        <td
+                          colSpan={visibleColumnCount + 1}
+                          className={`${styles.td} ${styles.validationErrorCell}`}
+                        >
+                          {errorItems}
+                        </td>
+                      </tr>,
+                    )
+                  }
+
+                  return rowElements
+                }
+
+                if (flatDndEnabled) {
+                  const nodeId = flatRowId(row)
+                  return (
+                    <SortableFlatGridRow
+                      key={row.id}
+                      row={row}
+                      index={index}
+                      classes={rowClasses}
+                      nodeId={nodeId}
+                      isDragging={draggedNodeId === nodeId}
+                      isDragEnabled={isDragEnabled}
+                    />
+                  )
+                }
+
+                return (
+                  <FlatGridRow
+                    key={row.id}
+                    row={row}
+                    index={index}
+                    classes={rowClasses}
+                  />
+                )
+              })}
+              {spacerBottom > 0 && (
+                <tr aria-hidden="true">
+                  <td
+                    className={styles.virtualSpacer}
+                    colSpan={visibleColumnCount + 1}
+                    style={{ height: spacerBottom }}
+                  />
+                </tr>
+              )}
+            </>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
 }
 
 function WaydGridInner<T>(
@@ -1012,10 +1268,6 @@ function WaydGridInner<T>(
     dndEnabled && !isLoading && !isEditing && !hasActiveFilters
 
   // ─── Render ──────────────────────────────────────────────
-  // While loading/empty, the table stretches to fill the wrapper so the
-  // single status row (and its spinner / empty message) centers vertically.
-  const showStatusRow = isLoading || rows.length === 0
-
   // TanStack returns one header group per depth; the LAST is always the leaf
   // columns, so any rows above it render as colspan bands. The band count
   // drives the sticky-offset CSS var (bands / leaf header / filter row stack).
@@ -1214,116 +1466,27 @@ function WaydGridInner<T>(
           aria-hidden="true"
         />
       </div>
-      <div
-        className={styles.tableWrapper}
-        ref={bodyViewportRef}
-        onScroll={handleBodyScroll}
-      >
-        <table
-          className={`${styles.tableElement}${
-            showStatusRow ? ` ${styles.tableElementFill}` : ''
-          }`}
-        >
-          {colGroup}
-          <tbody>
-          {isLoading ? (
-            <tr>
-              {/* Centering lives on the inner div — `display: flex` directly
-                  on a <td> breaks table-cell rendering in browsers. */}
-              <td colSpan={visibleColumnCount + 1} className={styles.td}>
-                <div className={styles.loading}>
-                  <Spin size="large" />
-                </div>
-              </td>
-            </tr>
-          ) : rows.length === 0 ? (
-            <tr>
-              <td colSpan={visibleColumnCount + 1} className={styles.td}>
-                <div className={styles.empty}>
-                  <WaydEmpty message={emptyMessage} />
-                </div>
-              </td>
-            </tr>
-          ) : isTree ? (
-            rows.flatMap((row, index) => {
-              const nodeId = (row.original as { id: string }).id
-              const isSelected = selectedRowId === nodeId
-              const isRowDragging = draggedNodeId === nodeId
-              const isDraftRow = nodeId.startsWith(draftPrefix)
-              const rowElements = [
-                <TreeGridRow
-                  key={row.id}
-                  row={row}
-                  index={index}
-                  classes={treeRowClasses}
-                  nodeId={nodeId}
-                  isSelected={isSelected}
-                  isDragging={isRowDragging}
-                  isDragEnabled={isDragEnabled && !isDraftRow}
-                  canEdit={canEdit}
-                  editableColumns={editableColumns}
-                  onRowClick={handleRowClickWithContext}
-                  onCellClick={handleCellClick}
-                />,
-              ]
-
-              if (isSelected && Object.keys(fieldErrors).length > 0) {
-                const errorItems = Object.entries(fieldErrors).map(
-                  ([field, error]) => (
-                    <div key={field} className={styles.validationErrorItem}>
-                      <span className={styles.validationErrorField}>
-                        {field}:
-                      </span>{' '}
-                      {error}
-                    </div>
-                  ),
-                )
-
-                rowElements.push(
-                  <tr
-                    key={`${row.id}-errors`}
-                    className={`${styles.tr} ${styles.validationErrorRow}`}
-                  >
-                    <td
-                      colSpan={visibleColumnCount + 1}
-                      className={`${styles.td} ${styles.validationErrorCell}`}
-                    >
-                      {errorItems}
-                    </td>
-                  </tr>,
-                )
-              }
-
-              return rowElements
-            })
-          ) : flatDndEnabled ? (
-            rows.map((row, index) => {
-              const nodeId = flatRowId(row)
-              return (
-                <SortableFlatGridRow
-                  key={row.id}
-                  row={row}
-                  index={index}
-                  classes={rowClasses}
-                  nodeId={nodeId}
-                  isDragging={draggedNodeId === nodeId}
-                  isDragEnabled={isDragEnabled}
-                />
-              )
-            })
-          ) : (
-            rows.map((row, index) => (
-              <FlatGridRow
-                key={row.id}
-                row={row}
-                index={index}
-                classes={rowClasses}
-              />
-            ))
-          )}
-          </tbody>
-        </table>
-      </div>
+      <GridBody
+        rows={rows}
+        bodyViewportRef={bodyViewportRef}
+        onBodyScroll={handleBodyScroll}
+        colGroup={colGroup}
+        isLoading={isLoading}
+        emptyMessage={emptyMessage}
+        visibleColumnCount={visibleColumnCount}
+        isTree={isTree}
+        flatDndEnabled={flatDndEnabled}
+        isDragEnabled={isDragEnabled}
+        canEdit={canEdit}
+        editableColumns={editableColumns}
+        draftPrefix={draftPrefix}
+        selectedRowId={selectedRowId}
+        draggedNodeId={draggedNodeId}
+        fieldErrors={fieldErrors}
+        flatRowId={flatRowId}
+        onRowClick={handleRowClickWithContext}
+        onCellClick={handleCellClick}
+      />
     </div>
   )
 
@@ -1384,7 +1547,8 @@ function WaydGridInner<T>(
  * and draft rows. Flat mode supports row-reorder drag-and-drop via
  * `onRowReorder`. Rows render through the row-renderer seam: the flat forms
  * ({@link FlatGridRow} / {@link SortableFlatGridRow}) or the tree form
- * ({@link TreeGridRow}).
+ * ({@link TreeGridRow}). Body rows are always virtualized (ag-grid style) —
+ * only the visible window plus overscan is mounted.
  */
 const WaydGrid = forwardRef(WaydGridInner) as <T>(
   props: WaydGridProps<T> & { ref?: Ref<WaydGridHandle> },

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -361,6 +361,13 @@ function GridBody<T>({
                     />,
                   ]
 
+                  // The error band is an extra <tr> the virtualizer doesn't
+                  // model — its height is missing from the spacer math.
+                  // Accepted: it exists only while the selected row is
+                  // mounted (active inline editing), overscan absorbs the
+                  // offset, and the estimate-derived geometry snaps back the
+                  // moment the band unmounts. If it ever visibly drifts, the
+                  // fix is per-row measureElement, not restructuring.
                   if (isSelected && Object.keys(fieldErrors).length > 0) {
                     const errorItems = Object.entries(fieldErrors).map(
                       ([field, error]) => (

--- a/Wayd.Web/src/wayd.web.reactclient/src/jest.setup.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/jest.setup.ts
@@ -306,6 +306,56 @@ if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = jest.fn()
 }
 
+// jsdom has no layout, so WaydGrid's scrolling body viewport measures 0×0 and
+// the row virtualizer would render zero rows (TanStack virtual bails on a
+// 0-height scroll rect; it reads offsetWidth/offsetHeight). Report a fixed
+// 800×600 viewport for that one element (marked data-grid-body-viewport) so
+// grids render a deterministic window: 600px ÷ 28px estimated rows = indexes
+// 0-21 visible, plus 10 overscan.
+const GRID_VIEWPORT_MARKER = 'data-grid-body-viewport'
+const GRID_VIEWPORT_WIDTH = 800
+const GRID_VIEWPORT_HEIGHT = 600
+
+const mockViewportDimension = (
+  property: 'offsetWidth' | 'offsetHeight' | 'clientWidth' | 'clientHeight',
+  value: number,
+) => {
+  const original = Object.getOwnPropertyDescriptor(
+    HTMLElement.prototype,
+    property,
+  )
+  Object.defineProperty(HTMLElement.prototype, property, {
+    configurable: true,
+    get(this: HTMLElement) {
+      if (this.hasAttribute?.(GRID_VIEWPORT_MARKER)) return value
+      return original?.get?.call(this) ?? 0
+    },
+  })
+}
+
+mockViewportDimension('offsetWidth', GRID_VIEWPORT_WIDTH)
+mockViewportDimension('offsetHeight', GRID_VIEWPORT_HEIGHT)
+mockViewportDimension('clientWidth', GRID_VIEWPORT_WIDTH)
+mockViewportDimension('clientHeight', GRID_VIEWPORT_HEIGHT)
+
+const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect
+Element.prototype.getBoundingClientRect = function (this: Element) {
+  if (this.hasAttribute?.(GRID_VIEWPORT_MARKER)) {
+    return {
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: GRID_VIEWPORT_WIDTH,
+      bottom: GRID_VIEWPORT_HEIGHT,
+      width: GRID_VIEWPORT_WIDTH,
+      height: GRID_VIEWPORT_HEIGHT,
+      toJSON: () => ({}),
+    } as DOMRect
+  }
+  return originalGetBoundingClientRect.call(this)
+}
+
 // Suppress console errors during tests
 // beforeAll(() => {
 //   console.error = jest.fn()


### PR DESCRIPTION
## Add row virtualization to WaydGrid (grid consolidation part 5)

Closes the last perf regression from the ag-grid migration: WaydGrid previously rendered every row in `table.getRowModel().rows` into the DOM, so large grids (work items: ~25k rows) mounted ~25k `<tr>`s. Rows are now virtualized with `@tanstack/react-virtual` — only the visible window plus overscan is mounted, matching ag-grid's default behavior. Virtualization is always on; no new props.

### How it works
- `useVirtualizer` windows the already-flattened/expanded row model, so flat and tree mode share one code path — tree expand/collapse flows through as a   count change and the scroll geometry shrinks/grows correctly.
- The virtualizer lives in a dedicated `GridBody` component (scroll viewport + body table + tbody), not in the grid itself: every overscan-window shift  re-renders the component that owns the virtualizer, and when that was the  whole grid, the header's antd controls (filter popovers, floating-filter  inputs) re-rendered every ~28px of scroll — visible stutter even on a  ~200-row grid. Confined to `GridBody`, a shift re-renders only the ~viewport  of rows; header, toolbar, and filters don't re-render during scrolling.
- Virtual offsets render as real spacer `<tr>`s (zero padding/border), keeping  the tbody a genuine table: the shared colgroup + `table-layout: fixed`  header/body alignment is untouched (verified 0px drift at full right scroll,  identical header/body `scrollWidth`).
- Fixed 28px row estimate (measured 27–29px in practice), 10-row overscan; no  `measureElement` needed.
- Zebra striping keys off the absolute display index so stripes don't shift as  the window moves.
- Editing/keyboard-nav/draft targets must be mounted to receive focus: the grid  now calls `scrollToIndex` on the selected row's index whenever the editing  selection changes.
- CSV export, `onDisplayedRowsChange`, and the grid handle read the row model  (not the DOM), so they still see all rows — covered by new tests.

### Loading/empty states are now viewport-centered overlays
The spinner and empty message used to render as a `<td>` spanning the fulltable, which centers at half the table's *scroll* width — on a many-column grid in a narrow window the spinner could sit entirely off-screen. They now render as an overlay anchored to the visible body viewport (ag-grid's loading/no-rows overlay model), centered both axes, with `pointer-events: none` so the scrollbar beneath stays usable. The overlay's positioning context sits outside the scroll container (absolutely-positioned children of a scroll container ride along with its scroll offset).

### Testing
- TanStack virtual reads the scroll element's `offsetWidth`/`offsetHeight` and  renders zero rows at 0 height, which jsdom always reports. The body viewport  now carries `data-grid-body-viewport`, and `jest.setup.ts` reports a fixed  800×600 viewport for that element — grids in jsdom render a deterministic  32-row window (22 visible + 10 overscan), so existing row-assertion tests run unchanged.
- New tests pin the virtualization contract: bounded DOM + exact spacer  heights for a 200-row dataset, window re-anchoring on scroll, and full-data  CSV export / displayed-rows callbacks.- Browser-verified on a 24,883-row work items grid (bounded DOM at ~40-50  rows, no blank flashes, 0px header/body drift at full right scroll,  filters/sort correct), a tree project plan (collapse/expand geometry exact),  and the WaydGridTransfer drag flow. Scroll stutter found on a ~200-row grid  during hands-on testing was fixed by the `GridBody` isolation above.
