### PR TITLE
Feature/add column persistence to waydgrid

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/claims-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/claims-grid.tsx
@@ -18,6 +18,7 @@ const ClaimsGrid = () => {
     <WaydGrid
       columns={columns}
       data={user?.claims ?? []}
+      persistStateKey="account-claims"
       csvFileName="claims"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/page.tsx
@@ -8,6 +8,7 @@ import ProfileForm from './profile-form'
 import ChangePasswordForm from './change-password-form'
 import ClaimsGrid from './claims-grid'
 import PersonalAccessTokens from './personal-access-tokens'
+import Preferences from './preferences'
 import useAuth from '../../../components/contexts/auth'
 import { useDocumentTitle } from '../../../hooks/use-document-title'
 import { useAppDispatch } from '@/src/hooks'
@@ -16,12 +17,14 @@ import { useGetProfileQuery } from '@/src/store/features/user-management/profile
 import { useMessage } from '@/src/components/contexts/messaging'
 enum AccountTabs {
   Profile = 'profile',
+  Preferences = 'preferences',
   Claims = 'claims',
   PersonalAccessTokens = 'personalAccessTokens',
 }
 
 const tabs = [
   { key: AccountTabs.Profile, tab: 'Profile' },
+  { key: AccountTabs.Preferences, tab: 'Preferences' },
   { key: AccountTabs.PersonalAccessTokens, tab: 'PATs' },
   { key: AccountTabs.Claims, tab: 'Claims' },
 ]
@@ -49,6 +52,8 @@ const AccountProfilePage = () => {
     switch (activeTab) {
       case AccountTabs.Profile:
         return React.createElement(ProfileForm, profileData)
+      case AccountTabs.Preferences:
+        return <Preferences />
       case AccountTabs.PersonalAccessTokens:
         return <PersonalAccessTokens />
       case AccountTabs.Claims:

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/personal-access-tokens.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/personal-access-tokens.tsx
@@ -241,6 +241,7 @@ const PersonalAccessTokens: FC = () => {
         data={tokens ?? []}
         isLoading={isLoading}
         onRefresh={refresh}
+        persistStateKey="account-pats"
         csvFileName="personal-access-tokens"
         emptyMessage="No PATs found."
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/preferences.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/preferences.test.tsx
@@ -1,0 +1,103 @@
+jest.mock('@/src/components/contexts/messaging', () => ({
+  useMessage: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+  }),
+}))
+
+import { render, screen, fireEvent } from '@testing-library/react'
+
+import Preferences from './preferences'
+import { GRID_PERSISTENCE_ENABLED_KEY } from '@/src/components/common/wayd-grid'
+
+describe('Preferences', () => {
+  beforeEach(() => {
+    // jest.setup's localStorage stub has no backing store — replace it with a
+    // real in-memory implementation
+    const localStorageMock = (() => {
+      let store: Record<string, string> = {}
+      return {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => {
+          store[key] = value
+        },
+        removeItem: (key: string) => {
+          delete store[key]
+        },
+        clear: () => {
+          store = {}
+        },
+        get length() {
+          return Object.keys(store).length
+        },
+        key: (index: number) => {
+          const keys = Object.keys(store)
+          return keys[index] ?? null
+        },
+      }
+    })()
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    })
+  })
+
+  it('defaults the remember-column-layouts switch to on', () => {
+    // Arrange / Act
+    render(<Preferences />)
+
+    // Assert
+    expect(
+      screen.getByRole('switch', { name: 'Remember column layouts' }),
+    ).toBeChecked()
+  })
+
+  it('writes the disabled flag when the switch is turned off', () => {
+    // Arrange
+    render(<Preferences />)
+
+    // Act
+    fireEvent.click(
+      screen.getByRole('switch', { name: 'Remember column layouts' }),
+    )
+
+    // Assert — the grid hook reads this exact key at effect time
+    expect(window.localStorage.getItem(GRID_PERSISTENCE_ENABLED_KEY)).toBe(
+      'false',
+    )
+  })
+
+  it('reflects a previously disabled flag', () => {
+    // Arrange
+    window.localStorage.setItem(GRID_PERSISTENCE_ENABLED_KEY, 'false')
+
+    // Act
+    render(<Preferences />)
+
+    // Assert
+    expect(
+      screen.getByRole('switch', { name: 'Remember column layouts' }),
+    ).not.toBeChecked()
+  })
+
+  it('reset-all clears every saved grid layout after confirmation', () => {
+    // Arrange
+    window.localStorage.setItem('wayd-grid:ppm-projects:v1', '{}')
+    window.localStorage.setItem('wayd-grid:team-sprints:v1', '{}')
+    window.localStorage.setItem('appTheme', '"dark"')
+    render(<Preferences />)
+
+    // Act — open the Popconfirm, then confirm
+    fireEvent.click(screen.getByRole('button', { name: 'Reset All' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Reset' }))
+
+    // Assert — grid layouts gone, unrelated keys untouched
+    expect(
+      window.localStorage.getItem('wayd-grid:ppm-projects:v1'),
+    ).toBeNull()
+    expect(
+      window.localStorage.getItem('wayd-grid:team-sprints:v1'),
+    ).toBeNull()
+    expect(window.localStorage.getItem('appTheme')).toBe('"dark"')
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/preferences.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/preferences.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { FC } from 'react'
+import { Button, Flex, Popconfirm, Switch, Typography } from 'antd'
+import {
+  GRID_PERSISTENCE_ENABLED_KEY,
+  clearAllGridColumnState,
+} from '@/src/components/common/wayd-grid'
+import { useLocalStorageState } from '@/src/hooks'
+import { useMessage } from '@/src/components/contexts/messaging'
+
+const { Text, Title } = Typography
+
+/**
+ * Account-level preferences. Grid column layouts are stored in this browser's
+ * localStorage (not on the server), so both controls act on this device only.
+ * Disabling keeps existing saved layouts (re-enabling restores them);
+ * "Reset all" deletes them.
+ */
+const Preferences: FC = () => {
+  const [rememberColumnLayouts, setRememberColumnLayouts] =
+    useLocalStorageState<boolean>(GRID_PERSISTENCE_ENABLED_KEY, true)
+  const messageApi = useMessage()
+
+  const onResetAllGridLayouts = () => {
+    clearAllGridColumnState()
+    messageApi.success('All saved grid column layouts have been reset.')
+  }
+
+  return (
+    <Flex vertical gap="large" style={{ maxWidth: 640 }}>
+      <div>
+        <Title level={5}>Grids</Title>
+        <Text type="secondary">
+          Grid column layouts are saved in this browser, so these settings
+          apply to this device only.
+        </Text>
+      </div>
+
+      <Flex justify="space-between" align="center" gap="middle">
+        <div>
+          <Text strong>Remember column layouts</Text>
+          <br />
+          <Text type="secondary">
+            Save each grid&apos;s column sizing, visibility, and pinning so
+            your layout is restored on your next visit. Turning this off keeps
+            existing saved layouts; they apply again when re-enabled.
+          </Text>
+        </div>
+        <Switch
+          checked={rememberColumnLayouts}
+          onChange={setRememberColumnLayouts}
+          aria-label="Remember column layouts"
+        />
+      </Flex>
+
+      <Flex justify="space-between" align="center" gap="middle">
+        <div>
+          <Text strong>Reset all grid layouts</Text>
+          <br />
+          <Text type="secondary">
+            Delete every saved column layout on this device. Grids return to
+            their default columns.
+          </Text>
+        </div>
+        <Popconfirm
+          title="Reset all grid layouts?"
+          description="This deletes every saved column layout on this device."
+          okText="Reset"
+          onConfirm={onResetAllGridLayouts}
+        >
+          <Button danger>Reset All</Button>
+        </Popconfirm>
+      </Flex>
+    </Flex>
+  )
+}
+
+export default Preferences

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/_components/team-memberships-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/_components/team-memberships-grid.tsx
@@ -143,6 +143,11 @@ const TeamMembershipsGrid = ({
         isLoading={isLoading}
         onRefresh={refresh}
         csvFileName="team-memberships"
+        persistStateKey={
+          teamType === 'Team'
+            ? 'team-memberships'
+            : 'team-of-teams-memberships'
+        }
       />
       {openEditTeamMembershipForm && selectedTeamMembership && (
         <EditTeamMembershipForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/_components/employee-teams-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/[key]/_components/employee-teams-grid.tsx
@@ -100,6 +100,7 @@ const EmployeeTeamsGrid = ({ employeeId }: Props) => {
       onRefresh={() => {
         refetch()
       }}
+      persistStateKey="employee-teams"
       csvFileName="employee-teams"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/employees/page.tsx
@@ -133,6 +133,7 @@ const EmployeeListPage = () => {
         isLoading={isLoading}
         onRefresh={refresh}
         csvFileName="employees"
+        persistStateKey="organizations-employees"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />
     </>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/team-of-teams/[key]/page.tsx
@@ -171,6 +171,7 @@ const TeamOfTeamsDetailsPage = (props: {
           newRisksAllowed: true,
           teamId: team?.id,
           hideTeamColumn: true,
+          persistStateKey: 'team-of-teams-risks',
         } as RisksGridProps)
       case TeamOfTeamsTabs.TeamMemberships:
         return createElement(TeamMembershipsGrid, {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/[key]/page.tsx
@@ -328,6 +328,7 @@ const TeamDetailsPage = (props: { params: Promise<{ key: string }> }) => {
           newRisksAllowed: true,
           teamId: team!.id!,
           hideTeamColumn: true,
+          persistStateKey: 'team-risks',
         } as RisksGridProps)
       case TeamTabs.TeamMemberships:
         return createElement(TeamMembershipsGrid, {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-backlog.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-backlog.tsx
@@ -17,6 +17,7 @@ const TeamBacklog: FC<TeamBacklogProps> = ({ teamId }) => {
       hideTeamColumn={true}
       isLoading={backlogQuery.isLoading}
       refetch={backlogQuery.refetch}
+      persistStateKey="team-backlog"
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-members-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-members-grid.tsx
@@ -160,6 +160,9 @@ const TeamMembersGrid = ({ teamId, teamType }: TeamMembersGridProps) => {
           refetch()
         }}
         csvFileName="team-members"
+        persistStateKey={
+          teamType === 'Team' ? 'team-members' : 'team-of-teams-members'
+        }
       />
       {editingMember && (
         <EditTeamMemberForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-operating-models-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-operating-models-grid.tsx
@@ -189,6 +189,7 @@ const TeamOperatingModelsGrid = ({
         data={operatingModelsData ?? []}
         isLoading={isLoading}
         onRefresh={refresh}
+        persistStateKey="team-operating-models"
         csvFileName="team-operating-models"
       />
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-sprints.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/_components/team-sprints.tsx
@@ -21,6 +21,7 @@ const TeamSprints: FC<TeamSprintsProps> = (props) => {
       isLoading={isLoading}
       refetch={refetch}
       hideTeam={true}
+      persistStateKey="team-sprints"
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/organizations/teams/page.tsx
@@ -117,6 +117,7 @@ const TeamListPage = () => {
         }}
         isLoading={isLoading}
         csvFileName="teams"
+        persistStateKey="organizations-teams"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />
       {isCreateOpen && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/details/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/details/page.tsx
@@ -124,6 +124,7 @@ const PlanningIntervalDetailsPage = (props: {
           teams: teamsData,
           isLoading: teamsIsLoading,
           refetch: refetchTeams,
+          persistStateKey: 'planning-interval-teams',
         } as TeamsGridProps)
       case PlanningIntervalTabs.SprintMappings:
         return (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/iterations/[iterationKey]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/iterations/[iterationKey]/page.tsx
@@ -131,6 +131,7 @@ const PlanningIntervalIterationDetailsPage = (props: {
             isLoading={backlogIsLoading}
             refetch={refetchBacklog}
             gridHeight={550}
+            persistStateKey="iteration-backlog"
           />
         )
       default:

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/health-report/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/health-report/page.tsx
@@ -164,6 +164,7 @@ const ObjectiveHealthReportPage = (props: {
         data={healthReport ?? []}
         isLoading={isLoading}
         onRefresh={refresh}
+        persistStateKey="pi-objectives-health-report"
         csvFileName="pi-objectives-health-report"
       />
     </>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/objectives/page.tsx
@@ -124,6 +124,7 @@ const PlanningIntervalObjectivesPage = (props: {
           hidePlanningIntervalColumn={true}
           hideTeamColumn={false}
           viewSelector={viewSelector}
+          persistStateKey="planning-interval-objectives"
         />
       )}
       {currentView === 'Timeline' && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/risks/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/[key]/risks/page.tsx
@@ -51,6 +51,7 @@ const PlanningIntervalRisksPage = (props: {
         refreshRisks={refetchRisks}
         newRisksAllowed={true}
         hideTeamColumn={false}
+        persistStateKey="planning-interval-risks"
       />
     </>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/pi-objective-health-report-grid.tsx
@@ -98,6 +98,7 @@ const PiObjectiveHealthReportGrid = (
       data={healthReportData ?? []}
       onRefresh={refresh}
       isLoading={isLoading}
+      persistStateKey="pi-objective-health-report"
       csvFileName="pi-objective-health-report"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/_components/planning-interval-objectives-grid.tsx
@@ -29,6 +29,8 @@ export interface PlanningIntervalObjectivesGridProps {
   hidePlanningIntervalColumn?: boolean
   hideTeamColumn?: boolean
   viewSelector?: React.ReactNode
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 interface SelectedObjective {
@@ -49,6 +51,7 @@ const PlanningIntervalObjectivesGrid = ({
   hidePlanningIntervalColumn = false,
   hideTeamColumn = false,
   viewSelector,
+  persistStateKey,
 }: PlanningIntervalObjectivesGridProps) => {
   const [hidePlanningInterval, setHidePlanningInterval] = useState<boolean>(
     hidePlanningIntervalColumn,
@@ -138,14 +141,20 @@ const PlanningIntervalObjectivesGrid = ({
         header: 'Stretch',
         meta: { columnType: 'yesNo' },
       },
-      {
-        id: 'planningInterval',
-        accessorKey: 'planningInterval.name',
-        header: 'Planning Interval',
-        meta: { hide: hidePlanningInterval },
-        cell: ({ row }) =>
-          renderPlanningIntervalLink(row.original.planningInterval),
-      },
+      // Context-dependent columns are excluded from the defs (not meta.hide)
+      // so they stay out of the column chooser and persisted layouts; the
+      // memo rebuilds when the toolbar switches flip.
+      ...(hidePlanningInterval
+        ? []
+        : [
+            {
+              id: 'planningInterval',
+              accessorKey: 'planningInterval.name',
+              header: 'Planning Interval',
+              cell: ({ row }) =>
+                renderPlanningIntervalLink(row.original.planningInterval),
+            } satisfies ColumnDef<PlanningIntervalObjectiveListDto, any>,
+          ]),
       {
         id: 'status',
         accessorKey: 'status.name',
@@ -153,13 +162,17 @@ const PlanningIntervalObjectivesGrid = ({
         size: 125,
         meta: { filterType: 'set' },
       },
-      {
-        id: 'team',
-        accessorKey: 'team.name',
-        header: 'Team',
-        meta: { hide: hideTeam, filterEnableSet: true },
-        cell: ({ row }) => renderTeamLink(row.original.team),
-      },
+      ...(hideTeam
+        ? []
+        : [
+            {
+              id: 'team',
+              accessorKey: 'team.name',
+              header: 'Team',
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderTeamLink(row.original.team),
+            } satisfies ColumnDef<PlanningIntervalObjectiveListDto, any>,
+          ]),
       {
         id: 'health',
         accessorFn: (row) => row.healthCheck?.status?.name ?? '',
@@ -272,6 +285,7 @@ const PlanningIntervalObjectivesGrid = ({
         isLoading={isLoading}
         onRefresh={refresh}
         csvFileName="pi-objectives"
+        persistStateKey={persistStateKey}
         rightSlot={
           <>
             <ControlItemsMenu items={controlItems} />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/planning-intervals/page.tsx
@@ -112,6 +112,7 @@ const PlanningIntervalListPage = () => {
         data={data}
         isLoading={isLoading}
         onRefresh={refresh}
+        persistStateKey="planning-intervals"
         csvFileName="planning-intervals"
       />
       {openCreatePlanningIntervalForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/poker-sessions/_components/poker-sessions-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/poker-sessions/_components/poker-sessions-grid.tsx
@@ -139,6 +139,7 @@ const PokerSessionsGrid: FC<PokerSessionsGridProps> = ({
       data={sessions}
       onRefresh={refetch}
       isLoading={isLoading}
+      persistStateKey="poker-sessions"
       csvFileName="poker-sessions"
       emptyMessage="No poker sessions found."
       rightSlot={

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmaps-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/roadmaps/_components/roadmaps-grid.tsx
@@ -76,6 +76,7 @@ const RoadmapsGrid: FC<RoadmapsGridProps> = (props: RoadmapsGridProps) => {
       data={props.roadmapsData}
       onRefresh={props.refreshRoadmaps}
       isLoading={props.roadmapsLoading}
+      persistStateKey="planning-roadmaps"
       csvFileName="roadmaps"
       rightSlot={props.viewSelector}
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/sprints/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/sprints/[key]/page.tsx
@@ -132,6 +132,7 @@ const SprintDetailsPage = (props: { params: Promise<{ key: string }> }) => {
             isLoading={workItemsDataIsLoading}
             refetch={refetchWorkItemsData}
             hideTeamColumn={true}
+            persistStateKey="sprint-backlog"
           />
         </Flex>
         <Divider size="small" />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/sprints/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/sprints/page.tsx
@@ -19,6 +19,7 @@ const SprintsPage: FC = () => {
         sprints={sprintsData ?? []}
         isLoading={isLoading}
         refetch={refetch}
+        persistStateKey="planning-sprints"
       />
     </>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/program-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/program-view-manager.tsx
@@ -58,6 +58,7 @@ const ProgramViewManager = (props: ProgramViewManagerProps) => {
           refetch={props.refetch}
           hidePortfolio={true}
           viewSelector={viewSelector}
+          persistStateKey="portfolio-programs"
         />
       )}
       {currentView === 'Timeline' && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/programs-grid.tsx
@@ -18,6 +18,8 @@ export interface ProgramsGridProps {
   hidePortfolio?: boolean
   gridHeight?: number | undefined
   viewSelector?: React.ReactNode | undefined
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const ProgramsGrid: FC<ProgramsGridProps> = (props: ProgramsGridProps) => {
@@ -45,14 +47,20 @@ const ProgramsGrid: FC<ProgramsGridProps> = (props: ProgramsGridProps) => {
             <LifecycleStatusTag status={row.original.status} />
           ) : null,
       },
-      {
-        id: 'portfolio',
-        accessorKey: 'portfolio.name',
-        header: 'Portfolio',
-        size: 200,
-        meta: { hide: props.hidePortfolio, filterEnableSet: true },
-        cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
-      },
+      // Context-redundant column: excluded from the defs (not meta.hide) so
+      // it stays out of the column chooser and persisted layouts.
+      ...(props.hidePortfolio
+        ? []
+        : [
+            {
+              id: 'portfolio',
+              accessorKey: 'portfolio.name',
+              header: 'Portfolio',
+              size: 200,
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
+            } satisfies ColumnDef<ProgramListDto, any>,
+          ]),
       {
         id: 'start',
         accessorKey: 'start',
@@ -104,6 +112,7 @@ const ProgramsGrid: FC<ProgramsGridProps> = (props: ProgramsGridProps) => {
       csvFileName="programs"
       rightSlot={props.viewSelector}
       height={props.gridHeight}
+      persistStateKey={props.persistStateKey}
       emptyMessage="No programs found."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/project-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/project-view-manager.tsx
@@ -44,6 +44,8 @@ interface ProjectViewManagerProps {
   hideProgram?: boolean
   groupByProgram?: boolean
   defaultView?: ProjectView
+  /** Column layout persistence key for the list view (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const ProjectViewManager = (props: ProjectViewManagerProps) => {
@@ -94,6 +96,7 @@ const ProjectViewManager = (props: ProjectViewManagerProps) => {
           hidePortfolio={props.hidePortfolio}
           hideProgram={props.hideProgram}
           viewSelector={viewSelector}
+          persistStateKey={props.persistStateKey}
         />
       )}
       {currentView === 'Timeline' && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/projects-grid.tsx
@@ -21,6 +21,8 @@ export interface ProjectsGridProps {
   hideProgram?: boolean
   gridHeight?: number | undefined
   viewSelector?: ReactNode | undefined
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const ProjectsGrid: FC<ProjectsGridProps> = (props: ProjectsGridProps) => {
@@ -75,22 +77,33 @@ const ProjectsGrid: FC<ProjectsGridProps> = (props: ProjectsGridProps) => {
           )
         },
       },
-      {
-        id: 'portfolio',
-        accessorKey: 'portfolio.name',
-        header: 'Portfolio',
-        size: 200,
-        meta: { hide: props.hidePortfolio, filterEnableSet: true },
-        cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
-      },
-      {
-        id: 'program',
-        accessorKey: 'program.name',
-        header: 'Program',
-        size: 200,
-        meta: { hide: props.hideProgram, filterEnableSet: true },
-        cell: ({ row }) => renderProgramLink(row.original.program),
-      },
+      // Context-redundant columns are excluded from the defs (not meta.hide):
+      // they never belong on the hosting page, so they shouldn't appear in
+      // the column chooser or the persisted layout either.
+      ...(props.hidePortfolio
+        ? []
+        : [
+            {
+              id: 'portfolio',
+              accessorKey: 'portfolio.name',
+              header: 'Portfolio',
+              size: 200,
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
+            } satisfies ColumnDef<ProjectListDto, any>,
+          ]),
+      ...(props.hideProgram
+        ? []
+        : [
+            {
+              id: 'program',
+              accessorKey: 'program.name',
+              header: 'Program',
+              size: 200,
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderProgramLink(row.original.program),
+            } satisfies ColumnDef<ProjectListDto, any>,
+          ]),
       {
         id: 'start',
         accessorKey: 'start',
@@ -148,6 +161,7 @@ const ProjectsGrid: FC<ProjectsGridProps> = (props: ProjectsGridProps) => {
       csvFileName="projects"
       rightSlot={props.viewSelector}
       height={props.gridHeight}
+      persistStateKey={props.persistStateKey}
       emptyMessage="No projects found."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiative-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiative-view-manager.tsx
@@ -60,6 +60,7 @@ const StrategicInitiativeViewManager = (
           refetch={props.refetch}
           hidePortfolio={true}
           viewSelector={viewSelector}
+          persistStateKey="portfolio-strategic-initiatives"
         />
       )}
       {currentView === 'Timeline' && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/_components/strategic-initiatives-grid.tsx
@@ -21,6 +21,8 @@ export interface StrategicInitiativesGridProps {
   hidePortfolio?: boolean
   gridHeight?: number | undefined
   viewSelector?: React.ReactNode | undefined
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 /** Renders a strategic initiative as a link to its page. */
@@ -62,14 +64,20 @@ const StrategicInitiativesGrid: FC<StrategicInitiativesGridProps> = (
             <LifecycleStatusTag status={row.original.status} />
           ) : null,
       },
-      {
-        id: 'portfolio',
-        accessorKey: 'portfolio.name',
-        header: 'Portfolio',
-        size: 200,
-        meta: { hide: props.hidePortfolio, filterEnableSet: true },
-        cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
-      },
+      // Context-redundant column: excluded from the defs (not meta.hide) so
+      // it stays out of the column chooser and persisted layouts.
+      ...(props.hidePortfolio
+        ? []
+        : [
+            {
+              id: 'portfolio',
+              accessorKey: 'portfolio.name',
+              header: 'Portfolio',
+              size: 200,
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderPortfolioLink(row.original.portfolio),
+            } satisfies ColumnDef<StrategicInitiativeListDto, any>,
+          ]),
       {
         id: 'start',
         accessorKey: 'start',
@@ -113,6 +121,7 @@ const StrategicInitiativesGrid: FC<StrategicInitiativesGridProps> = (
       csvFileName="strategic-initiatives"
       rightSlot={props.viewSelector}
       height={props.gridHeight}
+      persistStateKey={props.persistStateKey}
       emptyMessage="No strategic initiatives found."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/_components/ranking/project-ranking-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/_components/ranking/project-ranking-board.tsx
@@ -416,6 +416,7 @@ const ProjectRankingBoard = ({
         isLoading={isLoading}
         onRefresh={refetch}
         emptyMessage="No projects to rank."
+        persistStateKey="portfolio-project-ranking"
         csvFileName="portfolio-ranking"
         onRowReorder={canManage ? onRowReorder : undefined}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/[key]/page.tsx
@@ -276,6 +276,7 @@ const PortfolioDetailsPage = (props: { params: Promise<{ key: string }> }) => {
               isLoading={isLoadingProjects}
               refetch={refetchProjects}
               groupByProgram={true}
+              persistStateKey="portfolio-projects"
             />
           </>
         )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/_components/portfolios-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/_components/portfolios-grid.tsx
@@ -11,6 +11,8 @@ export interface PortfoliosGridProps {
   viewSelector: ReactElement
   isLoading: boolean
   refetch: () => void
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const PortfoliosGrid: React.FC<PortfoliosGridProps> = (
@@ -66,6 +68,7 @@ const PortfoliosGrid: React.FC<PortfoliosGridProps> = (
       isLoading={props.isLoading}
       csvFileName="portfolios"
       rightSlot={props.viewSelector}
+      persistStateKey={props.persistStateKey}
       emptyMessage="No portfolios found."
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/portfolios/page.tsx
@@ -99,6 +99,7 @@ const PortfoliosPage: FC = () => {
           viewSelector={viewSelector}
           isLoading={isLoading}
           refetch={refetch}
+          persistStateKey="ppm-portfolios"
         />
       )}
       {openCreatePortfolioForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/programs/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/programs/[key]/page.tsx
@@ -257,6 +257,7 @@ const ProgramDetailsPage = (props: { params: Promise<{ key: string }> }) => {
                 hidePortfolio={true}
                 hideProgram={true}
                 defaultView="Card"
+                persistStateKey="program-projects"
               />
             </Flex>
           </Flex>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/programs/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/programs/page.tsx
@@ -87,6 +87,7 @@ const ProgramsPage: FC = () => {
         programs={programData ?? []}
         isLoading={isLoading}
         refetch={refetch}
+        persistStateKey="ppm-programs"
       />
       {openCreateProgramForm && (
         <CreateProgramForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/[key]/_components/project-health-report-grid.tsx
@@ -82,6 +82,7 @@ const ProjectHealthReportGrid = ({
         refetch()
       }}
       isLoading={isLoading}
+      persistStateKey="project-health-report"
       csvFileName="project-health-report"
       emptyMessage="No health checks found."
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-team-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-team-grid.tsx
@@ -63,6 +63,7 @@ const ProjectTeamGrid: FC<ProjectTeamGridProps> = ({ projectIdOrKey }) => {
       data={teamData ?? []}
       onRefresh={refresh}
       isLoading={isLoading}
+      persistStateKey="project-team"
       csvFileName="project-team"
       emptyMessage="No team members assigned."
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-work-items-tree-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-work-items-tree-grid.tsx
@@ -262,6 +262,7 @@ const ProjectWorkItemsTreeGrid: FC<ProjectWorkItemsTreeGridProps> = ({
       height={gridHeight}
       onRefresh={async () => refetch()}
       rightSlot={viewSelector}
+      persistStateKey="project-work-items-tree"
       csvFileName="project-work-items"
       emptyMessage="No work items found"
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-work-items-view-manager.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/_components/project-work-items-view-manager.tsx
@@ -64,6 +64,7 @@ const ProjectWorkItemsViewManager = (
           hideProjectColumn={props.hideProjectColumn}
           viewSelector={viewSelector}
           gridHeight={props.gridHeight}
+          persistStateKey="project-work-items"
         />
       )}
     </>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/projects/page.tsx
@@ -108,6 +108,7 @@ const ProjectsPage: FC = () => {
         projects={projectData ?? []}
         isLoading={isLoading}
         refetch={refetch}
+        persistStateKey="ppm-projects"
       />
       {openCreateProjectForm && (
         <CreateProjectForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/[key]/page.tsx
@@ -379,6 +379,7 @@ const StrategicInitiativeDetailsPage = (props: {
                 hidePortfolio={false}
                 groupByProgram={true}
                 defaultView="Card"
+                persistStateKey="strategic-initiative-projects"
               />
             </Flex>
           </Flex>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/strategic-initiative-kpis-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/_components/strategic-initiative-kpis-grid.tsx
@@ -326,6 +326,7 @@ const StrategicInitiativeKpisGrid: FC<StrategicInitiativeKpisGridProps> = (
         isLoading={isLoading}
         height={gridHeight}
         emptyMessage="No KPIs found."
+        persistStateKey="strategic-initiative-kpis"
         getRowId={(kpi) => kpi.id}
         rightSlot={viewSelector}
         onRowReorder={canReorder ? onRowReorder : undefined}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/ppm/strategic-initiatives/page.tsx
@@ -97,6 +97,7 @@ const StrategicInitiativesPage: FC = () => {
         strategicInitiatives={strategicInitiativeData ?? []}
         isLoading={isLoading}
         refetch={refetch}
+        persistStateKey="ppm-strategic-initiatives"
       />
       {openCreateStrategicInitiativeForm && (
         <CreateStrategicInitiativeForm

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/active-tenant-migrations.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/_components/active-tenant-migrations.tsx
@@ -67,6 +67,7 @@ const ActiveTenantMigrations = ({
       onRefresh={() => {
         refetch()
       }}
+      persistStateKey="settings-tenant-migrations"
       csvFileName="tenant-migrations"
       emptyMessage="No tenant migrations are currently in progress."
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/auth/providers/page.tsx
@@ -307,6 +307,7 @@ const OidcProvidersPage = () => {
         data={providers ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-identity-providers"
         csvFileName="identity-providers"
       />
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/background-jobs/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/background-jobs/page.tsx
@@ -158,6 +158,7 @@ const BackgroundJobsListPage = () => {
         columns={columns}
         data={backgroundJobs}
         onRefresh={getRunningJobs}
+        persistStateKey="settings-background-jobs"
         csvFileName="background-jobs"
       />
       {openCreateRecurringJobForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/connections/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/connections/page.tsx
@@ -125,6 +125,7 @@ const ConnectionsPage = () => {
         data={connectionsData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-connections"
         csvFileName="connections"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/feature-management/feature-flags/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/feature-management/feature-flags/page.tsx
@@ -134,12 +134,19 @@ const FeatureFlagsListPage = () => {
         header: 'Enabled',
         meta: { columnType: 'yesNo' },
       },
-      {
-        id: 'isArchived',
-        accessorKey: 'isArchived',
-        header: 'Archived',
-        meta: { columnType: 'yesNo', hide: !includeArchived },
-      },
+      // Mode-dependent column: excluded from the defs (not meta.hide) so it
+      // stays out of the column chooser and persisted layouts; the memo
+      // rebuilds when the Include Archived switch flips.
+      ...(includeArchived
+        ? [
+            {
+              id: 'isArchived',
+              accessorKey: 'isArchived',
+              header: 'Archived',
+              meta: { columnType: 'yesNo' },
+            } satisfies ColumnDef<FeatureFlagListDto, any>,
+          ]
+        : []),
     ]
   }, [
     showRowActions,
@@ -172,6 +179,7 @@ const FeatureFlagsListPage = () => {
         data={featureFlags}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-feature-flags"
         csvFileName="feature-flags"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/organization/team-member-roles/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/organization/team-member-roles/page.tsx
@@ -174,6 +174,7 @@ const TeamMemberRolesPage = () => {
           refetch()
         }}
         isLoading={isLoading}
+        persistStateKey="settings-team-member-roles"
         csvFileName="team-member-roles"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/planning/estimation-scales/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/planning/estimation-scales/page.tsx
@@ -221,6 +221,7 @@ const EstimationScalesPage = () => {
         data={scaleData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-estimation-scales"
         csvFileName="estimation-scales"
       />
       {openCreateForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/expenditure-categories/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/expenditure-categories/page.tsx
@@ -120,6 +120,7 @@ const ExpenditureCategoriesPage = () => {
         data={categoryData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-expenditure-categories"
         csvFileName="expenditure-categories"
       />
       {openCreateExpenditureCategoryForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/_components/project-lifecycle-phases-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/_components/project-lifecycle-phases-list.tsx
@@ -206,6 +206,7 @@ const ProjectLifecyclePhasesList = ({
         data={sortedPhases}
         leftSlot={actions}
         onRefresh={loadData}
+        persistStateKey="settings-project-lifecycle-phases"
         csvFileName="project-lifecycle-phases"
       />
       {openAddPhaseForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/ppm/project-lifecycles/page.tsx
@@ -104,6 +104,7 @@ const ProjectLifecyclesPage = () => {
         data={lifecycleData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-project-lifecycles"
         csvFileName="project-lifecycles"
       />
       {openCreateForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-criteria-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-criteria-list.tsx
@@ -277,6 +277,7 @@ const ScoringModelCriteriaList = ({
         data={sortedCriteria}
         leftSlot={actions}
         onRefresh={loadData}
+        persistStateKey="settings-scoring-model-criteria"
         csvFileName="scoring-criteria"
       />
       {openAddForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-outputs-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-model-outputs-list.tsx
@@ -288,6 +288,7 @@ const ScoringModelOutputsList = ({
         data={sortedOutputs}
         leftSlot={actions}
         onRefresh={loadData}
+        persistStateKey="settings-scoring-model-outputs"
         csvFileName="scoring-outputs"
       />
       {openAddForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-scales-list.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/_components/scoring-scales-list.tsx
@@ -235,6 +235,7 @@ const ScoringScalesList = ({
           columns={makeLevelColumns(scale, sortedLevels)}
           data={sortedLevels}
           onRefresh={loadData}
+          persistStateKey="settings-scoring-scale-levels"
           csvFileName="scoring-scale-levels"
         />
       ),

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/scoring/scoring-models/page.tsx
@@ -116,6 +116,7 @@ const ScoringModelsPage = () => {
         data={scoringModelData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-scoring-models"
         csvFileName="scoring-models"
       />
       {openCreateForm && (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/_components/role-users-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/_components/role-users-grid.tsx
@@ -60,6 +60,7 @@ const RoleUsersGrid: FC<RoleUsersGridProps> = (props: RoleUsersGridProps) => {
       data={usersData ?? []}
       onRefresh={refresh}
       isLoading={isLoading}
+      persistStateKey="settings-role-users"
       csvFileName="role-users"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/roles/page.tsx
@@ -73,6 +73,7 @@ const RoleListPage = () => {
         data={roleData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-roles"
         csvFileName="roles"
       />
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/users/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/user-management/users/page.tsx
@@ -211,6 +211,7 @@ const UsersListPage = () => {
         data={usersData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-users"
         csvFileName="users"
       />
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-processes/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-processes/page.tsx
@@ -94,6 +94,7 @@ const WorkProcessesPage: React.FC = () => {
         data={workProcessesData ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-work-processes"
         csvFileName="work-processes"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-statuses/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-statuses/page.tsx
@@ -83,6 +83,7 @@ const WorkStatusesPage = () => {
         data={workStatuses ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-work-statuses"
         csvFileName="work-statuses"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-types/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/work-management/work-types/page.tsx
@@ -148,6 +148,7 @@ const WorkTypesPage = () => {
         data={workTypes ?? []}
         onRefresh={refresh}
         isLoading={isLoading}
+        persistStateKey="settings-work-types"
         csvFileName="work-types"
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/strategic-management/strategic-themes/_components/strategic-themes-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/strategic-management/strategic-themes/_components/strategic-themes-grid.tsx
@@ -50,6 +50,7 @@ const StrategicThemesGrid: React.FC<StrategicThemesGridProps> = (
       data={props.strategicThemesData}
       isLoading={props.strategicThemesLoading}
       onRefresh={props.refreshStrategicThemes}
+      persistStateKey="strategic-themes"
       csvFileName="strategic-themes"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/[key]/page.tsx
@@ -76,6 +76,7 @@ const WorkspaceDetailsPage = (props: { params: Promise<{ key: string }> }) => {
             workItems={workItemsQuery.data ?? []}
             isLoading={workItemsQuery.isLoading}
             refetch={workItemsQuery.refetch}
+            persistStateKey="workspace-work-items"
           />
         )
       default:

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/[key]/work-items/[workItemKey]/page.tsx
@@ -109,6 +109,7 @@ const WorkItemDetailsPage = (props: {
             isLoading={childWorkItemsQuery.isLoading}
             refetch={childWorkItemsQuery.refetch}
             hideParentColumn={true}
+            persistStateKey="work-item-children"
           />
         )
       case WorkItemTabs.Dashboard:

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/_components/workspaces-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/work/workspaces/_components/workspaces-grid.tsx
@@ -57,6 +57,7 @@ const WorkspacesGrid = (props: WorkspacesGridProps) => {
       data={props.workspaces ?? []}
       onRefresh={refresh}
       isLoading={props.isLoading}
+      persistStateKey="work-workspaces"
       csvFileName="workspaces"
       rightSlot={props.viewSelector}
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/team-dependencies-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/team-dependencies-grid.tsx
@@ -170,6 +170,7 @@ const TeamDependenciesGrid: FC<TeamDependenciesGridProps> = (props) => {
       data={props.dependencies}
       onRefresh={refresh}
       isLoading={props.isLoading}
+      persistStateKey="team-dependencies"
       csvFileName="team-dependencies"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/teams-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/organizations/teams-grid.tsx
@@ -7,6 +7,8 @@ export interface TeamsGridProps {
   teams: PlanningIntervalTeamResponse[]
   isLoading: boolean
   refetch: () => void
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const TeamsGrid: FC<TeamsGridProps> = (props) => {
@@ -58,6 +60,7 @@ const TeamsGrid: FC<TeamsGridProps> = (props) => {
       data={props.teams}
       onRefresh={refresh}
       isLoading={props.isLoading}
+      persistStateKey={props.persistStateKey}
       csvFileName="teams"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/risks-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/risks-grid.tsx
@@ -19,6 +19,8 @@ export interface RisksGridProps {
   newRisksAllowed?: boolean
   hideTeamColumn?: boolean
   gridHeight?: number
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const RisksGrid = ({
@@ -30,6 +32,7 @@ const RisksGrid = ({
   newRisksAllowed = false,
   hideTeamColumn = false,
   gridHeight,
+  persistStateKey,
 }: RisksGridProps) => {
   const [includeClosed, setIncludeClosed] = useState<boolean>(false)
   const [hideTeam, setHideTeam] = useState<boolean>(hideTeamColumn)
@@ -137,20 +140,33 @@ const RisksGrid = ({
           </Link>
         ),
       },
-      {
-        id: 'team',
-        accessorKey: 'team.name',
-        header: 'Team',
-        meta: { hide: hideTeam, filterEnableSet: true },
-        cell: ({ row }) => renderTeamLink(row.original.team),
-      },
-      {
-        id: 'status',
-        accessorKey: 'status',
-        header: 'Status',
-        size: 125,
-        meta: { hide: includeClosed === false, filterType: 'set' },
-      },
+      // Context/mode-dependent columns are excluded from the defs (not
+      // meta.hide) so they stay out of the column chooser and persisted
+      // layouts; the memo rebuilds when the toolbar switches flip.
+      ...(hideTeam
+        ? []
+        : [
+            {
+              id: 'team',
+              accessorKey: 'team.name',
+              header: 'Team',
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderTeamLink(row.original.team),
+            } satisfies ColumnDef<RiskListDto, any>,
+          ]),
+      // Status is only informative when closed risks are included — open
+      // risks all share one status.
+      ...(includeClosed
+        ? [
+            {
+              id: 'status',
+              accessorKey: 'status',
+              header: 'Status',
+              size: 125,
+              meta: { filterType: 'set' },
+            } satisfies ColumnDef<RiskListDto, any>,
+          ]
+        : []),
       {
         id: 'category',
         accessorKey: 'category',
@@ -202,6 +218,7 @@ const RisksGrid = ({
         isLoading={isLoadingRisks}
         onRefresh={refreshRisks}
         csvFileName="risks"
+        persistStateKey={persistStateKey}
         leftSlot={showActions ? actions() : undefined}
         rightSlot={<ControlItemsMenu items={controlItems} />}
       />

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprint-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprint-backlog-grid.tsx
@@ -23,6 +23,8 @@ export interface SprintBacklogGridProps {
   hideTeamColumn?: boolean
   hideSprintColumn?: boolean
   gridHeight?: number
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const SprintBacklogGrid = (props: SprintBacklogGridProps) => {
@@ -85,21 +87,32 @@ const SprintBacklogGrid = (props: SprintBacklogGridProps) => {
         sortingFn: workStatusCategorySort,
         meta: { filterType: 'set' },
       },
-      {
-        id: 'team',
-        accessorKey: 'team.name',
-        header: 'Team',
-        meta: { hide: hideTeamColumn, filterEnableSet: true },
-        cell: ({ row }) => renderTeamLink(row.original.team),
-      },
-      {
-        id: 'sprint',
-        accessorKey: 'sprint.name',
-        header: 'Sprint',
-        meta: { hide: hideSprintColumn, filterEnableSet: true },
-        cell: ({ row }) =>
-          renderSprintLink(row.original.sprint, { showTeamCode: false }),
-      },
+      // Context-redundant columns are excluded from the defs (not meta.hide):
+      // they never belong on the hosting page, so they shouldn't appear in
+      // the column chooser or the persisted layout either.
+      ...(hideTeamColumn
+        ? []
+        : [
+            {
+              id: 'team',
+              accessorKey: 'team.name',
+              header: 'Team',
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderTeamLink(row.original.team),
+            } satisfies ColumnDef<SprintBacklogItemDto, any>,
+          ]),
+      ...(hideSprintColumn
+        ? []
+        : [
+            {
+              id: 'sprint',
+              accessorKey: 'sprint.name',
+              header: 'Sprint',
+              meta: { filterEnableSet: true },
+              cell: ({ row }) =>
+                renderSprintLink(row.original.sprint, { showTeamCode: false }),
+            } satisfies ColumnDef<SprintBacklogItemDto, any>,
+          ]),
       {
         id: 'parentKey',
         accessorKey: 'parent.key',
@@ -160,6 +173,7 @@ const SprintBacklogGrid = (props: SprintBacklogGridProps) => {
       data={workItems ?? []}
       onRefresh={refresh}
       isLoading={props.isLoading}
+      persistStateKey={props.persistStateKey}
       csvFileName="sprint-backlog"
       emptyMessage="No planned work items"
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.test.tsx
@@ -184,8 +184,9 @@ describe('SprintsGrid', () => {
     expect(mockRefetch).toHaveBeenCalledTimes(1)
   })
 
-  it('hides the team column via meta.hide when hideTeam is set', () => {
-    // Arrange / Act
+  it('excludes the team column from the defs when hideTeam is set', () => {
+    // Arrange / Act — context-redundant columns are excluded, not meta-hidden,
+    // so they stay out of the column chooser and persisted layouts
     render(
       <SprintsGrid
         sprints={mockSprints}
@@ -198,11 +199,11 @@ describe('SprintsGrid', () => {
     // Assert
     const call = (WaydGridModule.WaydGrid as unknown as jest.Mock).mock
       .calls[0][0]
-    const teamColumn = call.columns.find((c: { id: string }) => c.id === 'team')
-    expect(teamColumn.meta.hide).toBe(true)
+    const ids = call.columns.map((c: { id: string }) => c.id)
+    expect(ids).not.toContain('team')
   })
 
-  it('does not hide the team column by default', () => {
+  it('includes the team column by default', () => {
     // Arrange / Act
     render(
       <SprintsGrid
@@ -217,5 +218,22 @@ describe('SprintsGrid', () => {
       .calls[0][0]
     const teamColumn = call.columns.find((c: { id: string }) => c.id === 'team')
     expect(teamColumn.meta.hide).toBeUndefined()
+  })
+
+  it('forwards persistStateKey to the grid', () => {
+    // Arrange / Act
+    render(
+      <SprintsGrid
+        sprints={mockSprints}
+        isLoading={false}
+        refetch={mockRefetch}
+        persistStateKey="team-sprints"
+      />,
+    )
+
+    // Assert
+    const call = (WaydGridModule.WaydGrid as unknown as jest.Mock).mock
+      .calls[0][0]
+    expect(call.persistStateKey).toBe('team-sprints')
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/planning/sprints-grid.tsx
@@ -19,6 +19,8 @@ export interface SprintsGridProps {
   refetch: () => void
   hideTeam?: boolean
   gridHeight?: number | undefined
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 /**
@@ -47,14 +49,20 @@ const SprintsGrid: FC<SprintsGridProps> = (props: SprintsGridProps) => {
         cell: ({ row }) =>
           renderSprintLink(row.original, { showTeamCode: false }),
       },
-      {
-        id: 'team',
-        accessorKey: 'team.name',
-        header: 'Team',
-        size: 200,
-        meta: { hide: props.hideTeam, filterEnableSet: true },
-        cell: ({ row }) => renderTeamLink(row.original.team),
-      },
+      // Context-redundant column: excluded from the defs (not meta.hide) so
+      // it stays out of the column chooser and persisted layouts.
+      ...(props.hideTeam
+        ? []
+        : [
+            {
+              id: 'team',
+              accessorKey: 'team.name',
+              header: 'Team',
+              size: 200,
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderTeamLink(row.original.team),
+            } satisfies ColumnDef<SprintListDto, any>,
+          ]),
       {
         id: 'state',
         accessorKey: 'state.name',
@@ -90,6 +98,7 @@ const SprintsGrid: FC<SprintsGridProps> = (props: SprintsGridProps) => {
       isLoading={props.isLoading}
       height={props.gridHeight}
       initialSorting={defaultSorting}
+      persistStateKey={props.persistStateKey}
       csvFileName="sprints"
       emptyMessage="No sprints found."
     />

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.test.ts
@@ -19,7 +19,7 @@ describe('column-autosize', () => {
     })
 
     it('sizes to the widest cell plus the cell allowance', () => {
-      // Arrange / Act — cell 200 + 18 beats header 50 + 76
+      // Arrange / Act — cell 200 + 18 beats header 50 + 48
       const width = computeAutosizeWidth({
         maxCellContentWidth: 200,
         headerContentWidth: 50,
@@ -30,14 +30,14 @@ describe('column-autosize', () => {
     })
 
     it('sizes to the header plus the header allowance when it is wider', () => {
-      // Arrange / Act — header 200 + 76 beats cell 100 + 18
+      // Arrange / Act — header 200 + 48 beats cell 100 + 18
       const width = computeAutosizeWidth({
         maxCellContentWidth: 100,
         headerContentWidth: 200,
       })
 
       // Assert
-      expect(width).toBe(276)
+      expect(width).toBe(248)
     })
 
     it('rounds fractional measurements up', () => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-autosize.ts
@@ -21,10 +21,12 @@ export const AUTOSIZE_MAX_WIDTH = 600
  *  computed width. */
 export const AUTOSIZE_CELL_ALLOWANCE = 18
 
-/** Horizontal overhead around the header label: th + content padding, plus
- *  reserved room for the sort icon and the column menu trigger (both live in
- *  the header cell whether currently visible or not). */
-export const AUTOSIZE_HEADER_ALLOWANCE = 76
+/** Horizontal overhead around the header label: th padding (8px per side),
+ *  plus reserved room for the sort icon, filter trigger, and column menu
+ *  trigger with the 4px flex gaps between them (the triggers occupy layout
+ *  space whether currently visible or not). Must track the header CSS —
+ *  thContent gap and .th padding in wayd-grid.module.css. */
+export const AUTOSIZE_HEADER_ALLOWANCE = 48
 
 export interface AutosizeWidthInput {
   /** Widest measured content among the rendered cells, px (0 = no cells). */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-row.tsx
@@ -18,6 +18,9 @@ export interface GridRowClasses {
   tr: string
   trAlt: string
   td: string
+  /** Applied to `td`s of numeric columns (right-aligned cells; headers are
+   *  unaffected — alignment is a body-cell concern only). */
+  tdNumeric?: string
   /** Sticky/edge classes for pinned columns' `td`s. */
   pinned?: PinnedCellClasses
 }
@@ -37,11 +40,25 @@ const pinnedTdProps = <T,>(
   }
 }
 
+/** The numeric-alignment class suffix (starting with a space) for a body
+ *  cell, or '' when the column isn't numeric / no class was supplied. */
+const numericTdClass = <T,>(
+  cell: Cell<T, unknown>,
+  classes: GridRowClasses,
+  numericColumnIds: ReadonlySet<string> | undefined,
+): string =>
+  classes.tdNumeric && numericColumnIds?.has(cell.column.id)
+    ? ` ${classes.tdNumeric}`
+    : ''
+
 export interface FlatGridRowProps<T> {
   row: Row<T>
   /** Display index within the rendered row list (drives zebra striping). */
   index: number
   classes: GridRowClasses
+  /** Column ids whose cells right-align (numeric columns); resolved once at
+   *  the grid level — see the grid's numericColumnIds. */
+  numericColumnIds?: ReadonlySet<string>
 }
 
 /**
@@ -56,7 +73,12 @@ export interface FlatGridRowProps<T> {
  * (the grids do); a directive here alone could not force a memoized parent to
  * re-create the element.
  */
-export function FlatGridRow<T>({ row, index, classes }: FlatGridRowProps<T>) {
+export function FlatGridRow<T>({
+  row,
+  index,
+  classes,
+  numericColumnIds,
+}: FlatGridRowProps<T>) {
   // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see GridHeaderCell
   'use no memo'
   return (
@@ -69,7 +91,7 @@ export function FlatGridRow<T>({ row, index, classes }: FlatGridRowProps<T>) {
           <td
             key={cell.id}
             data-column-id={cell.column.id}
-            className={`${classes.td}${pinned.className}`}
+            className={`${classes.td}${numericTdClass(cell, classes, numericColumnIds)}${pinned.className}`}
             style={pinned.style}
           >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -104,6 +126,7 @@ export function SortableFlatGridRow<T>({
   row,
   index,
   classes,
+  numericColumnIds,
   nodeId,
   isDragging,
   isDragEnabled,
@@ -123,7 +146,7 @@ export function SortableFlatGridRow<T>({
           <td
             key={cell.id}
             data-column-id={cell.column.id}
-            className={`${classes.td}${pinned.className}`}
+            className={`${classes.td}${numericTdClass(cell, classes, numericColumnIds)}${pinned.className}`}
             style={pinned.style}
           >
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
@@ -148,6 +171,8 @@ export interface TreeGridRowProps<T> {
   /** Display index within the rendered row list (drives zebra striping). */
   index: number
   classes: TreeGridRowClasses
+  /** Column ids whose cells right-align (numeric columns). */
+  numericColumnIds?: ReadonlySet<string>
   /** The row's data id (not TanStack's row.id). */
   nodeId: string
   /** Whether this row is selected for inline editing. */
@@ -178,6 +203,7 @@ export function TreeGridRow<T>({
   row,
   index,
   classes,
+  numericColumnIds,
   nodeId,
   isSelected,
   isDragging,
@@ -209,7 +235,7 @@ export function TreeGridRow<T>({
             key={cell.id}
             data-cell-id={`${nodeId}-${cell.column.id}`}
             data-column-id={cell.column.id}
-            className={`${classes.td}${
+            className={`${classes.td}${numericTdClass(cell, classes, numericColumnIds)}${
               isEditableCell ? ` ${classes.editableCell}` : ''
             }${pinned.className}`}
             style={pinned.style}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/index.ts
@@ -62,6 +62,19 @@ export type {
   UseGridTableOptions,
 } from './use-grid-table'
 
+// Column layout persistence (opt-in via WaydGrid's persistStateKey prop)
+export {
+  GRID_PERSISTENCE_ENABLED_KEY,
+  GRID_STATE_KEY_PREFIX,
+  GRID_STATE_VERSION,
+  clearAllGridColumnState,
+  gridStateStorageKey,
+  isGridPersistenceEnabled,
+  isPersistedColumnState,
+  useGridColumnStatePersistence,
+} from './use-grid-persistence'
+export type { PersistedColumnState } from './use-grid-persistence'
+
 // Column pinning (sticky rendering over TanStack's columnPinning state)
 export {
   getPinnedBandOffsets,

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/types.ts
@@ -47,6 +47,13 @@ export interface WaydGridColumnMeta {
    * `select` → `set`, `numericRange` → `number`. Omit to default to `text`.
    */
   filterType?: FilterType | 'select' | 'numericRange'
+  /**
+   * Cell text alignment override. By default, columns the grid resolves as
+   * numeric (explicit `filterType: 'number'` or all-number sampled data)
+   * right-align their BODY cells — headers always stay left-aligned. Set
+   * 'left' to opt a numeric column out, or 'right' to force it on.
+   */
+  align?: 'left' | 'right'
   /** Options for the 'set' (aka legacy 'select') filter type. */
   filterOptions?: FilterOption[]
   /**

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.test.ts
@@ -253,17 +253,19 @@ describe('use-grid-persistence', () => {
           columnPinning: { left: [], right: [] },
         }),
       ],
-    ])('ignores a stored entry with %s', (_label, raw) => {
+    ])('discards a stored entry with %s', (_label, raw) => {
       // Arrange
       window.localStorage.setItem(STORAGE_KEY, raw)
 
       // Act
       const { result } = renderHook(() => useHarness('test-grid'))
 
-      // Assert — defaults retained, no throw
+      // Assert — defaults retained, no throw, and the unusable entry is
+      // removed so it isn't re-reported on every mount
       expect(result.current.columnSizing).toEqual({})
       expect(result.current.userColumnVisibility).toEqual({})
       expect(result.current.columnPinning).toEqual({ left: [], right: [] })
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
     })
 
     it('flushes a pending debounced write on unmount', () => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.test.ts
@@ -1,0 +1,334 @@
+import { act, renderHook } from '@testing-library/react'
+
+import {
+  GRID_PERSISTENCE_ENABLED_KEY,
+  clearAllGridColumnState,
+  gridStateStorageKey,
+  useGridColumnStatePersistence,
+} from './use-grid-persistence'
+import { useGridState } from './use-grid-table'
+
+/** Composes the state hook with persistence exactly as WaydGridInner does. */
+const useHarness = (persistStateKey?: string) => {
+  const gridState = useGridState()
+  useGridColumnStatePersistence(gridState, persistStateKey)
+  return gridState
+}
+
+const STORAGE_KEY = gridStateStorageKey('test-grid')
+
+describe('use-grid-persistence', () => {
+  beforeAll(() => {
+    console.error = jest.fn()
+  })
+
+  beforeEach(() => {
+    // jest.setup's localStorage stub has no backing store — replace it with a
+    // real in-memory implementation (same pattern as use-local-storage-state.test.ts)
+    const localStorageMock = (() => {
+      let store: Record<string, string> = {}
+      return {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => {
+          store[key] = value
+        },
+        removeItem: (key: string) => {
+          delete store[key]
+        },
+        clear: () => {
+          store = {}
+        },
+        get length() {
+          return Object.keys(store).length
+        },
+        key: (index: number) => {
+          const keys = Object.keys(store)
+          return keys[index] ?? null
+        },
+      }
+    })()
+
+    Object.defineProperty(window, 'localStorage', {
+      value: localStorageMock,
+      writable: true,
+    })
+
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('useGridColumnStatePersistence', () => {
+    it('never touches storage without a persist key', () => {
+      // Arrange
+      const getItemSpy = jest.spyOn(window.localStorage, 'getItem')
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+
+      // Act
+      const { result } = renderHook(() => useHarness(undefined))
+      act(() => {
+        result.current.setColumnSizing({ name: 240 })
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert
+      expect(getItemSpy).not.toHaveBeenCalled()
+      expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('keeps defaults and writes nothing when no entry is stored', () => {
+      // Arrange
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+
+      // Act
+      const { result } = renderHook(() => useHarness('test-grid'))
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert — pristine grids leave no localStorage residue
+      expect(result.current.columnSizing).toEqual({})
+      expect(result.current.userColumnVisibility).toEqual({})
+      expect(result.current.columnPinning).toEqual({ left: [], right: [] })
+      expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('applies a stored entry to all three slices on mount', () => {
+      // Arrange
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          columnSizing: { name: 240 },
+          userColumnVisibility: { team: false },
+          columnPinning: { left: ['key'], right: [] },
+        }),
+      )
+
+      // Act
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Assert
+      expect(result.current.columnSizing).toEqual({ name: 240 })
+      expect(result.current.userColumnVisibility).toEqual({ team: false })
+      expect(result.current.columnPinning).toEqual({
+        left: ['key'],
+        right: [],
+      })
+    })
+
+    it('does not rewrite an unchanged loaded entry', () => {
+      // Arrange
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          columnSizing: { name: 240 },
+          userColumnVisibility: {},
+          columnPinning: { left: [], right: [] },
+        }),
+      )
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+
+      // Act
+      renderHook(() => useHarness('test-grid'))
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert — applying the loaded state must not trigger a save
+      expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('debounces rapid changes into a single write of the full payload', () => {
+      // Arrange
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Act — simulate a resize drag: many sizing updates in quick succession
+      act(() => {
+        result.current.setColumnSizing({ name: 210 })
+      })
+      act(() => {
+        result.current.setColumnSizing({ name: 230 })
+      })
+      act(() => {
+        result.current.setColumnSizing({ name: 250 })
+        result.current.setColumnPinning({ left: ['key'], right: [] })
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert
+      expect(setItemSpy).toHaveBeenCalledTimes(1)
+      expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        columnSizing: { name: 250 },
+        userColumnVisibility: {},
+        columnPinning: { left: ['key'], right: [] },
+      })
+    })
+
+    it('persists a visibility-only change (chooser toggle path)', () => {
+      // Arrange
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Act — exactly what WaydGrid's handleUserToggleColumn does
+      act(() => {
+        result.current.setUserColumnVisibility((prev) => ({
+          ...prev,
+          isActive: false,
+        }))
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert
+      expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        columnSizing: {},
+        userColumnVisibility: { isActive: false },
+        columnPinning: { left: [], right: [] },
+      })
+    })
+
+    it('removes the entry when resetColumnState restores the defaults', () => {
+      // Arrange
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          columnSizing: { name: 240 },
+          userColumnVisibility: { team: false },
+          columnPinning: { left: ['key'], right: [] },
+        }),
+      )
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Act
+      act(() => {
+        result.current.resetColumnState()
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert — reset doubles as "delete the stored layout"
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+    })
+
+    it('removes stale versioned and unversioned entries for the grid on load', () => {
+      // Arrange
+      window.localStorage.setItem('wayd-grid:test-grid', '{"old":true}')
+      window.localStorage.setItem('wayd-grid:test-grid:v0', '{"old":true}')
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          columnSizing: { name: 240 },
+          userColumnVisibility: {},
+          columnPinning: { left: [], right: [] },
+        }),
+      )
+      window.localStorage.setItem('wayd-grid:other-grid:v1', '{}')
+
+      // Act
+      renderHook(() => useHarness('test-grid'))
+
+      // Assert — only this grid's stale versions are cleaned
+      expect(window.localStorage.getItem('wayd-grid:test-grid')).toBeNull()
+      expect(window.localStorage.getItem('wayd-grid:test-grid:v0')).toBeNull()
+      expect(window.localStorage.getItem(STORAGE_KEY)).not.toBeNull()
+      expect(
+        window.localStorage.getItem('wayd-grid:other-grid:v1'),
+      ).not.toBeNull()
+    })
+
+    it.each([
+      ['malformed JSON', 'not-json{'],
+      ['wrong shape', JSON.stringify({ columnSizing: 'nope' })],
+      [
+        'wrong slice value types',
+        JSON.stringify({
+          columnSizing: { name: 'wide' },
+          userColumnVisibility: {},
+          columnPinning: { left: [], right: [] },
+        }),
+      ],
+    ])('ignores a stored entry with %s', (_label, raw) => {
+      // Arrange
+      window.localStorage.setItem(STORAGE_KEY, raw)
+
+      // Act
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Assert — defaults retained, no throw
+      expect(result.current.columnSizing).toEqual({})
+      expect(result.current.userColumnVisibility).toEqual({})
+      expect(result.current.columnPinning).toEqual({ left: [], right: [] })
+    })
+
+    it('flushes a pending debounced write on unmount', () => {
+      // Arrange
+      const { result, unmount } = renderHook(() => useHarness('test-grid'))
+      act(() => {
+        result.current.setColumnSizing({ name: 300 })
+      })
+
+      // Act — unmount before the debounce elapses (navigation away)
+      unmount()
+
+      // Assert
+      expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        columnSizing: { name: 300 },
+        userColumnVisibility: {},
+        columnPinning: { left: [], right: [] },
+      })
+    })
+
+    it('neither loads nor saves while persistence is disabled, keeping stored entries', () => {
+      // Arrange
+      window.localStorage.setItem(GRID_PERSISTENCE_ENABLED_KEY, 'false')
+      const storedJson = JSON.stringify({
+        columnSizing: { name: 240 },
+        userColumnVisibility: {},
+        columnPinning: { left: [], right: [] },
+      })
+      window.localStorage.setItem(STORAGE_KEY, storedJson)
+
+      // Act
+      const { result, unmount } = renderHook(() => useHarness('test-grid'))
+      act(() => {
+        result.current.setColumnSizing({ name: 999 })
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      unmount()
+
+      // Assert — defaults were not overwritten in-memory, and the stored
+      // entry survives untouched for when the user re-enables the feature
+      expect(result.current.columnSizing).toEqual({ name: 999 })
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBe(storedJson)
+    })
+  })
+
+  describe('clearAllGridColumnState', () => {
+    it('removes every grid entry but keeps the enabled flag and unrelated keys', () => {
+      // Arrange
+      window.localStorage.setItem('wayd-grid:one:v1', '{}')
+      window.localStorage.setItem('wayd-grid:two:v1', '{}')
+      window.localStorage.setItem(GRID_PERSISTENCE_ENABLED_KEY, 'false')
+      window.localStorage.setItem('appTheme', '"dark"')
+
+      // Act
+      clearAllGridColumnState()
+
+      // Assert
+      expect(window.localStorage.getItem('wayd-grid:one:v1')).toBeNull()
+      expect(window.localStorage.getItem('wayd-grid:two:v1')).toBeNull()
+      expect(window.localStorage.getItem(GRID_PERSISTENCE_ENABLED_KEY)).toBe(
+        'false',
+      )
+      expect(window.localStorage.getItem('appTheme')).toBe('"dark"')
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.ts
@@ -167,6 +167,14 @@ function removeStaleVersions(persistStateKey: string, storageKey: string) {
   keysToRemove.forEach((key) => window.localStorage.removeItem(key))
 }
 
+const tryParseJson = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw)
+  } catch {
+    return undefined
+  }
+}
+
 interface PendingWrite {
   storageKey: string
   /** null = remove the entry (all-default layout). */
@@ -244,7 +252,7 @@ export function useGridColumnStatePersistence(
       removeStaleVersions(persistStateKey, storageKey)
       const raw = window.localStorage.getItem(storageKey)
       if (raw) {
-        const parsed: unknown = JSON.parse(raw)
+        const parsed = tryParseJson(raw)
         if (isPersistedColumnState(parsed)) {
           setColumnSizing(parsed.columnSizing)
           setUserColumnVisibility(parsed.userColumnVisibility)
@@ -255,6 +263,13 @@ export function useGridColumnStatePersistence(
             parsed.userColumnVisibility,
             parsed.columnPinning,
           )
+        } else {
+          // Unusable entry (malformed JSON or wrong shape): discard it so the
+          // grid self-heals instead of re-reporting it on every mount.
+          console.error(
+            `Discarding unusable persisted grid state under "${storageKey}"`,
+          )
+          window.localStorage.removeItem(storageKey)
         }
       }
     } catch (error) {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.ts
@@ -1,0 +1,300 @@
+import { useEffect, useRef, type MutableRefObject } from 'react'
+import type {
+  ColumnPinningState,
+  ColumnSizingState,
+  VisibilityState,
+} from '@tanstack/react-table'
+
+import type { GridState } from './use-grid-table'
+
+/**
+ * Opt-in localStorage persistence of a grid's user column layout.
+ *
+ * Persists exactly three {@link GridState} slices — `columnSizing`,
+ * `userColumnVisibility` (the raw user layer, never the merged
+ * columnVisibility), and `columnPinning` — under
+ * `wayd-grid:{persistStateKey}:v{GRID_STATE_VERSION}`. Sorting, filters, and
+ * search are deliberately session-only.
+ *
+ * Design notes:
+ * - State is applied in a mount effect (one post-mount re-render), NOT via a
+ *   lazy useState initializer: WaydGrid is SSR-rendered by most consumers and
+ *   column widths appear in the markup, so reading localStorage during the
+ *   first render would cause a hydration mismatch.
+ * - A grid whose layout matches the defaults has NO stored entry (the entry
+ *   is removed rather than written), so Reset Columns doubles as "delete the
+ *   stored layout".
+ * - Cross-tab sync is deliberately omitted: last writer wins and the next
+ *   mount picks it up. Concurrent same-key grids are safe — the whole payload
+ *   is written atomically.
+ * - Persisted ids for columns absent from the current defs are inert:
+ *   TanStack ignores unknown ids in sizing/visibility maps and filters them
+ *   from pinning arrays. Bump {@link GRID_STATE_VERSION} on wholesale shape
+ *   or column renames.
+ */
+
+/** Prefix shared by every key this feature writes to localStorage. */
+export const GRID_STATE_KEY_PREFIX = 'wayd-grid:'
+
+/** Bump when the persisted payload shape changes — stale versions are removed on load. */
+export const GRID_STATE_VERSION = 1
+
+/**
+ * Device-wide kill switch (Account → Preferences). Absent = enabled. Stored
+ * layouts are kept while disabled so re-enabling restores them.
+ */
+export const GRID_PERSISTENCE_ENABLED_KEY = `${GRID_STATE_KEY_PREFIX}persistence-enabled`
+
+const SAVE_DEBOUNCE_MS = 250
+
+export interface PersistedColumnState {
+  columnSizing: ColumnSizingState
+  userColumnVisibility: VisibilityState
+  columnPinning: ColumnPinningState
+}
+
+/** The versioned localStorage key for a grid's persisted column state. */
+export const gridStateStorageKey = (persistStateKey: string): string =>
+  `${GRID_STATE_KEY_PREFIX}${persistStateKey}:v${GRID_STATE_VERSION}`
+
+/**
+ * Whether column layout persistence is enabled on this device. Read at
+ * effect time by the grid hook (grids remount on navigation, so a toggle on
+ * the Account page takes effect on the next grid mount).
+ */
+export function isGridPersistenceEnabled(): boolean {
+  if (typeof window === 'undefined') return false
+  try {
+    return (
+      window.localStorage.getItem(GRID_PERSISTENCE_ENABLED_KEY) !== 'false'
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Removes every persisted grid layout (all `wayd-grid:*` entries except the
+ * enabled flag). The Account page's "Reset all grid layouts" action.
+ */
+export function clearAllGridColumnState(): void {
+  if (typeof window === 'undefined') return
+  try {
+    const keysToRemove: string[] = []
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const key = window.localStorage.key(i)
+      if (
+        key?.startsWith(GRID_STATE_KEY_PREFIX) &&
+        key !== GRID_PERSISTENCE_ENABLED_KEY
+      ) {
+        keysToRemove.push(key)
+      }
+    }
+    keysToRemove.forEach((key) => window.localStorage.removeItem(key))
+  } catch (error) {
+    console.error('Error clearing persisted grid column state:', error)
+  }
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isRecordOf = (
+  value: unknown,
+  entryType: 'number' | 'boolean',
+): boolean =>
+  isPlainObject(value) &&
+  Object.values(value).every((entry) => typeof entry === entryType)
+
+const isPinningSide = (value: unknown): boolean =>
+  value === undefined ||
+  (Array.isArray(value) && value.every((id) => typeof id === 'string'))
+
+/** Shape guard for a parsed payload — malformed entries are ignored on load. */
+export function isPersistedColumnState(
+  value: unknown,
+): value is PersistedColumnState {
+  if (!isPlainObject(value)) return false
+  const { columnSizing, userColumnVisibility, columnPinning } = value
+  return (
+    isRecordOf(columnSizing, 'number') &&
+    isRecordOf(userColumnVisibility, 'boolean') &&
+    isPlainObject(columnPinning) &&
+    isPinningSide(columnPinning.left) &&
+    isPinningSide(columnPinning.right)
+  )
+}
+
+/**
+ * Serializes the three slices, or null when everything is default — the
+ * null payload means "remove the entry" so pristine/reset grids leave no
+ * localStorage residue.
+ */
+function buildPayloadJson(
+  columnSizing: ColumnSizingState,
+  userColumnVisibility: VisibilityState,
+  columnPinning: ColumnPinningState,
+): string | null {
+  const isDefault =
+    Object.keys(columnSizing).length === 0 &&
+    Object.keys(userColumnVisibility).length === 0 &&
+    !columnPinning.left?.length &&
+    !columnPinning.right?.length
+  if (isDefault) return null
+  const payload: PersistedColumnState = {
+    columnSizing,
+    userColumnVisibility,
+    columnPinning,
+  }
+  return JSON.stringify(payload)
+}
+
+/** Removes older-versioned (and unversioned) entries for the same grid. */
+function removeStaleVersions(persistStateKey: string, storageKey: string) {
+  const unversionedKey = `${GRID_STATE_KEY_PREFIX}${persistStateKey}`
+  const versionPrefix = `${unversionedKey}:v`
+  const keysToRemove: string[] = []
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i)
+    if (
+      key !== null &&
+      key !== storageKey &&
+      (key === unversionedKey || key.startsWith(versionPrefix))
+    ) {
+      keysToRemove.push(key)
+    }
+  }
+  keysToRemove.forEach((key) => window.localStorage.removeItem(key))
+}
+
+interface PendingWrite {
+  storageKey: string
+  /** null = remove the entry (all-default layout). */
+  json: string | null
+}
+
+function flushPendingWrite(
+  pendingWriteRef: MutableRefObject<PendingWrite | null>,
+  lastWrittenRef: MutableRefObject<string | null>,
+) {
+  const pending = pendingWriteRef.current
+  if (!pending) return
+  pendingWriteRef.current = null
+  try {
+    if (pending.json === null) {
+      window.localStorage.removeItem(pending.storageKey)
+    } else {
+      window.localStorage.setItem(pending.storageKey, pending.json)
+    }
+    lastWrittenRef.current = pending.json
+  } catch (error) {
+    console.error(
+      `Error writing localStorage key "${pending.storageKey}":`,
+      error,
+    )
+  }
+}
+
+type PersistableGridState = Pick<
+  GridState,
+  | 'columnSizing'
+  | 'setColumnSizing'
+  | 'userColumnVisibility'
+  | 'setUserColumnVisibility'
+  | 'columnPinning'
+  | 'setColumnPinning'
+>
+
+/**
+ * Loads the grid's persisted column layout on mount and saves changes back
+ * (debounced — column resize fires per mousemove). No-ops when
+ * `persistStateKey` is undefined or persistence is disabled on this device.
+ *
+ * `persistStateKey` must be stable for the life of the grid.
+ */
+export function useGridColumnStatePersistence(
+  gridState: PersistableGridState,
+  persistStateKey: string | undefined,
+): void {
+  const {
+    columnSizing,
+    setColumnSizing,
+    userColumnVisibility,
+    setUserColumnVisibility,
+    columnPinning,
+    setColumnPinning,
+  } = gridState
+
+  const storageKey = persistStateKey
+    ? gridStateStorageKey(persistStateKey)
+    : undefined
+
+  // Gates saving until the load effect ran — without it the save effect could
+  // clobber the stored entry with defaults on mount. Stays false when
+  // persistence is off, which also disables saving.
+  const loadedRef = useRef(false)
+  const lastWrittenRef = useRef<string | null>(null)
+  const pendingWriteRef = useRef<PendingWrite | null>(null)
+
+  // ─── Load once on mount ─────────────────────────────────
+  useEffect(() => {
+    if (!persistStateKey || !storageKey) return
+    if (!isGridPersistenceEnabled()) return
+    try {
+      removeStaleVersions(persistStateKey, storageKey)
+      const raw = window.localStorage.getItem(storageKey)
+      if (raw) {
+        const parsed: unknown = JSON.parse(raw)
+        if (isPersistedColumnState(parsed)) {
+          setColumnSizing(parsed.columnSizing)
+          setUserColumnVisibility(parsed.userColumnVisibility)
+          setColumnPinning(parsed.columnPinning)
+          // Normalized so the post-apply save pass short-circuits.
+          lastWrittenRef.current = buildPayloadJson(
+            parsed.columnSizing,
+            parsed.userColumnVisibility,
+            parsed.columnPinning,
+          )
+        }
+      }
+    } catch (error) {
+      console.error(`Error reading localStorage key "${storageKey}":`, error)
+    }
+    loadedRef.current = true
+  }, [
+    persistStateKey,
+    storageKey,
+    setColumnSizing,
+    setUserColumnVisibility,
+    setColumnPinning,
+  ])
+
+  // ─── Save on change (trailing debounce) ─────────────────
+  useEffect(() => {
+    if (!storageKey || !loadedRef.current) return
+    const json = buildPayloadJson(
+      columnSizing,
+      userColumnVisibility,
+      columnPinning,
+    )
+    if (json === lastWrittenRef.current) {
+      // Values are back to what's stored — cancel any pending stale write.
+      pendingWriteRef.current = null
+      return
+    }
+    pendingWriteRef.current = { storageKey, json }
+    const timer = setTimeout(
+      () => flushPendingWrite(pendingWriteRef, lastWrittenRef),
+      SAVE_DEBOUNCE_MS,
+    )
+    return () => clearTimeout(timer)
+  }, [storageKey, columnSizing, userColumnVisibility, columnPinning])
+
+  // ─── Flush a pending write on unmount ───────────────────
+  // Runs after the save effect's cleanup (declaration order), so the cleared
+  // timer's write still lands instead of being lost on navigation.
+  useEffect(
+    () => () => flushPendingWrite(pendingWriteRef, lastWrittenRef),
+    [],
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
@@ -30,9 +30,9 @@ import { stringContainsFilter } from './grid-filters'
  *
  * Every user-adjustable column state slice (columnSizing,
  * userColumnVisibility, columnPinning, sorting) lives here as plain
- * serializable state — grid state persistence will serialize exactly these
- * slices, so new column state must be added here, not scattered into
- * components.
+ * serializable state — useGridColumnStatePersistence (use-grid-persistence.ts)
+ * serializes the column-layout slices, so new column state must be added
+ * here, not scattered into components.
  */
 export interface GridState {
   sorting: SortingState

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/index.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/index.ts
@@ -92,6 +92,13 @@ export type {
   DependencyHealthTarget,
 } from '../wayd-grid-core/cell-renderers'
 
+// Column layout persistence (opt-in via WaydGrid's persistStateKey prop) —
+// the account-page controls live outside the grid, hence the re-export
+export {
+  GRID_PERSISTENCE_ENABLED_KEY,
+  clearAllGridColumnState,
+} from '../wayd-grid-core/use-grid-persistence'
+
 // Components (toolbar reconciled into the shared grid core; aliases kept)
 export { default as WaydGridToolbar } from '../wayd-grid-core/grid-toolbar'
 export type { GridToolbarProps as WaydGridToolbarProps } from '../wayd-grid-core/grid-toolbar'

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/types.ts
@@ -137,6 +137,15 @@ export interface WaydGridProps<T> {
 
   // -- Grid state --
   /**
+   * Opt-in localStorage persistence of the user's column layout (sizing,
+   * show/hide choices, pinning) under `wayd-grid:{key}:v1`. Keys are per page
+   * context — stable, human-readable, route-independent kebab-case (e.g.
+   * 'ppm-projects', 'team-backlog'); shared grid components should expose
+   * this as a pass-through prop so each page site supplies its own. Omit for
+   * no persistence. Sorting/filters/search are deliberately not persisted.
+   */
+  persistStateKey?: string
+  /**
    * Fires with the displayed rows (post filter + sort, in display order)
    * whenever that set changes — including on mount. For consumers deriving
    * external UI (e.g. a chart) from the grid state.

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
@@ -184,6 +184,12 @@
   flex: 0 1 auto;
 }
 
+/* Numeric columns right-align their body cells so magnitudes line up;
+   headers deliberately stay left-aligned (see meta.align). */
+.tdNumeric {
+  text-align: right;
+}
+
 /* Floating-filter cell: input fills the width, filter-popup icon on the right. */
 .floatingCell {
   display: flex;

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
@@ -109,7 +109,7 @@
 }
 
 .th {
-  padding: 5px var(--ant-padding-sm);
+  padding: 5px var(--ant-padding-xs);
   background: var(--wayd-grid-header-bg);
   border-bottom: 1px solid var(--ant-color-border);
   /* Secondary (muted) text keeps headers from overpowering the data rows —
@@ -162,22 +162,15 @@
   display: none;
 }
 
-.thResizable {
-  padding-left: var(--ant-padding-sm);
-}
-
-/* Gap between the header title and the column divider on the right edge. */
-.thResizable .thContent {
-  padding-right: var(--ant-padding-sm);
-}
-
 /* Fills the th (not shrink-to-fit) so the column-menu trigger can anchor to
    the far right edge via margin-left: auto; the label and sort/filter icons
-   stay left, hugging the text. */
+   stay left, hugging the text. No extra right padding for the resizer — its
+   10px hit strip mostly overlays the th's own 8px padding, so the label
+   keeps every pixel it can get in narrow columns. */
 .thContent {
   display: flex;
   align-items: center;
-  gap: var(--ant-margin-xs);
+  gap: var(--ant-margin-xxs);
   width: 100%;
   min-width: 0;
   overflow: hidden;

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
@@ -15,6 +15,7 @@ import type { ColumnDef } from '@tanstack/react-table'
 
 import WaydGrid from './wayd-grid'
 import { SET_FILTER_BLANK } from '../wayd-grid-core/filters'
+import { gridStateStorageKey } from '../wayd-grid-core/use-grid-persistence'
 import type { WaydGridHandle, WaydGridColumnMeta } from './types'
 import { downloadCsvWithTimestamp } from '@/src/utils/csv-utils'
 
@@ -1204,4 +1205,134 @@ describe('WaydGrid', () => {
       expect(bodyCells('name')[0].style.left).toBe('')
     })
   })
+
+  describe('column state persistence (persistStateKey)', () => {
+    const STORAGE_KEY = gridStateStorageKey('test-grid')
+
+    beforeEach(() => {
+      // jest.setup's localStorage stub has no backing store — replace it with
+      // a real in-memory implementation for persistence round-trips
+      const localStorageMock = (() => {
+        let store: Record<string, string> = {}
+        return {
+          getItem: (key: string) => store[key] ?? null,
+          setItem: (key: string, value: string) => {
+            store[key] = value
+          },
+          removeItem: (key: string) => {
+            delete store[key]
+          },
+          clear: () => {
+            store = {}
+          },
+          get length() {
+            return Object.keys(store).length
+          },
+          key: (index: number) => {
+            const keys = Object.keys(store)
+            return keys[index] ?? null
+          },
+        }
+      })()
+      Object.defineProperty(window, 'localStorage', {
+        value: localStorageMock,
+        writable: true,
+      })
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      jest.useRealTimers()
+    })
+
+    it('restores sizing, user visibility, and pinning from a stored entry', () => {
+      // Arrange
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          columnSizing: { name: 240 },
+          userColumnVisibility: { type: false },
+          columnPinning: { left: ['isEnabled'], right: [] },
+        }),
+      )
+      const ref = createRef<WaydGridHandle>()
+
+      // Act
+      renderGrid({ ref, persistStateKey: 'test-grid' })
+
+      // Assert — the user-hidden column is gone from the DOM (the raw user
+      // layer flows through mergeColumnVisibility), the pinned column leads,
+      // and the stored width is applied
+      expect(
+        document.querySelector('th[data-column-id="type"]'),
+      ).not.toBeInTheDocument()
+      const headerRow = document.querySelector(
+        'thead tr:not([data-role])',
+      ) as HTMLElement
+      expect(
+        headerRow
+          .querySelector('th[data-column-id]')
+          ?.getAttribute('data-column-id'),
+      ).toBe('isEnabled')
+      expect(ref.current!.table.getColumn('name').getSize()).toBe(240)
+    })
+
+    it('saves changes and restores them on a fresh mount', () => {
+      // Arrange
+      const ref = createRef<WaydGridHandle>()
+      const { unmount } = renderGrid({ ref, persistStateKey: 'test-grid' })
+
+      // Act — resize and pin through the table (wired to useGridState), let
+      // the debounce elapse, then remount
+      act(() => {
+        ref.current!.table.setColumnSizing({ name: 300 })
+        ref.current!.table.getColumn('type').pin('left')
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      unmount()
+
+      // Assert — the entry holds the full payload
+      expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        columnSizing: { name: 300 },
+        userColumnVisibility: {},
+        columnPinning: { left: ['type'], right: [] },
+      })
+
+      // Act — fresh mount restores it
+      const ref2 = createRef<WaydGridHandle>()
+      renderGrid({ ref: ref2, persistStateKey: 'test-grid' })
+
+      // Assert
+      expect(ref2.current!.table.getColumn('name').getSize()).toBe(300)
+      const headerRow = document.querySelector(
+        'thead tr:not([data-role])',
+      ) as HTMLElement
+      expect(
+        headerRow
+          .querySelector('th[data-column-id]')
+          ?.getAttribute('data-column-id'),
+      ).toBe('type')
+    })
+
+    it('never touches storage without a persistStateKey', () => {
+      // Arrange
+      const getItemSpy = jest.spyOn(window.localStorage, 'getItem')
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+      const ref = createRef<WaydGridHandle>()
+
+      // Act
+      renderGrid({ ref })
+      act(() => {
+        ref.current!.table.setColumnSizing({ name: 300 })
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert
+      expect(getItemSpy).not.toHaveBeenCalled()
+      expect(setItemSpy).not.toHaveBeenCalled()
+    })
+  })
+
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
@@ -1335,4 +1335,57 @@ describe('WaydGrid', () => {
     })
   })
 
+  describe('numeric cell alignment', () => {
+    // `id` is numeric in DATA, so its filter/data type infers to 'number'.
+    const numericColumns: ColumnDef<Flag, unknown>[] = [
+      ...columns,
+      { id: 'id', accessorKey: 'id', header: 'Id' },
+    ]
+
+    it('right-aligns body cells of a data-inferred numeric column, but not its header', () => {
+      // Arrange / Act
+      renderGrid({ columns: numericColumns })
+
+      // Assert — numeric cells carry the alignment class; the header and
+      // text-column cells do not
+      expect(bodyCells('id')[0].className).toContain('tdNumeric')
+      expect(
+        document.querySelector('th[data-column-id="id"]')?.className,
+      ).not.toContain('tdNumeric')
+      expect(bodyCells('name')[0].className).not.toContain('tdNumeric')
+    })
+
+    it('meta.align overrides the default in both directions', () => {
+      // Arrange
+      const overriddenColumns: ColumnDef<Flag, unknown>[] = [
+        {
+          id: 'name',
+          accessorKey: 'name',
+          header: 'Name',
+          meta: { align: 'right' } satisfies WaydGridColumnMeta,
+        },
+        {
+          id: 'id',
+          accessorKey: 'id',
+          header: 'Id',
+          meta: { align: 'left' } satisfies WaydGridColumnMeta,
+        },
+      ]
+
+      // Act
+      renderGrid({ columns: overriddenColumns })
+
+      // Assert
+      expect(bodyCells('name')[0].className).toContain('tdNumeric')
+      expect(bodyCells('id')[0].className).not.toContain('tdNumeric')
+    })
+
+    it('leaves boolean (yesNo set-filter) columns left-aligned', () => {
+      // Arrange / Act
+      renderGrid()
+
+      // Assert
+      expect(bodyCells('isEnabled')[0].className).not.toContain('tdNumeric')
+    })
+  })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -17,6 +17,7 @@ import { Popover, Spin } from 'antd'
 import type { FormInstance } from 'antd'
 import { FilterFilled, FilterOutlined } from '@ant-design/icons'
 import {
+  type Column,
   type ColumnDef,
   type Header,
   type Row,
@@ -234,6 +235,7 @@ const rowClasses: GridRowClasses = {
   tr: styles.tr,
   trAlt: styles.trAlt,
   td: styles.td,
+  tdNumeric: styles.tdNumeric,
   pinned: {
     pinned: styles.tdPinned,
     pinnedLeftEdge: styles.pinnedLeftEdge,
@@ -246,6 +248,37 @@ const treeRowClasses: TreeGridRowClasses = {
   trEditable: styles.trEditable,
   trSelected: styles.trSelected,
   editableCell: styles.editableCell,
+}
+
+/**
+ * Resolves a column's filter/data type. An explicit `meta.filterType`
+ * (including one applied by a `columnType`) always wins; otherwise the type is
+ * inferred from the column's data by sampling its faceted unique values:
+ *   - all sampled values are numbers      → 'number'
+ *   - all sampled values are Dates        → 'date'
+ *   - otherwise                           → 'text'
+ * Empty/mixed data falls back to 'text'. Drives both the per-column filter UI
+ * and numeric cell alignment, so the two never disagree.
+ */
+const resolveColumnFilterType = <T,>(column: Column<T, unknown>): FilterType => {
+  const meta = column.columnDef.meta
+  if (meta?.filterType) return resolveFilterType(meta.filterType)
+
+  // Display columns (actions, checkboxes — no accessor) have no values to
+  // sample; TanStack's faceted-values util throws on them.
+  if (!column.accessorFn) return 'text'
+
+  const sample: unknown[] = []
+  for (const v of column.getFacetedUniqueValues().keys()) {
+    if (v === null || v === undefined || v === '') continue
+    sample.push(v)
+    if (sample.length >= 20) break // enough to infer; avoid scanning huge sets
+  }
+  if (sample.length === 0) return 'text'
+
+  if (sample.every((v) => typeof v === 'number')) return 'number'
+  if (sample.every((v) => v instanceof Date)) return 'date'
+  return 'text'
 }
 
 interface GridBodyProps<T> {
@@ -261,6 +294,8 @@ interface GridBodyProps<T> {
   isLoading: boolean
   emptyMessage: string
   visibleColumnCount: number
+  /** Column ids whose body cells right-align (numeric columns). */
+  numericColumnIds: ReadonlySet<string>
   isTree: boolean
   flatDndEnabled: boolean
   isDragEnabled: boolean
@@ -291,6 +326,7 @@ function GridBody<T>({
   isLoading,
   emptyMessage,
   visibleColumnCount,
+  numericColumnIds,
   isTree,
   flatDndEnabled,
   isDragEnabled,
@@ -390,6 +426,7 @@ function GridBody<T>({
                       row={row}
                       index={index}
                       classes={treeRowClasses}
+                      numericColumnIds={numericColumnIds}
                       nodeId={nodeId}
                       isSelected={isSelected}
                       isDragging={isRowDragging}
@@ -449,6 +486,7 @@ function GridBody<T>({
                       row={row}
                       index={index}
                       classes={rowClasses}
+                      numericColumnIds={numericColumnIds}
                       nodeId={nodeId}
                       isDragging={draggedNodeId === nodeId}
                       isDragEnabled={isDragEnabled}
@@ -462,6 +500,7 @@ function GridBody<T>({
                     row={row}
                     index={index}
                     classes={rowClasses}
+                    numericColumnIds={numericColumnIds}
                   />
                 )
               })}
@@ -1059,6 +1098,26 @@ function WaydGridInner<T>(
     : data.length
   const visibleColumnCount = table.getVisibleLeafColumns().length
 
+  // Columns whose BODY cells right-align: explicit meta.align wins, otherwise
+  // numeric columns (same resolution as the filter UI). Headers stay
+  // left-aligned regardless. Recomputed when the data changes — the inference
+  // samples the faceted values, which are empty until rows arrive.
+  const numericColumnIds = useMemo(() => {
+    // The table is a stable identity whose faceted samples mutate underneath;
+    // data and resolvedColumns are the real recompute triggers.
+    void data
+    void resolvedColumns
+    const ids = new Set<string>()
+    for (const column of table.getAllLeafColumns()) {
+      const align = column.columnDef.meta?.align
+      if (align === 'left') continue
+      if (align === 'right' || resolveColumnFilterType(column) === 'number') {
+        ids.add(column.id)
+      }
+    }
+    return ids
+  }, [table, data, resolvedColumns])
+
   const toggleDateTreeNode = useCallback((columnId: string, nodeKey: string) => {
     setDateTreeExpanded((prev) => {
       const current = prev[columnId] ?? EMPTY_NODE_SET
@@ -1148,31 +1207,8 @@ function WaydGridInner<T>(
 
   const showFloatingFilters = showColumnFilters && includeFloatingFilters
 
-  /**
-   * Resolves a column's filter type. An explicit `meta.filterType` (including
-   * one applied by a `columnType`) always wins; otherwise the type is inferred
-   * from the column's data by sampling its faceted unique values:
-   *   - all sampled values are numbers      → 'number'
-   *   - all sampled values are Dates        → 'date'
-   *   - otherwise                           → 'text'
-   * Empty/mixed data falls back to 'text'.
-   */
-  const columnFilterType = (header: Header<T, unknown>): FilterType => {
-    const meta = header.column.columnDef.meta
-    if (meta?.filterType) return resolveFilterType(meta.filterType)
-
-    const sample: unknown[] = []
-    for (const v of header.column.getFacetedUniqueValues().keys()) {
-      if (v === null || v === undefined || v === '') continue
-      sample.push(v)
-      if (sample.length >= 20) break // enough to infer; avoid scanning huge sets
-    }
-    if (sample.length === 0) return 'text'
-
-    if (sample.every((v) => typeof v === 'number')) return 'number'
-    if (sample.every((v) => v instanceof Date)) return 'date'
-    return 'text'
-  }
+  const columnFilterType = (header: Header<T, unknown>): FilterType =>
+    resolveColumnFilterType(header.column)
 
   /**
    * Wraps a trigger element in the multi-condition {@link FilterPopup} popover.
@@ -1645,6 +1681,7 @@ function WaydGridInner<T>(
         isLoading={isLoading}
         emptyMessage={emptyMessage}
         visibleColumnCount={visibleColumnCount}
+        numericColumnIds={numericColumnIds}
         isTree={isTree}
         flatDndEnabled={flatDndEnabled}
         isDragEnabled={isDragEnabled}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -111,6 +111,7 @@ import {
   useGridEditing,
   type GridEditingConfig,
 } from '../wayd-grid-core/use-grid-editing'
+import { useGridColumnStatePersistence } from '../wayd-grid-core/use-grid-persistence'
 import {
   mergeColumnVisibility,
   useGridState,
@@ -518,6 +519,7 @@ function WaydGridInner<T>(
     includeColumnFilters = true,
     includeFloatingFilters = true,
     getRowId,
+    persistStateKey,
     onDisplayedRowsChange,
     onRowReorder,
     getSubRows,
@@ -580,6 +582,7 @@ function WaydGridInner<T>(
 
   // ─── State ───────────────────────────────────────────────
   const gridState = useGridState({ initialSorting })
+  useGridColumnStatePersistence(gridState, persistStateKey)
   const {
     searchValue,
     onSearchChange,

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/cycle-time-report.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/cycle-time-report.tsx
@@ -44,11 +44,14 @@ interface CycleTimeReportContentProps {
     | { type: 'team'; teamCode: string }
     | { type: 'employee'; employeeId: string }
   workItemsScope: string
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const CycleTimeReportContent: FC<CycleTimeReportContentProps> = ({
   source,
   workItemsScope,
+  persistStateKey,
 }) => {
   const doneFromPresets = [30, 60, 90, 120, 180].map((days) => ({
     label: `${days} Days`,
@@ -220,6 +223,7 @@ const CycleTimeReportContent: FC<CycleTimeReportContentProps> = ({
         refetch={refetch}
         showStats={true}
         onDisplayedRowsChange={setChartWorkItems}
+        persistStateKey={persistStateKey}
       />
     </Flex>
   )
@@ -230,6 +234,7 @@ export const CycleTimeReport: FC<CycleTimeReportProps> = ({ teamCode }) => {
     <CycleTimeReportContent
       source={{ type: 'team', teamCode }}
       workItemsScope="Shows work items owned by the selected team."
+      persistStateKey="team-cycle-time"
     />
   )
 }
@@ -241,6 +246,7 @@ export const EmployeeCycleTimeReport: FC<EmployeeCycleTimeReportProps> = ({
     <CycleTimeReportContent
       source={{ type: 'employee', employeeId }}
       workItemsScope="Shows work items assigned to this employee."
+      persistStateKey="employee-cycle-time"
     />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-dependencies-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-item-dependencies-grid.tsx
@@ -152,6 +152,7 @@ const WorkItemDependenciesGrid: FC<WorkItemDependenciesGridProps> = (props) => {
       onRefresh={refresh}
       isLoading={props.isLoading}
       initialSorting={[{ id: 'type', desc: false }]}
+      persistStateKey="work-item-dependencies"
       csvFileName="work-item-dependencies"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-backlog-grid.tsx
@@ -21,6 +21,8 @@ export interface WorkItemsBacklogGridProps {
   hideTeamColumn: boolean
   isLoading: boolean
   refetch: () => void
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
@@ -71,13 +73,19 @@ const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
         sortingFn: workStatusCategorySort,
         meta: { filterType: 'set' },
       },
-      {
-        id: 'team',
-        accessorKey: 'team.name',
-        header: 'Team',
-        meta: { hide: props.hideTeamColumn, filterEnableSet: true },
-        cell: ({ row }) => renderTeamLink(row.original.team),
-      },
+      // Context-redundant column: excluded from the defs (not meta.hide) so
+      // it stays out of the column chooser and persisted layouts.
+      ...(props.hideTeamColumn
+        ? []
+        : [
+            {
+              id: 'team',
+              accessorKey: 'team.name',
+              header: 'Team',
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderTeamLink(row.original.team),
+            } satisfies ColumnDef<WorkItemBacklogItemDto, any>,
+          ]),
       {
         id: 'sprint',
         accessorKey: 'sprint.name',
@@ -144,6 +152,7 @@ const WorkItemsBacklogGrid = (props: WorkItemsBacklogGridProps) => {
       data={props.workItems ?? []}
       onRefresh={refresh}
       isLoading={props.isLoading}
+      persistStateKey={props.persistStateKey}
       csvFileName="work-items-backlog"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/work/work-items-grid.tsx
@@ -27,6 +27,8 @@ export interface WorkItemsGridProps {
    *  changes — e.g. the cycle-time report syncs its chart to the grid. */
   onDisplayedRowsChange?: (workItems: WorkItemListDto[]) => void
   viewSelector?: ReactNode | undefined
+  /** Column layout persistence key for the hosting page (see WaydGridProps). */
+  persistStateKey?: string
 }
 
 const WorkItemsGrid: FC<WorkItemsGridProps> = (props) => {
@@ -91,31 +93,36 @@ const WorkItemsGrid: FC<WorkItemsGridProps> = (props) => {
         meta: { filterEnableSet: true },
         cell: ({ row }) => renderSprintLink(row.original.sprint),
       },
-      {
-        id: 'parentKey',
-        accessorKey: 'parent.key',
-        header: 'Parent Key',
-        sortingFn: workItemKeySort,
-        meta: { hide: props.hideParentColumn },
-        cell: ({ row }) =>
-          renderWorkItemLink(
-            row.original.parent
-              ? {
-                  key: row.original.parent.key,
-                  workspaceKey: row.original.parent.workspaceKey,
-                  externalViewWorkItemUrl:
-                    row.original.parent.externalViewWorkItemUrl,
-                }
-              : null,
-          ),
-      },
-      {
-        id: 'parentTitle',
-        accessorKey: 'parent.title',
-        header: 'Parent',
-        size: 400,
-        meta: { hide: props.hideParentColumn },
-      },
+      // Context-redundant columns are excluded from the defs (not meta.hide):
+      // they never belong on the hosting page, so they shouldn't appear in
+      // the column chooser or the persisted layout either.
+      ...(props.hideParentColumn
+        ? []
+        : [
+            {
+              id: 'parentKey',
+              accessorKey: 'parent.key',
+              header: 'Parent Key',
+              sortingFn: workItemKeySort,
+              cell: ({ row }) =>
+                renderWorkItemLink(
+                  row.original.parent
+                    ? {
+                        key: row.original.parent.key,
+                        workspaceKey: row.original.parent.workspaceKey,
+                        externalViewWorkItemUrl:
+                          row.original.parent.externalViewWorkItemUrl,
+                      }
+                    : null,
+                ),
+            } satisfies ColumnDef<WorkItemListDto, any>,
+            {
+              id: 'parentTitle',
+              accessorKey: 'parent.title',
+              header: 'Parent',
+              size: 400,
+            } satisfies ColumnDef<WorkItemListDto, any>,
+          ]),
       {
         id: 'assignedTo',
         accessorKey: 'assignedTo.name',
@@ -123,14 +130,22 @@ const WorkItemsGrid: FC<WorkItemsGridProps> = (props) => {
         meta: { filterEnableSet: true },
         cell: ({ row }) => renderAssignedToLink(row.original.assignedTo),
       },
-      {
-        id: 'project',
-        accessorKey: 'project.name',
-        header: 'Project',
-        size: 300,
-        meta: { hide: props.hideProjectColumn, filterEnableSet: true },
-        cell: ({ row }) => renderProjectLink(row.original.project),
-      },
+      ...(props.hideProjectColumn
+        ? []
+        : [
+            {
+              id: 'project',
+              accessorKey: 'project.name',
+              header: 'Project',
+              size: 300,
+              meta: { filterEnableSet: true },
+              cell: ({ row }) => renderProjectLink(row.original.project),
+            } satisfies ColumnDef<WorkItemListDto, any>,
+          ]),
+      // The stats columns stay on meta.hide (NOT def-exclusion): the grid's
+      // initialSorting sorts by the hidden 'done' column, and TanStack drops
+      // sort entries whose column has no def — excluding them would silently
+      // change the default row order on non-stats pages.
       {
         id: 'activated',
         accessorKey: 'activated',
@@ -168,6 +183,7 @@ const WorkItemsGrid: FC<WorkItemsGridProps> = (props) => {
       initialSorting={[{ id: 'done', desc: true }]}
       onDisplayedRowsChange={props.onDisplayedRowsChange}
       rightSlot={props.viewSelector}
+      persistStateKey={props.persistStateKey}
       csvFileName="work-items"
     />
   )

--- a/Wayd.Web/src/wayd.web.reactclient/wayd.web.reactclient.esproj
+++ b/Wayd.Web/src/wayd.web.reactclient/wayd.web.reactclient.esproj
@@ -1,26 +1,25 @@
 ﻿<Project Sdk="Microsoft.VisualStudio.JavaScript.Sdk">
-  <PropertyGroup>
-    <!-- Folder where production build objects will be placed -->
-    <BuildOutputFolder>$(MSBuildProjectDirectory)\build</BuildOutputFolder>
-    <!-- Exclude heavy folders from Visual Studio project scanning -->
-    <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
-    <ShouldRunBuildScript>false</ShouldRunBuildScript>
-  </PropertyGroup>
-  <ItemGroup>
-    <Folder Remove="node_modules\**" />
-    <Content Remove="node_modules\**" />
-    <None Remove="node_modules\**" />
-    <Folder Remove=".next\**" />
-    <Content Remove=".next\**" />
-    <None Remove=".next\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include=".docker\Dockerfile" />
-  </ItemGroup>
-  <ItemGroup>
-    <TypeScriptConfiguration Remove=".docker\**" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Remove=".docker\**" />
-  </ItemGroup>
+    <PropertyGroup>
+        <!-- Folder where production build objects will be placed -->
+        <BuildOutputFolder>$(MSBuildProjectDirectory)\build</BuildOutputFolder>
+        <!-- Exclude heavy folders from Visual Studio project scanning -->
+        <ShouldRunNpmInstall>false</ShouldRunNpmInstall>
+        <ShouldRunBuildScript>false</ShouldRunBuildScript>
+    </PropertyGroup>
+    <ItemGroup>
+        <Folder Remove="node_modules\**;.next\**;build\**;dist\**;coverage\**" />
+        <Content Remove="node_modules\**;.next\**;build\**;dist\**;coverage\**" />
+        <None Remove="node_modules\**;.next\**;build\**;dist\**;coverage\**" />
+        <TypeScriptCompile Remove="node_modules\**;.next\**;build\**;dist\**;coverage\**" />
+        <TypeScriptConfiguration Remove="node_modules\**;.next\**;build\**;dist\**;coverage\**" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Include=".docker\Dockerfile" />
+    </ItemGroup>
+    <ItemGroup>
+        <TypeScriptConfiguration Remove=".docker\**" />
+    </ItemGroup>
+    <ItemGroup>
+        <None Remove=".docker\**" />
+    </ItemGroup>
 </Project>


### PR DESCRIPTION
## Add column layout persistence to WaydGrid

Grids now remember the user's column layout. Every WaydGrid persists the user's **column sizing, visibility (Choose Columns), and pinning** to localStorage and restores it on the next visit. Sorting, filters, and search remain session-only by design.

### How it works

- New `useGridColumnStatePersistence` hook in `wayd-grid-core`, wired into WaydGrid behind an opt-in `persistStateKey` prop. No key → no persistence, zero behavior change.
- State is stored per grid under `wayd-grid:{key}:v1` (versioned; stale versions are cleaned up on load). An all-default layout **removes** the entry, so pristine grids leave no localStorage residue and the column menu's existing **Reset Columns** doubles as "delete the stored layout."
- Persisted state applies in a mount effect rather than lazy state init — WaydGrid is SSR-rendered and column widths appear in markup, so lazy localStorage reads would cause hydration mismatches. Saves are debounced (~250ms; column resize fires per mousemove) with an unmount flush.
- Stale column ids in a stored layout are tolerated: TanStack ignores unknown ids, so layouts survive column additions/removals. `GRID_STATE_VERSION` is the escape hatch for wholesale renames.

### Keys are per page context, not per component

Shared grid components (`WorkItemsGrid`, `SprintsGrid`, `RisksGrid`, …) expose `persistStateKey` as a pass-through prop and each page site supplies its own key (e.g. `team-backlog` vs `workspace-work-items`, `team-sprints` vs `planning-sprints`), since what the user wants to see differs per context. Tree and List views of the same data keep separate layouts (`project-work-items` / `project-work-items-tree`).

**Every WaydGrid render site is wired** (~55 sites) except `WaydGridTransfer`'s two internal picker grids, which stay keyless by design — transient selection UIs keep default layouts.

### Account page controls

New **Preferences** tab on the account page:

- **Remember column layouts** switch — a device-level kill switch. Disabling stops load/save but keeps saved layouts, so re-enabling restores them.
- **Reset all grid layouts** — confirmed action that deletes every saved layout on the device.

Both note that layouts are stored in the browser (device-local).

### Convention change: conditional column defs instead of `meta.hide`

Most `meta.hide` usage predated users being able to manage visibility themselves. New rule, applied repo-wide:

- A column that can **never be meaningful in a context** (`hideTeam` on a team page, `hidePortfolio` on a portfolio page) or only applies in a mode (include closed/archived) is **excluded from the column defs** — keeping it out of the column chooser and persisted layouts.
- `meta.hide` remains only for permission/actions columns, and the work-items stats columns (`activated`/`done`/`cycleTime`) — the grid's default sort targets the hidden `done` column, and TanStack drops sort entries for columns with no definition, so def-excluding them would change the default row order.

### Also in this PR

- **Tighter header spacing** — removed redundant resizer padding, reduced header flex gaps (8→4px) and th padding (12→8px). Narrow columns recover ~28px of label width (fixes truncated headers like "Ra…"); `AUTOSIZE_HEADER_ALLOWANCE` tracks the new overhead (76→48).
- **Numeric columns right-align their cells** by default — resolved with the same data-type inference the filter UI uses (explicit `filterType: 'number'` or all-number sampled data), so alignment and filters never disagree. Headers stay left-aligned. New `meta.align: 'left' | 'right'` overrides per column.

### Testing

- New unit suite for the persistence hook (load/save/debounce/reset/versioning/malformed payloads/kill switch/unmount flush) and the Preferences tab.
- WaydGrid integration tests: restore-on-mount, save→remount round trip, keyless grids never touch storage, numeric alignment (including `meta.align` overrides).
- Full suite: 159 suites / 2,448 tests passing; verified end-to-end in the browser (save → reload restores; per-grid reset deletes the entry; independent layouts per page context).
