### PR TITLE
Feature/add column reordering to waydgrid

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/preferences.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/account/profile/preferences.tsx
@@ -42,9 +42,9 @@ const Preferences: FC = () => {
           <Text strong>Remember column layouts</Text>
           <br />
           <Text type="secondary">
-            Save each grid&apos;s column sizing, visibility, and pinning so
-            your layout is restored on your next visit. Turning this off keeps
-            existing saved layouts; they apply again when re-enabled.
+            Save each grid&apos;s column sizing, visibility, pinning, and order
+            so your layout is restored on your next visit. Turning this off
+            keeps existing saved layouts; they apply again when re-enabled.
           </Text>
         </div>
         <Switch

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/actions-column.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/actions-column.test.tsx
@@ -39,8 +39,8 @@ describe('createActionsColumn', () => {
       expect(col.enableColumnFilter).toBe(false)
       expect(col.enableResizing).toBe(false)
       expect(col.header).toBe('')
-      // No meta.hide unless the caller opts in.
-      expect(col.meta).toBeUndefined()
+      // The actions column always opts out of reordering; no hide unless asked.
+      expect(col.meta).toEqual({ enableReordering: false })
     })
 
     it('honors id, size, and hide overrides', () => {
@@ -55,7 +55,7 @@ describe('createActionsColumn', () => {
       // Assert
       expect(col.id).toBe('rowMenu')
       expect(col.size).toBe(72)
-      expect(col.meta).toEqual({ hide: true })
+      expect(col.meta).toEqual({ enableReordering: false, hide: true })
     })
   })
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/actions-column.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/actions-column.tsx
@@ -92,7 +92,8 @@ export const createActionsColumn = <T,>({
   enableColumnFilter: false,
   enableResizing: false,
   enableGlobalFilter: false,
-  meta: hide === undefined ? undefined : { hide },
+  // The actions column always holds its position — no drag grip, rejects drops.
+  meta: { enableReordering: false, ...(hide === undefined ? {} : { hide }) },
   cell: ({ row }: { row: Row<T> }) => (
     <ActionsCell row={row.original} getItems={getItems} ariaLabel={ariaLabel} />
   ),

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.module.css
@@ -68,6 +68,33 @@ th:hover .trigger,
   background-color: var(--ant-color-fill-tertiary);
 }
 
+/* The checkbox + label portion of a row — the flex child that grows so the
+   label truncates while the grip stays fixed-width. */
+.chooserRowLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--ant-margin-xs);
+  min-width: 0;
+  flex: 1;
+  cursor: pointer;
+}
+
+/* Drag grip for reordering. Always visible while reordering is on (unlike the
+   header grip, which hover-reveals) so the list reads as sortable at a glance. */
+.chooserDragHandle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--ant-color-text-quaternary);
+  cursor: grab;
+  touch-action: none;
+}
+
+.chooserDragHandle:active {
+  cursor: grabbing;
+}
+
 .chooserLabel {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-menu.tsx
@@ -5,6 +5,7 @@ import { Button, Checkbox, Dropdown, Input, Modal } from 'antd'
 import type { MenuProps } from 'antd'
 import {
   CheckOutlined,
+  HolderOutlined,
   MoreOutlined,
   PushpinOutlined,
   ReloadOutlined,
@@ -15,7 +16,23 @@ import {
   ControlOutlined,
 } from '@ant-design/icons'
 import type { ColumnPinningPosition, Header, Table } from '@tanstack/react-table'
+import {
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 
+import { getOrderedAllLeafColumns } from './column-order'
 import styles from './column-menu.module.css'
 
 /** A leaf column offered in the Choose Columns panel. */
@@ -37,16 +54,17 @@ const resolveChooserLabel = (columnDef: {
 }
 
 /**
- * The leaf columns the user may show/hide, in column-def order. Excludes
- * consumer-controlled columns (`meta.hide === true` — those stay reactive to
- * the consumer's flag), columns with hiding disabled, and structural columns
- * with no displayable label (e.g. the row-actions column).
+ * The leaf columns the user may show/hide, in on-screen display order (so the
+ * checkbox list matches the grid left-to-right, reflecting reorder + pinning).
+ * Excludes consumer-controlled columns (`meta.hide === true` — those stay
+ * reactive to the consumer's flag), columns with hiding disabled, and
+ * structural columns with no displayable label (e.g. the row-actions column).
  */
 export function getColumnChooserOptions<T>(
   table: Table<T>,
 ): ColumnChooserOption[] {
   const options: ColumnChooserOption[] = []
-  for (const column of table.getAllLeafColumns()) {
+  for (const column of getOrderedAllLeafColumns(table)) {
     if (column.columnDef.meta?.hide === true) continue
     if (!column.getCanHide()) continue
     const label = resolveChooserLabel(column.columnDef)
@@ -298,6 +316,9 @@ export function ColumnMenuTrigger<T>({
         aria-label="Column menu"
         className={`${styles.trigger}${open ? ` ${styles.triggerOpen}` : ''}`}
         onClick={(e) => e.stopPropagation()}
+        // The whole header cell is a column-reorder drag handle; keep a click on
+        // the menu button from starting a drag.
+        onPointerDown={(e) => e.stopPropagation()}
       >
         <MoreOutlined />
       </button>
@@ -311,6 +332,58 @@ export interface ColumnChooserModalProps<T> {
   onClose: () => void
   /** Writes the USER visibility layer for one column. */
   onToggleColumn: (columnId: string, visible: boolean) => void
+  /** Whether drag-to-reorder is offered in the list (off for grouped-header
+   *  grids, matching header-drag). Default false. */
+  reorderEnabled?: boolean
+  /** Moves `activeId` to `overId`'s position (section-aware; the grid owns the
+   *  rules). Called on a list drop. */
+  onReorderColumn?: (activeId: string, overId: string) => void
+}
+
+/** One draggable chooser row: a grip, a visibility checkbox, and the label. */
+function ChooserRow({
+  option,
+  reorderEnabled,
+  lockedOn,
+  onToggle,
+}: {
+  option: ColumnChooserOption
+  reorderEnabled: boolean
+  /** Keep the last visible column checked-and-disabled. */
+  lockedOn: boolean
+  onToggle: (visible: boolean) => void
+}) {
+  const { setNodeRef, transform, transition, isDragging, listeners, attributes } =
+    useSortable({ id: option.id, disabled: !reorderEnabled })
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : undefined,
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className={styles.chooserRow}>
+      {reorderEnabled && (
+        <span
+          {...attributes}
+          {...listeners}
+          role="button"
+          aria-label="Reorder column"
+          className={styles.chooserDragHandle}
+        >
+          <HolderOutlined />
+        </span>
+      )}
+      <label className={styles.chooserRowLabel}>
+        <Checkbox
+          checked={option.visible}
+          disabled={lockedOn}
+          onChange={(e) => onToggle(e.target.checked)}
+        />
+        <span className={styles.chooserLabel}>{option.label}</span>
+      </label>
+    </div>
+  )
 }
 
 /**
@@ -327,10 +400,17 @@ export function ColumnChooserModal<T>({
   open,
   onClose,
   onToggleColumn,
+  reorderEnabled = false,
+  onReorderColumn,
 }: ColumnChooserModalProps<T>) {
   // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see GridHeaderCell
   'use no memo'
   const [search, setSearch] = useState('')
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor),
+  )
 
   const options = getColumnChooserOptions(table)
   const visibleCount = options.filter((col) => col.visible).length
@@ -338,6 +418,37 @@ export function ColumnChooserModal<T>({
   const shownOptions = query
     ? options.filter((col) => col.label.toLowerCase().includes(query))
     : options
+
+  // Reordering is meaningful only over the full, unfiltered list — a filtered
+  // subset hides the drop neighbours. Grips show when the feature is on and no
+  // search is narrowing the list.
+  const canReorder = reorderEnabled && !!onReorderColumn && query === ''
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      onReorderColumn?.(String(active.id), String(over.id))
+    }
+  }
+
+  const list = (
+    <div className={styles.chooserList}>
+      {shownOptions.map((col) => (
+        <ChooserRow
+          key={col.id}
+          option={col}
+          reorderEnabled={canReorder}
+          // Keep the last visible column locked on — hiding every column would
+          // leave an empty table with no header to reopen the chooser from.
+          lockedOn={col.visible && visibleCount === 1}
+          onToggle={(visible) => onToggleColumn(col.id, visible)}
+        />
+      ))}
+      {shownOptions.length === 0 && (
+        <div className={styles.chooserEmpty}>No matches</div>
+      )}
+    </div>
+  )
 
   return (
     <Modal
@@ -361,24 +472,22 @@ export function ColumnChooserModal<T>({
           value={search}
           onChange={(e) => setSearch(e.target.value)}
         />
-        <div className={styles.chooserList}>
-          {shownOptions.map((col) => (
-            <label key={col.id} className={styles.chooserRow}>
-              <Checkbox
-                checked={col.visible}
-                // Keep the last visible column locked on — hiding every
-                // column would leave an empty table with no header to
-                // reopen the chooser from.
-                disabled={col.visible && visibleCount === 1}
-                onChange={(e) => onToggleColumn(col.id, e.target.checked)}
-              />
-              <span className={styles.chooserLabel}>{col.label}</span>
-            </label>
-          ))}
-          {shownOptions.length === 0 && (
-            <div className={styles.chooserEmpty}>No matches</div>
-          )}
-        </div>
+        {canReorder ? (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={shownOptions.map((col) => col.id)}
+              strategy={verticalListSortingStrategy}
+            >
+              {list}
+            </SortableContext>
+          </DndContext>
+        ) : (
+          list
+        )}
       </div>
     </Modal>
   )

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-order.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-order.test.ts
@@ -1,0 +1,182 @@
+import {
+  createTable,
+  getCoreRowModel,
+  type ColumnDef,
+  type TableState,
+} from '@tanstack/react-table'
+
+import { reconcileColumnOrder, reorderIds } from './column-order'
+
+describe('column-order', () => {
+  describe('reconcileColumnOrder', () => {
+    it('returns the def order when the stored order is empty', () => {
+      // Arrange
+      const current = ['a', 'b', 'c']
+
+      // Act
+      const result = reconcileColumnOrder([], current)
+
+      // Assert
+      expect(result).toEqual(['a', 'b', 'c'])
+    })
+
+    it('preserves a stored reordering of unchanged columns', () => {
+      // Arrange
+      const stored = ['c', 'a', 'b']
+      const current = ['a', 'b', 'c']
+
+      // Act
+      const result = reconcileColumnOrder(stored, current)
+
+      // Assert
+      expect(result).toEqual(['c', 'a', 'b'])
+    })
+
+    it('drops stored ids for columns that no longer exist', () => {
+      // Arrange — 'x' was removed from the defs
+      const stored = ['c', 'x', 'a', 'b']
+      const current = ['a', 'b', 'c']
+
+      // Act
+      const result = reconcileColumnOrder(stored, current)
+
+      // Assert
+      expect(result).toEqual(['c', 'a', 'b'])
+    })
+
+    it('inserts a newly added column at its def position, not the end', () => {
+      // Arrange — 'b' is new (stored order predates it); def order is a,b,c,d
+      const stored = ['d', 'a', 'c']
+      const current = ['a', 'b', 'c', 'd']
+
+      // Act
+      const result = reconcileColumnOrder(stored, current)
+
+      // Assert — 'b' lands between 'a' and 'c' (its def neighbours), while the
+      // stored reordering of the others is preserved
+      expect(result).toEqual(['d', 'a', 'b', 'c'])
+    })
+
+    it('places a new first-def column ahead of its def-later neighbour', () => {
+      // Arrange — 'a' is new and sits first in the defs
+      const stored = ['c', 'b']
+      const current = ['a', 'b', 'c']
+
+      // Act
+      const result = reconcileColumnOrder(stored, current)
+
+      // Assert — 'a' precedes 'b' (its only already-placed def-later neighbour)
+      expect(result).toEqual(['a', 'c', 'b'])
+    })
+
+    it('appends a new last-def column after all stored ids', () => {
+      // Arrange — 'c' is new and sits last in the defs
+      const stored = ['b', 'a']
+      const current = ['a', 'b', 'c']
+
+      // Act
+      const result = reconcileColumnOrder(stored, current)
+
+      // Assert
+      expect(result).toEqual(['b', 'a', 'c'])
+    })
+  })
+
+  describe('reorderIds', () => {
+    it('moves the active id to the over id position', () => {
+      // Arrange / Act
+      const result = reorderIds(['a', 'b', 'c', 'd'], 'b', 'd')
+
+      // Assert
+      expect(result).toEqual(['a', 'c', 'd', 'b'])
+    })
+
+    it('returns the same reference for a no-op move (same id)', () => {
+      // Arrange
+      const ids = ['a', 'b', 'c']
+
+      // Act
+      const result = reorderIds(ids, 'b', 'b')
+
+      // Assert
+      expect(result).toBe(ids)
+    })
+
+    it('returns the same reference when either id is absent', () => {
+      // Arrange
+      const ids = ['a', 'b', 'c']
+
+      // Act / Assert
+      expect(reorderIds(ids, 'z', 'a')).toBe(ids)
+      expect(reorderIds(ids, 'a', 'z')).toBe(ids)
+    })
+  })
+
+  // Guards the composition the whole feature rests on: columnOrder governs the
+  // center section only; each pinned section follows its columnPinning array.
+  describe('columnOrder × pinning composition (TanStack)', () => {
+    type Item = { a: string; b: string; c: string; d: string }
+    const data: Item[] = [{ a: '1', b: '2', c: '3', d: '4' }]
+    const columns: ColumnDef<Item, any>[] = [
+      { id: 'a', accessorKey: 'a', header: 'A' },
+      { id: 'b', accessorKey: 'b', header: 'B' },
+      { id: 'c', accessorKey: 'c', header: 'C' },
+      { id: 'd', accessorKey: 'd', header: 'D' },
+    ]
+
+    const buildTable = (state: Partial<TableState>) =>
+      createTable<Item>({
+        data,
+        columns,
+        getCoreRowModel: getCoreRowModel(),
+        state: {
+          columnSizing: {},
+          columnVisibility: {},
+          columnPinning: { left: [], right: [] },
+          columnOrder: [],
+          ...state,
+        } as TableState,
+        onStateChange: () => {},
+        renderFallbackValue: null,
+      })
+
+    /** Rendered leaf order the grid's colgroup uses. */
+    const renderedOrder = (table: ReturnType<typeof buildTable>) =>
+      [
+        ...table.getLeftVisibleLeafColumns(),
+        ...table.getCenterVisibleLeafColumns(),
+        ...table.getRightVisibleLeafColumns(),
+      ].map((col) => col.id)
+
+    it('reorders the center section by columnOrder', () => {
+      // Arrange / Act
+      const table = buildTable({ columnOrder: ['c', 'a', 'b', 'd'] })
+
+      // Assert
+      expect(renderedOrder(table)).toEqual(['c', 'a', 'b', 'd'])
+    })
+
+    it('orders pinned sections by the pin array, not columnOrder', () => {
+      // Arrange — pin d then a left; columnOrder tries the opposite order
+      const table = buildTable({
+        columnPinning: { left: ['d', 'a'], right: [] },
+        columnOrder: ['a', 'b', 'c', 'd'],
+      })
+
+      // Act / Assert — left section follows the pin array [d, a]; center keeps
+      // columnOrder for the rest
+      expect(renderedOrder(table)).toEqual(['d', 'a', 'b', 'c'])
+    })
+
+    it('applies columnOrder only within the center when some columns are pinned', () => {
+      // Arrange — b pinned right; center order reversed
+      const table = buildTable({
+        columnPinning: { left: [], right: ['b'] },
+        columnOrder: ['d', 'c', 'a', 'b'],
+      })
+
+      // Act / Assert — center is [d, c, a] (columnOrder minus pinned), b sticks right
+      expect(renderedOrder(table)).toEqual(['d', 'c', 'a', 'b'])
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-order.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/column-order.ts
@@ -1,0 +1,132 @@
+import { arrayMove } from '@dnd-kit/sortable'
+import type { Column, ColumnOrderState, Table } from '@tanstack/react-table'
+
+/**
+ * Column-ordering helpers for WaydGrid. Pure and table-agnostic so they're
+ * unit-testable without a table instance.
+ *
+ * Background — how TanStack (v8) composes columnOrder with pinning:
+ *  - `columnOrder` is a list of leaf column ids. TanStack orders the columns
+ *    by it, then APPENDS any leaf id missing from the list at the end (not at
+ *    its def position).
+ *  - The rendered order is left-pinned → center → right-pinned. Only the
+ *    CENTER section follows `columnOrder`; each pinned section is ordered by
+ *    its `columnPinning` array, which ignores `columnOrder` entirely.
+ *
+ * So the grid keeps `columnOrder` as the FULL leaf-id order (pinned ids
+ * included but inert for pinned sections) and reorders within it for center
+ * drags; pinned-section drags reorder the relevant `columnPinning` array.
+ */
+
+/**
+ * Reconciles a persisted (or otherwise stale) column order against the current
+ * leaf columns so it's safe to hand to TanStack:
+ *  - keeps stored ids that still exist, in their stored order,
+ *  - inserts each current id absent from the stored order at its DEF index
+ *    (so a newly added column appears where its def author placed it, rather
+ *    than being appended to the end as TanStack would do),
+ *  - drops stored ids for columns that no longer exist.
+ *
+ * An empty stored order returns the def order (identity), which the grid then
+ * treats as "no custom order".
+ *
+ * @param storedOrder  the persisted order (may reference removed columns / omit new ones)
+ * @param currentLeafIds  the current leaf column ids in DEF order
+ */
+export function reconcileColumnOrder(
+  storedOrder: ColumnOrderState,
+  currentLeafIds: string[],
+): ColumnOrderState {
+  const currentSet = new Set(currentLeafIds)
+  // Known stored ids, in stored order (removed ids dropped).
+  const kept = storedOrder.filter((id) => currentSet.has(id))
+  const keptSet = new Set(kept)
+
+  const defIndexOf = new Map(currentLeafIds.map((id, i) => [id, i]))
+
+  // Walk the def order; splice each not-yet-placed id in just AFTER the most
+  // recent already-placed id that is def-earlier than it. Anchoring on the
+  // def-earlier neighbour (rather than the first def-later one) respects a
+  // user's reordering: a new column follows its def predecessor wherever the
+  // user moved that predecessor to.
+  const result: string[] = [...kept]
+  currentLeafIds.forEach((id, defIndex) => {
+    if (keptSet.has(id)) return
+    let insertAt = 0
+    for (let i = 0; i < result.length; i++) {
+      if ((defIndexOf.get(result[i]) ?? -1) < defIndex) {
+        insertAt = i + 1
+      }
+    }
+    result.splice(insertAt, 0, id)
+    keptSet.add(id)
+  })
+
+  return result
+}
+
+/**
+ * Moves `activeId` to `overId`'s position within a list of ids (a full
+ * columnOrder or a single columnPinning side). No-op — returns the same
+ * reference — when either id is absent or they're identical, so callers can
+ * safely bail on a non-move.
+ */
+export function reorderIds(
+  ids: string[],
+  activeId: string,
+  overId: string,
+): string[] {
+  if (activeId === overId) return ids
+  const from = ids.indexOf(activeId)
+  const to = ids.indexOf(overId)
+  if (from < 0 || to < 0) return ids
+  return arrayMove(ids, from, to)
+}
+
+/**
+ * The visible leaf columns in RENDER order: left-pinned → center → right-pinned
+ * (the center honours columnOrder). Everything that iterates columns for the
+ * user — the colgroup, CSV export, the column chooser, autosize-all — must use
+ * this, because plain getVisibleLeafColumns() stays in def order and ignores
+ * both pinning and columnOrder.
+ */
+export function getOrderedVisibleLeafColumns<T>(
+  table: Table<T>,
+): Column<T, unknown>[] {
+  // The pin-section getters read table.getState().columnPinning; a headless
+  // harness may omit it. columnOrder is still applied by getVisibleLeafColumns,
+  // so fall back to that (def-position for pinned, but nothing is pinned when
+  // there's no pinning state anyway).
+  if (!table.getState().columnPinning) return table.getVisibleLeafColumns()
+  return [
+    ...table.getLeftVisibleLeafColumns(),
+    ...table.getCenterVisibleLeafColumns(),
+    ...table.getRightVisibleLeafColumns(),
+  ]
+}
+
+/**
+ * ALL leaf columns (visible AND hidden) in the on-screen left→center→right
+ * order: left-pinned first (pin-array order), then the unpinned columns in
+ * columnOrder sequence, then right-pinned. Like {@link
+ * getOrderedVisibleLeafColumns} but keeps hidden columns, so the Choose
+ * Columns list mirrors the display order while still listing hideable columns
+ * the user has turned off.
+ */
+export function getOrderedAllLeafColumns<T>(
+  table: Table<T>,
+): Column<T, unknown>[] {
+  const { left = [], right = [] } = table.getState().columnPinning ?? {}
+  const pinned = new Set([...left, ...right])
+  // getAllLeafColumns() already applies columnOrder to every leaf.
+  const byId = new Map(
+    table.getAllLeafColumns().map((column) => [column.id, column]),
+  )
+  const lookup = (id: string) => byId.get(id)
+  const leftCols = left.map(lookup).filter(Boolean) as Column<T, unknown>[]
+  const rightCols = right.map(lookup).filter(Boolean) as Column<T, unknown>[]
+  const centerCols = table
+    .getAllLeafColumns()
+    .filter((column) => !pinned.has(column.id))
+  return [...leftCols, ...centerCols, ...rightCols]
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-export.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-export.ts
@@ -4,6 +4,7 @@ import {
   generateCsv,
   downloadCsvWithTimestamp,
 } from '@/src/utils/csv-utils'
+import { getOrderedVisibleLeafColumns } from './column-order'
 
 /** Header text for a column: meta.exportHeader → string header → column id. */
 const resolveExportHeader = <T>(column: Column<T, unknown>): string => {
@@ -31,9 +32,10 @@ const ancestorAtDepth = <T>(
 /**
  * Exports a grid to CSV and triggers the download (filename gets a timestamp).
  *
- * Exports only what's on screen: the currently *visible* leaf columns (so
- * hidden columns are excluded) and the *filtered/sorted* rows (getRowModel).
- * Values come from TanStack's own accessors (row.getValue), so nested
+ * Exports only what's on screen: the currently *visible* leaf columns in their
+ * displayed order (so hidden columns are excluded and reordered/pinned columns
+ * export in the order the user sees) and the *filtered/sorted* rows
+ * (getRowModel). Values come from TanStack's own accessors (row.getValue), so nested
  * accessorKeys like `status.name` resolve correctly and column-type
  * transforms (e.g. yesNo's boolean → "Yes"/"No") are reflected.
  *
@@ -45,12 +47,14 @@ const ancestorAtDepth = <T>(
  * overrides the header text, and `exportFormatter` maps each value.
  */
 export function exportGridToCsv<T>(table: Table<T>, csvFileName: string): void {
-  const exportableColumns = table.getVisibleLeafColumns().filter((column) => {
-    const meta = column.columnDef.meta
-    if (meta?.enableExport === false) return false
-    // Only columns with an accessor produce a value worth exporting.
-    return column.accessorFn != null
-  })
+  const exportableColumns = getOrderedVisibleLeafColumns(table).filter(
+    (column) => {
+      const meta = column.columnDef.meta
+      if (meta?.enableExport === false) return false
+      // Only columns with an accessor produce a value worth exporting.
+      return column.accessorFn != null
+    },
+  )
 
   const headers = exportableColumns.map(resolveExportHeader)
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
@@ -9,6 +9,8 @@ import {
 } from 'react'
 import { ArrowUpOutlined, ArrowDownOutlined } from '@ant-design/icons'
 import { type Header, flexRender } from '@tanstack/react-table'
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import WaydTooltip from '@/src/components/common/wayd-tooltip'
 
 /**
@@ -80,6 +82,24 @@ export interface GridHeaderCellClasses {
   thText: string
   resizer: string
   resizerActive: string
+  /** Applied to the `<th>` when the column is reorderable (grab cursor). */
+  thDraggable?: string
+  /** Applied to the `<th>` while this column is being dragged. */
+  thDragging?: string
+}
+
+/**
+ * Sortable wiring for a reorderable header cell, produced by
+ * {@link useHeaderCellSortable} and threaded into {@link GridHeaderCell}. The
+ * whole `<th>` is the drag handle: it carries `handleProps` (drag listeners),
+ * `setNodeRef`, and `style` so it translates while dragging.
+ */
+export interface HeaderCellSortable {
+  setNodeRef: (node: HTMLElement | null) => void
+  style: CSSProperties
+  isDragging: boolean
+  /** Spread onto the `<th>` (drag listeners + a11y attributes). */
+  handleProps: Record<string, unknown>
 }
 
 export interface GridHeaderCellProps<T> {
@@ -98,6 +118,38 @@ export interface GridHeaderCellProps<T> {
   thClassName?: string
   /** Extra inline style for the `<th>` (e.g. the sticky pinning inset). */
   thStyle?: CSSProperties
+  /** Column-reorder sortable wiring from {@link useHeaderCellSortable}. When
+   *  omitted the cell isn't draggable (grouped-header grids, the actions
+   *  column, or a placeholder). */
+  sortable?: HeaderCellSortable
+}
+
+/**
+ * Per-header sortable hook for column reordering — the whole header cell is the
+ * drag handle. Ids are namespaced `col:<id>` so a shared DnD context can tell
+ * column drags from row drags. Disabled cells still call the hook (hooks must
+ * be unconditional) but return no listeners.
+ */
+export function useHeaderCellSortable(
+  columnId: string,
+  disabled: boolean,
+): HeaderCellSortable {
+  const { setNodeRef, transform, transition, isDragging, listeners, attributes } =
+    useSortable({ id: `col:${columnId}`, disabled })
+  return {
+    setNodeRef,
+    style: {
+      // Only translate horizontally — a header cell reorders along the row.
+      transform: transform
+        ? CSS.Transform.toString({ ...transform, y: 0, scaleX: 1, scaleY: 1 })
+        : undefined,
+      transition,
+      // Keep the dragged cell above its neighbours' sticky/pinned stacking.
+      zIndex: isDragging ? 3 : undefined,
+    },
+    isDragging,
+    handleProps: { ...listeners, ...attributes },
+  }
 }
 
 /**
@@ -121,6 +173,7 @@ export function GridHeaderCell<T>({
   menuSlot,
   thClassName,
   thStyle,
+  sortable,
 }: GridHeaderCellProps<T>) {
   // eslint-disable-next-line react-compiler/react-compiler -- false-positive "unused directive"; see doc comment
   'use no memo'
@@ -149,12 +202,22 @@ export function GridHeaderCell<T>({
 
   return (
     <th
+      // The WHOLE header cell is the drag handle: dnd-kit's PointerSensor only
+      // activates after ~8px of movement, so a plain click still falls through
+      // to onClick (sort). Interactive children (resizer, filter, menu) stop
+      // pointerdown propagation so grabbing them never starts a column drag.
+      {...sortable?.handleProps}
       // Anchors autosize's header-label lookup (with the text marker below).
       data-column-id={header.column.id}
+      ref={sortable?.setNodeRef}
       className={`${classes.th}${canSort ? ` ${classes.thSortable}` : ''}${
         canResize ? ` ${classes.thResizable}` : ''
+      }${sortable ? ` ${classes.thDraggable}` : ''}${
+        sortable?.isDragging && classes.thDragging
+          ? ` ${classes.thDragging}`
+          : ''
       }${thClassName ? ` ${thClassName}` : ''}`}
-      style={thStyle}
+      style={sortable ? { ...thStyle, ...sortable.style } : thStyle}
       onClick={handleSortClick}
     >
       <span className={classes.thContent}>
@@ -174,11 +237,33 @@ export function GridHeaderCell<T>({
           onTouchStart={handleResizeStart}
           onDoubleClick={() => header.column.resetSize()}
           onClick={(e) => e.stopPropagation()}
+          // Don't let a resize grab start a column drag (drag listens on the th).
+          onPointerDown={(e) => e.stopPropagation()}
           className={`${classes.resizer}${
             header.column.getIsResizing() ? ` ${classes.resizerActive}` : ''
           }`}
         />
       )}
     </th>
+  )
+}
+
+/**
+ * A {@link GridHeaderCell} wired for column-reorder drag. Calls
+ * {@link useHeaderCellSortable} (unconditionally — hooks rules) and threads the
+ * sortable wiring in; pass `reorderable: false` to render a plain,
+ * non-draggable cell (grouped-header grids, the actions column, placeholders).
+ * Extracted so the per-header hook lives in its own component instead of a map
+ * callback.
+ */
+export function SortableHeaderCell<T>({
+  reorderable,
+  ...cellProps
+}: GridHeaderCellProps<T> & { reorderable: boolean }) {
+  // eslint-disable-next-line react-compiler/react-compiler -- same mutable-header caveat as GridHeaderCell
+  'use no memo'
+  const sortable = useHeaderCellSortable(cellProps.header.column.id, !reorderable)
+  return (
+    <GridHeaderCell {...cellProps} sortable={reorderable ? sortable : undefined} />
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/grid-header-row.tsx
@@ -144,8 +144,11 @@ export function useHeaderCellSortable(
         ? CSS.Transform.toString({ ...transform, y: 0, scaleX: 1, scaleY: 1 })
         : undefined,
       transition,
-      // Keep the dragged cell above its neighbours' sticky/pinned stacking.
-      zIndex: isDragging ? 3 : undefined,
+      // Float the dragged cell above every other header while dragging. The
+      // grid's header cells are z-index 20 and pinned headers 22 (see
+      // wayd-grid.module.css); this inline value must clear both so the
+      // dragged column never slides behind a neighbour or a pinned column.
+      zIndex: isDragging ? 30 : undefined,
     },
     isDragging,
     handleProps: { ...listeners, ...attributes },

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/types.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/types.ts
@@ -75,6 +75,12 @@ export interface WaydGridColumnMeta {
   maxFilterConditions?: number
   /** Placeholder text for text/numericRange filter inputs. */
   filterPlaceholder?: string
+  /**
+   * Whether the user may drag this column to reorder it. Default: true.
+   * Structural columns that must hold their position (e.g. the row-actions
+   * column) set this to `false` so they get no drag grip and reject drops.
+   */
+  enableReordering?: boolean
   /** Whether to include this column in CSV export. Default: true if the column has an accessor. */
   enableExport?: boolean
   /** Custom CSV formatter for this column's values. */

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.test.ts
@@ -95,7 +95,7 @@ describe('use-grid-persistence', () => {
       expect(setItemSpy).not.toHaveBeenCalled()
     })
 
-    it('applies a stored entry to all three slices on mount', () => {
+    it('applies a stored entry to all four slices on mount', () => {
       // Arrange
       window.localStorage.setItem(
         STORAGE_KEY,
@@ -103,6 +103,7 @@ describe('use-grid-persistence', () => {
           columnSizing: { name: 240 },
           userColumnVisibility: { team: false },
           columnPinning: { left: ['key'], right: [] },
+          columnOrder: ['team', 'name', 'key'],
         }),
       )
 
@@ -116,6 +117,74 @@ describe('use-grid-persistence', () => {
         left: ['key'],
         right: [],
       })
+      expect(result.current.columnOrder).toEqual(['team', 'name', 'key'])
+    })
+
+    it('loads a pre-ordering v1 entry (no columnOrder key) as an empty order', () => {
+      // Arrange — an entry written before column ordering existed
+      window.localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify({
+          columnSizing: { name: 240 },
+          userColumnVisibility: {},
+          columnPinning: { left: [], right: [] },
+        }),
+      )
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+
+      // Act
+      const { result } = renderHook(() => useHarness('test-grid'))
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert — still valid, order defaults to [], and nothing is rewritten
+      expect(result.current.columnSizing).toEqual({ name: 240 })
+      expect(result.current.columnOrder).toEqual([])
+      expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('persists an order-only change and omits an empty order from the payload', () => {
+      // Arrange
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Act
+      act(() => {
+        result.current.setColumnOrder(['team', 'name'])
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert
+      expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        columnSizing: {},
+        userColumnVisibility: {},
+        columnPinning: { left: [], right: [] },
+        columnOrder: ['team', 'name'],
+      })
+    })
+
+    it('treats an empty order as default (no write)', () => {
+      // Arrange
+      const setItemSpy = jest.spyOn(window.localStorage, 'setItem')
+      const { result } = renderHook(() => useHarness('test-grid'))
+
+      // Act — set then clear the order back to empty
+      act(() => {
+        result.current.setColumnOrder(['team', 'name'])
+      })
+      act(() => {
+        result.current.setColumnOrder([])
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+
+      // Assert — back to all-default: no residual entry
+      expect(window.localStorage.getItem(STORAGE_KEY)).toBeNull()
+      // The set-then-clear collapses to a no-op write.
+      expect(setItemSpy).not.toHaveBeenCalled()
     })
 
     it('does not rewrite an unchanged loaded entry', () => {
@@ -200,6 +269,7 @@ describe('use-grid-persistence', () => {
           columnSizing: { name: 240 },
           userColumnVisibility: { team: false },
           columnPinning: { left: ['key'], right: [] },
+          columnOrder: ['team', 'name'],
         }),
       )
       const { result } = renderHook(() => useHarness('test-grid'))

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-persistence.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, type MutableRefObject } from 'react'
 import type {
+  ColumnOrderState,
   ColumnPinningState,
   ColumnSizingState,
   VisibilityState,
@@ -10,9 +11,9 @@ import type { GridState } from './use-grid-table'
 /**
  * Opt-in localStorage persistence of a grid's user column layout.
  *
- * Persists exactly three {@link GridState} slices — `columnSizing`,
+ * Persists exactly four {@link GridState} slices — `columnSizing`,
  * `userColumnVisibility` (the raw user layer, never the merged
- * columnVisibility), and `columnPinning` — under
+ * columnVisibility), `columnPinning`, and `columnOrder` — under
  * `wayd-grid:{persistStateKey}:v{GRID_STATE_VERSION}`. Sorting, filters, and
  * search are deliberately session-only.
  *
@@ -29,8 +30,13 @@ import type { GridState } from './use-grid-table'
  *   is written atomically.
  * - Persisted ids for columns absent from the current defs are inert:
  *   TanStack ignores unknown ids in sizing/visibility maps and filters them
- *   from pinning arrays. Bump {@link GRID_STATE_VERSION} on wholesale shape
- *   or column renames.
+ *   from pinning arrays. `columnOrder` is reconciled against the live defs by
+ *   the grid (reconcileColumnOrder) before it reaches the table, so a stale or
+ *   partial order can't strand columns. Bump {@link GRID_STATE_VERSION} on
+ *   wholesale shape or column renames.
+ * - `columnOrder` is optional in the persisted payload: v1 entries written
+ *   before column ordering existed have no `columnOrder` key and still load
+ *   (treated as no custom order), so the version stays at 1.
  */
 
 /** Prefix shared by every key this feature writes to localStorage. */
@@ -51,6 +57,8 @@ export interface PersistedColumnState {
   columnSizing: ColumnSizingState
   userColumnVisibility: VisibilityState
   columnPinning: ColumnPinningState
+  /** Optional so pre-ordering v1 entries stay valid; absent = no custom order. */
+  columnOrder?: ColumnOrderState
 }
 
 /** The versioned localStorage key for a grid's persisted column state. */
@@ -106,7 +114,8 @@ const isRecordOf = (
   isPlainObject(value) &&
   Object.values(value).every((entry) => typeof entry === entryType)
 
-const isPinningSide = (value: unknown): boolean =>
+/** A string[] (columnPinning side, columnOrder) or absent. */
+const isStringArrayOrAbsent = (value: unknown): boolean =>
   value === undefined ||
   (Array.isArray(value) && value.every((id) => typeof id === 'string'))
 
@@ -115,13 +124,15 @@ export function isPersistedColumnState(
   value: unknown,
 ): value is PersistedColumnState {
   if (!isPlainObject(value)) return false
-  const { columnSizing, userColumnVisibility, columnPinning } = value
+  const { columnSizing, userColumnVisibility, columnPinning, columnOrder } =
+    value
   return (
     isRecordOf(columnSizing, 'number') &&
     isRecordOf(userColumnVisibility, 'boolean') &&
     isPlainObject(columnPinning) &&
-    isPinningSide(columnPinning.left) &&
-    isPinningSide(columnPinning.right)
+    isStringArrayOrAbsent(columnPinning.left) &&
+    isStringArrayOrAbsent(columnPinning.right) &&
+    isStringArrayOrAbsent(columnOrder)
   )
 }
 
@@ -134,17 +145,22 @@ function buildPayloadJson(
   columnSizing: ColumnSizingState,
   userColumnVisibility: VisibilityState,
   columnPinning: ColumnPinningState,
+  columnOrder: ColumnOrderState,
 ): string | null {
   const isDefault =
     Object.keys(columnSizing).length === 0 &&
     Object.keys(userColumnVisibility).length === 0 &&
     !columnPinning.left?.length &&
-    !columnPinning.right?.length
+    !columnPinning.right?.length &&
+    columnOrder.length === 0
   if (isDefault) return null
   const payload: PersistedColumnState = {
     columnSizing,
     userColumnVisibility,
     columnPinning,
+    // Omit an empty order so the payload matches a grid that never reordered
+    // (keeps entries minimal; the load path defaults a missing order to []).
+    ...(columnOrder.length > 0 ? { columnOrder } : {}),
   }
   return JSON.stringify(payload)
 }
@@ -211,6 +227,8 @@ type PersistableGridState = Pick<
   | 'setUserColumnVisibility'
   | 'columnPinning'
   | 'setColumnPinning'
+  | 'columnOrder'
+  | 'setColumnOrder'
 >
 
 /**
@@ -231,6 +249,8 @@ export function useGridColumnStatePersistence(
     setUserColumnVisibility,
     columnPinning,
     setColumnPinning,
+    columnOrder,
+    setColumnOrder,
   } = gridState
 
   const storageKey = persistStateKey
@@ -254,14 +274,17 @@ export function useGridColumnStatePersistence(
       if (raw) {
         const parsed = tryParseJson(raw)
         if (isPersistedColumnState(parsed)) {
+          const loadedOrder = parsed.columnOrder ?? []
           setColumnSizing(parsed.columnSizing)
           setUserColumnVisibility(parsed.userColumnVisibility)
           setColumnPinning(parsed.columnPinning)
+          setColumnOrder(loadedOrder)
           // Normalized so the post-apply save pass short-circuits.
           lastWrittenRef.current = buildPayloadJson(
             parsed.columnSizing,
             parsed.userColumnVisibility,
             parsed.columnPinning,
+            loadedOrder,
           )
         } else {
           // Unusable entry (malformed JSON or wrong shape): discard it so the
@@ -282,6 +305,7 @@ export function useGridColumnStatePersistence(
     setColumnSizing,
     setUserColumnVisibility,
     setColumnPinning,
+    setColumnOrder,
   ])
 
   // ─── Save on change (trailing debounce) ─────────────────
@@ -291,6 +315,7 @@ export function useGridColumnStatePersistence(
       columnSizing,
       userColumnVisibility,
       columnPinning,
+      columnOrder,
     )
     if (json === lastWrittenRef.current) {
       // Values are back to what's stored — cancel any pending stale write.
@@ -303,7 +328,13 @@ export function useGridColumnStatePersistence(
       SAVE_DEBOUNCE_MS,
     )
     return () => clearTimeout(timer)
-  }, [storageKey, columnSizing, userColumnVisibility, columnPinning])
+  }, [
+    storageKey,
+    columnSizing,
+    userColumnVisibility,
+    columnPinning,
+    columnOrder,
+  ])
 
   // ─── Flush a pending write on unmount ───────────────────
   // Runs after the save effect's cleanup (declaration order), so the cleared

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.test.ts
@@ -33,13 +33,22 @@ describe('use-grid-table', () => {
   })
 
   describe('useGridState', () => {
-    it('resetColumnState restores sizing, user visibility, and pinning only', () => {
+    it('starts columnOrder empty', () => {
+      // Arrange / Act
+      const { result } = renderHook(() => useGridState())
+
+      // Assert
+      expect(result.current.columnOrder).toEqual([])
+    })
+
+    it('resetColumnState restores sizing, user visibility, pinning, and order only', () => {
       // Arrange — user-adjusted column state plus an active sort and filter
       const { result } = renderHook(() => useGridState())
       act(() => {
         result.current.setColumnSizing({ name: 240 })
         result.current.setUserColumnVisibility({ team: false })
         result.current.setColumnPinning({ left: ['name'], right: [] })
+        result.current.setColumnOrder(['team', 'name'])
         result.current.setSorting([{ id: 'name', desc: false }])
         result.current.setColumnFilters([{ id: 'name', value: 'x' }])
       })
@@ -49,11 +58,12 @@ describe('use-grid-table', () => {
         result.current.resetColumnState()
       })
 
-      // Assert — column state cleared; sort/filters untouched (that's the
-      // toolbar Clear button's job)
+      // Assert — column state cleared (incl. order); sort/filters untouched
+      // (that's the toolbar Clear button's job)
       expect(result.current.columnSizing).toEqual({})
       expect(result.current.userColumnVisibility).toEqual({})
       expect(result.current.columnPinning).toEqual({ left: [], right: [] })
+      expect(result.current.columnOrder).toEqual([])
       expect(result.current.sorting).toEqual([{ id: 'name', desc: false }])
       expect(result.current.columnFilters).toEqual([
         { id: 'name', value: 'x' },

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid-core/use-grid-table.ts
@@ -3,6 +3,7 @@ import {
   type Column,
   type ColumnDef,
   type ColumnFiltersState,
+  type ColumnOrderState,
   type ColumnPinningState,
   type ColumnSizingState,
   type SortingState,
@@ -29,10 +30,10 @@ import { stringContainsFilter } from './grid-filters'
  * between creating the state and creating the table.
  *
  * Every user-adjustable column state slice (columnSizing,
- * userColumnVisibility, columnPinning, sorting) lives here as plain
- * serializable state — useGridColumnStatePersistence (use-grid-persistence.ts)
- * serializes the column-layout slices, so new column state must be added
- * here, not scattered into components.
+ * userColumnVisibility, columnPinning, columnOrder, sorting) lives here as
+ * plain serializable state — useGridColumnStatePersistence
+ * (use-grid-persistence.ts) serializes the column-layout slices, so new column
+ * state must be added here, not scattered into components.
  */
 export interface GridState {
   sorting: SortingState
@@ -52,6 +53,17 @@ export interface GridState {
   >
   columnPinning: ColumnPinningState
   setColumnPinning: React.Dispatch<React.SetStateAction<ColumnPinningState>>
+  /**
+   * The user's column order as a list of leaf column ids (TanStack
+   * columnOrder). Governs the CENTER section's order; each pinned section is
+   * ordered by its columnPinning array instead (TanStack builds pinned
+   * sections from the pin arrays, ignoring columnOrder). Ids absent from the
+   * list are appended by TanStack — the grid reconciles a persisted order
+   * against the live defs so newly added columns land at their def position;
+   * see reconcileColumnOrder.
+   */
+  columnOrder: ColumnOrderState
+  setColumnOrder: React.Dispatch<React.SetStateAction<ColumnOrderState>>
   searchValue: string
   setSearchValue: React.Dispatch<React.SetStateAction<string>>
   /** Toolbar search input change handler. */
@@ -59,9 +71,9 @@ export interface GridState {
   /** Clears search, sorting, and column filters (plus the grid's own extras). */
   onClearFilters: () => void
   /**
-   * Restores the column defs' defaults: sizing, user visibility, and pinning
-   * (the column menu's Reset Columns). Sort and filters are deliberately NOT
-   * reset — that's the toolbar Clear button ({@link onClearFilters}).
+   * Restores the column defs' defaults: sizing, user visibility, pinning, and
+   * order (the column menu's Reset Columns). Sort and filters are deliberately
+   * NOT reset — that's the toolbar Clear button ({@link onClearFilters}).
    */
   resetColumnState: () => void
   /** True when any search, column filter, or sort is active. */
@@ -95,6 +107,7 @@ export function useGridState(options?: UseGridStateOptions): GridState {
     useState<VisibilityState>({})
   const [columnPinning, setColumnPinning] =
     useState<ColumnPinningState>(EMPTY_COLUMN_PINNING)
+  const [columnOrder, setColumnOrder] = useState<ColumnOrderState>([])
   const [searchValue, setSearchValue] = useState('')
 
   const onSearchChange = (e: ChangeEvent<HTMLInputElement>) => {
@@ -112,6 +125,7 @@ export function useGridState(options?: UseGridStateOptions): GridState {
     setColumnSizing({})
     setUserColumnVisibility({})
     setColumnPinning(EMPTY_COLUMN_PINNING)
+    setColumnOrder([])
   }
 
   const hasActiveFilters =
@@ -128,6 +142,8 @@ export function useGridState(options?: UseGridStateOptions): GridState {
     setUserColumnVisibility,
     columnPinning,
     setColumnPinning,
+    columnOrder,
+    setColumnOrder,
     searchValue,
     setSearchValue,
     onSearchChange,
@@ -212,6 +228,8 @@ export function useGridTable<T>({
     setColumnSizing,
     columnPinning,
     setColumnPinning,
+    columnOrder,
+    setColumnOrder,
     searchValue,
     setSearchValue,
   } = gridState
@@ -246,6 +264,7 @@ export function useGridTable<T>({
       columnFilters,
       columnSizing,
       columnPinning,
+      columnOrder,
       ...extraState,
     },
     onGlobalFilterChange: (value) => setSearchValue(String(value ?? '')),
@@ -253,5 +272,6 @@ export function useGridTable<T>({
     onColumnFiltersChange: setColumnFilters,
     onColumnSizingChange: setColumnSizing,
     onColumnPinningChange: setColumnPinning,
+    onColumnOrderChange: setColumnOrder,
   })
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.module.css
@@ -184,6 +184,28 @@
   flex: 0 1 auto;
 }
 
+/*
+ * Reorderable header cell — the WHOLE cell is the drag handle (no separate grip
+ * taking up label width). A grab cursor signals it; dnd-kit's 8px activation
+ * distance means a plain click still sorts. touch-action:none lets a touch drag
+ * reorder instead of scrolling. The resizer overrides the cursor at the edge.
+ */
+.thDraggable {
+  cursor: grab;
+  touch-action: none;
+}
+
+.thDraggable:active {
+  cursor: grabbing;
+}
+
+/* The cell being dragged: lift it and drop the header background's opacity so
+   the drop target underneath reads through. */
+.thDragging {
+  opacity: 0.85;
+  background: var(--wayd-grid-header-bg);
+}
+
 /* Numeric columns right-align their body cells so magnitudes line up;
    headers deliberately stay left-aligned (see meta.align). */
 .tdNumeric {

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.test.tsx
@@ -15,6 +15,7 @@ import type { ColumnDef } from '@tanstack/react-table'
 
 import WaydGrid from './wayd-grid'
 import { SET_FILTER_BLANK } from '../wayd-grid-core/filters'
+import { createActionsColumn } from '../wayd-grid-core/actions-column'
 import { gridStateStorageKey } from '../wayd-grid-core/use-grid-persistence'
 import type { WaydGridHandle, WaydGridColumnMeta } from './types'
 import { downloadCsvWithTimestamp } from '@/src/utils/csv-utils'
@@ -1206,6 +1207,119 @@ describe('WaydGrid', () => {
     })
   })
 
+  describe('column reordering', () => {
+    /** data-column-id of every leaf header cell, in rendered order. */
+    const headerOrder = () => {
+      const headerRow = document.querySelector(
+        'thead tr:not([data-role])',
+      ) as HTMLElement
+      return Array.from(
+        headerRow.querySelectorAll('th[data-column-id]'),
+      ).map((th) => th.getAttribute('data-column-id'))
+    }
+
+    it('renders columns in the applied columnOrder', () => {
+      // Arrange
+      const ref = createRef<WaydGridHandle>()
+      renderGrid({ ref })
+      expect(headerOrder()).toEqual(['name', 'type', 'isEnabled'])
+
+      // Act — move isEnabled to the front
+      act(() => {
+        ref.current!.table.setColumnOrder(['isEnabled', 'name', 'type'])
+      })
+
+      // Assert — header and body cells both follow the new order
+      expect(headerOrder()).toEqual(['isEnabled', 'name', 'type'])
+      const firstBodyRow = document.querySelector('tbody tr') as HTMLElement
+      expect(
+        firstBodyRow
+          .querySelector('td[data-column-id]')
+          ?.getAttribute('data-column-id'),
+      ).toBe('isEnabled')
+    })
+
+    /** Leaf header cells that are drag-reorderable (whole cell is the handle;
+     *  dnd-kit stamps aria-roledescription="sortable" on it). */
+    const reorderableHeaders = () =>
+      document.querySelectorAll(
+        'thead tr:not([data-role]) th[data-column-id][aria-roledescription="sortable"]',
+      )
+
+    it('makes every reorderable leaf header cell a drag handle', () => {
+      // Arrange / Act
+      renderGrid()
+
+      // Assert — the whole cell is draggable (no separate grip element)
+      expect(reorderableHeaders().length).toBe(3)
+      expect(
+        document.querySelectorAll('[aria-label="Reorder column"]'),
+      ).toHaveLength(0)
+    })
+
+    it('makes no header cell a drag handle on a grouped-header grid', () => {
+      // Arrange — a band splits reordering, so it is disabled
+      const groupedColumns: ColumnDef<Flag, unknown>[] = [
+        {
+          id: 'group',
+          header: 'Group',
+          columns: [
+            { id: 'name', accessorKey: 'name', header: 'Name' },
+            { id: 'type', accessorKey: 'type', header: 'Type' },
+          ],
+        },
+      ]
+
+      // Act
+      renderGrid({ columns: groupedColumns })
+
+      // Assert
+      expect(reorderableHeaders()).toHaveLength(0)
+    })
+
+    it('keeps the actions column from becoming a drag handle', () => {
+      // Arrange — actions column opts out of reordering
+      const withActions: ColumnDef<Flag, unknown>[] = [
+        ...columns,
+        createActionsColumn<Flag>({
+          getItems: () => [{ key: 'edit', label: 'Edit' }],
+        }),
+      ]
+
+      // Act
+      renderGrid({ columns: withActions })
+
+      // Assert — the actions header is not draggable; the 3 data columns are
+      const actionsTh = document.querySelector(
+        'thead tr:not([data-role]) th[data-column-id="actions"]',
+      ) as HTMLElement
+      expect(actionsTh.getAttribute('aria-roledescription')).not.toBe(
+        'sortable',
+      )
+      expect(reorderableHeaders().length).toBe(3)
+    })
+
+    it('exports CSV in the displayed column order', () => {
+      // Arrange
+      mockDownloadCsv.mockClear()
+      const ref = createRef<WaydGridHandle>()
+      const { container } = renderGrid({ ref })
+
+      // Act — reorder, then click the toolbar export (download icon) button
+      act(() => {
+        ref.current!.table.setColumnOrder(['type', 'isEnabled', 'name'])
+      })
+      const exportBtn = container
+        .querySelector('[aria-label="download"]')
+        ?.closest('button') as HTMLButtonElement
+      fireEvent.click(exportBtn)
+
+      // Assert — the header row of the CSV follows the display order
+      const csv = mockDownloadCsv.mock.calls.at(-1)?.[0] as string
+      expect(csv.split('\n')[0]).toBe('Type,Enabled,Name')
+    })
+  })
+
   describe('column state persistence (persistStateKey)', () => {
     const STORAGE_KEY = gridStateStorageKey('test-grid')
 
@@ -1332,6 +1446,42 @@ describe('WaydGrid', () => {
       // Assert
       expect(getItemSpy).not.toHaveBeenCalled()
       expect(setItemSpy).not.toHaveBeenCalled()
+    })
+
+    it('persists a column reorder and restores it on a fresh mount', () => {
+      // Arrange
+      const ref = createRef<WaydGridHandle>()
+      const { unmount } = renderGrid({ ref, persistStateKey: 'test-grid' })
+
+      // Act — reorder, let the debounce elapse, remount
+      act(() => {
+        ref.current!.table.setColumnOrder(['isEnabled', 'name', 'type'])
+      })
+      act(() => {
+        jest.advanceTimersByTime(1000)
+      })
+      unmount()
+
+      // Assert — the payload carries the order
+      expect(JSON.parse(window.localStorage.getItem(STORAGE_KEY)!)).toEqual({
+        columnSizing: {},
+        userColumnVisibility: {},
+        columnPinning: { left: [], right: [] },
+        columnOrder: ['isEnabled', 'name', 'type'],
+      })
+
+      // Act — fresh mount restores the display order
+      renderGrid({ persistStateKey: 'test-grid' })
+
+      // Assert
+      const headerRow = document.querySelector(
+        'thead tr:not([data-role])',
+      ) as HTMLElement
+      expect(
+        Array.from(headerRow.querySelectorAll('th[data-column-id]')).map((th) =>
+          th.getAttribute('data-column-id'),
+        ),
+      ).toEqual(['isEnabled', 'name', 'type'])
     })
   })
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/wayd-grid.tsx
@@ -32,11 +32,13 @@ import {
   type DragCancelEvent,
   type DragEndEvent,
   type DragStartEvent,
+  type Modifier,
   closestCenter,
 } from '@dnd-kit/core'
 import {
   SortableContext,
   arrayMove,
+  horizontalListSortingStrategy,
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 
@@ -60,6 +62,11 @@ import {
 } from '../wayd-grid-core/filters'
 
 import { applySafeAccessor } from '../wayd-grid-core/column-accessors'
+import {
+  getOrderedVisibleLeafColumns,
+  reconcileColumnOrder,
+  reorderIds,
+} from '../wayd-grid-core/column-order'
 import {
   computeAutosizeWidth,
   measureColumnContent,
@@ -90,8 +97,8 @@ import {
 } from '../wayd-grid-core/draft-utils'
 import { exportGridToCsv } from '../wayd-grid-core/grid-export'
 import {
-  GridHeaderCell,
   GridHeaderContent,
+  SortableHeaderCell,
   useResizeClickGuard,
   type GridHeaderCellClasses,
 } from '../wayd-grid-core/grid-header-row'
@@ -132,6 +139,13 @@ const EMPTY_NODE_SET: Set<string> = new Set<string>()
 const EMPTY_DATA: never[] = []
 const EMPTY_FIELD_ERRORS: Record<string, string> = {}
 const DRAFT_SCROLL_MARGIN = 8
+
+/** Column-reorder drags move along the header row only — lock the y axis.
+ *  (Inlined rather than pulling in @dnd-kit/modifiers for one function.) */
+const restrictToHorizontalAxis: Modifier = ({ transform }) => ({
+  ...transform,
+  y: 0,
+})
 
 /** Fixed row-height estimate for the virtualizer. Rows are uniform in
  * practice (.td: 4px padding + 1px border + one no-wrap text line), so a
@@ -215,6 +229,8 @@ const headerCellClasses: GridHeaderCellClasses = {
   thText: styles.thText,
   resizer: styles.resizer,
   resizerActive: styles.resizerActive,
+  thDraggable: styles.thDraggable,
+  thDragging: styles.thDragging,
 }
 
 // Pinned-column sticky classes per cell kind. The edge classes (the divider
@@ -630,6 +646,9 @@ function WaydGridInner<T>(
     setColumnSizing,
     userColumnVisibility,
     setUserColumnVisibility,
+    columnOrder,
+    setColumnOrder,
+    setColumnPinning,
     resetColumnState,
   } = gridState
   const resizeGuard = useResizeClickGuard()
@@ -926,6 +945,51 @@ function WaydGridInner<T>(
     [consumerColumnVisibility, userColumnVisibility],
   )
 
+  // Leaf column ids in DEF order (recursing bands), for reconciling the
+  // persisted/user column order against the live defs.
+  const leafColumnIds = useMemo<string[]>(() => {
+    const ids: string[] = []
+    const collect = (cols: typeof resolvedColumns) => {
+      for (const col of cols) {
+        const children = (col as { columns?: typeof resolvedColumns }).columns
+        if (children) {
+          collect(children)
+          continue
+        }
+        const id =
+          col.id ??
+          (col as { accessorKey?: string | number }).accessorKey?.toString()
+        if (id) ids.push(id)
+      }
+    }
+    collect(resolvedColumns)
+    return ids
+  }, [resolvedColumns])
+
+  // The order actually fed to TanStack: the user's order reconciled against the
+  // live defs so removed columns drop out and columns added since (or absent
+  // from a persisted order) land at their def position instead of being
+  // appended to the end. The RAW gridState.columnOrder is what persists — this
+  // derivative never round-trips to storage, so defs changing between pages
+  // can't rewrite the stored order.
+  const effectiveColumnOrder = useMemo(
+    () => reconcileColumnOrder(columnOrder, leafColumnIds),
+    [columnOrder, leafColumnIds],
+  )
+
+  // Column reordering is on for every flat/tree grid EXCEPT grouped-header
+  // grids: reordering leaves across band boundaries would split bands, so the
+  // simplest safe scope is to disable header-drag reordering when any def is a
+  // band. (The modal reorder is likewise gated on this.)
+  const hasGroupedHeaders = useMemo(
+    () =>
+      resolvedColumns.some(
+        (col) => (col as { columns?: unknown[] }).columns !== undefined,
+      ),
+    [resolvedColumns],
+  )
+  const columnReorderEnabled = !hasGroupedHeaders
+
   // ─── Flattened tree for DnD ──────────────────────────────
   const flattenedNodes = useMemo(
     () =>
@@ -1072,7 +1136,7 @@ function WaydGridInner<T>(
           }
         : {}),
     },
-    extraState: { columnVisibility },
+    extraState: { columnVisibility, columnOrder: effectiveColumnOrder },
   })
 
   tableRef.current = table
@@ -1083,6 +1147,63 @@ function WaydGridInner<T>(
     getDisplayedRows: () =>
       table.getRowModel().rows.map((row: Row<T>) => row.original),
   }))
+
+  // ─── Header column-reorder DnD ───────────────────────────
+  // Section-aware move shared by header-grip drag and the Choose Columns modal.
+  // Reorders WITHIN the active column's section only: the center section via
+  // columnOrder, each pinned side via its columnPinning array (TanStack orders
+  // pinned sections by the pin array, ignoring columnOrder). A cross-section
+  // move, a no-op, or a move touching a non-reorderable column is ignored —
+  // dragging never pins/unpins (that stays the column menu's job).
+  const moveColumn = useCallback(
+    (activeId: string, overId: string) => {
+      if (activeId === overId) return
+
+      const activeColumn = table.getColumn(activeId)
+      const overColumn = table.getColumn(overId)
+      if (
+        activeColumn?.columnDef.meta?.enableReordering === false ||
+        overColumn?.columnDef.meta?.enableReordering === false
+      ) {
+        return
+      }
+
+      const activeSide = activeColumn?.getIsPinned() ?? false
+      const overSide = overColumn?.getIsPinned() ?? false
+      if (activeSide !== overSide) return
+
+      if (activeSide === false) {
+        // Center: reorder within the full columnOrder (pinned ids ride along
+        // inertly). Seed from the reconciled order so a first-ever reorder
+        // persists a complete, self-consistent order.
+        setColumnOrder(reorderIds(effectiveColumnOrder, activeId, overId))
+        return
+      }
+
+      // Pinned: reorder that side's pin array.
+      setColumnPinning((prev) => {
+        const side = prev[activeSide] ?? []
+        const next = reorderIds(side, activeId, overId)
+        if (next === side) return prev
+        return { ...prev, [activeSide]: next }
+      })
+    },
+    [table, effectiveColumnOrder, setColumnOrder, setColumnPinning],
+  )
+
+  const handleColumnDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event
+      if (!over) return
+      // Sortable ids are namespaced `col:<id>` so a shared context could tell
+      // column drags from row drags; strip it back to the column id.
+      moveColumn(
+        String(active.id).replace(/^col:/, ''),
+        String(over.id).replace(/^col:/, ''),
+      )
+    },
+    [moveColumn],
+  )
 
   const rows = table.getRowModel().rows
 
@@ -1159,8 +1280,7 @@ function WaydGridInner<T>(
 
   const autosizeAllColumns = useCallback(() => {
     autosizeColumns(
-      table
-        .getVisibleLeafColumns()
+      getOrderedVisibleLeafColumns(table)
         .filter((column) => column.getCanResize())
         .map((column) => column.id),
     )
@@ -1285,6 +1405,8 @@ function WaydGridInner<T>(
               isFiltered ? ` ${styles.filterTriggerActive}` : ''
             }`}
             onClick={(e) => e.stopPropagation()}
+            // Header cell is a reorder drag handle — don't drag from the icon.
+            onPointerDown={(e) => e.stopPropagation()}
           >
             {isFiltered ? <FilterFilled /> : <FilterOutlined />}
           </span>
@@ -1438,16 +1560,19 @@ function WaydGridInner<T>(
   const leafHeaderGroup = headerGroups[headerGroups.length - 1]
   const groupHeaderRows = headerGroups.slice(0, -1)
 
-  // Visible leaf columns in RENDER order: left-pinned → center → right-pinned.
-  // getHeaderGroups() and row.getVisibleCells() emit this order when columns
-  // are pinned, but plain getVisibleLeafColumns() stays in def order — the
+  // Visible leaf columns in RENDER order: left-pinned → center → right-pinned
+  // (center honours columnOrder). getHeaderGroups() and row.getVisibleCells()
+  // emit this order, but plain getVisibleLeafColumns() stays in def order — the
   // colgroup must follow the rendered order or the shared <col> widths would
   // apply to the wrong columns.
-  const orderedVisibleLeafColumns = [
-    ...table.getLeftVisibleLeafColumns(),
-    ...table.getCenterVisibleLeafColumns(),
-    ...table.getRightVisibleLeafColumns(),
-  ]
+  const orderedVisibleLeafColumns = getOrderedVisibleLeafColumns(table)
+
+  // Sortable ids for the header row's SortableContext, namespaced `col:` (the
+  // same ids the header cells' useSortable use). In display order so dnd-kit's
+  // index math lines up with what the user sees.
+  const columnSortableIds = orderedVisibleLeafColumns.map(
+    (column) => `col:${column.id}`,
+  )
 
   // Rendered into BOTH tables (header + body) — with table-layout: fixed,
   // identical colgroups guarantee the two tables' columns align exactly.
@@ -1463,20 +1588,20 @@ function WaydGridInner<T>(
     </colgroup>
   )
 
-  const tableContent = (
-    <div className={styles.tableArea}>
-      <div className={styles.headerArea}>
-        <div className={styles.headerViewport} ref={headerViewportRef}>
-          <table
-            className={styles.tableElement}
-            style={
-              {
-                '--wayd-grid-group-header-rows': groupHeaderRows.length,
-              } as React.CSSProperties
-            }
-          >
-            {colGroup}
-            <thead>
+  // The header table, optionally wrapped in a column-reorder DnD context. The
+  // context is header-scoped and separate from the row/tree DnD context below,
+  // so column drags and row drags never share sensors or collision detection.
+  const headerTable = (
+    <table
+      className={styles.tableElement}
+      style={
+        {
+          '--wayd-grid-group-header-rows': groupHeaderRows.length,
+        } as React.CSSProperties
+      }
+    >
+      {colGroup}
+      <thead>
           {/* Grouped-header band rows — plain colspan cells, no
               sort/filter/resize; placeholders render empty. */}
           {groupHeaderRows.map((headerGroup, bandIndex) => (
@@ -1530,10 +1655,15 @@ function WaydGridInner<T>(
                 !header.isPlaceholder &&
                 header.column.getCanFilter()
               const pinned = getPinnedOffsets(header.column)
+              const reorderable =
+                columnReorderEnabled &&
+                !header.isPlaceholder &&
+                header.column.columnDef.meta?.enableReordering !== false
 
               return (
-                <GridHeaderCell
+                <SortableHeaderCell
                   key={header.id}
+                  reorderable={reorderable}
                   header={header}
                   resizeGuard={resizeGuard}
                   classes={headerCellClasses}
@@ -1663,7 +1793,32 @@ function WaydGridInner<T>(
             </tr>
           )}
         </thead>
-          </table>
+    </table>
+  )
+
+  const headerTableContent = columnReorderEnabled ? (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCenter}
+      modifiers={[restrictToHorizontalAxis]}
+      onDragEnd={handleColumnDragEnd}
+    >
+      <SortableContext
+        items={columnSortableIds}
+        strategy={horizontalListSortingStrategy}
+      >
+        {headerTable}
+      </SortableContext>
+    </DndContext>
+  ) : (
+    headerTable
+  )
+
+  const tableContent = (
+    <div className={styles.tableArea}>
+      <div className={styles.headerArea}>
+        <div className={styles.headerViewport} ref={headerViewportRef}>
+          {headerTableContent}
         </div>
         {/* Spacer above the body's vertical scrollbar — same header band
             styling, sized from the live scrollbar measurement. */}
@@ -1748,6 +1903,8 @@ function WaydGridInner<T>(
         open={isColumnChooserOpen}
         onClose={() => setIsColumnChooserOpen(false)}
         onToggleColumn={handleUserToggleColumn}
+        reorderEnabled={columnReorderEnabled}
+        onReorderColumn={moveColumn}
       />
     </div>
   )

--- a/docs-site/sidebars.ts
+++ b/docs-site/sidebars.ts
@@ -101,6 +101,7 @@ const sidebars: SidebarsConfig = {
             'contributing/adding-a-feature',
             'contributing/database',
             'contributing/frontend',
+            'contributing/wayd-grid',
             'contributing/api',
           ],
         },

--- a/docs/contributing/frontend.mdx
+++ b/docs/contributing/frontend.mdx
@@ -61,6 +61,12 @@ Only use `theme.useToken()` when you need token values in JavaScript logic.
 - **React Context** for auth, theme, and messaging
 - **Local state** (`useState`) for component-specific state
 
+## Data Grids
+
+All data grids use the **`WaydGrid`** house component (built on TanStack Table) — never Ant Design's `Table` or raw TanStack Table. It provides a consistent toolbar, Excel-style column filters, sorting, column sizing/visibility/pinning/reordering, row virtualization, CSV export, opt-in column-layout persistence, and (opt-in) tree mode, drag-and-drop, and inline editing.
+
+See **[WaydGrid](./wayd-grid.mdx)** for the full usage guide — props, column `meta`, how to enable/disable each feature, and persistence.
+
 ## PWA (Progressive Web App)
 
 The client app is installable as a PWA, providing a native app-like experience with app shell caching and network-first API strategy.

--- a/docs/contributing/index.mdx
+++ b/docs/contributing/index.mdx
@@ -25,6 +25,7 @@ Welcome to the Wayd developer documentation. This section covers everything you 
 - [Adding a Feature](./adding-a-feature.mdx) — Step-by-step guide for implementing new features
 - [Database & Migrations](./database.mdx) — Database patterns, migrations, and EF Core usage
 - [Frontend Development](./frontend.mdx) — Next.js, React, and Ant Design patterns
+- [WaydGrid](./wayd-grid.mdx) — Using the house data-grid component (filtering, sorting, pinning, reordering, persistence, tree mode)
 - [API Development](./api.mdx) — API endpoint patterns and conventions
 
 ## Migration

--- a/docs/contributing/wayd-grid.mdx
+++ b/docs/contributing/wayd-grid.mdx
@@ -1,0 +1,237 @@
+---
+title: WaydGrid
+description: How to use the WaydGrid house component — data grids with filtering, sorting, pinning, reordering, column persistence, tree mode, and inline editing.
+sidebar_position: 7
+audience: [developer, agent]
+---
+
+# WaydGrid
+
+`WaydGrid` is Wayd's house data-grid component, built on [TanStack Table](https://tanstack.com/table). It's the single grid used across the app — flat lists, grouped headers, and hierarchical (tree) data — with a consistent toolbar, Excel-style column filters, sorting, column sizing/visibility/pinning/reordering, always-on row virtualization, CSV export, and (opt-in) inline editing and drag-and-drop.
+
+Import it from the barrel:
+
+```typescript
+import { WaydGrid, createActionsColumn } from '@/src/components/common/wayd-grid'
+import type { ColumnDef } from '@tanstack/react-table'
+```
+
+:::tip Always use `WaydGrid`
+Never reach for Ant Design's `Table` or raw TanStack Table directly. `WaydGrid` is the seam that keeps grids consistent and lets us swap the engine once. Columns are plain TanStack [`ColumnDef`](https://tanstack.com/table/latest/docs/api/core/column-def)s, extended with a small `meta` object (see [Column meta](#column-meta)).
+:::
+
+## Minimal example
+
+A read-only grid needs only `columns` and `data`:
+
+```tsx
+const columns: ColumnDef<Widget, any>[] = [
+  { id: 'name', accessorKey: 'name', header: 'Name', size: 250 },
+  { id: 'status', accessorKey: 'status', header: 'Status' },
+]
+
+<WaydGrid columns={columns} data={widgets} isLoading={isLoading} />
+```
+
+`data` may be `undefined` while a query is loading — the grid treats it as empty (no crash). Provide `isLoading` to show the spinner.
+
+## Feature flags at a glance
+
+Most functionality is **on by default**; you turn things _off_ with a prop, or turn opt-in behaviour _on_ by supplying its handler. This table is the quick reference for "how do I enable/disable X".
+
+| Capability | Default | How to change it |
+| --- | --- | --- |
+| Global quick-search box | On | `includeGlobalSearch={false}` to hide |
+| CSV export button | On | `includeExportButton={false}` to hide; `csvFileName="..."` names the file |
+| Per-column filters (popup) | On | `includeColumnFilters={false}` to disable all column filtering UI |
+| Floating filter row (under headers) | On | `includeFloatingFilters={false}` (ignored when `includeColumnFilters={false}`) |
+| Column sizing (resize handles) | On | Per column: `enableResizing: false` in the def |
+| Column sorting | On | Per column: `enableSorting: false` in the def |
+| Column show/hide (Choose Columns) | On | Per column: `enableHiding: false`, or hide reactively with `meta.hide` |
+| Column pinning (⋮ menu → Pin) | On | Per column: `enableColumnPinning`/`enablePinning: false` |
+| **Column reordering** (drag headers) | On | Auto-disabled on grouped-header grids; per column: `meta.enableReordering: false` |
+| **Column layout persistence** | Off | Provide `persistStateKey="..."` to turn it on |
+| Row virtualization | On (always) | Not configurable — the visible window plus overscan is mounted |
+| Initial sort on mount | Off | `initialSorting={[{ id: 'name', desc: false }]}` |
+| Toolbar refresh button | Off | Provide `onRefresh={() => refetch()}` |
+| Tree mode | Off | Provide `getSubRows` |
+| Row-reorder drag-and-drop (flat) | Off | Provide `onRowReorder` |
+| Reparenting drag-and-drop (tree) | Off | Provide `enableDragAndDrop` + `onNodeMove` |
+| Inline editing | Off | Provide `editingConfig` |
+
+## Core props
+
+```tsx
+<WaydGrid<Widget>
+  columns={columns}          // ColumnDef[] or (ctx) => ColumnDef[]
+  data={widgets}             // Widget[] | undefined
+  isLoading={isLoading}
+  onRefresh={() => refetch()}        // shows the toolbar refresh button
+  emptyMessage="No widgets found"
+  csvFileName="widgets"              // CSV download name prefix
+  persistStateKey="ppm-widgets"      // opt-in column persistence (see below)
+  initialSorting={[{ id: 'name', desc: false }]}
+  height={480}                       // fixed px; omit to fill remaining viewport height
+  rightSlot={<MyToolbarControls />}  // custom toolbar content (far right)
+  leftSlot={<CreateButton />}        // custom toolbar content (left)
+/>
+```
+
+- **`columns`** can be a function `(context) => ColumnDef[]` when the defs need editing/DnD/draft state (see [Tree mode & editing](#tree-mode--editing)).
+- **`height`** omitted → the grid auto-sizes to fill the remaining viewport height (ag-grid style). Pass a number for a fixed height.
+- **`leftSlot` / `rightSlot`** inject custom toolbar content; `helpContent` fills a help popover.
+- **`getRowId`** supplies a stable row id (required for `onRowReorder`); it falls back to `row.original.id`, then a TanStack index id.
+- **`onDisplayedRowsChange`** fires with the post-filter/sort rows whenever that set changes — for deriving external UI (e.g. a chart) from the grid.
+
+## Columns
+
+Columns are TanStack `ColumnDef`s. The most common shape:
+
+```tsx
+{
+  id: 'status',
+  accessorKey: 'status',        // supports dotted paths: 'status.name'
+  header: 'Status',             // keep this a plain string — CSV export and the
+                                //   column chooser read it
+  size: 120,                    // px; also resizable at runtime
+  meta: { /* WaydGrid extras — see below */ },
+}
+```
+
+### Column meta
+
+`meta` is TanStack's per-column bag, augmented with WaydGrid fields (`WaydGridColumnMeta`, strongly typed everywhere):
+
+| `meta` field | Purpose |
+| --- | --- |
+| `columnType` | Declarative type preset: `'yesNo'`, `'dateOnly'`, `'dateTime'` (see [Column types](#column-types)) |
+| `hide` | Reactively hide the column (AG Grid `hide` style) while keeping it defined. Stays out of the chooser; the user can't show it |
+| `filterType` | Filter/data type: `'text' \| 'number' \| 'date' \| 'dateTime' \| 'set'` (aliases `'select'`→`set`, `'numericRange'`→`number`). Defaults to `'text'` |
+| `filterOptions` | `{ label, value }[]` for a `set` filter (stable order + labels) |
+| `filterEnableSet` | On a text column, also offer the Excel-style checkbox set filter alongside the text filter |
+| `align` | `'left' \| 'right'` — override numeric right-alignment of body cells |
+| `headerTooltip` | Tooltip on the header label (keep `header` a plain string) |
+| `maxFilterConditions` | Cap AND/OR conditions in the filter popup (default 5) |
+| `enableReordering` | Set `false` so the column can't be dragged to reorder (and rejects drops). Used by the actions column |
+| `enableExport` | `false` excludes the column from CSV |
+| `exportHeader` / `exportFormatter` | Override the CSV header text / format each value |
+
+### Column types
+
+Instead of hand-wiring cell formatting + filter config, declare a type:
+
+```tsx
+{ id: 'active', accessorKey: 'isActive', header: 'Active', meta: { columnType: 'yesNo' } }
+{ id: 'due', accessorKey: 'dueDate', header: 'Due', meta: { columnType: 'dateOnly' } }
+{ id: 'created', accessorKey: 'createdOn', header: 'Created', meta: { columnType: 'dateTime' } }
+```
+
+- **`yesNo`** — boolean → "Yes"/"No" for both display and the set filter.
+- **`dateOnly` / `dateTime`** — formatted for display while the raw value drives chronological sort and the date filter.
+
+Explicit column fields always win over a type's defaults.
+
+### The actions column
+
+Row action menus use the shared `createActionsColumn` helper — a fixed-width `⋯` dropdown that renders nothing for rows with no items, always holds its position (never sorted, filtered, resized, or reordered), and hides itself when the user can't act on any row:
+
+```tsx
+createActionsColumn<Widget>({
+  hide: !canManage,                 // drop the column entirely when unusable
+  ariaLabel: 'Widget actions',
+  getItems: (widget) => [
+    canEdit && { key: 'edit', label: 'Edit', onClick: () => edit(widget) },
+    canDelete && { key: 'delete', label: 'Delete', danger: true, onClick: () => remove(widget) },
+  ].filter(Boolean) as ItemType[],
+})
+```
+
+## Filtering, sorting & the column menu
+
+These come for free — no wiring beyond the column defs:
+
+- **Global quick-search** filters across every column with an accessor (opt a column out with `enableGlobalFilter: false`).
+- **Per-column filters** — an Excel-style popup per column (text/number/date conditions, or a checkbox set list), plus a compact floating-filter row under the headers. The filter UI is inferred from the data or set explicitly via `meta.filterType`.
+- **Sorting** — click a header to sort; Ctrl/⌘-click adds a column to a multi-sort.
+- **The `⋮` column menu** on each header offers: Sort, Pin Column (left/right/none), Autosize (this column / all columns), Choose Columns, and **Reset Columns**.
+
+**Reset Columns** restores the columns' default sizing, visibility, pinning, **and order** — it deliberately does _not_ clear sorting or filters (the toolbar's Clear button does that).
+
+## Column reordering
+
+Reordering is **on by default**. The whole header cell is the drag handle — grab a header and drag it left/right to reorder. A plain click still sorts (a drag only starts after a few pixels of movement); the resize edge, filter icon, and `⋮` menu don't trigger a drag. Columns can also be reordered by dragging rows in the **Choose Columns** modal.
+
+Rules:
+
+- Reordering happens **within a section**: unpinned columns reorder among themselves, and each pinned side (left/right) reorders within itself. Dragging never pins or unpins — that's the `⋮` menu's job.
+- **Grouped-header grids** (defs with a `columns` band) disable reordering, so bands can't be split.
+- A column can opt out with `meta.enableReordering: false` (the actions column does this automatically).
+
+The order is persisted alongside the rest of the column layout when `persistStateKey` is set (see below).
+
+## Column layout persistence
+
+Persistence is **opt-in**: give the grid a `persistStateKey` and it saves the user's **column sizing, show/hide choices, pinning, and order** to this browser's `localStorage`, restoring them on the next visit.
+
+```tsx
+<WaydGrid columns={columns} data={data} persistStateKey="ppm-projects" />
+```
+
+- **Sorting, filters, and search are _not_ persisted** — they're session-only.
+- A pristine or reset grid stores nothing (the entry is removed), so **Reset Columns** also clears the saved layout.
+- Persisted state that references removed columns is ignored; columns added later appear at their def position.
+
+### Choosing a key
+
+`persistStateKey` is **per page context**, not per component — a stable, human-readable, route-independent kebab-case string, e.g. `'ppm-projects'`, `'settings-feature-flags'`, `'team-backlog'`. Two grids that should share a layout use the same key; two that shouldn't must differ.
+
+Shared grid components (used on more than one page) should expose `persistStateKey` as a pass-through prop so each page supplies its own key, rather than hardcoding one.
+
+Stored under `wayd-grid:{persistStateKey}:v1`. Give a **visible** column a plain-string `header` so it appears in the Choose Columns list.
+
+### The device-wide controls
+
+Two account-level controls (**Account → Preferences → Grids**) cover every persisted grid automatically — no per-grid wiring:
+
+- **Remember column layouts** — the kill switch. When off, grids neither save nor restore layouts; existing saved layouts are kept and re-apply when it's turned back on.
+- **Reset all grid layouts** — deletes every saved layout on this device.
+
+These act on this browser only (layouts live in `localStorage`, not on the server).
+
+## Tree mode & editing
+
+Providing `getSubRows` turns on **tree mode**: rows expand/collapse, and a filter match keeps the ancestor chain visible. Layered on top of tree mode are optional reparenting drag-and-drop, inline editing, and draft rows.
+
+```tsx
+<WaydGrid<WorkItemTreeNode>
+  data={rootNodes}
+  getSubRows={(node) => node.children}
+  columns={(ctx) => buildColumns(ctx)}   // function form: reads editing/DnD state
+  enableDragAndDrop
+  onNodeMove={async (nodeId, parentId, order) => reparent(nodeId, parentId, order)}
+  moveValidator={myMoveValidator}
+  editingConfig={editingConfig}
+/>
+```
+
+- **Flat row reorder**: instead of `getSubRows`, provide `onRowReorder` (and `getRowId`) for a draggable flat list. Dragging auto-disables while the grid is sorted, filtered, searched, loading, or editing.
+- **Reparenting DnD** (tree): `enableDragAndDrop` + `onNodeMove`; supply a `moveValidator` for domain rules and `onMoveRejected` to surface a reason.
+- **Inline editing**: pass an `editingConfig` (`GridInlineEditingConfig`). The `columns` function receives a `GridColumnContext` with the editing/DnD/draft state so cells can render editors and drag handles reactively.
+
+These features are involved — read the JSDoc on `WaydGridProps` in [`types.ts`](https://github.com/destacey/Wayd/blob/main/Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/types.ts) and follow an existing consumer (e.g. the project work-items tree grid) when wiring them.
+
+## CSV export
+
+The toolbar export button downloads the **currently visible** columns (respecting hide/pinning/order) and the **filtered + sorted** rows, in display order. Grouped headers export as band rows above the leaf headers. Control it per column with `meta.enableExport`, `meta.exportHeader`, and `meta.exportFormatter`; name the file with the `csvFileName` prop.
+
+## Conventions
+
+- **Case-insensitive sorting** — never plain-`.sort()` user-facing lists; use `caseInsensitiveCompare` from the barrel.
+- **Context-redundant columns** (e.g. a Project column on a single project's page) — omit them from the defs conditionally rather than `meta.hide`, so they stay out of the chooser and persisted layouts. Don't def-exclude a column named in `initialSorting`.
+- **Theme tokens only** — the grid styles from Ant Design tokens; don't hardcode colors in cells.
+
+## Reference
+
+- Public API & JSDoc: `Wayd.Web/src/wayd.web.reactclient/src/components/common/wayd-grid/` (types in `types.ts`, component in `wayd-grid.tsx`).
+- Shared grid engine (filters, column menu, pinning, persistence, DnD): `components/common/wayd-grid-core/`.
+- The barrel `@/src/components/common/wayd-grid` is the single import surface for consumers.


### PR DESCRIPTION
## Add persisted column reordering to WaydGrid

Users can now drag grid columns to reorder them, and the order persists per grid alongside the existing sizing / visibility / pinning layout from the column-persistence work. This is the last piece of the WaydGrid migration & improvement effort, so it also adds the first dedicated usage documentation for the component.

### What's new

**Column reordering (on by default)**
- **Drag a column header** to reorder it — the *whole header cell* is the drag handle, so there's no grip icon eating label width. A plain click still sorts (dnd-kit only starts a drag after ~8px of movement); the resize edge, filter icon, and `⋮` menu never start a drag.
- The **Choose Columns modal** also supports drag-to-reorder (a grip per row).
- Reordering is **within a section only**: unpinned columns reorder among themselves and each pinned side reorders within itself. Dragging never pins/unpins — that stays the `⋮` menu's job.
- **Grouped-header grids** disable reordering (so bands can't be split), and a column can opt out via `meta.enableReordering: false` (the actions column does this automatically).

**Persistence**
- Column order is saved in the existing `wayd-grid:{key}:v1` payload for grids with a `persistStateKey`. **The version stays at `1`** — `columnOrder` is optional in the shape guard, so entries written before this change still load.
- An empty order counts as default, so pristine and reset grids store nothing. **Reset Columns** now restores default order too, and the Account → Preferences kill switch / "Reset all" already cover it.
- A persisted order is reconciled against the live column defs: removed columns drop out, and columns added later (or absent from an old order) land at their **def position** rather than being appended. The raw order is what persists; a reconciled derivative feeds the table, so defs changing between pages can't corrupt the stored order.

**Follow-on fixes**
- CSV export, the column chooser, and autosize-all now iterate columns in the **displayed order** (previously def order).
- Account → Preferences copy updated to mention column order alongside sizing/visibility/pinning.

**Documentation**
- New **[WaydGrid contributing guide](docs/contributing/wayd-grid.mdx)** — props, column `meta` and types, the actions column, filtering/sorting/column menu, reordering, persistence, tree mode/editing/DnD, and CSV export. It leads with an **enable/disable reference table** for every capability. Cross-linked from the contributing index and frontend guide, and added to the docs sidebar.

### How to use

Reordering needs no consumer changes — it's on for every grid. To persist it, the grid just needs a `persistStateKey` (same as the rest of the column layout):

```tsx
<WaydGrid columns={columns} data={data} persistStateKey="ppm-projects" />
```

### Testing
- Unit tests for the reconcileColumnOrder / reorderIds helpers and columnOrder × pinning composition, the columnOrder state slice, and persistence round-trips (including old entries without columnOrder).
- Integration tests in wayd-grid.test.tsx: reorder → unmount → remount restores; CSV follows display order; the actions column stays put; grouped-header grids expose no drag handles.
- Full frontend suite (160 suites / 2470 tests), tsc --noEmit, and lint all clean.
- Browser-verified end-to-end: click-sorts-not-drags, drag reorders header + body, resize still independent, menu/filter open without dragging, and order persists across reload with Reset Columns clearing it.
- Docs site builds cleanly (link checker + MDX validation pass).
