### PR TITLE
Feature/setup integrationtest for ef

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -103,6 +103,7 @@
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
     <PackageVersion Include="NetArchTest.Rules" Version="1.3.2" />
     <PackageVersion Include="NodaTime.Testing" Version="3.3.3" />
+    <PackageVersion Include="Testcontainers.MsSql" Version="4.13.0" />
     <PackageVersion Include="xunit.v3" Version="3.2.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Wayd.Common/src/Wayd.Common.Application/Wayd.Common.Application.csproj
+++ b/Wayd.Common/src/Wayd.Common.Application/Wayd.Common.Application.csproj
@@ -22,6 +22,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="Wayd.Common.Application.Tests" />
+        <InternalsVisibleTo Include="Wayd.Organization.IntegrationTests" />
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 

--- a/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Wayd.Organization.Application.csproj
+++ b/Wayd.Services/Wayd.Organization/src/Wayd.Organization.Application/Wayd.Organization.Application.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <InternalsVisibleTo Include="Wayd.Organization.Application.Tests" />
+        <InternalsVisibleTo Include="Wayd.Organization.IntegrationTests" />
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2" />
     </ItemGroup>
 

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/GlobalUsings.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,3 @@
+global using FluentAssertions;
+global using NodaTime;
+global using Xunit;

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/OrganizationSeeder.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/OrganizationSeeder.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore;
+using Wayd.Common.Domain.Employees;
+using Wayd.Common.Domain.Models.Organizations;
+using Wayd.Common.Models;
+using Wayd.Infrastructure.Persistence.Context;
+using Wayd.Organization.Domain.Enums;
+using Wayd.Organization.Domain.Models;
+
+namespace Wayd.Organization.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Persists Organization entities through their real domain create paths, so every value converter and
+/// column type is exercised on the way into the container the same way production writes them.
+/// </summary>
+internal static class OrganizationSeeder
+{
+    public static async Task<Team> SeedTeam(WaydDbContext context, string code, string name, CancellationToken cancellationToken)
+    {
+        var team = Team.Create(
+            name,
+            new TeamCode(code),
+            description: null,
+            activeDate: SqlServerDbContextFixture.FixedNow.InUtc().Date,
+            Methodology.Kanban,
+            SizingMethod.Count,
+            SqlServerDbContextFixture.FixedNow);
+
+        await context.Teams.AddAsync(team, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return team;
+    }
+
+    public static async Task<Employee> SeedEmployee(WaydDbContext context, string employeeNumber, string email, CancellationToken cancellationToken)
+    {
+        var employee = Employee.Create(
+            new PersonName("Ada", null, "Lovelace"),
+            employeeNumber,
+            hireDate: SqlServerDbContextFixture.FixedNow,
+            new EmailAddress(email),
+            jobTitle: "Engineer",
+            department: "Engineering",
+            officeLocation: null,
+            managerId: null,
+            isActive: true,
+            employeeType: null,
+            SqlServerDbContextFixture.FixedNow);
+
+        await context.Employees.AddAsync(employee, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return employee;
+    }
+
+    public static async Task<TeamMemberRole> SeedRole(WaydDbContext context, string name, CancellationToken cancellationToken)
+    {
+        var role = TeamMemberRole.Create(name, description: null).Value;
+
+        await context.TeamMemberRoles.AddAsync(role, cancellationToken);
+        await context.SaveChangesAsync(cancellationToken);
+        return role;
+    }
+}

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/SqlServerDbContextFixture.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/SqlServerDbContextFixture.cs
@@ -1,0 +1,108 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using Moq;
+using Testcontainers.MsSql;
+using Wayd.Common.Application.Events;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Domain.Events;
+using Wayd.Infrastructure.Common.Services;
+using Wayd.Infrastructure.Persistence;
+using Wayd.Infrastructure.Persistence.Context;
+
+namespace Wayd.Organization.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Starts a single SQL Server container per test class and applies the real
+/// <c>Wayd.Infrastructure.Migrators.MSSQL</c> migrations against it, then hands out <see cref="WaydDbContext"/>
+/// instances pointed at that container. This exercises the production EF provider, so value converters
+/// (e.g. <c>TeamCode</c> → <c>varchar</c>), NodaTime mapping, and the SQL-graph node/edge tables all behave
+/// exactly as they do in production — the very reason Testcontainers is used here instead of SQLite.
+/// </summary>
+/// <remarks>Requires Docker to be running on the machine executing the tests.</remarks>
+public sealed class SqlServerDbContextFixture : IAsyncLifetime
+{
+    // A fixed instant so audit/system columns are deterministic and no test ever reaches for DateTime.UtcNow.
+    public static readonly Instant FixedNow = Instant.FromUtc(2026, 1, 15, 9, 30, 0);
+
+    // Pin the image so the schema is built against a known SQL Server engine on every machine/CI run.
+    private readonly MsSqlContainer _container =
+        new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+
+    private DbContextOptions<WaydDbContext> _options = null!;
+    private IOptions<DatabaseSettings> _databaseSettings = null!;
+
+    public async ValueTask InitializeAsync()
+    {
+        await _container.StartAsync();
+
+        var connectionString = _container.GetConnectionString();
+
+        // Drive OnConfiguring down the SqlServer + NodaTime path (DBProvider "mssql"), exactly as production.
+        _databaseSettings = Options.Create(new DatabaseSettings
+        {
+            DBProvider = "mssql",
+            ConnectionString = connectionString,
+        });
+
+        _options = new DbContextOptionsBuilder<WaydDbContext>()
+            .UseSqlServer(connectionString, sql =>
+            {
+                sql.MigrationsAssembly("Wayd.Infrastructure.Migrators.MSSQL");
+                sql.UseNodaTime();
+            })
+            .Options;
+
+        // Apply the real migrations so the schema — varchar columns, converters and the SQL-graph
+        // TeamNodes / TeamMembershipEdges tables — matches production.
+        await using var context = CreateContext();
+        await context.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _container.DisposeAsync();
+    }
+
+    /// <summary>Creates a fresh <see cref="WaydDbContext"/> against the container, with no-op collaborators.</summary>
+    public WaydDbContext CreateContext()
+    {
+        var currentUser = new Mock<ICurrentUser>();
+        currentUser.Setup(u => u.GetUserId()).Returns("integration-test-user");
+
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.SetupGet(d => d.Now).Returns(FixedNow);
+        dateTimeProvider.SetupGet(d => d.Today).Returns(FixedNow.InUtc().Date);
+
+        var events = new Mock<IEventPublisher>();
+        events.Setup(e => e.PublishAsync(It.IsAny<IEvent>())).Returns(Task.CompletedTask);
+
+        var correlationId = new Mock<IRequestCorrelationIdProvider>();
+        correlationId.SetupGet(c => c.CorrelationId).Returns("integration-test-correlation");
+
+        return new WaydDbContext(
+            _options,
+            currentUser.Object,
+            dateTimeProvider.Object,
+            _databaseSettings,
+            events.Object,
+            correlationId.Object);
+    }
+
+    /// <summary>
+    /// Removes all Organization rows the import handlers touch so each test starts from a clean slate,
+    /// including the SQL-graph node/edge tables that <see cref="Wayd.Organization.Application"/>'s team import
+    /// writes via raw MERGE. Ordered to respect foreign keys.
+    /// </summary>
+    public async Task ResetOrganizationData(CancellationToken cancellationToken)
+    {
+        await using var context = CreateContext();
+
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[TeamMembershipEdges];", cancellationToken);
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[TeamNodes];", cancellationToken);
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[TeamMembers];", cancellationToken);
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[TeamOperatingModels];", cancellationToken);
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[TeamMemberRoles];", cancellationToken);
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[Teams];", cancellationToken);
+        await context.Database.ExecuteSqlRawAsync("DELETE FROM [Organization].[Employees];", cancellationToken);
+    }
+}

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/SqlServerDbContextFixture.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/SqlServerDbContextFixture.cs
@@ -12,11 +12,16 @@ using Wayd.Infrastructure.Persistence.Context;
 namespace Wayd.Organization.IntegrationTests.Infrastructure;
 
 /// <summary>
-/// Starts a single SQL Server container per test class and applies the real
-/// <c>Wayd.Infrastructure.Migrators.MSSQL</c> migrations against it, then hands out <see cref="WaydDbContext"/>
-/// instances pointed at that container. This exercises the production EF provider, so value converters
-/// (e.g. <c>TeamCode</c> → <c>varchar</c>), NodaTime mapping, and the SQL-graph node/edge tables all behave
-/// exactly as they do in production — the very reason Testcontainers is used here instead of SQLite.
+/// Starts a SQL Server container and applies the real <c>Wayd.Infrastructure.Migrators.MSSQL</c> migrations
+/// against it, then hands out <see cref="WaydDbContext"/> instances pointed at that container. This exercises
+/// the production EF provider, so value converters (e.g. <c>TeamCode</c> → <c>varchar</c>), NodaTime mapping,
+/// and the SQL-graph node/edge tables all behave exactly as they do in production — the very reason
+/// Testcontainers is used here instead of SQLite.
+/// <para>
+/// This is a collection fixture (see <see cref="SqlServerTestCollection"/>): one container and one migrated
+/// schema are shared by every test class in the collection, so tests must not assume a private database.
+/// Reset the rows you touch with <see cref="ResetOrganizationData"/> at the start of each test.
+/// </para>
 /// </summary>
 /// <remarks>Requires Docker to be running on the machine executing the tests.</remarks>
 public sealed class SqlServerDbContextFixture : IAsyncLifetime
@@ -24,9 +29,11 @@ public sealed class SqlServerDbContextFixture : IAsyncLifetime
     // A fixed instant so audit/system columns are deterministic and no test ever reaches for DateTime.UtcNow.
     public static readonly Instant FixedNow = Instant.FromUtc(2026, 1, 15, 9, 30, 0);
 
-    // Pin the image so the schema is built against a known SQL Server engine on every machine/CI run.
-    private readonly MsSqlContainer _container =
-        new MsSqlBuilder("mcr.microsoft.com/mssql/server:2022-latest").Build();
+    // Pinned to a concrete CU rather than a floating tag (e.g. 2022-latest), so the schema is built against
+    // the same SQL Server engine on every machine and CI run. Bump deliberately.
+    private const string SqlServerImage = "mcr.microsoft.com/mssql/server:2022-CU25-GDR2-ubuntu-22.04";
+
+    private readonly MsSqlContainer _container = new MsSqlBuilder(SqlServerImage).Build();
 
     private DbContextOptions<WaydDbContext> _options = null!;
     private IOptions<DatabaseSettings> _databaseSettings = null!;

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/SqlServerTestCollection.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Infrastructure/SqlServerTestCollection.cs
@@ -1,0 +1,12 @@
+namespace Wayd.Organization.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Shares a single <see cref="SqlServerDbContextFixture"/> — and therefore one SQL Server container and one
+/// migrated schema — across every integration test class in this project. Each test resets the Organization
+/// data it touches, so the classes are isolated without paying the per-class container start-up cost.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class SqlServerTestCollection : ICollectionFixture<SqlServerDbContextFixture>
+{
+    public const string Name = "SqlServer integration tests";
+}

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Sut/ImportEmployeesCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Sut/ImportEmployeesCommandHandlerTests.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Wayd.Common.Application.Employees.Commands;
+using Wayd.Common.Application.Employees.Dtos;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Models;
+using Wayd.Organization.IntegrationTests.Infrastructure;
+
+namespace Wayd.Organization.IntegrationTests.Sut;
+
+/// <summary>
+/// Integration tests for <see cref="ImportEmployeesCommandHandler"/> against a real SQL Server container.
+/// Employees are pervasive NodaTime carriers (<c>HireDate</c>, system-audit columns) and the manager-linkage
+/// pass runs a real <c>IN</c> query over the container, so this exercises the production provider end-to-end.
+/// </summary>
+[Collection(SqlServerTestCollection.Name)]
+public sealed class ImportEmployeesCommandHandlerTests
+{
+    private readonly SqlServerDbContextFixture _fixture;
+
+    public ImportEmployeesCommandHandlerTests(SqlServerDbContextFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static ImportEmployeesCommandHandler CreateHandler(Wayd.Infrastructure.Persistence.Context.WaydDbContext context)
+    {
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.SetupGet(d => d.Now).Returns(SqlServerDbContextFixture.FixedNow);
+
+        return new ImportEmployeesCommandHandler(context, dateTimeProvider.Object, NullLogger<ImportEmployeesCommandHandler>.Instance);
+    }
+
+    private static ImportEmployeeDto Employee(string number, string firstName, string lastName, string email, string? managerNumber = null) =>
+        new(
+            number,
+            firstName,
+            null,
+            lastName,
+            new EmailAddress(email),
+            HireDate: SqlServerDbContextFixture.FixedNow,
+            JobTitle: "Engineer",
+            Department: "Engineering",
+            OfficeLocation: null,
+            ManagerNumber: managerNumber);
+
+    [Fact]
+    public async Task Handle_ImportsEmployees_AndResolvesManagerLinkageAcrossTheBatch()
+    {
+        // Arrange — the report appears before its manager, so linkage must resolve regardless of row order.
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await _fixture.ResetOrganizationData(cancellationToken);
+
+        var command = new ImportEmployeesCommand(
+        [
+            Employee("E-1001", "Ada", "Lovelace", "ada@acme.example", managerNumber: "E-2001"),
+            Employee("E-2001", "Grace", "Hopper", "grace@acme.example"),
+        ]);
+
+        // Act
+        await using var handlerContext = _fixture.CreateContext();
+        var result = await CreateHandler(handlerContext).Handle(command, cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+
+        await using var assertContext = _fixture.CreateContext();
+        var employees = await assertContext.Employees.ToListAsync(cancellationToken);
+        employees.Should().HaveCount(2);
+
+        var manager = employees.Single(e => e.EmployeeNumber == "E-2001");
+        var report = employees.Single(e => e.EmployeeNumber == "E-1001");
+        report.ManagerId.Should().Be(manager.Id);
+        manager.ManagerId.Should().BeNull();
+    }
+}

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Sut/ImportTeamMembersCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Sut/ImportTeamMembersCommandHandlerTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Organization.Application.Teams.Commands;
+using Wayd.Organization.Application.Teams.Dtos;
+using Wayd.Organization.IntegrationTests.Infrastructure;
+
+namespace Wayd.Organization.IntegrationTests.Sut;
+
+/// <summary>
+/// Integration tests for <see cref="ImportTeamMembersCommandHandler"/> against a real SQL Server container.
+///
+/// This is the regression guard for the value-object-in-query translation bug: the handler filters teams with
+/// <c>.Where(t =&gt; teamCodeValues.Contains(t.Code))</c>. Against LINQ-to-objects fakes that always passes,
+/// but the equivalent <c>t.Code.Value</c> only fails against a real relational provider — EF can translate the
+/// value-converted <c>t.Code</c> but not <c>t.Code.Value</c>. Reverting the handler to <c>t.Code.Value</c>
+/// makes <see cref="Handle_AddsMembers_FilteringTeamsByValueConvertedCode"/> fail with a translation error,
+/// which is exactly what makes this test guard the bug.
+/// </summary>
+[Collection(SqlServerTestCollection.Name)]
+public sealed class ImportTeamMembersCommandHandlerTests
+{
+    private readonly SqlServerDbContextFixture _fixture;
+
+    public ImportTeamMembersCommandHandlerTests(SqlServerDbContextFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task Handle_AddsMembers_FilteringTeamsByValueConvertedCode()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await _fixture.ResetOrganizationData(cancellationToken);
+
+        await using (var seedContext = _fixture.CreateContext())
+        {
+            await OrganizationSeeder.SeedTeam(seedContext, "PAY", "Payments", cancellationToken);
+            await OrganizationSeeder.SeedTeam(seedContext, "PLAT", "Platform", cancellationToken);
+            await OrganizationSeeder.SeedEmployee(seedContext, "E-1001", "ada@acme.example", cancellationToken);
+            await OrganizationSeeder.SeedEmployee(seedContext, "E-1002", "grace@acme.example", cancellationToken);
+            await OrganizationSeeder.SeedRole(seedContext, "Engineer", cancellationToken);
+        }
+
+        var command = new ImportTeamMembersCommand(
+        [
+            new ImportTeamMemberDto("PAY", "E-1001", "Engineer"),
+            new ImportTeamMemberDto("PLAT", "E-1002", "Engineer"),
+        ]);
+
+        // Act — a fresh context so the handler resolves teams by executing the SQL IN over the varchar column.
+        await using var handlerContext = _fixture.CreateContext();
+        var handler = new ImportTeamMembersCommandHandler(handlerContext, NullLogger<ImportTeamMembersCommandHandler>.Instance);
+        var result = await handler.Handle(command, cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+
+        await using var assertContext = _fixture.CreateContext();
+        var members = await assertContext.TeamMembers
+            .Include(m => m.Team)
+            .Include(m => m.Employee)
+            .ToListAsync(cancellationToken);
+
+        members.Should().HaveCount(2);
+        members.Select(m => m.Team.Code.Value).Should().BeEquivalentTo(["PAY", "PLAT"]);
+    }
+
+    [Fact]
+    public async Task Handle_Fails_WhenTeamCodeUnresolved()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await _fixture.ResetOrganizationData(cancellationToken);
+
+        await using (var seedContext = _fixture.CreateContext())
+        {
+            await OrganizationSeeder.SeedTeam(seedContext, "PAY", "Payments", cancellationToken);
+            await OrganizationSeeder.SeedEmployee(seedContext, "E-1001", "ada@acme.example", cancellationToken);
+            await OrganizationSeeder.SeedRole(seedContext, "Engineer", cancellationToken);
+        }
+
+        var command = new ImportTeamMembersCommand([new ImportTeamMemberDto("NOPE", "E-1001", "Engineer")]);
+
+        // Act
+        await using var handlerContext = _fixture.CreateContext();
+        var handler = new ImportTeamMembersCommandHandler(handlerContext, NullLogger<ImportTeamMembersCommandHandler>.Instance);
+        var result = await handler.Handle(command, cancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("team code 'NOPE'");
+
+        await using var assertContext = _fixture.CreateContext();
+        (await assertContext.TeamMembers.AnyAsync(cancellationToken)).Should().BeFalse();
+    }
+}

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Sut/ImportTeamsCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Sut/ImportTeamsCommandHandlerTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Domain.Enums.Organization;
+using Wayd.Common.Domain.Models.Organizations;
+using Wayd.Organization.Application.Teams.Commands;
+using Wayd.Organization.Application.Teams.Dtos;
+using Wayd.Organization.IntegrationTests.Infrastructure;
+
+namespace Wayd.Organization.IntegrationTests.Sut;
+
+/// <summary>
+/// Integration tests for <see cref="ImportTeamsCommandHandler"/> against a real SQL Server container.
+///
+/// This handler persists teams relationally and then syncs each one into the SQL-graph <c>TeamNodes</c> table
+/// via a raw <c>MERGE ... $node_id</c> statement (<see cref="Wayd.Infrastructure.Persistence.Context.WaydDbContext.UpsertTeamNode"/>).
+/// That graph path is unrepresentable in SQLite or an in-memory fake, so only a real SQL Server exercises it —
+/// which is the core reason this project uses Testcontainers.
+/// </summary>
+[Collection(SqlServerTestCollection.Name)]
+public sealed class ImportTeamsCommandHandlerTests
+{
+    private readonly SqlServerDbContextFixture _fixture;
+
+    public ImportTeamsCommandHandlerTests(SqlServerDbContextFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static ImportTeamsCommandHandler CreateHandler(Wayd.Infrastructure.Persistence.Context.WaydDbContext context)
+    {
+        var dateTimeProvider = new Mock<IDateTimeProvider>();
+        dateTimeProvider.SetupGet(d => d.Now).Returns(SqlServerDbContextFixture.FixedNow);
+
+        return new ImportTeamsCommandHandler(context, dateTimeProvider.Object, NullLogger<ImportTeamsCommandHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_PersistsTeams_AndSyncsThemIntoTheGraphNodes()
+    {
+        // Arrange
+        var cancellationToken = TestContext.Current.CancellationToken;
+        await _fixture.ResetOrganizationData(cancellationToken);
+
+        var activeDate = SqlServerDbContextFixture.FixedNow.InUtc().Date;
+        var command = new ImportTeamsCommand(
+        [
+            new ImportTeamDto(TeamType.Team, "Payments", new TeamCode("PAY"), "Owns billing", activeDate),
+            new ImportTeamDto(TeamType.TeamOfTeams, "Platform Group", new TeamCode("PLATGRP"), null, activeDate),
+        ]);
+
+        // Act
+        await using var handlerContext = _fixture.CreateContext();
+        var result = await CreateHandler(handlerContext).Handle(command, cancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue(result.IsFailure ? result.Error : null);
+
+        await using var assertContext = _fixture.CreateContext();
+
+        var teams = await assertContext.BaseTeams.ToListAsync(cancellationToken);
+        teams.Select(t => t.Code.Value).Should().BeEquivalentTo(["PAY", "PLATGRP"]);
+
+        // The MERGE landed both teams in the graph node table (queried by the same value-converted Code).
+        var nodeCodes = await assertContext.Database
+            .SqlQuery<string>($"SELECT [Code] AS [Value] FROM [Organization].[TeamNodes]")
+            .ToListAsync(cancellationToken);
+        nodeCodes.Should().BeEquivalentTo(["PAY", "PLATGRP"]);
+    }
+}

--- a/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Wayd.Organization.IntegrationTests.csproj
+++ b/Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Wayd.Organization.IntegrationTests.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="FluentAssertions" />
+        <PackageReference Include="Moq" />
+        <PackageReference Include="Moq.AutoMock" />
+        <PackageReference Include="NodaTime.Testing" />
+        <PackageReference Include="Testcontainers.MsSql" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" />
+        <PackageReference Include="xunit.v3" />
+        <PackageReference Include="xunit.runner.visualstudio">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <!-- The real WaydDbContext, its configuration and the SQL Server migrations, so value converters,
+             NodaTime mapping, varchar columns and the graph tables all behave exactly as in production. -->
+        <ProjectReference Include="..\..\..\..\Wayd.Infrastructure\src\Wayd.Infrastructure.Migrators.MSSQL\Wayd.Infrastructure.Migrators.MSSQL.csproj" />
+        <ProjectReference Include="..\..\src\Wayd.Organization.Application\Wayd.Organization.Application.csproj" />
+        <ProjectReference Include="..\..\..\..\Wayd.Common\src\Wayd.Common.Application\Wayd.Common.Application.csproj" />
+        <ProjectReference Include="..\Wayd.Organization.TestData\Wayd.Organization.TestData.csproj" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit" />
+    </ItemGroup>
+
+</Project>

--- a/Wayd.slnx
+++ b/Wayd.slnx
@@ -67,6 +67,7 @@
   <Folder Name="/Wayd.Services/Wayd.Organization/tests/">
     <Project Path="Wayd.Services/Wayd.Organization/tests/Wayd.Organization.Application.Tests/Wayd.Organization.Application.Tests.csproj" />
     <Project Path="Wayd.Services/Wayd.Organization/tests/Wayd.Organization.Domain.Tests/Wayd.Organization.Domain.Tests.csproj" />
+    <Project Path="Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests/Wayd.Organization.IntegrationTests.csproj" />
     <Project Path="Wayd.Services/Wayd.Organization/tests/Wayd.Organization.TestData/Wayd.Organization.TestData.csproj" />
   </Folder>
   <Folder Name="/Wayd.Services/Wayd.Planning/" />


### PR DESCRIPTION
## Summary

Adds a Testcontainers-backed SQL Server integration test project for the Organization service, guarding the class of bug where a value object referenced inside an EF `IQueryable` fails to translate against a real relational provider but passes silently against LINQ-to-objects fakes.

Closes #654

## Motivation

`ImportTeamMembersCommandHandler` previously referenced `t.Code.Value` inside an EF query. `TeamCode` is persisted via `HasConversion` to a single `varchar` column, so EF can translate `t.Code` but **not** `t.Code.Value` — it throws only against a real relational provider. All 5 unit tests passed while the handler was broken, because `FakeOrganizationDbContext` is LINQ-to-objects.

No test guarded this. Now one does.

## Approach

Testcontainers SQL Server rather than SQLite. SQLite against the real `WaydDbContext` was investigated and rejected in the issue — `BaseDbContext.OnConfiguring` throws for any provider but SqlServer, NodaTime mapping is registered only on the `UseSqlServer` path, and `TeamNodes`/`TeamMembershipEdges` are SQL-graph tables written via raw `MERGE … $node_id`. Testcontainers runs the exact production provider, so value converters, NodaTime, varchar and graph tables all behave as in prod and the bug genuinely reproduces.

**Tradeoff: this project's tests require Docker.**

## Changes

**New project** `Wayd.Services/Wayd.Organization/tests/Wayd.Organization.IntegrationTests` (added to `Wayd.slnx`):

- `SqlServerDbContextFixture` — `IAsyncLifetime` fixture starting one pinned `mssql/server:2022-latest` container and applying the real `Wayd.Infrastructure.Migrators.MSSQL` migrations via `MigrateAsync`, so the schema (varchar columns, converters, graph tables) matches production. Hands out real `WaydDbContext` instances with stubbed collaborators: no-op `IEventPublisher`, fixed `Instant` through `IDateTimeProvider`, stub `ICurrentUser` and correlation-id provider. `DatabaseSettings.DBProvider = "mssql"` drives `OnConfiguring` down the SqlServer + NodaTime path. `ResetOrganizationData` clears the touched tables (including the graph node/edge tables) between tests.
- `SqlServerTestCollection` — collection fixture so a single container and migrated schema are shared across all test classes, rather than paying container start-up per class.
- `OrganizationSeeder` — seeds teams, employees and roles through their real domain create paths.

**Tests:**

| Test class | What it exercises |
| --- | --- |
| `ImportTeamMembersCommandHandlerTests` | The regression guard — real `IN` translation over the value-converted `varchar` code, plus an unresolved-code case |
| `ImportTeamsCommandHandlerTests` | The graph `MERGE` path via `UpsertTeamNode`, unrepresentable in SQLite or a fake |
| `ImportEmployeesCommandHandlerTests` | NodaTime carriers and the manager-linkage `IN` query across a batch |

**Supporting edits:**

- `Directory.Packages.props` — added `Testcontainers.MsSql` 4.13.0 (`Microsoft.EntityFrameworkCore.SqlServer` was already present at the EF Core major in use).
- `InternalsVisibleTo` for the new project on `Wayd.Organization.Application` and `Wayd.Common.Application` (both import handlers are `internal`).

No production code changed.

## Verification

- `dotnet build Wayd.slnx` — clean, 0 warnings.
- `dotnet test` on the new project — **4/4 pass** against a real SQL Server container.
- `Wayd.ArchitectureTests` — **65/65 pass**; the `.IntegrationTests` suffix is accepted with no change to `ProjectConventions.cs`.
- **Regression proven:** reverting the handler to `.Where(t => teamCodes.Contains(t.Code.Value))` makes the regression test fail with `The LINQ expression '...Code.Value' could not be translated` — the exact bug class, invisible to the existing unit tests. The handler was then restored (verified clean `git diff`).

## Notes for reviewers

- **Docker must be running** to execute this project's tests; the SQL Server image is pulled on first run.
- `ImportEmployeesCommand` lives in `Wayd.Common`, not Organization, and doesn't itself have the value-object bug — it's covered here because the issue asked to extend to it and the project already references `Wayd.Common.Application`. If we'd rather keep this project strictly Organization-scoped, that test can move to a Common integration project later.
