### PR TITLE
Feature/add column menu to waydgrid

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.test.ts
@@ -1,0 +1,167 @@
+import {
+  AUTOSIZE_MAX_WIDTH,
+  AUTOSIZE_MIN_WIDTH,
+  computeAutosizeWidth,
+  measureColumnContent,
+} from './column-autosize'
+
+describe('column-autosize', () => {
+  describe('computeAutosizeWidth', () => {
+    it('falls back to the min width when nothing measured', () => {
+      // Arrange / Act
+      const width = computeAutosizeWidth({
+        maxCellContentWidth: 0,
+        headerContentWidth: 0,
+      })
+
+      // Assert
+      expect(width).toBe(AUTOSIZE_MIN_WIDTH)
+    })
+
+    it('sizes to the widest cell plus the cell allowance', () => {
+      // Arrange / Act — cell 200 + 18 beats header 50 + 76
+      const width = computeAutosizeWidth({
+        maxCellContentWidth: 200,
+        headerContentWidth: 50,
+      })
+
+      // Assert
+      expect(width).toBe(218)
+    })
+
+    it('sizes to the header plus the header allowance when it is wider', () => {
+      // Arrange / Act — header 200 + 76 beats cell 100 + 18
+      const width = computeAutosizeWidth({
+        maxCellContentWidth: 100,
+        headerContentWidth: 200,
+      })
+
+      // Assert
+      expect(width).toBe(276)
+    })
+
+    it('rounds fractional measurements up', () => {
+      // Arrange / Act
+      const width = computeAutosizeWidth({
+        maxCellContentWidth: 100.4,
+        headerContentWidth: 0,
+      })
+
+      // Assert
+      expect(width).toBe(119)
+    })
+
+    it('clamps to the default max width', () => {
+      // Arrange / Act
+      const width = computeAutosizeWidth({
+        maxCellContentWidth: 5000,
+        headerContentWidth: 0,
+      })
+
+      // Assert
+      expect(width).toBe(AUTOSIZE_MAX_WIDTH)
+    })
+
+    it('respects the column def min/max over the defaults', () => {
+      // Arrange / Act / Assert
+      expect(
+        computeAutosizeWidth({
+          maxCellContentWidth: 0,
+          headerContentWidth: 0,
+          minWidth: 120,
+        }),
+      ).toBe(120)
+      expect(
+        computeAutosizeWidth({
+          maxCellContentWidth: 5000,
+          headerContentWidth: 0,
+          maxWidth: 250,
+        }),
+      ).toBe(250)
+    })
+  })
+
+  describe('measureColumnContent', () => {
+    let headerRoot: HTMLElement
+    let bodyRoot: HTMLElement
+    let rectSpy: jest.SpyInstance
+
+    beforeEach(() => {
+      // jsdom has no layout — report a width derived from the text so the
+      // grouping/max logic is observable (10px per character).
+      rectSpy = jest
+        .spyOn(Element.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: Element) {
+          return { width: (this.textContent ?? '').length * 10 } as DOMRect
+        })
+
+      const host = document.createElement('div')
+      headerRoot = document.createElement('div')
+      headerRoot.innerHTML =
+        '<table><thead><tr>' +
+        '<th data-column-id="name"><span data-column-header-text="">Name</span></th>' +
+        '<th data-column-id="team"><span data-column-header-text="">Team</span></th>' +
+        '</tr></thead></table>'
+      bodyRoot = document.createElement('div')
+      bodyRoot.innerHTML =
+        '<table><tbody>' +
+        '<tr><td data-column-id="name">Wolverine</td><td data-column-id="team">A</td></tr>' +
+        '<tr><td data-column-id="name">Ant</td><td data-column-id="team">Falcons</td></tr>' +
+        '</tbody></table>'
+      host.append(headerRoot, bodyRoot)
+      document.body.appendChild(host)
+    })
+
+    afterEach(() => {
+      rectSpy.mockRestore()
+      document.body.innerHTML = ''
+    })
+
+    it('measures the header label and the widest rendered cell per column', () => {
+      // Arrange / Act
+      const measured = measureColumnContent(headerRoot, bodyRoot, [
+        'name',
+        'team',
+      ])
+
+      // Assert — max cell wins per column ('Wolverine' = 90, 'Falcons' = 70)
+      expect(measured.get('name')).toEqual({
+        headerContentWidth: 40,
+        maxCellContentWidth: 90,
+      })
+      expect(measured.get('team')).toEqual({
+        headerContentWidth: 40,
+        maxCellContentWidth: 70,
+      })
+    })
+
+    it('ignores columns that were not requested', () => {
+      // Arrange / Act
+      const measured = measureColumnContent(headerRoot, bodyRoot, ['name'])
+
+      // Assert
+      expect(Array.from(measured.keys())).toEqual(['name'])
+    })
+
+    it('reports zeros for a column with no rendered DOM', () => {
+      // Arrange / Act
+      const measured = measureColumnContent(headerRoot, bodyRoot, ['missing'])
+
+      // Assert
+      expect(measured.get('missing')).toEqual({
+        headerContentWidth: 0,
+        maxCellContentWidth: 0,
+      })
+    })
+
+    it('removes the off-screen measurer when done', () => {
+      // Arrange / Act
+      measureColumnContent(headerRoot, bodyRoot, ['name'])
+
+      // Assert — no stray absolutely-positioned measurement nodes left behind
+      expect(
+        bodyRoot.parentElement?.querySelectorAll(':scope > div[style]'),
+      ).toHaveLength(0)
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.ts
@@ -1,0 +1,145 @@
+/**
+ * Column autosize for the Wayd grid. TanStack has no built-in autosize, so
+ * this measures the RENDERED window only — under row virtualization that's
+ * all the DOM that exists (ag-grid measured the same way) — and the result is
+ * applied through the shared `columnSizing` state (never DOM mutation) so the
+ * colgroup shared by the header and body tables updates both.
+ *
+ * Measuring is a clone pass: each cell's children are cloned into an
+ * off-screen inline-block holder (nowrap, no width constraint), so content
+ * that the live cell clips with ellipsis — or that fills the cell with
+ * `width: 100%` flex wrappers — reports its intrinsic content width. All
+ * holders are laid out first and measured in one pass (one reflow).
+ */
+
+/** Sane clamp defaults when a column def declares no minSize/maxSize. */
+export const AUTOSIZE_MIN_WIDTH = 60
+export const AUTOSIZE_MAX_WIDTH = 600
+
+/** Horizontal box overhead around a body cell's content: td padding (7px per
+ *  side) + border + a rounding buffer so ellipsis never reappears at the
+ *  computed width. */
+export const AUTOSIZE_CELL_ALLOWANCE = 18
+
+/** Horizontal overhead around the header label: th + content padding, plus
+ *  reserved room for the sort icon and the column menu trigger (both live in
+ *  the header cell whether currently visible or not). */
+export const AUTOSIZE_HEADER_ALLOWANCE = 76
+
+export interface AutosizeWidthInput {
+  /** Widest measured content among the rendered cells, px (0 = no cells). */
+  maxCellContentWidth: number
+  /** Measured header label width, px (0 = no measurable header). */
+  headerContentWidth: number
+  cellAllowance?: number
+  headerAllowance?: number
+  /** Column def clamps; fall back to the AUTOSIZE_MIN/MAX defaults. */
+  minWidth?: number
+  maxWidth?: number
+}
+
+/**
+ * The width to apply for an autosized column: content + allowance, wide
+ * enough for both the widest cell and the header label, clamped to the
+ * column's (or the default) min/max.
+ */
+export function computeAutosizeWidth(input: AutosizeWidthInput): number {
+  const {
+    maxCellContentWidth,
+    headerContentWidth,
+    cellAllowance = AUTOSIZE_CELL_ALLOWANCE,
+    headerAllowance = AUTOSIZE_HEADER_ALLOWANCE,
+    minWidth = AUTOSIZE_MIN_WIDTH,
+    maxWidth = AUTOSIZE_MAX_WIDTH,
+  } = input
+
+  const cellWidth =
+    maxCellContentWidth > 0 ? maxCellContentWidth + cellAllowance : 0
+  const headerWidth =
+    headerContentWidth > 0 ? headerContentWidth + headerAllowance : 0
+  const measured = Math.ceil(Math.max(cellWidth, headerWidth))
+  return Math.min(Math.max(measured, minWidth), maxWidth)
+}
+
+export interface ColumnContentMeasurement {
+  headerContentWidth: number
+  maxCellContentWidth: number
+}
+
+/**
+ * Measures the rendered content width of each requested column: the header
+ * label (the `[data-column-header-text]` span inside the column's `th`) and
+ * every rendered `td[data-column-id]` body cell. Returns raw content widths —
+ * {@link computeAutosizeWidth} adds allowances and clamps.
+ *
+ * The measurer is appended inside the grid so clones inherit the grid's font
+ * and theme variables. Browser-only by nature; in layoutless environments
+ * (jsdom) every measurement is 0 and autosize falls back to the min width.
+ */
+export function measureColumnContent(
+  headerRoot: HTMLElement,
+  bodyRoot: HTMLElement,
+  columnIds: string[],
+): Map<string, ColumnContentMeasurement> {
+  const results = new Map<string, ColumnContentMeasurement>()
+  if (columnIds.length === 0) return results
+
+  const wanted = new Set(columnIds)
+  const measurer = document.createElement('div')
+  measurer.style.cssText =
+    'position:absolute;visibility:hidden;pointer-events:none;top:-10000px;left:0;white-space:nowrap;'
+
+  /** Clones an element's children into a fresh inline-block holder. */
+  const addHolder = (source: Element): HTMLElement => {
+    const holder = document.createElement('div')
+    holder.style.display = 'inline-block'
+    for (const child of Array.from(source.childNodes)) {
+      holder.appendChild(child.cloneNode(true))
+    }
+    measurer.appendChild(holder)
+    return holder
+  }
+
+  // Build every holder before reading any width — one layout pass.
+  const headerHolders = new Map<string, HTMLElement>()
+  for (const id of columnIds) {
+    const label = headerRoot.querySelector(
+      `th[data-column-id="${CSS.escape(id)}"] [data-column-header-text]`,
+    )
+    if (label) headerHolders.set(id, addHolder(label))
+  }
+
+  const cellHolders = new Map<string, HTMLElement[]>()
+  for (const cell of Array.from(
+    bodyRoot.querySelectorAll('td[data-column-id]'),
+  )) {
+    const id = cell.getAttribute('data-column-id')
+    if (!id || !wanted.has(id)) continue
+    const holders = cellHolders.get(id) ?? []
+    holders.push(addHolder(cell))
+    cellHolders.set(id, holders)
+  }
+
+  // Attach next to the body viewport (not inside it — extra content in the
+  // scroll container would perturb its scrollWidth while attached).
+  const host = bodyRoot.parentElement ?? bodyRoot
+  host.appendChild(measurer)
+  try {
+    for (const id of columnIds) {
+      const headerContentWidth =
+        headerHolders.get(id)?.getBoundingClientRect().width ?? 0
+      let maxCellContentWidth = 0
+      for (const holder of cellHolders.get(id) ?? []) {
+        maxCellContentWidth = Math.max(
+          maxCellContentWidth,
+          holder.getBoundingClientRect().width,
+        )
+      }
+      results.set(id, { headerContentWidth, maxCellContentWidth })
+    }
+  } finally {
+    measurer.remove()
+  }
+
+  return results
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.module.css
@@ -1,0 +1,83 @@
+/*
+ * Column menu (⋮) trigger, ag-grid style: sits at the right end of the header
+ * cell content, hidden until the header is hovered, the trigger is keyboard-
+ * focused, or its menu is open. Opacity (not display) so the header layout
+ * never shifts when it appears.
+ */
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  /* Far right of the header cell (the header content row is a full-width
+     flex container); the label and sort/filter icons stay left. */
+  margin-left: auto;
+  cursor: pointer;
+  color: var(--ant-color-text-quaternary);
+  font-size: 12px;
+  flex-shrink: 0;
+  padding: 2px;
+  border: 0;
+  background: none;
+  border-radius: var(--ant-border-radius-sm);
+  opacity: 0;
+  transition:
+    color 0.2s,
+    opacity 0.2s;
+}
+
+/* th:hover is an element selector, so it reaches across CSS modules to the
+   owning grid's header cell. */
+th:hover .trigger,
+.trigger:focus-visible,
+.triggerOpen {
+  opacity: 1;
+}
+
+.trigger:hover {
+  color: var(--ant-color-text-secondary);
+  background-color: var(--ant-color-fill-secondary);
+}
+
+/* ─── Choose Columns modal ── */
+
+.chooserPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ant-margin-xs);
+}
+
+/* A long grid has dozens of leaf columns — scroll inside the modal. */
+.chooserList {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.chooserRow {
+  display: flex;
+  align-items: center;
+  gap: var(--ant-margin-xs);
+  padding: 2px var(--ant-padding-xxs);
+  cursor: pointer;
+  border-radius: var(--ant-border-radius-sm);
+}
+
+.chooserRow:hover {
+  background-color: var(--ant-color-fill-tertiary);
+}
+
+.chooserLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+.chooserEmpty {
+  padding: var(--ant-padding-xs);
+  color: var(--ant-color-text-tertiary);
+  font-size: var(--ant-font-size-sm);
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.test.tsx
@@ -1,0 +1,318 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import {
+  createTable,
+  getCoreRowModel,
+  type ColumnDef,
+  type TableState,
+  type VisibilityState,
+} from '@tanstack/react-table'
+
+import {
+  COLUMN_MENU_KEYS,
+  ColumnChooserModal,
+  buildColumnMenuItems,
+  getColumnChooserOptions,
+  type ColumnMenuItemsInput,
+} from './column-menu'
+
+type Item = { name: string; team: string; secret: string; flagged: string }
+
+const data: Item[] = [
+  { name: 'Widget', team: 'Falcons', secret: 'x', flagged: 'y' },
+]
+
+const buildChooserTable = (
+  columns: ColumnDef<Item, any>[],
+  columnVisibility: VisibilityState = {},
+) => {
+  const state: Partial<TableState> = {
+    columnVisibility,
+    columnPinning: { left: [], right: [] },
+    columnSizing: {},
+  }
+  return createTable<Item>({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: state as TableState,
+    onStateChange: () => {},
+    renderFallbackValue: null,
+  })
+}
+
+/** Flattened keys of a built items array (submenu children inlined). */
+const itemKeys = (items: ReturnType<typeof buildColumnMenuItems>): string[] =>
+  (items ?? []).flatMap((item) => {
+    if (!item || !('key' in item) || item.key == null) return []
+    const children =
+      'children' in item && Array.isArray(item.children)
+        ? itemKeys(item.children as ReturnType<typeof buildColumnMenuItems>)
+        : []
+    return [String(item.key), ...children]
+  })
+
+const baseInput: ColumnMenuItemsInput = {
+  canSort: true,
+  sortState: false,
+  canPin: true,
+  pinnedState: false,
+  canResize: true,
+  hasHidableColumns: true,
+}
+
+describe('column-menu', () => {
+  describe('getColumnChooserOptions', () => {
+    it('lists hidable leaf columns with their visibility', () => {
+      // Arrange
+      const table = buildChooserTable(
+        [
+          { id: 'name', accessorKey: 'name', header: 'Name' },
+          { id: 'team', accessorKey: 'team', header: 'Team' },
+        ],
+        { team: false },
+      )
+
+      // Act
+      const options = getColumnChooserOptions(table)
+
+      // Assert
+      expect(options).toEqual([
+        { id: 'name', label: 'Name', visible: true },
+        { id: 'team', label: 'Team', visible: false },
+      ])
+    })
+
+    it('excludes consumer-hidden (meta.hide), unhidable, and unlabeled columns', () => {
+      // Arrange — meta.hide=true is consumer-controlled; enableHiding=false is
+      // locked; an empty header with no exportHeader (actions-style) has no
+      // displayable label
+      const table = buildChooserTable([
+        { id: 'name', accessorKey: 'name', header: 'Name' },
+        {
+          id: 'secret',
+          accessorKey: 'secret',
+          header: 'Secret',
+          meta: { hide: true },
+        },
+        {
+          id: 'flagged',
+          accessorKey: 'flagged',
+          header: 'Flagged',
+          enableHiding: false,
+        },
+        { id: 'actions', header: '' },
+      ])
+
+      // Act
+      const options = getColumnChooserOptions(table)
+
+      // Assert
+      expect(options.map((o) => o.id)).toEqual(['name'])
+    })
+
+    it('falls back to meta.exportHeader when the header is not a string', () => {
+      // Arrange
+      const table = buildChooserTable([
+        {
+          id: 'name',
+          accessorKey: 'name',
+          header: () => null,
+          meta: { exportHeader: 'Name (export)' },
+        },
+      ])
+
+      // Act
+      const options = getColumnChooserOptions(table)
+
+      // Assert
+      expect(options).toEqual([
+        { id: 'name', label: 'Name (export)', visible: true },
+      ])
+    })
+
+    it('resolves visibility through grouped column defs', () => {
+      // Arrange
+      const table = buildChooserTable([
+        {
+          id: 'group',
+          header: 'Group',
+          columns: [
+            { id: 'name', accessorKey: 'name', header: 'Name' },
+            { id: 'team', accessorKey: 'team', header: 'Team' },
+          ],
+        },
+      ])
+
+      // Act
+      const options = getColumnChooserOptions(table)
+
+      // Assert — leaves only, no band entry
+      expect(options.map((o) => o.id)).toEqual(['name', 'team'])
+    })
+  })
+
+  describe('buildColumnMenuItems', () => {
+    it('builds the full menu for a sortable, pinnable, resizable column', () => {
+      // Arrange / Act
+      const keys = itemKeys(buildColumnMenuItems(baseInput))
+
+      // Assert
+      expect(keys).toEqual([
+        COLUMN_MENU_KEYS.sortAsc,
+        COLUMN_MENU_KEYS.sortDesc,
+        COLUMN_MENU_KEYS.pin,
+        COLUMN_MENU_KEYS.pinLeft,
+        COLUMN_MENU_KEYS.pinRight,
+        COLUMN_MENU_KEYS.pinNone,
+        COLUMN_MENU_KEYS.autosizeThis,
+        COLUMN_MENU_KEYS.autosizeAll,
+        COLUMN_MENU_KEYS.chooseColumns,
+        COLUMN_MENU_KEYS.reset,
+      ])
+    })
+
+    it('adds Clear Sort only while the column is sorted', () => {
+      // Arrange / Act
+      const unsorted = itemKeys(buildColumnMenuItems(baseInput))
+      const sorted = itemKeys(
+        buildColumnMenuItems({ ...baseInput, sortState: 'asc' }),
+      )
+
+      // Assert
+      expect(unsorted).not.toContain(COLUMN_MENU_KEYS.sortClear)
+      expect(sorted).toContain(COLUMN_MENU_KEYS.sortClear)
+    })
+
+    it('omits sections a column does not support', () => {
+      // Arrange / Act — e.g. the actions column: no sort, no pin, no resize
+      const keys = itemKeys(
+        buildColumnMenuItems({
+          ...baseInput,
+          canSort: false,
+          canPin: false,
+          canResize: false,
+          hasHidableColumns: false,
+        }),
+      )
+
+      // Assert — Autosize All and Reset remain grid-level actions
+      expect(keys).toEqual([
+        COLUMN_MENU_KEYS.autosizeAll,
+        COLUMN_MENU_KEYS.reset,
+      ])
+    })
+
+    it('marks the active pin option with a check icon', () => {
+      // Arrange / Act
+      const items = buildColumnMenuItems({
+        ...baseInput,
+        pinnedState: 'left',
+      })
+      const pin = (items ?? []).find(
+        (item) => item && 'key' in item && item.key === COLUMN_MENU_KEYS.pin,
+      ) as { children: { key: string; icon?: unknown }[] }
+
+      // Assert — only Pin Left carries the check
+      const iconsByKey = Object.fromEntries(
+        pin.children.map((child) => [child.key, child.icon !== undefined]),
+      )
+      expect(iconsByKey).toEqual({
+        [COLUMN_MENU_KEYS.pinLeft]: true,
+        [COLUMN_MENU_KEYS.pinRight]: false,
+        [COLUMN_MENU_KEYS.pinNone]: false,
+      })
+    })
+
+  })
+
+  describe('ColumnChooserModal', () => {
+    const chooserColumns: ColumnDef<Item, any>[] = [
+      { id: 'name', accessorKey: 'name', header: 'Name' },
+      { id: 'team', accessorKey: 'team', header: 'Team' },
+      { id: 'flagged', accessorKey: 'flagged', header: 'Flagged' },
+    ]
+
+    const renderModal = (
+      columnVisibility: VisibilityState = {},
+      onToggleColumn: jest.Mock = jest.fn(),
+      onClose: jest.Mock = jest.fn(),
+    ) => {
+      const table = buildChooserTable(chooserColumns, columnVisibility)
+      render(
+        <ColumnChooserModal
+          table={table}
+          open
+          onClose={onClose}
+          onToggleColumn={onToggleColumn}
+        />,
+      )
+      return { onToggleColumn, onClose }
+    }
+
+    /** The checkbox input inside the row labeled `label`. */
+    const checkboxFor = (label: string) =>
+      screen
+        .getByText(label)
+        .closest('label')!
+        .querySelector('input[type="checkbox"]') as HTMLInputElement
+
+    it('lists every hidable column with its current visibility', () => {
+      // Arrange / Act
+      renderModal({ team: false })
+
+      // Assert
+      expect(checkboxFor('Name').checked).toBe(true)
+      expect(checkboxFor('Team').checked).toBe(false)
+      expect(checkboxFor('Flagged').checked).toBe(true)
+    })
+
+    it('toggles apply per column without closing the modal', () => {
+      // Arrange
+      const { onToggleColumn, onClose } = renderModal({ team: false })
+
+      // Act — hide one column, show another (multiple changes in one visit)
+      fireEvent.click(checkboxFor('Flagged'))
+      fireEvent.click(checkboxFor('Team'))
+
+      // Assert
+      expect(onToggleColumn).toHaveBeenNthCalledWith(1, 'flagged', false)
+      expect(onToggleColumn).toHaveBeenNthCalledWith(2, 'team', true)
+      expect(onClose).not.toHaveBeenCalled()
+    })
+
+    it('locks the last visible column on', () => {
+      // Arrange / Act — only Name still visible
+      const { onToggleColumn } = renderModal({ team: false, flagged: false })
+
+      // Assert — its checkbox is disabled and clicking does nothing
+      expect(checkboxFor('Name').disabled).toBe(true)
+      fireEvent.click(checkboxFor('Name'))
+      expect(onToggleColumn).not.toHaveBeenCalled()
+    })
+
+    it('filters the list by search', () => {
+      // Arrange
+      renderModal()
+
+      // Act
+      fireEvent.change(screen.getByPlaceholderText('Search columns...'), {
+        target: { value: 'tea' },
+      })
+
+      // Assert
+      expect(screen.getByText('Team')).toBeInTheDocument()
+      expect(screen.queryByText('Flagged')).not.toBeInTheDocument()
+    })
+
+    it('closes via the Done button', () => {
+      // Arrange
+      const { onClose } = renderModal()
+
+      // Act
+      fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+
+      // Assert
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.tsx
@@ -1,0 +1,380 @@
+'use client'
+
+import { useState } from 'react'
+import { Button, Checkbox, Dropdown, Input, Modal } from 'antd'
+import type { MenuProps } from 'antd'
+import {
+  CheckOutlined,
+  MoreOutlined,
+  PushpinOutlined,
+  ReloadOutlined,
+  SearchOutlined,
+  SortAscendingOutlined,
+  SortDescendingOutlined,
+  ColumnWidthOutlined,
+  ControlOutlined,
+} from '@ant-design/icons'
+import type { ColumnPinningPosition, Header, Table } from '@tanstack/react-table'
+
+import styles from './column-menu.module.css'
+
+/** A leaf column offered in the Choose Columns panel. */
+export interface ColumnChooserOption {
+  id: string
+  label: string
+  visible: boolean
+}
+
+/** Chooser label: string header → meta.exportHeader → none (excluded). */
+const resolveChooserLabel = (columnDef: {
+  header?: unknown
+  meta?: { exportHeader?: string }
+}): string | undefined => {
+  if (typeof columnDef.header === 'string' && columnDef.header.trim() !== '') {
+    return columnDef.header
+  }
+  return columnDef.meta?.exportHeader
+}
+
+/**
+ * The leaf columns the user may show/hide, in column-def order. Excludes
+ * consumer-controlled columns (`meta.hide === true` — those stay reactive to
+ * the consumer's flag), columns with hiding disabled, and structural columns
+ * with no displayable label (e.g. the row-actions column).
+ */
+export function getColumnChooserOptions<T>(
+  table: Table<T>,
+): ColumnChooserOption[] {
+  const options: ColumnChooserOption[] = []
+  for (const column of table.getAllLeafColumns()) {
+    if (column.columnDef.meta?.hide === true) continue
+    if (!column.getCanHide()) continue
+    const label = resolveChooserLabel(column.columnDef)
+    if (!label) continue
+    options.push({ id: column.id, label, visible: column.getIsVisible() })
+  }
+  return options
+}
+
+/** Everything {@link buildColumnMenuItems} needs, as plain values so the
+ *  item-building logic is unit-testable without a table instance. */
+export interface ColumnMenuItemsInput {
+  canSort: boolean
+  sortState: false | 'asc' | 'desc'
+  canPin: boolean
+  pinnedState: ColumnPinningPosition
+  canResize: boolean
+  /** Whether the grid has any user-hidable columns (shows Choose Columns). */
+  hasHidableColumns: boolean
+}
+
+/** Menu item keys (also the switch keys in the click handler). */
+export const COLUMN_MENU_KEYS = {
+  sortAsc: 'sort-asc',
+  sortDesc: 'sort-desc',
+  sortClear: 'sort-clear',
+  pin: 'pin',
+  pinLeft: 'pin-left',
+  pinRight: 'pin-right',
+  pinNone: 'pin-none',
+  autosizeThis: 'autosize-this',
+  autosizeAll: 'autosize-all',
+  chooseColumns: 'choose-columns',
+  reset: 'reset-columns',
+} as const
+
+/**
+ * Builds the antd menu items for one column's header menu: set-sort items
+ * (with Clear Sort while this column is sorted), the Pin Column submenu, the
+ * autosize pair, Choose Columns (opens the {@link ColumnChooserModal}), and
+ * Reset Columns.
+ */
+export function buildColumnMenuItems(
+  input: ColumnMenuItemsInput,
+): MenuProps['items'] {
+  const {
+    canSort,
+    sortState,
+    canPin,
+    pinnedState,
+    canResize,
+    hasHidableColumns,
+  } = input
+
+  const items: NonNullable<MenuProps['items']> = []
+
+  if (canSort) {
+    items.push(
+      {
+        key: COLUMN_MENU_KEYS.sortAsc,
+        label: 'Sort Ascending',
+        icon: <SortAscendingOutlined />,
+      },
+      {
+        key: COLUMN_MENU_KEYS.sortDesc,
+        label: 'Sort Descending',
+        icon: <SortDescendingOutlined />,
+      },
+    )
+    if (sortState) {
+      items.push({ key: COLUMN_MENU_KEYS.sortClear, label: 'Clear Sort' })
+    }
+    items.push({ type: 'divider' })
+  }
+
+  if (canPin) {
+    const pinCheck = (position: ColumnPinningPosition) =>
+      pinnedState === position ? <CheckOutlined /> : undefined
+    items.push(
+      {
+        key: COLUMN_MENU_KEYS.pin,
+        label: 'Pin Column',
+        icon: <PushpinOutlined />,
+        children: [
+          {
+            key: COLUMN_MENU_KEYS.pinLeft,
+            label: 'Pin Left',
+            icon: pinCheck('left'),
+          },
+          {
+            key: COLUMN_MENU_KEYS.pinRight,
+            label: 'Pin Right',
+            icon: pinCheck('right'),
+          },
+          {
+            key: COLUMN_MENU_KEYS.pinNone,
+            label: 'No Pin',
+            icon: pinCheck(false),
+          },
+        ],
+      },
+      { type: 'divider' },
+    )
+  }
+
+  if (canResize) {
+    items.push({
+      key: COLUMN_MENU_KEYS.autosizeThis,
+      label: 'Autosize This Column',
+      icon: <ColumnWidthOutlined />,
+    })
+  }
+  items.push(
+    { key: COLUMN_MENU_KEYS.autosizeAll, label: 'Autosize All Columns' },
+    { type: 'divider' },
+  )
+
+  if (hasHidableColumns) {
+    items.push({
+      key: COLUMN_MENU_KEYS.chooseColumns,
+      label: 'Choose Columns',
+      icon: <ControlOutlined />,
+    })
+  }
+
+  items.push({
+    key: COLUMN_MENU_KEYS.reset,
+    label: 'Reset Columns',
+    icon: <ReloadOutlined />,
+  })
+
+  return items
+}
+
+export interface ColumnMenuTriggerProps<T> {
+  header: Header<T, unknown>
+  table: Table<T>
+  /** Controlled open state — the grid owns one open-menu column id (same
+   *  pattern as the filter popovers) so the trigger's DOM stays stable. */
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  /** Opens the grid's {@link ColumnChooserModal}. */
+  onOpenColumnChooser: () => void
+  onAutosizeColumn: (columnId: string) => void
+  onAutosizeAllColumns: () => void
+  onResetColumns: () => void
+}
+
+/**
+ * The `⋮` column-menu trigger + dropdown for one leaf header cell. Rendered
+ * into {@link GridHeaderCell}'s menu slot; visible on header hover, focus,
+ * and while open. Sort items SET the sort (single column) — multi-sort stays
+ * ctrl/meta-click on the header.
+ *
+ * Reads TanStack column state (sort/pin/visibility) from a mutable instance —
+ * the same staleness hazard as the grid — hence `'use no memo'`.
+ */
+export function ColumnMenuTrigger<T>({
+  header,
+  table,
+  open,
+  onOpenChange,
+  onOpenColumnChooser,
+  onAutosizeColumn,
+  onAutosizeAllColumns,
+  onResetColumns,
+}: ColumnMenuTriggerProps<T>) {
+  // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see GridHeaderCell
+  'use no memo'
+  const column = header.column
+
+  const items = buildColumnMenuItems({
+    canSort: column.getCanSort(),
+    sortState: column.getIsSorted(),
+    canPin: column.getCanPin(),
+    pinnedState: column.getIsPinned(),
+    canResize: column.getCanResize(),
+    hasHidableColumns: getColumnChooserOptions(table).length > 0,
+  })
+
+  const handleMenuClick: MenuProps['onClick'] = ({ key, domEvent }) => {
+    // The menu portals to document.body, but React events still bubble to the
+    // logical parent <th> — never let a menu click toggle the sort.
+    domEvent.stopPropagation()
+
+    switch (key) {
+      case COLUMN_MENU_KEYS.sortAsc:
+        table.setSorting([{ id: column.id, desc: false }])
+        break
+      case COLUMN_MENU_KEYS.sortDesc:
+        table.setSorting([{ id: column.id, desc: true }])
+        break
+      case COLUMN_MENU_KEYS.sortClear:
+        table.setSorting((prev) => prev.filter((s) => s.id !== column.id))
+        break
+      case COLUMN_MENU_KEYS.pinLeft:
+        column.pin('left')
+        break
+      case COLUMN_MENU_KEYS.pinRight:
+        column.pin('right')
+        break
+      case COLUMN_MENU_KEYS.pinNone:
+        column.pin(false)
+        break
+      case COLUMN_MENU_KEYS.autosizeThis:
+        onAutosizeColumn(column.id)
+        break
+      case COLUMN_MENU_KEYS.autosizeAll:
+        onAutosizeAllColumns()
+        break
+      case COLUMN_MENU_KEYS.chooseColumns:
+        onOpenColumnChooser()
+        break
+      case COLUMN_MENU_KEYS.reset:
+        onResetColumns()
+        break
+      default:
+        return
+    }
+    onOpenChange(false)
+  }
+
+  return (
+    <Dropdown
+      trigger={['click']}
+      open={open}
+      // Menu-sourced close requests fire on EVERY item click; closing is
+      // decided in handleMenuClick instead (chooser toggles keep it open).
+      onOpenChange={(nextOpen, info) => {
+        if (info.source === 'menu') return
+        onOpenChange(nextOpen)
+      }}
+      menu={{ items, onClick: handleMenuClick }}
+      getPopupContainer={() => document.body}
+      // Stop popup clicks from bubbling (through the portal) to the <th>
+      // sort handler — same guard as the filter popovers.
+      popupRender={(menu) => (
+        <div onClick={(e) => e.stopPropagation()}>{menu}</div>
+      )}
+      placement="bottomRight"
+    >
+      <button
+        type="button"
+        aria-label="Column menu"
+        className={`${styles.trigger}${open ? ` ${styles.triggerOpen}` : ''}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <MoreOutlined />
+      </button>
+    </Dropdown>
+  )
+}
+
+export interface ColumnChooserModalProps<T> {
+  table: Table<T>
+  open: boolean
+  onClose: () => void
+  /** Writes the USER visibility layer for one column. */
+  onToggleColumn: (columnId: string, visible: boolean) => void
+}
+
+/**
+ * The Choose Columns modal (opened from any column menu): a searchable
+ * checkbox per user-hidable leaf column. Toggles apply to the grid
+ * immediately — the modal stays open so multiple columns can be shown/hidden
+ * in one visit; Done just closes it.
+ *
+ * Reads live column visibility from the mutable TanStack instance — hence
+ * `'use no memo'`.
+ */
+export function ColumnChooserModal<T>({
+  table,
+  open,
+  onClose,
+  onToggleColumn,
+}: ColumnChooserModalProps<T>) {
+  // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see GridHeaderCell
+  'use no memo'
+  const [search, setSearch] = useState('')
+
+  const options = getColumnChooserOptions(table)
+  const visibleCount = options.filter((col) => col.visible).length
+  const query = search.trim().toLowerCase()
+  const shownOptions = query
+    ? options.filter((col) => col.label.toLowerCase().includes(query))
+    : options
+
+  return (
+    <Modal
+      title="Choose Columns"
+      open={open}
+      onCancel={onClose}
+      afterClose={() => setSearch('')}
+      width={380}
+      footer={
+        <Button type="primary" onClick={onClose}>
+          Done
+        </Button>
+      }
+    >
+      <div className={styles.chooserPanel}>
+        <Input
+          size="small"
+          allowClear
+          placeholder="Search columns..."
+          prefix={<SearchOutlined />}
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <div className={styles.chooserList}>
+          {shownOptions.map((col) => (
+            <label key={col.id} className={styles.chooserRow}>
+              <Checkbox
+                checked={col.visible}
+                // Keep the last visible column locked on — hiding every
+                // column would leave an empty table with no header to
+                // reopen the chooser from.
+                disabled={col.visible && visibleCount === 1}
+                onChange={(e) => onToggleColumn(col.id, e.target.checked)}
+              />
+              <span className={styles.chooserLabel}>{col.label}</span>
+            </label>
+          ))}
+          {shownOptions.length === 0 && (
+            <div className={styles.chooserEmpty}>No matches</div>
+          )}
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.tsx
@@ -188,6 +188,10 @@ export interface ColumnMenuTriggerProps<T> {
    *  pattern as the filter popovers) so the trigger's DOM stays stable. */
   open: boolean
   onOpenChange: (open: boolean) => void
+  /** Whether the grid has any user-hidable columns — computed ONCE at the
+   *  grid level and shared by every trigger (deriving it here would rescan
+   *  all leaf columns per header cell, O(N²) across a header render). */
+  hasHidableColumns: boolean
   /** Opens the grid's {@link ColumnChooserModal}. */
   onOpenColumnChooser: () => void
   onAutosizeColumn: (columnId: string) => void
@@ -209,6 +213,7 @@ export function ColumnMenuTrigger<T>({
   table,
   open,
   onOpenChange,
+  hasHidableColumns,
   onOpenColumnChooser,
   onAutosizeColumn,
   onAutosizeAllColumns,
@@ -224,7 +229,7 @@ export function ColumnMenuTrigger<T>({
     canPin: column.getCanPin(),
     pinnedState: column.getIsPinned(),
     canResize: column.getCanResize(),
-    hasHidableColumns: getColumnChooserOptions(table).length > 0,
+    hasHidableColumns,
   })
 
   const handleMenuClick: MenuProps['onClick'] = ({ key, domEvent }) => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-pinning.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-pinning.test.ts
@@ -1,0 +1,223 @@
+import {
+  createTable,
+  getCoreRowModel,
+  type ColumnDef,
+  type ColumnPinningState,
+  type TableState,
+} from '@tanstack/react-table'
+
+import {
+  getPinnedBandOffsets,
+  getPinnedOffsets,
+  pinnedCellClassNames,
+  pinnedCellStyle,
+  type PinnedCellClasses,
+} from './column-pinning'
+
+type Item = { a: string; b: string; c: string; d: string }
+
+const data: Item[] = [{ a: '1', b: '2', c: '3', d: '4' }]
+
+const leafColumns: ColumnDef<Item, any>[] = [
+  { id: 'a', accessorKey: 'a', header: 'A', size: 100 },
+  { id: 'b', accessorKey: 'b', header: 'B', size: 200 },
+  { id: 'c', accessorKey: 'c', header: 'C', size: 50 },
+  { id: 'd', accessorKey: 'd', header: 'D', size: 80 },
+]
+
+/** Headless table with the given pinning state (sizes from the defs). */
+const buildTable = (
+  columnPinning: ColumnPinningState,
+  columns: ColumnDef<Item, any>[] = leafColumns,
+) =>
+  createTable<Item>({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    state: {
+      columnPinning,
+      columnSizing: {},
+      columnVisibility: {},
+    } as TableState,
+    onStateChange: () => {},
+    renderFallbackValue: null,
+  })
+
+const classes: PinnedCellClasses = {
+  pinned: 'pinned',
+  pinnedLeftEdge: 'left-edge',
+  pinnedRightEdge: 'right-edge',
+}
+
+describe('column-pinning', () => {
+  describe('getPinnedOffsets', () => {
+    it('returns undefined for an unpinned column', () => {
+      // Arrange
+      const table = buildTable({ left: [], right: [] })
+
+      // Act
+      const offsets = getPinnedOffsets(table.getColumn('a')!)
+
+      // Assert
+      expect(offsets).toBeUndefined()
+    })
+
+    it('offsets left-pinned columns by the preceding pinned widths', () => {
+      // Arrange — b (200) then c (50) pinned left
+      const table = buildTable({ left: ['b', 'c'], right: [] })
+
+      // Act
+      const first = getPinnedOffsets(table.getColumn('b')!)
+      const second = getPinnedOffsets(table.getColumn('c')!)
+
+      // Assert
+      expect(first).toEqual({ side: 'left', offset: 0, isEdge: false })
+      expect(second).toEqual({ side: 'left', offset: 200, isEdge: true })
+    })
+
+    it('offsets right-pinned columns by the following pinned widths', () => {
+      // Arrange — a (100) then d (80) pinned right; d renders last
+      const table = buildTable({ left: [], right: ['a', 'd'] })
+
+      // Act
+      const first = getPinnedOffsets(table.getColumn('a')!)
+      const last = getPinnedOffsets(table.getColumn('d')!)
+
+      // Assert — a is the FIRST right-pinned column (the edge), offset by d
+      expect(first).toEqual({ side: 'right', offset: 80, isEdge: true })
+      expect(last).toEqual({ side: 'right', offset: 0, isEdge: false })
+    })
+
+    it('orders left → center → right sections for the shared colgroup', () => {
+      // Arrange — the grid builds its colgroup from the three pin-section
+      // methods because getHeaderGroups/getVisibleCells render that order
+      // while plain getVisibleLeafColumns stays in def order
+      const table = buildTable({ left: ['c'], right: ['a'] })
+
+      // Act
+      const order = [
+        ...table.getLeftVisibleLeafColumns(),
+        ...table.getCenterVisibleLeafColumns(),
+        ...table.getRightVisibleLeafColumns(),
+      ].map((col) => col.id)
+
+      // Assert
+      expect(order).toEqual(['c', 'b', 'd', 'a'])
+      // Def order — reordering here would silently fix the colgroup, so pin
+      // sections must stay explicit.
+      expect(table.getVisibleLeafColumns().map((col) => col.id)).toEqual([
+        'a',
+        'b',
+        'c',
+        'd',
+      ])
+    })
+  })
+
+  describe('getPinnedBandOffsets', () => {
+    const groupedColumns: ColumnDef<Item, any>[] = [
+      {
+        id: 'group',
+        header: 'Group',
+        columns: [
+          { id: 'a', accessorKey: 'a', header: 'A', size: 100 },
+          { id: 'b', accessorKey: 'b', header: 'B', size: 200 },
+        ],
+      },
+      { id: 'c', accessorKey: 'c', header: 'C', size: 50 },
+      { id: 'd', accessorKey: 'd', header: 'D', size: 80 },
+    ]
+
+    /** The band-row headers (all rows above the leaf row). */
+    const bandHeaders = (columnPinning: ColumnPinningState) => {
+      const table = buildTable(columnPinning, groupedColumns)
+      const groups = table.getHeaderGroups()
+      return groups.slice(0, -1).flatMap((group) => group.headers)
+    }
+
+    it('returns undefined for a band over unpinned leaves', () => {
+      // Arrange
+      const headers = bandHeaders({ left: [], right: [] })
+      const band = headers.find((h) => h.column.id === 'group')!
+
+      // Act / Assert
+      expect(getPinnedBandOffsets(band)).toBeUndefined()
+    })
+
+    it('sticks a band over left-pinned leaves at the first leaf offset', () => {
+      // Arrange — whole group pinned left
+      const headers = bandHeaders({ left: ['a', 'b'], right: [] })
+      const band = headers.find(
+        (h) => h.column.id === 'group' && !h.isPlaceholder,
+      )!
+
+      // Act
+      const offsets = getPinnedBandOffsets(band)
+
+      // Assert — spans both leaves, contains the pinned edge (b)
+      expect(offsets).toEqual({ side: 'left', offset: 0, isEdge: true })
+    })
+
+    it('splits a band whose leaves are torn apart by pinning', () => {
+      // Arrange — pinning a and c reorders leaves to [a, c, b, d]: the group
+      // band renders once over a (pinned) and once over b (center)
+      const headers = bandHeaders({ left: ['a', 'c'], right: [] })
+      const groupBands = headers.filter((h) => h.column.id === 'group')
+
+      // Act
+      const offsets = groupBands.map((h) => getPinnedBandOffsets(h))
+
+      // Assert — one pinned section cell (a is not the pinned edge — c is),
+      // one unpinned
+      expect(groupBands).toHaveLength(2)
+      expect(offsets).toContainEqual({
+        side: 'left',
+        offset: 0,
+        isEdge: false,
+      })
+      expect(offsets).toContain(undefined)
+    })
+
+    it('renders a band unpinned while its leaves stay adjacent but mixed', () => {
+      // Arrange — pinning only b reorders leaves to [b, a, ...] but the pair
+      // stays adjacent, so TanStack emits ONE band over a mixed
+      // pinned/unpinned run; the band scrolls (documented limitation) while
+      // leaf b still sticks
+      const headers = bandHeaders({ left: ['b'], right: [] })
+      const groupBands = headers.filter((h) => h.column.id === 'group')
+
+      // Act / Assert
+      expect(groupBands).toHaveLength(1)
+      expect(getPinnedBandOffsets(groupBands[0])).toBeUndefined()
+    })
+  })
+
+  describe('pinnedCellStyle', () => {
+    it('maps the side to the matching inset', () => {
+      // Arrange / Act / Assert
+      expect(
+        pinnedCellStyle({ side: 'left', offset: 120, isEdge: false }),
+      ).toEqual({ left: 120 })
+      expect(
+        pinnedCellStyle({ side: 'right', offset: 40, isEdge: true }),
+      ).toEqual({ right: 40 })
+      expect(pinnedCellStyle(undefined)).toBeUndefined()
+    })
+  })
+
+  describe('pinnedCellClassNames', () => {
+    it('adds the edge class only on the section edge', () => {
+      // Arrange / Act / Assert
+      expect(
+        pinnedCellClassNames({ side: 'left', offset: 0, isEdge: false }, classes),
+      ).toBe('pinned')
+      expect(
+        pinnedCellClassNames({ side: 'left', offset: 0, isEdge: true }, classes),
+      ).toBe('pinned left-edge')
+      expect(
+        pinnedCellClassNames({ side: 'right', offset: 0, isEdge: true }, classes),
+      ).toBe('pinned right-edge')
+      expect(pinnedCellClassNames(undefined, classes)).toBe('')
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-pinning.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-pinning.ts
@@ -1,0 +1,104 @@
+import type { CSSProperties } from 'react'
+import type { Column, Header } from '@tanstack/react-table'
+
+/**
+ * Sticky-rendering facts for a pinned column's cells, derived from TanStack's
+ * columnPinning state. TanStack owns the state model (and reorders pinned
+ * columns to the table edges in getVisibleLeafColumns / getVisibleCells /
+ * getHeaderGroups); the grid renders the stick itself: `position: sticky`
+ * with these offsets on the pinned `th`s and `td`s in BOTH tables.
+ */
+export interface PinnedColumnOffsets {
+  side: 'left' | 'right'
+  /** Sticky inset in px — `left` for left-pinned, `right` for right-pinned:
+   *  the summed widths of the other pinned columns between this one and its
+   *  table edge. */
+  offset: number
+  /** Last left-pinned / first right-pinned column — where the grid draws the
+   *  divider edge between the pinned and scrolling sections. */
+  isEdge: boolean
+}
+
+/** Pinned offsets for a leaf column's cells, or undefined when unpinned. */
+export function getPinnedOffsets<T>(
+  column: Column<T, unknown>,
+): PinnedColumnOffsets | undefined {
+  const side = column.getIsPinned()
+  if (!side) return undefined
+  return side === 'left'
+    ? {
+        side,
+        offset: column.getStart('left'),
+        isEdge: column.getIsLastColumn('left'),
+      }
+    : {
+        side,
+        offset: column.getAfter('right'),
+        isEdge: column.getIsFirstColumn('right'),
+      }
+}
+
+/**
+ * Pinned offsets for a grouped-header band cell. TanStack splits a group
+ * spanning pinned + unpinned leaves into one band cell per pin section, so a
+ * rendered band cell's leaves are single-section by construction — but guard
+ * anyway: a mixed or unpinned band renders unpinned.
+ *
+ * The band sticks at its leftmost (left-pinned) / rightmost (right-pinned)
+ * leaf's offset and draws the divider edge when it contains the edge leaf.
+ */
+export function getPinnedBandOffsets<T>(
+  header: Header<T, unknown>,
+): PinnedColumnOffsets | undefined {
+  const leaves = header.getLeafHeaders()
+  const columns =
+    leaves.length > 0 ? leaves.map((leaf) => leaf.column) : [header.column]
+  const side = columns[0].getIsPinned()
+  if (!side || columns.some((col) => col.getIsPinned() !== side)) {
+    return undefined
+  }
+  return side === 'left'
+    ? {
+        side,
+        offset: Math.min(...columns.map((col) => col.getStart('left'))),
+        isEdge: columns.some((col) => col.getIsLastColumn('left')),
+      }
+    : {
+        side,
+        offset: Math.min(...columns.map((col) => col.getAfter('right'))),
+        isEdge: columns.some((col) => col.getIsFirstColumn('right')),
+      }
+}
+
+/** The inline sticky inset for a pinned cell (`left` or `right`), or
+ *  undefined when unpinned. Merged into the cell's `style`. */
+export function pinnedCellStyle(
+  offsets: PinnedColumnOffsets | undefined,
+): CSSProperties | undefined {
+  if (!offsets) return undefined
+  return offsets.side === 'left'
+    ? { left: offsets.offset }
+    : { right: offsets.offset }
+}
+
+/**
+ * CSS-module class names the owning grid supplies for pinned cells: the base
+ * sticky/background class plus the divider-edge variants.
+ */
+export interface PinnedCellClasses {
+  pinned: string
+  pinnedLeftEdge: string
+  pinnedRightEdge: string
+}
+
+/** The pinned classes for a cell as one string ('' when unpinned). */
+export function pinnedCellClassNames(
+  offsets: PinnedColumnOffsets | undefined,
+  classes: PinnedCellClasses,
+): string {
+  if (!offsets) return ''
+  if (!offsets.isEdge) return classes.pinned
+  return `${classes.pinned} ${
+    offsets.side === 'left' ? classes.pinnedLeftEdge : classes.pinnedRightEdge
+  }`
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import { useRef, type MouseEvent, type ReactNode, type TouchEvent } from 'react'
+import {
+  useRef,
+  type CSSProperties,
+  type MouseEvent,
+  type ReactNode,
+  type TouchEvent,
+} from 'react'
 import { ArrowUpOutlined, ArrowDownOutlined } from '@ant-design/icons'
 import { type Header, flexRender } from '@tanstack/react-table'
 import WaydTooltip from '@/src/components/common/wayd-tooltip'
@@ -85,6 +91,13 @@ export interface GridHeaderCellProps<T> {
   /** Optional filter affordance rendered after the sort icon (e.g. the
    *  wayd-grid filter popover trigger). */
   filterSlot?: ReactNode
+  /** Optional column-menu trigger rendered last in the header content (the
+   *  wayd-grid ⋮ dropdown). */
+  menuSlot?: ReactNode
+  /** Extra class for the `<th>` (e.g. the grid's pinned-column class). */
+  thClassName?: string
+  /** Extra inline style for the `<th>` (e.g. the sticky pinning inset). */
+  thStyle?: CSSProperties
 }
 
 /**
@@ -105,6 +118,9 @@ export function GridHeaderCell<T>({
   resizeGuard,
   classes,
   filterSlot,
+  menuSlot,
+  thClassName,
+  thStyle,
 }: GridHeaderCellProps<T>) {
   // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see doc comment
   'use no memo'
@@ -133,17 +149,21 @@ export function GridHeaderCell<T>({
 
   return (
     <th
+      // Anchors autosize's header-label lookup (with the text marker below).
+      data-column-id={header.column.id}
       className={`${classes.th}${canSort ? ` ${classes.thSortable}` : ''}${
         canResize ? ` ${classes.thResizable}` : ''
-      }`}
+      }${thClassName ? ` ${thClassName}` : ''}`}
+      style={thStyle}
       onClick={handleSortClick}
     >
       <span className={classes.thContent}>
-        <span className={classes.thText}>
+        <span className={classes.thText} data-column-header-text="">
           <GridHeaderContent header={header} />
         </span>
         {sortIcon}
         {filterSlot}
+        {menuSlot}
       </span>
 
       {canResize && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-row.tsx
@@ -1,16 +1,40 @@
 'use client'
 
-import { type Row, flexRender } from '@tanstack/react-table'
+import { type Cell, type Row, flexRender } from '@tanstack/react-table'
 import { GridSortableRow } from './dnd/grid-dnd'
+import {
+  getPinnedOffsets,
+  pinnedCellClassNames,
+  pinnedCellStyle,
+  type PinnedCellClasses,
+} from './column-pinning'
 
 /**
  * CSS-module class names the owning grid supplies for body rows, so the shared
- * markup picks up the grid's own zebra/cell styling.
+ * markup picks up the grid's own zebra/cell styling. The pinned set is
+ * optional — a grid without column pinning just omits it.
  */
 export interface GridRowClasses {
   tr: string
   trAlt: string
   td: string
+  /** Sticky/edge classes for pinned columns' `td`s. */
+  pinned?: PinnedCellClasses
+}
+
+/** The pinned class suffix (starting with a space) + inline style for a body
+ *  cell, or empties when the column is unpinned / pinning classes not given. */
+const pinnedTdProps = <T,>(
+  cell: Cell<T, unknown>,
+  classes: GridRowClasses,
+): { className: string; style?: React.CSSProperties } => {
+  if (!classes.pinned) return { className: '' }
+  const offsets = getPinnedOffsets(cell.column)
+  if (!offsets) return { className: '' }
+  return {
+    className: ` ${pinnedCellClassNames(offsets, classes.pinned)}`,
+    style: pinnedCellStyle(offsets),
+  }
 }
 
 export interface FlatGridRowProps<T> {
@@ -39,15 +63,19 @@ export function FlatGridRow<T>({ row, index, classes }: FlatGridRowProps<T>) {
     <tr
       className={`${classes.tr}${index % 2 === 1 ? ` ${classes.trAlt}` : ''}`}
     >
-      {row.getVisibleCells().map((cell) => (
-        <td
-          key={cell.id}
-          data-column-id={cell.column.id}
-          className={classes.td}
-        >
-          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-        </td>
-      ))}
+      {row.getVisibleCells().map((cell) => {
+        const pinned = pinnedTdProps(cell, classes)
+        return (
+          <td
+            key={cell.id}
+            data-column-id={cell.column.id}
+            className={`${classes.td}${pinned.className}`}
+            style={pinned.style}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </td>
+        )
+      })}
       {/* Filler data cell keeps the zebra/hover band edge-to-edge. */}
       <td aria-hidden="true" className={classes.td} />
     </tr>
@@ -89,15 +117,19 @@ export function SortableFlatGridRow<T>({
       isDragging={isDragging}
       className={`${classes.tr}${index % 2 === 1 ? ` ${classes.trAlt}` : ''}`}
     >
-      {row.getVisibleCells().map((cell) => (
-        <td
-          key={cell.id}
-          data-column-id={cell.column.id}
-          className={classes.td}
-        >
-          {flexRender(cell.column.columnDef.cell, cell.getContext())}
-        </td>
-      ))}
+      {row.getVisibleCells().map((cell) => {
+        const pinned = pinnedTdProps(cell, classes)
+        return (
+          <td
+            key={cell.id}
+            data-column-id={cell.column.id}
+            className={`${classes.td}${pinned.className}`}
+            style={pinned.style}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </td>
+        )
+      })}
       {/* Filler data cell keeps the zebra/hover band edge-to-edge. */}
       <td aria-hidden="true" className={classes.td} />
     </GridSortableRow>
@@ -170,6 +202,7 @@ export function TreeGridRow<T>({
       {row.getVisibleCells().map((cell) => {
         const isEditableCell =
           isSelected && editableColumns.includes(cell.column.id)
+        const pinned = pinnedTdProps(cell, classes)
 
         return (
           <td
@@ -178,7 +211,8 @@ export function TreeGridRow<T>({
             data-column-id={cell.column.id}
             className={`${classes.td}${
               isEditableCell ? ` ${classes.editableCell}` : ''
-            }`}
+            }${pinned.className}`}
+            style={pinned.style}
             onClick={onCellClick}
           >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/index.ts
@@ -51,12 +51,54 @@ export { dateSortBy, sortEmptyLast } from './grid-sorting'
 export { exportGridToCsv } from './grid-export'
 
 // Table config + shared state hooks
-export { useGridState, useGridTable } from './use-grid-table'
+export {
+  mergeColumnVisibility,
+  useGridState,
+  useGridTable,
+} from './use-grid-table'
 export type {
   GridState,
   UseGridStateOptions,
   UseGridTableOptions,
 } from './use-grid-table'
+
+// Column pinning (sticky rendering over TanStack's columnPinning state)
+export {
+  getPinnedBandOffsets,
+  getPinnedOffsets,
+  pinnedCellClassNames,
+  pinnedCellStyle,
+} from './column-pinning'
+export type {
+  PinnedCellClasses,
+  PinnedColumnOffsets,
+} from './column-pinning'
+
+// Column autosize (measure rendered content, apply via columnSizing)
+export {
+  AUTOSIZE_MAX_WIDTH,
+  AUTOSIZE_MIN_WIDTH,
+  computeAutosizeWidth,
+  measureColumnContent,
+} from './column-autosize'
+export type {
+  AutosizeWidthInput,
+  ColumnContentMeasurement,
+} from './column-autosize'
+
+// Per-column header menu (⋮ — sort, pin, autosize, choose columns, reset)
+export {
+  ColumnChooserModal,
+  ColumnMenuTrigger,
+  buildColumnMenuItems,
+  getColumnChooserOptions,
+} from './column-menu'
+export type {
+  ColumnChooserModalProps,
+  ColumnChooserOption,
+  ColumnMenuItemsInput,
+  ColumnMenuTriggerProps,
+} from './column-menu'
 
 // Toolbar (search, row count, refresh, clear, export, help)
 export { default as GridToolbar } from './grid-toolbar'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.test.ts
@@ -1,0 +1,63 @@
+import { act, renderHook } from '@testing-library/react'
+
+import { mergeColumnVisibility, useGridState } from './use-grid-table'
+
+describe('use-grid-table', () => {
+  describe('mergeColumnVisibility', () => {
+    it('lets a consumer-hidden column override a user show choice', () => {
+      // Arrange / Act
+      const merged = mergeColumnVisibility({ secret: false }, { secret: true })
+
+      // Assert
+      expect(merged).toEqual({ secret: false })
+    })
+
+    it('lets the user hide a column the consumer shows', () => {
+      // Arrange / Act
+      const merged = mergeColumnVisibility({ name: true }, { name: false })
+
+      // Assert
+      expect(merged).toEqual({ name: false })
+    })
+
+    it('keeps consumer-shown columns visible absent a user choice', () => {
+      // Arrange / Act
+      const merged = mergeColumnVisibility(
+        { name: true, secret: false },
+        { team: false },
+      )
+
+      // Assert
+      expect(merged).toEqual({ name: true, secret: false, team: false })
+    })
+  })
+
+  describe('useGridState', () => {
+    it('resetColumnState restores sizing, user visibility, and pinning only', () => {
+      // Arrange — user-adjusted column state plus an active sort and filter
+      const { result } = renderHook(() => useGridState())
+      act(() => {
+        result.current.setColumnSizing({ name: 240 })
+        result.current.setUserColumnVisibility({ team: false })
+        result.current.setColumnPinning({ left: ['name'], right: [] })
+        result.current.setSorting([{ id: 'name', desc: false }])
+        result.current.setColumnFilters([{ id: 'name', value: 'x' }])
+      })
+
+      // Act
+      act(() => {
+        result.current.resetColumnState()
+      })
+
+      // Assert — column state cleared; sort/filters untouched (that's the
+      // toolbar Clear button's job)
+      expect(result.current.columnSizing).toEqual({})
+      expect(result.current.userColumnVisibility).toEqual({})
+      expect(result.current.columnPinning).toEqual({ left: [], right: [] })
+      expect(result.current.sorting).toEqual([{ id: 'name', desc: false }])
+      expect(result.current.columnFilters).toEqual([
+        { id: 'name', value: 'x' },
+      ])
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
@@ -3,11 +3,13 @@ import {
   type Column,
   type ColumnDef,
   type ColumnFiltersState,
+  type ColumnPinningState,
   type ColumnSizingState,
   type SortingState,
   type Table,
   type TableOptions,
   type TableState,
+  type VisibilityState,
   getCoreRowModel,
   getFilteredRowModel,
   getSortedRowModel,
@@ -17,13 +19,20 @@ import {
 import { stringContainsFilter } from './grid-filters'
 
 /**
- * Shared grid state: sorting, column filters, column sizing, and the global
- * quick-search value, plus the toolbar wiring derived from them. Created by
- * {@link useGridState} and consumed by {@link useGridTable}.
+ * Shared grid state: sorting, column filters, column sizing, user column
+ * visibility, column pinning, and the global quick-search value, plus the
+ * toolbar wiring derived from them. Created by {@link useGridState} and
+ * consumed by {@link useGridTable}.
  *
  * Split from useGridTable so a grid can build state-dependent column
  * definitions (e.g. TreeGrid's column context reads the active filters)
  * between creating the state and creating the table.
+ *
+ * Every user-adjustable column state slice (columnSizing,
+ * userColumnVisibility, columnPinning, sorting) lives here as plain
+ * serializable state — grid state persistence will serialize exactly these
+ * slices, so new column state must be added here, not scattered into
+ * components.
  */
 export interface GridState {
   sorting: SortingState
@@ -32,12 +41,29 @@ export interface GridState {
   setColumnFilters: React.Dispatch<React.SetStateAction<ColumnFiltersState>>
   columnSizing: ColumnSizingState
   setColumnSizing: React.Dispatch<React.SetStateAction<ColumnSizingState>>
+  /**
+   * The USER's show/hide choices (column chooser) — a layer on top of the
+   * consumer's reactive `meta.hide` visibility; see
+   * {@link mergeColumnVisibility} for how the two combine.
+   */
+  userColumnVisibility: VisibilityState
+  setUserColumnVisibility: React.Dispatch<
+    React.SetStateAction<VisibilityState>
+  >
+  columnPinning: ColumnPinningState
+  setColumnPinning: React.Dispatch<React.SetStateAction<ColumnPinningState>>
   searchValue: string
   setSearchValue: React.Dispatch<React.SetStateAction<string>>
   /** Toolbar search input change handler. */
   onSearchChange: (e: ChangeEvent<HTMLInputElement>) => void
   /** Clears search, sorting, and column filters (plus the grid's own extras). */
   onClearFilters: () => void
+  /**
+   * Restores the column defs' defaults: sizing, user visibility, and pinning
+   * (the column menu's Reset Columns). Sort and filters are deliberately NOT
+   * reset — that's the toolbar Clear button ({@link onClearFilters}).
+   */
+  resetColumnState: () => void
   /** True when any search, column filter, or sort is active. */
   hasActiveFilters: boolean
 }
@@ -51,9 +77,13 @@ export interface UseGridStateOptions {
   initialSorting?: SortingState
 }
 
+/** Empty pinning state (nothing pinned) — also what Reset restores. */
+const EMPTY_COLUMN_PINNING: ColumnPinningState = { left: [], right: [] }
+
 /**
- * Owns the four shared state slices (sorting, column filters, column sizing,
- * global search) and the toolbar handlers derived from them.
+ * Owns the shared state slices (sorting, column filters, column sizing, user
+ * column visibility, column pinning, global search) and the toolbar handlers
+ * derived from them.
  */
 export function useGridState(options?: UseGridStateOptions): GridState {
   const [sorting, setSorting] = useState<SortingState>(
@@ -61,6 +91,10 @@ export function useGridState(options?: UseGridStateOptions): GridState {
   )
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
   const [columnSizing, setColumnSizing] = useState<ColumnSizingState>({})
+  const [userColumnVisibility, setUserColumnVisibility] =
+    useState<VisibilityState>({})
+  const [columnPinning, setColumnPinning] =
+    useState<ColumnPinningState>(EMPTY_COLUMN_PINNING)
   const [searchValue, setSearchValue] = useState('')
 
   const onSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -74,6 +108,12 @@ export function useGridState(options?: UseGridStateOptions): GridState {
     options?.onClear?.()
   }
 
+  const resetColumnState = () => {
+    setColumnSizing({})
+    setUserColumnVisibility({})
+    setColumnPinning(EMPTY_COLUMN_PINNING)
+  }
+
   const hasActiveFilters =
     !!searchValue || columnFilters.length > 0 || sorting.length > 0
 
@@ -84,12 +124,39 @@ export function useGridState(options?: UseGridStateOptions): GridState {
     setColumnFilters,
     columnSizing,
     setColumnSizing,
+    userColumnVisibility,
+    setUserColumnVisibility,
+    columnPinning,
+    setColumnPinning,
     searchValue,
     setSearchValue,
     onSearchChange,
     onClearFilters,
+    resetColumnState,
     hasActiveFilters,
   }
+}
+
+/**
+ * Combines the consumer's reactive `meta.hide` visibility with the user's
+ * column-chooser choices into the TanStack columnVisibility map.
+ *
+ * Rules: a column the consumer hides (`meta.hide === true`) is
+ * consumer-controlled — it stays hidden no matter what the user chose (it is
+ * also excluded from the chooser). For every other column the user's choice
+ * wins; absent a user choice, the consumer's `meta.hide: false` (or no entry
+ * at all) leaves the column visible.
+ */
+export function mergeColumnVisibility(
+  consumerVisibility: VisibilityState,
+  userVisibility: VisibilityState,
+): VisibilityState {
+  const merged: VisibilityState = { ...userVisibility }
+  for (const [id, visible] of Object.entries(consumerVisibility)) {
+    if (!visible) merged[id] = false
+    else if (!(id in merged)) merged[id] = true
+  }
+  return merged
 }
 
 /** Global quick-search applies to any column with an accessor unless the
@@ -143,6 +210,8 @@ export function useGridTable<T>({
     setColumnFilters,
     columnSizing,
     setColumnSizing,
+    columnPinning,
+    setColumnPinning,
     searchValue,
     setSearchValue,
   } = gridState
@@ -166,17 +235,23 @@ export function useGridTable<T>({
     },
     enableColumnResizing: true,
     columnResizeMode: 'onChange',
+    // Pinning is state-only in TanStack (getVisibleLeafColumns / getVisibleCells /
+    // getHeaderGroups reorder pinned columns to the edges); the sticky rendering
+    // is the grid's (see column-pinning.ts).
+    enableColumnPinning: true,
     ...tableOptions,
     state: {
       globalFilter: searchValue,
       sorting,
       columnFilters,
       columnSizing,
+      columnPinning,
       ...extraState,
     },
     onGlobalFilterChange: (value) => setSearchValue(String(value ?? '')),
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
     onColumnSizingChange: setColumnSizing,
+    onColumnPinningChange: setColumnPinning,
   })
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
@@ -171,11 +171,14 @@
   padding-right: var(--ant-padding-sm);
 }
 
+/* Fills the th (not shrink-to-fit) so the column-menu trigger can anchor to
+   the far right edge via margin-left: auto; the label and sort/filter icons
+   stay left, hugging the text. */
 .thContent {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: var(--ant-margin-xs);
-  max-width: 100%;
+  width: 100%;
   min-width: 0;
   overflow: hidden;
 }
@@ -185,7 +188,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   min-width: 0;
-  flex: 1;
+  flex: 0 1 auto;
 }
 
 /* Floating-filter cell: input fills the width, filter-popup icon on the right. */
@@ -556,6 +559,77 @@
 .trSelected .inlineRowAction {
   opacity: 1;
   pointer-events: auto;
+}
+
+/* ─── Pinned columns ────────────────────────────────────── */
+
+/*
+ * Pinning is position: sticky + a left/right inset (set inline from
+ * TanStack's pinning offsets) on the pinned column's cells in BOTH tables.
+ * TanStack already reorders pinned columns to the table edges in the shared
+ * colgroup, so the header and body stick identically. Pinned cells must paint
+ * OPAQUE — the zebra/hover/selected tints are semi-transparent overlays, so
+ * they composite over the container background as a flat gradient (same
+ * technique as the header band) or scrolled-under content would bleed
+ * through.
+ */
+
+/* Header cells are already sticky (top) and opaque; pinning adds the
+   horizontal stick via the inline inset and a z-index above unpinned
+   header cells so those slide beneath on horizontal scroll. */
+.thPinned {
+  z-index: 22;
+}
+
+.filterThPinned {
+  z-index: 21;
+}
+
+.tdPinned {
+  position: sticky;
+  z-index: 2;
+  background: var(--ant-color-bg-container);
+}
+
+.trAlt .tdPinned {
+  background: linear-gradient(
+      var(--ant-color-fill-quaternary),
+      var(--ant-color-fill-quaternary)
+    )
+    var(--ant-color-bg-container);
+}
+
+.trSelected .tdPinned {
+  background: var(--ant-color-bg-container);
+}
+
+.tr[data-dragging='true'] .tdPinned {
+  background: linear-gradient(
+      var(--ant-color-fill-tertiary),
+      var(--ant-color-fill-tertiary)
+    )
+    var(--ant-color-bg-container);
+}
+
+/* After the alt/selected rules so the hover tint wins on those rows too
+   (specificity ties break by order for the background-image component). */
+.tr:hover .tdPinned {
+  background: linear-gradient(
+      var(--ant-color-fill-secondary),
+      var(--ant-color-fill-secondary)
+    )
+    var(--ant-color-bg-container);
+}
+
+/* Divider edge between the pinned and scrolling sections: an inset shadow
+   line (no layout impact — border widths would desync the two tables'
+   scroll widths) on the last left-pinned / first right-pinned cells. */
+.pinnedLeftEdge {
+  box-shadow: inset -1px 0 0 var(--ant-color-border);
+}
+
+.pinnedRightEdge {
+  box-shadow: inset 1px 0 0 var(--ant-color-border);
 }
 
 /* ─── Tree mode: drag and drop ──────────────────────────── */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
@@ -1153,8 +1153,12 @@ describe('WaydGrid', () => {
         ref.current!.table.getColumn('type').pin('left')
       })
 
-      // Assert — header and body cells lead with the pinned column
-      const headerRow = document.querySelector('thead tr') as HTMLElement
+      // Assert — header and body cells lead with the pinned column. Target
+      // the leaf header row explicitly (band/floating rows carry data-role),
+      // so this survives grids with grouped headers.
+      const headerRow = document.querySelector(
+        'thead tr:not([data-role])',
+      ) as HTMLElement
       const firstTh = headerRow.querySelector('th[data-column-id]')
       expect(firstTh?.getAttribute('data-column-id')).toBe('type')
       const firstBodyRow = document.querySelector('tbody tr') as HTMLElement

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
@@ -1116,4 +1116,88 @@ describe('WaydGrid', () => {
       expect(names).toEqual(['planning-poker', 'roadmap', 'insights'])
     })
   })
+
+  describe('column menu', () => {
+    it('renders a menu trigger in every leaf header cell', () => {
+      // Arrange / Act
+      renderGrid()
+
+      // Assert — one ⋮ trigger per column (portal-driven menu behavior is
+      // exercised in the browser, not jsdom)
+      expect(screen.getAllByLabelText('Column menu')).toHaveLength(
+        columns.length,
+      )
+    })
+
+    it('opening the menu does not toggle the column sort', () => {
+      // Arrange
+      renderGrid()
+      const namesBefore = bodyCells('name').map((c) => c.textContent)
+
+      // Act — the trigger sits inside the sortable <th>
+      fireEvent.click(screen.getAllByLabelText('Column menu')[0])
+
+      // Assert — row order untouched
+      expect(bodyCells('name').map((c) => c.textContent)).toEqual(namesBefore)
+    })
+  })
+
+  describe('column pinning', () => {
+    it('reorders a left-pinned column to the front of both tables', () => {
+      // Arrange
+      const ref = createRef<WaydGridHandle>()
+      renderGrid({ ref })
+
+      // Act
+      act(() => {
+        ref.current!.table.getColumn('type').pin('left')
+      })
+
+      // Assert — header and body cells lead with the pinned column
+      const headerRow = document.querySelector('thead tr') as HTMLElement
+      const firstTh = headerRow.querySelector('th[data-column-id]')
+      expect(firstTh?.getAttribute('data-column-id')).toBe('type')
+      const firstBodyRow = document.querySelector('tbody tr') as HTMLElement
+      const firstTd = firstBodyRow.querySelector('td[data-column-id]')
+      expect(firstTd?.getAttribute('data-column-id')).toBe('type')
+    })
+
+    it('applies the sticky inset to pinned header and body cells', () => {
+      // Arrange
+      const ref = createRef<WaydGridHandle>()
+      renderGrid({ ref })
+
+      // Act — pin two columns left; the second is offset by the first's width
+      act(() => {
+        ref.current!.table.getColumn('name').pin('left')
+        ref.current!.table.getColumn('type').pin('left')
+      })
+
+      // Assert
+      const nameTh = document.querySelector(
+        'th[data-column-id="name"]',
+      ) as HTMLElement
+      const typeTh = document.querySelector(
+        'th[data-column-id="type"]',
+      ) as HTMLElement
+      expect(nameTh.style.left).toBe('0px')
+      expect(typeTh.style.left).toBe(
+        `${ref.current!.table.getColumn('name').getSize()}px`,
+      )
+      const nameTd = bodyCells('name')[0]
+      expect(nameTd.style.left).toBe('0px')
+    })
+
+    it('leaves unpinned cells without a sticky inset', () => {
+      // Arrange / Act
+      renderGrid()
+
+      // Assert
+      const nameTh = document.querySelector(
+        'th[data-column-id="name"]',
+      ) as HTMLElement
+      expect(nameTh.style.left).toBe('')
+      expect(bodyCells('name')[0].style.left).toBe('')
+    })
+  })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -59,6 +59,21 @@ import {
 } from '../wayd-grid-core/filters'
 
 import { applySafeAccessor } from '../wayd-grid-core/column-accessors'
+import {
+  computeAutosizeWidth,
+  measureColumnContent,
+} from '../wayd-grid-core/column-autosize'
+import {
+  ColumnChooserModal,
+  ColumnMenuTrigger,
+} from '../wayd-grid-core/column-menu'
+import {
+  getPinnedBandOffsets,
+  getPinnedOffsets,
+  pinnedCellClassNames,
+  pinnedCellStyle,
+  type PinnedCellClasses,
+} from '../wayd-grid-core/column-pinning'
 import { applyColumnType } from '../wayd-grid-core/column-types'
 import { useGridDndSensors } from '../wayd-grid-core/dnd/grid-dnd'
 import {
@@ -95,7 +110,11 @@ import {
   useGridEditing,
   type GridEditingConfig,
 } from '../wayd-grid-core/use-grid-editing'
-import { useGridState, useGridTable } from '../wayd-grid-core/use-grid-table'
+import {
+  mergeColumnVisibility,
+  useGridState,
+  useGridTable,
+} from '../wayd-grid-core/use-grid-table'
 import styles from './wayd-grid.module.css'
 import type {
   GridColumnContext,
@@ -195,10 +214,29 @@ const headerCellClasses: GridHeaderCellClasses = {
   resizerActive: styles.resizerActive,
 }
 
+// Pinned-column sticky classes per cell kind. The edge classes (the divider
+// between the pinned and scrolling sections) are shared.
+const headerPinnedClasses: PinnedCellClasses = {
+  pinned: styles.thPinned,
+  pinnedLeftEdge: styles.pinnedLeftEdge,
+  pinnedRightEdge: styles.pinnedRightEdge,
+}
+
+const filterPinnedClasses: PinnedCellClasses = {
+  pinned: styles.filterThPinned,
+  pinnedLeftEdge: styles.pinnedLeftEdge,
+  pinnedRightEdge: styles.pinnedRightEdge,
+}
+
 const rowClasses: GridRowClasses = {
   tr: styles.tr,
   trAlt: styles.trAlt,
   td: styles.td,
+  pinned: {
+    pinned: styles.tdPinned,
+    pinnedLeftEdge: styles.pinnedLeftEdge,
+    pinnedRightEdge: styles.pinnedRightEdge,
+  },
 }
 
 const treeRowClasses: TreeGridRowClasses = {
@@ -541,12 +579,25 @@ function WaydGridInner<T>(
 
   // ─── State ───────────────────────────────────────────────
   const gridState = useGridState({ initialSorting })
-  const { searchValue, onSearchChange, onClearFilters, hasActiveFilters } =
-    gridState
+  const {
+    searchValue,
+    onSearchChange,
+    onClearFilters,
+    hasActiveFilters,
+    setColumnSizing,
+    userColumnVisibility,
+    setUserColumnVisibility,
+    resetColumnState,
+  } = gridState
   const resizeGuard = useResizeClickGuard()
   const [openFilterColumnId, setOpenFilterColumnId] = useState<string | null>(
     null,
   )
+  // One open column menu at a time, owned here (same anchor-stability pattern
+  // as openFilterColumnId — a controlled dropdown must keep its trigger DOM).
+  const [openMenuColumnId, setOpenMenuColumnId] = useState<string | null>(null)
+  // Choose Columns modal — one per grid, opened from any column's menu.
+  const [isColumnChooserOpen, setIsColumnChooserOpen] = useState(false)
   // Expanded date-tree node keys per column, owned here (above the filter
   // popover). The popover's content is rebuilt whenever the column filter
   // changes, so state kept inside the DateFilterPanel is lost on toggle; keeping
@@ -806,7 +857,7 @@ function WaydGridInner<T>(
 
   // meta.hide → columnVisibility (AG Grid `hide` style), recursing into
   // grouped defs (TanStack shrinks a band's colSpan as its leaves hide).
-  const columnVisibility = useMemo<VisibilityState>(() => {
+  const consumerColumnVisibility = useMemo<VisibilityState>(() => {
     const visibility: VisibilityState = {}
     const collect = (cols: typeof resolvedColumns) => {
       for (const col of cols) {
@@ -823,6 +874,14 @@ function WaydGridInner<T>(
     collect(resolvedColumns)
     return visibility
   }, [resolvedColumns])
+
+  // The user's Choose Columns choices layer on top: consumer-hidden columns
+  // stay hidden (and out of the chooser); user choices win everywhere else.
+  const columnVisibility = useMemo<VisibilityState>(
+    () =>
+      mergeColumnVisibility(consumerColumnVisibility, userColumnVisibility),
+    [consumerColumnVisibility, userColumnVisibility],
+  )
 
   // ─── Flattened tree for DnD ──────────────────────────────
   const flattenedNodes = useMemo(
@@ -1005,6 +1064,66 @@ function WaydGridInner<T>(
       return { ...prev, [columnId]: next }
     })
   }, [])
+
+  // ─── Column menu (sort / pin / autosize / choose / reset) ──
+  /**
+   * Sizes columns to their rendered content (header label + the virtualized
+   * window's cells — all the DOM that exists; ag-grid measured the same way).
+   * Applies through columnSizing so the shared colgroup updates both tables.
+   */
+  const autosizeColumns = useCallback(
+    (columnIds: string[]) => {
+      const headerRoot = headerViewportRef.current
+      const bodyRoot = bodyViewportRef.current
+      if (!headerRoot || !bodyRoot) return
+      const measured = measureColumnContent(headerRoot, bodyRoot, columnIds)
+      setColumnSizing((prev) => {
+        const next = { ...prev }
+        for (const [id, m] of measured) {
+          const columnDef = table.getColumn(id)?.columnDef
+          next[id] = computeAutosizeWidth({
+            maxCellContentWidth: m.maxCellContentWidth,
+            headerContentWidth: m.headerContentWidth,
+            minWidth: columnDef?.minSize,
+            maxWidth: columnDef?.maxSize,
+          })
+        }
+        return next
+      })
+    },
+    [setColumnSizing, table],
+  )
+
+  const autosizeAllColumns = useCallback(() => {
+    autosizeColumns(
+      table
+        .getVisibleLeafColumns()
+        .filter((column) => column.getCanResize())
+        .map((column) => column.id),
+    )
+  }, [autosizeColumns, table])
+
+  const handleUserToggleColumn = useCallback(
+    (columnId: string, visible: boolean) => {
+      setUserColumnVisibility((prev) => ({ ...prev, [columnId]: visible }))
+    },
+    [setUserColumnVisibility],
+  )
+
+  const renderColumnMenu = (header: Header<T, unknown>) => (
+    <ColumnMenuTrigger
+      header={header}
+      table={table}
+      open={openMenuColumnId === header.column.id}
+      onOpenChange={(open) =>
+        setOpenMenuColumnId(open ? header.column.id : null)
+      }
+      onOpenColumnChooser={() => setIsColumnChooserOpen(true)}
+      onAutosizeColumn={(columnId) => autosizeColumns([columnId])}
+      onAutosizeAllColumns={autosizeAllColumns}
+      onResetColumns={resetColumnState}
+    />
+  )
 
   // ─── CSV export ──────────────────────────────────────────
   const onExportCsv = useCallback(() => {
@@ -1274,11 +1393,22 @@ function WaydGridInner<T>(
   const leafHeaderGroup = headerGroups[headerGroups.length - 1]
   const groupHeaderRows = headerGroups.slice(0, -1)
 
+  // Visible leaf columns in RENDER order: left-pinned → center → right-pinned.
+  // getHeaderGroups() and row.getVisibleCells() emit this order when columns
+  // are pinned, but plain getVisibleLeafColumns() stays in def order — the
+  // colgroup must follow the rendered order or the shared <col> widths would
+  // apply to the wrong columns.
+  const orderedVisibleLeafColumns = [
+    ...table.getLeftVisibleLeafColumns(),
+    ...table.getCenterVisibleLeafColumns(),
+    ...table.getRightVisibleLeafColumns(),
+  ]
+
   // Rendered into BOTH tables (header + body) — with table-layout: fixed,
   // identical colgroups guarantee the two tables' columns align exactly.
   const colGroup = (
     <colgroup>
-      {table.getVisibleLeafColumns().map((column) => (
+      {orderedVisibleLeafColumns.map((column) => (
         <col key={column.id} width={column.getSize()} />
       ))}
       {/* Filler column absorbs leftover width so the table fills the
@@ -1306,22 +1436,33 @@ function WaydGridInner<T>(
               sort/filter/resize; placeholders render empty. */}
           {groupHeaderRows.map((headerGroup, bandIndex) => (
             <tr key={headerGroup.id} data-role="header-band">
-              {headerGroup.headers.map((header) => (
-                <th
-                  key={header.id}
-                  colSpan={header.colSpan}
-                  // Placeholders (ungrouped columns passing through the band
-                  // level) are empty — hide them from assistive tech so
-                  // screen readers don't announce blank column headers.
-                  aria-hidden={header.isPlaceholder || undefined}
-                  className={`${styles.th} ${styles.groupTh}`}
-                  style={{
-                    top: `calc(${bandIndex} * var(--wayd-grid-header-row-height))`,
-                  }}
-                >
-                  <GridHeaderContent header={header} />
-                </th>
-              ))}
+              {headerGroup.headers.map((header) => {
+                // TanStack splits a band spanning pinned + unpinned leaves
+                // into one cell per pin section; a pinned section's cell
+                // sticks at its leaves' offset.
+                const bandPinned = getPinnedBandOffsets(header)
+                return (
+                  <th
+                    key={header.id}
+                    colSpan={header.colSpan}
+                    // Placeholders (ungrouped columns passing through the band
+                    // level) are empty — hide them from assistive tech so
+                    // screen readers don't announce blank column headers.
+                    aria-hidden={header.isPlaceholder || undefined}
+                    className={`${styles.th} ${styles.groupTh}${
+                      bandPinned
+                        ? ` ${pinnedCellClassNames(bandPinned, headerPinnedClasses)}`
+                        : ''
+                    }`}
+                    style={{
+                      top: `calc(${bandIndex} * var(--wayd-grid-header-row-height))`,
+                      ...pinnedCellStyle(bandPinned),
+                    }}
+                  >
+                    <GridHeaderContent header={header} />
+                  </th>
+                )
+              })}
               {/* Filler band cell — carries the band across the empty width. */}
               <th
                 aria-hidden="true"
@@ -1343,6 +1484,7 @@ function WaydGridInner<T>(
                 !showFloatingFilters &&
                 !header.isPlaceholder &&
                 header.column.getCanFilter()
+              const pinned = getPinnedOffsets(header.column)
 
               return (
                 <GridHeaderCell
@@ -1355,6 +1497,17 @@ function WaydGridInner<T>(
                       ? renderFilterPopover(header)
                       : undefined
                   }
+                  menuSlot={
+                    !header.isPlaceholder
+                      ? renderColumnMenu(header)
+                      : undefined
+                  }
+                  thClassName={
+                    pinned
+                      ? pinnedCellClassNames(pinned, headerPinnedClasses)
+                      : undefined
+                  }
+                  thStyle={pinnedCellStyle(pinned)}
                 />
               )
             })}
@@ -1375,11 +1528,19 @@ function WaydGridInner<T>(
             >
               {leafHeaderGroup.headers.map((header) => {
                 const column = header.column
+                const pinned = getPinnedOffsets(column)
+                const filterThClassName = `${styles.filterTh}${
+                  pinned
+                    ? ` ${pinnedCellClassNames(pinned, filterPinnedClasses)}`
+                    : ''
+                }`
+                const filterThStyle = pinnedCellStyle(pinned)
                 if (header.isPlaceholder || !column.getCanFilter()) {
                   return (
                     <th
                       key={`${header.id}-floating`}
-                      className={styles.filterTh}
+                      className={filterThClassName}
+                      style={filterThStyle}
                     />
                   )
                 }
@@ -1394,7 +1555,8 @@ function WaydGridInner<T>(
                   return (
                     <th
                       key={`${header.id}-floating`}
-                      className={styles.filterTh}
+                      className={filterThClassName}
+                      style={filterThStyle}
                       onClick={(e) => e.stopPropagation()}
                     >
                       {renderSetFilter(header)}
@@ -1416,7 +1578,8 @@ function WaydGridInner<T>(
                 return (
                   <th
                     key={`${header.id}-floating`}
-                    className={styles.filterTh}
+                    className={filterThClassName}
+                    style={filterThStyle}
                     onClick={(e) => e.stopPropagation()}
                   >
                     <div className={styles.floatingCell}>
@@ -1533,6 +1696,13 @@ function WaydGridInner<T>(
       ) : (
         tableContent
       )}
+
+      <ColumnChooserModal
+        table={table}
+        open={isColumnChooserOpen}
+        onClose={() => setIsColumnChooserOpen(false)}
+        onToggleColumn={handleUserToggleColumn}
+      />
     </div>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -66,6 +66,7 @@ import {
 import {
   ColumnChooserModal,
   ColumnMenuTrigger,
+  getColumnChooserOptions,
 } from '../wayd-grid-core/column-menu'
 import {
   getPinnedBandOffsets,
@@ -1110,6 +1111,10 @@ function WaydGridInner<T>(
     [setUserColumnVisibility],
   )
 
+  // Computed once per grid render and shared by every header's menu trigger
+  // (each trigger deriving it would rescan all leaf columns per column).
+  const hasHidableColumns = getColumnChooserOptions(table).length > 0
+
   const renderColumnMenu = (header: Header<T, unknown>) => (
     <ColumnMenuTrigger
       header={header}
@@ -1118,6 +1123,7 @@ function WaydGridInner<T>(
       onOpenChange={(open) =>
         setOpenMenuColumnId(open ? header.column.id : null)
       }
+      hasHidableColumns={hasHidableColumns}
       onOpenColumnChooser={() => setIsColumnChooserOpen(true)}
       onAutosizeColumn={(columnId) => autosizeColumns([columnId])}
       onAutosizeAllColumns={autosizeAllColumns}


### PR DESCRIPTION
## Add a per-column header menu to WaydGrid (sort, pin, autosize, choose columns, reset)

Restores the ag-grid per-column header menu on the unified WaydGrid. Every leaf header cell gets a hover-visible `⋮` trigger (far right of the cell, keyboard-focusable) opening a menu with:

- **Sort Ascending / Sort Descending** — sets a single-column sort (multi-sort stays ctrl/⌘-click on the header); **Clear Sort** appears while the column is sorted and removes only this column's sort.
- **Pin Column ▸ Pin Left / Pin Right / No Pin** — new grid capability (details below); active option is check-marked.
- **Autosize This Column / Autosize All Columns** — sizes to rendered content.
- **Choose Columns** — opens a searchable checkbox **modal**; toggles apply to the grid live and the modal stays open, so multiple columns can be shown/hidden in one visit. The last visible column is locked on. (A Dropdown submenu was tried first and rejected: antd collapses a submenu to its parent level on every item click.)
- **Reset Columns** — restores column-def defaults for sizing, user visibility, and pinning. Sort/filters are deliberately untouched (that's the toolbar Clear button).

Row grouping and column reordering are out of scope.

### Column pinning

Pin = **TanStack's `columnPinning` state model + our sticky rendering**, and pinned columns **reorder to the table edges** (left-pinned first, right-pinned last), matching ag-grid. Rendering is `position: sticky` with `left`/`right` insets from `getStart('left')`/`getAfter('right')` on the pinned `th`s and `td`s in both the header and body tables, z-layered under the sticky header rows, with a divider edge (inset box-shadow, zero layout impact) on the last-left/first-right pinned column.

Two gotchas worth knowing:

- **TanStack v8.21.3 inconsistency**: `getHeaderGroups()` and `row.getVisibleCells()` reorder by pinning, but `table.getVisibleLeafColumns()` does not. The shared colgroup is now built from `getLeftVisibleLeafColumns() + getCenterVisibleLeafColumns() + getRightVisibleLeafColumns()`; a unit test guards that contract so it can't silently regress.
- **Opaque pinned cells**: zebra/hover/selected tints are semi-transparent overlays, so pinned cells composite the tint over `--ant-color-bg-container` via a flat gradient (same technique the header band already used) — scrolled-under content cannot bleed through.

**Known limitation**: a grouped-header band whose pinned + unpinned leaves remain adjacent renders as one mixed cell and scrolls (the leaf headers underneath still pin correctly); when pinning tears a group apart, TanStack splits the band and each section cell sticks with its leaves.

### Autosize

TanStack has no built-in autosize, so we measure the rendered window only (all the DOM that exists under virtualization; ag-grid did the same): each cell's children are cloned into off-screen inline-block nowrap holders and measured in one layout pass — plain `scrollWidth`/Range measurement fails on `width:100%` flex cell wrappers. Result = max(header label + allowance, widest cell + allowance), clamped to the column's `minSize`/`maxSize` (defaults 60–600px), applied through the shared `columnSizing` state so the single colgroup updates both tables.

### State (persistence-ready)

All user-adjustable column state now lives in `useGridState` as plain serializable slices — `columnSizing`, `userColumnVisibility`, `columnPinning`, `sorting` — with a single `resetColumnState()`. The next branch (grid state persistence) serializes exactly that object. User visibility is a layer over consumer `meta.hide` (`mergeColumnVisibility`): consumer-hidden columns stay hidden and are excluded from the chooser; user choices win everywhere else, so reactive `meta.hide` flags keep working.

### Files

- `wayd-grid-core/column-menu.tsx` (+ css) — `ColumnMenuTrigger`, `ColumnChooserModal`, pure `buildColumnMenuItems`/`getColumnChooserOptions`
- `wayd-grid-core/column-pinning.ts` — offset/class/style helpers over TanStack pinning state
- `wayd-grid-core/column-autosize.ts` — clone-measurement + pure width math
- `wayd-grid-core/use-grid-table.ts` — new state slices, `resetColumnState`, `mergeColumnVisibility`, pinning wired into the table
- `wayd-grid-core/grid-header-row.tsx` / `grid-row.tsx` — menu slot + pinned cell props through the shared seams
- `wayd-grid/wayd-grid.tsx` (+ css) — wiring, pinned band/filter-row cells, colgroup pin ordering, chooser modal

### Verification

- `npx tsc --noEmit`, eslint (one pre-existing `useReactTable` compiler warning), full jest: **157 suites / 2423 tests green** (~45 new: pinning offsets & band splits, autosize math & measurement, menu item building, chooser modal interaction, `useGridState` reset, grid pinning integration).
- Browser-verified on the work items grid (wide, flat) and the project plan tree grid: menu opens without sorting; sort/autosize/chooser/reset all correct; pin left+right simultaneously with **0px header/body drift at full right scroll** (measured), opaque zebra/hover on pinned cells, floating filter row sticks with its column, tree indent/expand/collapse unaffected while pinned.
