### PR TITLE
Feature/setup dispatcher facade

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Application/Auditing/GetMyAuditLogsQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Auditing/GetMyAuditLogsQuery.cs
@@ -2,7 +2,7 @@
 
 namespace Wayd.Common.Application.Auditing;
 
-public sealed record GetMyAuditLogsQuery : IRequest<List<AuditDto>>
+public sealed record GetMyAuditLogsQuery : IQuery<List<AuditDto>>
 {
 }
 

--- a/Wayd.Common/src/Wayd.Common.Application/ConfigureServices.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/ConfigureServices.cs
@@ -2,6 +2,7 @@
 using Mapster;
 using Mapster.Utils;
 using Microsoft.Extensions.DependencyInjection;
+using Wayd.Common.Application.Dispatching;
 
 namespace Wayd.Common.Application;
 
@@ -20,6 +21,8 @@ public static class ConfigureServices
             config.AddOpenBehavior(typeof(ValidationBehavior<,>));
             config.AddOpenBehavior(typeof(PerformanceBehavior<,>));
         });
+
+        services.AddScoped<IDispatcher, MediatRDispatcher>();
 
         TypeAdapterConfig.GlobalSettings.Scan(assembly);
         TypeAdapterConfig.GlobalSettings.ScanInheritedTypes(assembly);

--- a/Wayd.Common/src/Wayd.Common.Application/Dispatching/MediatRDispatcher.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Dispatching/MediatRDispatcher.cs
@@ -1,0 +1,22 @@
+﻿using MediatR;
+
+namespace Wayd.Common.Application.Dispatching;
+
+/// <summary>
+/// <see cref="IDispatcher"/> implementation backed by MediatR's <see cref="ISender"/>. This is the
+/// only place in the application that depends on MediatR's dispatch surface; every other call site
+/// goes through <see cref="IDispatcher"/>.
+/// </summary>
+internal sealed class MediatRDispatcher(ISender sender) : IDispatcher
+{
+    private readonly ISender _sender = sender;
+
+    public Task<Result> Send(ICommand command, CancellationToken cancellationToken = default)
+        => _sender.Send(command, cancellationToken);
+
+    public Task<Result<TResponse>> Send<TResponse>(ICommand<TResponse> command, CancellationToken cancellationToken = default)
+        => _sender.Send(command, cancellationToken);
+
+    public Task<TResponse> Send<TResponse>(IQuery<TResponse> query, CancellationToken cancellationToken = default)
+        => _sender.Send(query, cancellationToken);
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Interfaces/IDispatcher.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Interfaces/IDispatcher.cs
@@ -1,0 +1,36 @@
+﻿namespace Wayd.Common.Application.Interfaces;
+
+/// <summary>
+/// Dispatches commands and queries to their handlers. This is the single seam through which the
+/// application talks to the underlying mediator, so the dispatcher implementation (MediatR today)
+/// can be swapped without touching call sites.
+/// </summary>
+/// <remarks>
+/// The response type is inferred from the <see cref="ICommand"/>/<see cref="ICommand{TResponse}"/>/
+/// <see cref="IQuery{TResponse}"/> markers, so call sites read identically to the previous
+/// <c>ISender.Send</c> usage. No underlying mediator types (e.g. MediatR's <c>IRequest</c>) appear
+/// in this contract, keeping it implementable over any dispatcher — including Wolverine's
+/// <c>IMessageBus.InvokeAsync&lt;T&gt;(object message)</c>.
+/// </remarks>
+public interface IDispatcher
+{
+    /// <summary>Dispatches a command that yields a plain <see cref="Result"/>.</summary>
+    /// <param name="command">The command to dispatch.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The result of handling the command.</returns>
+    Task<Result> Send(ICommand command, CancellationToken cancellationToken = default);
+
+    /// <summary>Dispatches a command that yields a <see cref="Result{TResponse}"/>.</summary>
+    /// <typeparam name="TResponse">The type carried by a successful result.</typeparam>
+    /// <param name="command">The command to dispatch.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The result of handling the command.</returns>
+    Task<Result<TResponse>> Send<TResponse>(ICommand<TResponse> command, CancellationToken cancellationToken = default);
+
+    /// <summary>Dispatches a query that yields <typeparamref name="TResponse"/>.</summary>
+    /// <typeparam name="TResponse">The type returned by the query.</typeparam>
+    /// <param name="query">The query to dispatch.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The query response.</returns>
+    Task<TResponse> Send<TResponse>(IQuery<TResponse> query, CancellationToken cancellationToken = default);
+}

--- a/Wayd.Common/src/Wayd.Common.Application/Search/GlobalSearchQuery.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Search/GlobalSearchQuery.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.Common.Application.Search.Dtos;
+﻿using Wayd.Common.Application.Search.Dtos;
 using Wayd.Common.Domain.Authorization;
 
 namespace Wayd.Common.Application.Search;
@@ -7,7 +6,7 @@ namespace Wayd.Common.Application.Search;
 public sealed record GlobalSearchQuery(string SearchTerm, int MaxResultsPerCategory = 5)
     : IQuery<Result<GlobalSearchResultDto>>;
 
-internal sealed class GlobalSearchQueryHandler(ISender sender, ICurrentUser currentUser, ILogger<GlobalSearchQueryHandler> logger)
+internal sealed class GlobalSearchQueryHandler(IDispatcher dispatcher, ICurrentUser currentUser, ILogger<GlobalSearchQueryHandler> logger)
     : IQueryHandler<GlobalSearchQuery, Result<GlobalSearchResultDto>>
 {
     private const string AppRequestName = nameof(GlobalSearchQuery);
@@ -79,7 +78,7 @@ internal sealed class GlobalSearchQueryHandler(ISender sender, ICurrentUser curr
     {
         try
         {
-            var response = await sender.Send(query, cancellationToken);
+            var response = await dispatcher.Send(query, cancellationToken);
             return response.Categories;
         }
         catch (Exception ex)

--- a/Wayd.Common/src/Wayd.Common.Domain/Wayd.Common.Domain.csproj
+++ b/Wayd.Common/src/Wayd.Common.Domain/Wayd.Common.Domain.csproj
@@ -3,7 +3,6 @@
     <ItemGroup>
         <PackageReference Include="CSharpFunctionalExtensions" />
         <PackageReference Include="FluentValidation" />
-        <PackageReference Include="MediatR.Contracts" />
         <PackageReference Include="NCalc.Core" />
         <PackageReference Include="NodaTime" />
     </ItemGroup>

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.CreateUpdate.cs
@@ -942,7 +942,7 @@ internal partial class UserService
         // User-to-Employee linkage is keyed on email regardless of which PeopleSync connector
         // is currently active. EmployeeNumber's value depends on the source's preferences
         // (Entra User.Id, Workday Employee_ID, etc.) and isn't a stable cross-source key.
-        var employeeId = await _sender.Send(new GetEmployeeByEmailQuery(email));
+        var employeeId = await _dispatcher.Send(new GetEmployeeByEmailQuery(email));
         if (employeeId.IsNullEmptyOrDefault())
         {
             employeeId = null;

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Identity/UserService.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
 using Mapster;
-using MediatR;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -16,7 +15,7 @@ internal partial class UserService(
     RoleManager<ApplicationRole> roleManager,
     WaydDbContext db,
     IEventPublisher events,
-    ISender sender,
+    IDispatcher dispatcher,
     IDateTimeProvider dateTimeProvider,
     ICurrentUser currentUser,
     IUserIdentityStore userIdentityStore,
@@ -28,7 +27,7 @@ internal partial class UserService(
     private readonly RoleManager<ApplicationRole> _roleManager = roleManager;
     private readonly WaydDbContext _db = db;
     private readonly IEventPublisher _events = events;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ICurrentUser _currentUser = currentUser;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
     private readonly IUserIdentityStore _userIdentityStore = userIdentityStore;

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
@@ -1,5 +1,4 @@
 ﻿using System.Security.Claims;
-using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore.Query;
@@ -27,7 +26,7 @@ public class UserServiceTests
     private readonly Mock<IEventPublisher> _mockEvents;
     private readonly Mock<ILogger<UserService>> _mockLogger;
     private readonly TestingDateTimeProvider _dateTimeProvider;
-    private readonly Mock<ISender> _mockSender;
+    private readonly Mock<IDispatcher> _mockSender;
     private readonly Mock<ICurrentUser> _mockCurrentUser;
     private readonly Mock<IUserIdentityStore> _mockUserIdentityStore;
     private readonly Mock<IOidcProviderRegistry> _mockOidcProviderRegistry;
@@ -55,7 +54,7 @@ public class UserServiceTests
         _mockEvents = new Mock<IEventPublisher>();
         _mockLogger = new Mock<ILogger<UserService>>();
         _dateTimeProvider = new TestingDateTimeProvider(DateTime.UtcNow);
-        _mockSender = new Mock<ISender>();
+        _mockSender = new Mock<IDispatcher>();
         _mockCurrentUser = new Mock<ICurrentUser>();
         _mockCurrentUser.Setup(x => x.GetUserId()).Returns("current-user-id");
         _mockUserIdentityStore = new Mock<IUserIdentityStore>();

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/Identity/UserServiceTests.cs
@@ -26,7 +26,7 @@ public class UserServiceTests
     private readonly Mock<IEventPublisher> _mockEvents;
     private readonly Mock<ILogger<UserService>> _mockLogger;
     private readonly TestingDateTimeProvider _dateTimeProvider;
-    private readonly Mock<IDispatcher> _mockSender;
+    private readonly Mock<IDispatcher> _mockDispatcher;
     private readonly Mock<ICurrentUser> _mockCurrentUser;
     private readonly Mock<IUserIdentityStore> _mockUserIdentityStore;
     private readonly Mock<IOidcProviderRegistry> _mockOidcProviderRegistry;
@@ -54,7 +54,7 @@ public class UserServiceTests
         _mockEvents = new Mock<IEventPublisher>();
         _mockLogger = new Mock<ILogger<UserService>>();
         _dateTimeProvider = new TestingDateTimeProvider(DateTime.UtcNow);
-        _mockSender = new Mock<IDispatcher>();
+        _mockDispatcher = new Mock<IDispatcher>();
         _mockCurrentUser = new Mock<ICurrentUser>();
         _mockCurrentUser.Setup(x => x.GetUserId()).Returns("current-user-id");
         _mockUserIdentityStore = new Mock<IUserIdentityStore>();
@@ -76,7 +76,7 @@ public class UserServiceTests
             _mockRoleManager.Object,
             null!, // WaydDbContext - not used by these methods
             _mockEvents.Object,
-            _mockSender.Object,
+            _mockDispatcher.Object,
             _dateTimeProvider,
             _mockCurrentUser.Object,
             _mockUserIdentityStore.Object,
@@ -1264,7 +1264,7 @@ public class UserServiceTests
         _mockRoleManager.Setup(x => x.FindByIdAsync(It.IsAny<string>()))
             .ReturnsAsync((string id) => new ApplicationRole("Contributor") { Id = id });
 
-        _mockSender.Setup(s => s.Send(It.IsAny<Wayd.Common.Application.Employees.Queries.GetEmployeeByEmailQuery>(), It.IsAny<CancellationToken>()))
+        _mockDispatcher.Setup(s => s.Send(It.IsAny<Wayd.Common.Application.Employees.Queries.GetEmployeeByEmailQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(employeeId);
     }
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommand.cs
@@ -1,9 +1,6 @@
-﻿using MediatR;
-using Microsoft.EntityFrameworkCore;
-using Wayd.Common.Application.Interfaces.ExternalWork;
+﻿using Wayd.Common.Application.Interfaces.ExternalWork;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
 using Wayd.Common.Domain.Models;
-using NodaTime;
 
 namespace Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
 
@@ -15,7 +12,7 @@ public sealed record SyncAzureDevOpsConnectionConfigurationCommand(
     List<IExternalTeam> Teams)
     : ICommand;
 
-internal sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppIntegrationDbContext appIntegrationDbContext, IDateTimeProvider dateTimeProvider, ILogger<SyncAzureDevOpsConnectionConfigurationCommandHandler> logger, IAzureDevOpsService azureDevOpsService, ISender sender) : ICommandHandler<SyncAzureDevOpsConnectionConfigurationCommand>
+internal sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppIntegrationDbContext appIntegrationDbContext, IDateTimeProvider dateTimeProvider, ILogger<SyncAzureDevOpsConnectionConfigurationCommandHandler> logger, IAzureDevOpsService azureDevOpsService, IDispatcher dispatcher) : ICommandHandler<SyncAzureDevOpsConnectionConfigurationCommand>
 {
     private const string AppRequestName = nameof(SyncAzureDevOpsConnectionConfigurationCommand);
 
@@ -23,7 +20,7 @@ internal sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppI
     private readonly Instant _timestamp = dateTimeProvider.Now;
     private readonly ILogger<SyncAzureDevOpsConnectionConfigurationCommandHandler> _logger = logger;
     private readonly IAzureDevOpsService _azureDevOpsService = azureDevOpsService;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     public async Task<Result> Handle(SyncAzureDevOpsConnectionConfigurationCommand request, CancellationToken cancellationToken)
     {
@@ -49,7 +46,7 @@ internal sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppI
             // get workspace internal ids after setting system id
             var workspaceIds = connection.Configuration.Workspaces.Where(w => w.IntegrationState?.InternalId != null).Select(w => w.IntegrationState!.InternalId).ToList();
 
-            var setSystemIdOnWorkspacesResult = await _sender.Send(new SetSystemIdOnExternalWorkspacesCommand(workspaceIds, connection.Connector, connection.SystemId!), cancellationToken);
+            var setSystemIdOnWorkspacesResult = await _dispatcher.Send(new SetSystemIdOnExternalWorkspacesCommand(workspaceIds, connection.Connector, connection.SystemId!), cancellationToken);
             if (setSystemIdOnWorkspacesResult.IsFailure)
             {
                 _logger.LogError("Failed to set SystemId on external workspaces for connection {ConnectionId}. {Error}", connection.Id, setSystemIdOnWorkspacesResult.Error);
@@ -151,7 +148,7 @@ internal sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppI
                 "Detected work process change for workspace {WorkspaceId}: {OldProcessId} -> {NewProcessId}. Updating Wayd workspace.",
                 workspaceInternalId, previousProcessId, workspace.WorkProcessId);
     
-            var changeResult = await _sender.Send(
+            var changeResult = await _dispatcher.Send(
                 new ChangeExternalWorkspaceWorkProcessCommand(workspaceInternalId, workspace.WorkProcessId.Value),
                 cancellationToken);
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsInitManager.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsInitManager.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.AppIntegration.Application.Connections.Commands;
+﻿using Wayd.AppIntegration.Application.Connections.Commands;
 using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
 using Wayd.AppIntegration.Application.Connections.Dtos.AzureDevOps;
 using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
@@ -16,17 +15,17 @@ using Wayd.Common.Models;
 
 namespace Wayd.AppIntegration.Application.Connections.Managers;
 
-public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logger, IAzureDevOpsService azureDevOpsService, ISender sender) : IAzureDevOpsInitManager
+public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logger, IAzureDevOpsService azureDevOpsService, IDispatcher dispatcher) : IAzureDevOpsInitManager
 {
     private readonly ILogger<AzureDevOpsInitManager> _logger = logger;
     private readonly IAzureDevOpsService _azureDevOpsService = azureDevOpsService;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     public async Task<Result> SyncOrganizationConfiguration(Guid connectionId, CancellationToken cancellationToken, Guid? syncId = null)
     {
         try
         {
-            var connection = await _sender.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
+            var connection = await _dispatcher.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
             if (connection is null)
             {
                 _logger.LogError("Unable to find Azure DevOps connection with id {ConnectionId}.", connectionId);
@@ -86,7 +85,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                     workspaces.Add(workspace);
                 }
 
-                var existingWorkProcessIntegrationStates = await _sender.Send(new GetIntegrationRegistrationsForWorkProcessesQuery(), cancellationToken);
+                var existingWorkProcessIntegrationStates = await _dispatcher.Send(new GetIntegrationRegistrationsForWorkProcessesQuery(), cancellationToken);
 
                 // Load Teams
                 List<IExternalTeam> teams = [];
@@ -100,7 +99,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                     teams = teamsResult.Value;
                 }
 
-                var syncConfigurationResult = await _sender.Send(new SyncAzureDevOpsConnectionConfigurationCommand(connectionId, processes, workspaces, existingWorkProcessIntegrationStates, teams), cancellationToken);
+                var syncConfigurationResult = await _dispatcher.Send(new SyncAzureDevOpsConnectionConfigurationCommand(connectionId, processes, workspaces, existingWorkProcessIntegrationStates, teams), cancellationToken);
 
                 return syncConfigurationResult;
             }
@@ -134,10 +133,10 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 // Check if another connection has already created a WorkProcess for this ExternalId.
                 // Azure DevOps built-in processes (Agile, Scrum, CMMI, Basic) share the same GUID across
                 // all organizations, so we reuse the existing WorkProcess rather than creating a duplicate.
-                var existsGlobally = await _sender.Send(new ExternalWorkProcessExistsQuery(workProcessExternalId), cancellationToken);
+                var existsGlobally = await _dispatcher.Send(new ExternalWorkProcessExistsQuery(workProcessExternalId), cancellationToken);
                 if (existsGlobally)
                 {
-                    var existingRegistrations = await _sender.Send(new GetIntegrationRegistrationsForWorkProcessesQuery(workProcessExternalId), cancellationToken);
+                    var existingRegistrations = await _dispatcher.Send(new GetIntegrationRegistrationsForWorkProcessesQuery(workProcessExternalId), cancellationToken);
                     var existingRegistration = existingRegistrations.FirstOrDefault();
                     if (existingRegistration is null)
                     {
@@ -147,7 +146,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
 
                     _logger.LogInformation("Reusing existing work process {WorkProcessInternalId} for Azure DevOps process {WorkProcessExternalId} on connection {ConnectionId}.", existingRegistration.IntegrationState.InternalId, workProcessExternalId, connectionId);
 
-                    var linkResult = await _sender.Send(new UpdateAzureDevOpsWorkProcessIntegrationStateCommand(connectionId, existingRegistration), cancellationToken);
+                    var linkResult = await _dispatcher.Send(new UpdateAzureDevOpsWorkProcessIntegrationStateCommand(connectionId, existingRegistration), cancellationToken);
 
                     return linkResult.IsSuccess
                         ? Result.Success(existingRegistration.IntegrationState.InternalId)
@@ -172,20 +171,20 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 var workTypes = processResult.Value.WorkTypes.OfType<IExternalWorkType>().ToList();
                 if (workTypes.Count != 0)
                 {
-                    var levels = await _sender.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
+                    var levels = await _dispatcher.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
                     if (levels is null)
                         return Result.Failure<Guid>("Unable to get work type levels.");
 
                     int defaultLevelId = levels.Where(l => l.Tier.Id == (int)WorkTypeTier.Other).Select(l => l.Id).SingleOrDefault();
 
-                    var syncWorkTypesResult = await _sender.Send(new SyncExternalWorkTypesCommand(workTypes, defaultLevelId), cancellationToken);
+                    var syncWorkTypesResult = await _dispatcher.Send(new SyncExternalWorkTypesCommand(workTypes, defaultLevelId), cancellationToken);
                     if (syncWorkTypesResult.IsFailure)
                         return syncWorkTypesResult.ConvertFailure<Guid>();
                 }
 
                 if (processResult.Value.WorkStatuses.Count != 0)
                 {
-                    var syncWorkStatusesResult = await _sender.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);
+                    var syncWorkStatusesResult = await _dispatcher.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);
                     if (syncWorkStatusesResult.IsFailure)
                         return syncWorkStatusesResult.ConvertFailure<Guid>();
                 }
@@ -193,7 +192,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 var workProcessSchemes = new List<CreateWorkProcessSchemeDto>(processResult.Value.WorkTypes.Count);
                 foreach (var workType in processResult.Value.WorkTypes)
                 {
-                    var createWorkflowResult = await _sender.Send(new CreateExternalWorkflowCommand(
+                    var createWorkflowResult = await _dispatcher.Send(new CreateExternalWorkflowCommand(
                         $"{processResult.Value.Name} - {workType.Name}",
                         "Auto-generated workflow for Azure DevOps work process.",
                         workType), cancellationToken);
@@ -203,11 +202,11 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                     workProcessSchemes.Add(CreateWorkProcessSchemeDto.Create(workType.Name, workType.IsActive, createWorkflowResult.Value));
                 }
 
-                var createProcessResult = await _sender.Send(new CreateExternalWorkProcessCommand(processResult.Value, workProcessSchemes), cancellationToken);
+                var createProcessResult = await _dispatcher.Send(new CreateExternalWorkProcessCommand(processResult.Value, workProcessSchemes), cancellationToken);
                 if (createProcessResult.IsFailure)
                     return createProcessResult.ConvertFailure<Guid>();
 
-                var updateIntegrationStateResult = await _sender.Send(new UpdateAzureDevOpsWorkProcessIntegrationStateCommand(connectionId, new IntegrationRegistration<Guid, Guid>(workProcessExternalId, createProcessResult.Value)), cancellationToken);
+                var updateIntegrationStateResult = await _dispatcher.Send(new UpdateAzureDevOpsWorkProcessIntegrationStateCommand(connectionId, new IntegrationRegistration<Guid, Guid>(workProcessExternalId, createProcessResult.Value)), cancellationToken);
 
                 return updateIntegrationStateResult.IsSuccess
                     ? Result.Success(createProcessResult.Value.InternalId)
@@ -231,14 +230,14 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 if (connectionCheckResult.IsFailure)
                     return connectionCheckResult.ConvertFailure<Guid>();
 
-                var exists = await _sender.Send(new ExternalWorkspaceExistsQuery(workspaceExternalId.ToString()), cancellationToken);
+                var exists = await _dispatcher.Send(new ExternalWorkspaceExistsQuery(workspaceExternalId.ToString()), cancellationToken);
                 if (exists)
                 {
                     _logger.LogError("Unable to initialize a workspace {WorkspaceExternalId} from Azure DevOps for connection {ConnectionId} because it is already integrated.", workspaceExternalId, connectionId);
                     return Result.Failure<Guid>($"Unable to initialize a workspace {workspaceExternalId} from Azure DevOps for connection {connectionId} because it is already integrated.");
                 }
 
-                var isDuplicateKey = await _sender.Send(new WorkspaceKeyExistsQuery(workspaceKey), cancellationToken);
+                var isDuplicateKey = await _dispatcher.Send(new WorkspaceKeyExistsQuery(workspaceKey), cancellationToken);
                 if (isDuplicateKey)
                 {
                     _logger.LogWarning("Unable to initialize a workspace {WorkspaceExternalId} from Azure DevOps for connection {ConnectionId} because the workspace key {WorkspaceKey} is already in use.", workspaceExternalId, connectionId, workspaceKey);
@@ -267,11 +266,11 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 if (workspaceResult.IsFailure)
                     return workspaceResult.ConvertFailure<Guid>();
 
-                var createWorkspaceResult = await _sender.Send(new CreateExternalWorkspaceCommand(Connector.AzureDevOps, systemId, workspaceResult.Value, new WorkspaceKey(workspaceKey), workspaceName, externalViewWorkItemUrlTemplate), cancellationToken);
+                var createWorkspaceResult = await _dispatcher.Send(new CreateExternalWorkspaceCommand(Connector.AzureDevOps, systemId, workspaceResult.Value, new WorkspaceKey(workspaceKey), workspaceName, externalViewWorkItemUrlTemplate), cancellationToken);
                 if (createWorkspaceResult.IsFailure)
                     return createWorkspaceResult.ConvertFailure<Guid>();
 
-                var updateIntegrationStateResult = await _sender.Send(new UpdateAzureDevOpsWorkspaceIntegrationStateCommand(connectionId, new IntegrationRegistration<Guid, Guid>(workspaceExternalId, createWorkspaceResult.Value)), cancellationToken);
+                var updateIntegrationStateResult = await _dispatcher.Send(new UpdateAzureDevOpsWorkspaceIntegrationStateCommand(connectionId, new IntegrationRegistration<Guid, Guid>(workspaceExternalId, createWorkspaceResult.Value)), cancellationToken);
 
                 return updateIntegrationStateResult.IsSuccess
                     ? Result.Success(createWorkspaceResult.Value.InternalId)
@@ -317,7 +316,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
 
     private async Task<Result<AzureDevOpsConnectionDetailsDto>> GetValidConnectionDetails(Guid connectionId, CancellationToken cancellationToken)
     {
-        var connection = await _sender.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
+        var connection = await _dispatcher.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
         if (connection is null)
         {
             _logger.LogError("Unable to find Azure DevOps connection with id {ConnectionId}.", connectionId);

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text.Json;
 using Ardalis.GuardClauses;
-using MediatR;
 using NodaTime;
 using Wayd.AppIntegration.Application.Connections.Dtos.AzureDevOps;
 using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
@@ -24,7 +23,7 @@ namespace Wayd.AppIntegration.Application.Connections.Managers;
 public sealed class AzureDevOpsWorkItemSource(
     ILogger<AzureDevOpsWorkItemSource> logger,
     IAzureDevOpsService azureDevOpsService,
-    ISender sender,
+    IDispatcher dispatcher,
     IAzureDevOpsInitManager initManager) : IWorkItemSource
 {
     public const string TeamSettingsFilterKey = "azdo.teamSettings";
@@ -33,7 +32,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
     private readonly ILogger<AzureDevOpsWorkItemSource> _logger = logger;
     private readonly IAzureDevOpsService _azureDevOpsService = azureDevOpsService;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IAzureDevOpsInitManager _initManager = initManager;
 
     private SyncableConnectionDescriptor? _descriptor;
@@ -87,7 +86,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
         // Load fresh state so workspace/process integration flags reflect the most recent
         // RefreshOrganizationConfiguration() result.
-        var connection = await _sender.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
+        var connection = await _dispatcher.Send(new GetAzureDevOpsConnectionQuery(connectionId), cancellationToken);
         if (connection is null)
             return Result.Failure<IReadOnlyList<WorkspaceSyncTarget>>($"Unable to load Azure DevOps connection {connectionId}.");
 
@@ -158,7 +157,7 @@ public sealed class AzureDevOpsWorkItemSource(
         if (workspaceResult.IsFailure)
             return workspaceResult.ConvertFailure();
 
-        var updateResult = await _sender.Send(new UpdateExternalWorkspaceCommand(workspaceResult.Value), cancellationToken);
+        var updateResult = await _dispatcher.Send(new UpdateExternalWorkspaceCommand(workspaceResult.Value), cancellationToken);
         return updateResult;
     }
 
@@ -172,7 +171,7 @@ public sealed class AzureDevOpsWorkItemSource(
         if (iterationsResult.IsFailure)
             return iterationsResult.ConvertFailure();
 
-        return await _sender.Send(new SyncAzureDevOpsIterationsCommand(systemId, iterationsResult.Value, teamMappings), cancellationToken);
+        return await _dispatcher.Send(new SyncAzureDevOpsIterationsCommand(systemId, iterationsResult.Value, teamMappings), cancellationToken);
     }
 
     public async Task<Result<WorkspaceItemsSyncResult>> SyncWorkItems(WorkspaceSyncTarget target, SyncType syncType, Guid syncId, CancellationToken cancellationToken)
@@ -187,7 +186,7 @@ public sealed class AzureDevOpsWorkItemSource(
             _ => _minSyncDate
         };
 
-        var workTypesResult = await _sender.Send(new GetWorkspaceWorkTypesQuery(target.InternalWorkspaceId), cancellationToken);
+        var workTypesResult = await _dispatcher.Send(new GetWorkspaceWorkTypesQuery(target.InternalWorkspaceId), cancellationToken);
         if (workTypesResult.IsFailure)
             return workTypesResult.ConvertFailure<WorkspaceItemsSyncResult>();
 
@@ -208,8 +207,8 @@ public sealed class AzureDevOpsWorkItemSource(
         }
         else if (workItemsResult.Value.Count > 0)
         {
-            var iterationMappings = await _sender.Send(new GetIterationMappingsQuery(Connector.AzureDevOps, ctx.SystemId), cancellationToken);
-            var syncResult = await _sender.Send(new SyncExternalWorkItemsCommand(target.InternalWorkspaceId, workItemsResult.Value, teamMappings, iterationMappings), cancellationToken);
+            var iterationMappings = await _dispatcher.Send(new GetIterationMappingsQuery(Connector.AzureDevOps, ctx.SystemId), cancellationToken);
+            var syncResult = await _dispatcher.Send(new SyncExternalWorkItemsCommand(target.InternalWorkspaceId, workItemsResult.Value, teamMappings, iterationMappings), cancellationToken);
             if (syncResult.IsFailure)
             {
                 hadPartialFailure = true;
@@ -234,7 +233,7 @@ public sealed class AzureDevOpsWorkItemSource(
             }
             else if (parentsResult.Value.Count > 0)
             {
-                var syncResult = await _sender.Send(new SyncExternalWorkItemParentChangesCommand(target.InternalWorkspaceId, parentsResult.Value), cancellationToken);
+                var syncResult = await _dispatcher.Send(new SyncExternalWorkItemParentChangesCommand(target.InternalWorkspaceId, parentsResult.Value), cancellationToken);
                 if (syncResult.IsFailure)
                 {
                     hadPartialFailure = true;
@@ -258,7 +257,7 @@ public sealed class AzureDevOpsWorkItemSource(
         }
         else if (depsResult.Value.Count > 0)
         {
-            var syncResult = await _sender.Send(new SyncExternalWorkItemDependencyChangesCommand(target.InternalWorkspaceId, depsResult.Value), cancellationToken);
+            var syncResult = await _dispatcher.Send(new SyncExternalWorkItemDependencyChangesCommand(target.InternalWorkspaceId, depsResult.Value), cancellationToken);
             if (syncResult.IsFailure)
             {
                 hadPartialFailure = true;
@@ -281,7 +280,7 @@ public sealed class AzureDevOpsWorkItemSource(
         }
         else if (deletedResult.Value.Length > 0)
         {
-            var syncResult = await _sender.Send(new DeleteExternalWorkItemsCommand(target.InternalWorkspaceId, deletedResult.Value), cancellationToken);
+            var syncResult = await _dispatcher.Send(new DeleteExternalWorkItemsCommand(target.InternalWorkspaceId, deletedResult.Value), cancellationToken);
             if (syncResult.IsFailure)
             {
                 hadPartialFailure = true;
@@ -334,7 +333,7 @@ public sealed class AzureDevOpsWorkItemSource(
         var workTypes = processResult.Value.WorkTypes.OfType<Wayd.Common.Application.Interfaces.ExternalWork.IExternalWorkType>().ToList();
         if (workTypes.Count != 0)
         {
-            var levels = await _sender.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
+            var levels = await _dispatcher.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
             if (levels is null)
                 return Result.Failure("Unable to get work type levels.");
 
@@ -351,19 +350,19 @@ public sealed class AzureDevOpsWorkItemSource(
             if (defaultLevelId == -1)
                 return Result.Failure("Unable to get work type levels.");
 
-            var syncWorkTypesResult = await _sender.Send(new SyncExternalWorkTypesCommand(workTypes, defaultLevelId), cancellationToken);
+            var syncWorkTypesResult = await _dispatcher.Send(new SyncExternalWorkTypesCommand(workTypes, defaultLevelId), cancellationToken);
             if (syncWorkTypesResult.IsFailure)
                 return syncWorkTypesResult;
         }
 
         if (processResult.Value.WorkStatuses.Count != 0)
         {
-            var syncWorkStatusesResult = await _sender.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);
+            var syncWorkStatusesResult = await _dispatcher.Send(new SyncExternalWorkStatusesCommand(processResult.Value.WorkStatuses), cancellationToken);
             if (syncWorkStatusesResult.IsFailure)
                 return syncWorkStatusesResult;
         }
 
-        var workProcessSchemes = await _sender.Send(new GetWorkProcessSchemesQuery(workProcessInternalId), cancellationToken);
+        var workProcessSchemes = await _dispatcher.Send(new GetWorkProcessSchemesQuery(workProcessInternalId), cancellationToken);
         var workProcessSchemesByWorkTypeName = workProcessSchemes.ToDictionary(s => s.WorkType.Name);
 
         var workflowMappings = new List<CreateWorkProcessSchemeDto>(processResult.Value.WorkTypes.Count);
@@ -372,7 +371,7 @@ public sealed class AzureDevOpsWorkItemSource(
             workProcessSchemesByWorkTypeName.TryGetValue(workType.Name, out var scheme);
             if (scheme is null || scheme.Workflow is null)
             {
-                var createWorkflowResult = await _sender.Send(new CreateExternalWorkflowCommand(
+                var createWorkflowResult = await _dispatcher.Send(new CreateExternalWorkflowCommand(
                     $"{processResult.Value.Name} - {workType.Name}",
                     "Auto-generated workflow for Azure DevOps work process.",
                     workType), cancellationToken);
@@ -383,7 +382,7 @@ public sealed class AzureDevOpsWorkItemSource(
             }
             else
             {
-                var syncWorkflowResult = await _sender.Send(new UpdateExternalWorkflowCommand(scheme.Workflow.Id, scheme.Workflow.Name, scheme.Workflow.Description, workType), cancellationToken);
+                var syncWorkflowResult = await _dispatcher.Send(new UpdateExternalWorkflowCommand(scheme.Workflow.Id, scheme.Workflow.Name, scheme.Workflow.Description, workType), cancellationToken);
                 if (syncWorkflowResult.IsFailure)
                     return syncWorkflowResult;
 
@@ -391,7 +390,7 @@ public sealed class AzureDevOpsWorkItemSource(
             }
         }
 
-        var updateWorkProcessResult = await _sender.Send(new UpdateExternalWorkProcessCommand(processResult.Value, processResult.Value.WorkTypes, workflowMappings), cancellationToken);
+        var updateWorkProcessResult = await _dispatcher.Send(new UpdateExternalWorkProcessCommand(processResult.Value, processResult.Value.WorkTypes, workflowMappings), cancellationToken);
         return updateWorkProcessResult.IsSuccess ? Result.Success() : updateWorkProcessResult;
     }
 
@@ -427,7 +426,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
     private async Task<DateTime> GetWorkspaceMostRecentChangeDate(Guid workspaceId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new GetWorkspaceMostRecentChangeDateQuery(workspaceId), cancellationToken);
+        var result = await _dispatcher.Send(new GetWorkspaceMostRecentChangeDateQuery(workspaceId), cancellationToken);
         return result.IsSuccess && result.Value != null
             ? ((Instant)result.Value).ToDateTimeUtc()
             : _minSyncDate;

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/PeopleSyncRunner.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/PeopleSyncRunner.cs
@@ -1,6 +1,5 @@
 ﻿using System.Diagnostics;
 using System.Text.Json;
-using MediatR;
 using Wayd.AppIntegration.Application.Interfaces;
 using Wayd.AppIntegration.Domain.Interfaces;
 using Wayd.Common.Application.Employees.Commands;
@@ -22,7 +21,7 @@ namespace Wayd.AppIntegration.Application.Connections.Managers;
 /// </summary>
 public sealed class PeopleSyncRunner(
     ILogger<PeopleSyncRunner> logger,
-    ISender sender,
+    IDispatcher dispatcher,
     IAppIntegrationDbContext db,
     IDateTimeProvider clock,
     IEmployeeSourceFactory sourceFactory,
@@ -30,7 +29,7 @@ public sealed class PeopleSyncRunner(
     IUserService userService) : IPeopleSyncRunner
 {
     private readonly ILogger<PeopleSyncRunner> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IAppIntegrationDbContext _db = db;
     private readonly IDateTimeProvider _clock = clock;
     private readonly IEmployeeSourceFactory _sourceFactory = sourceFactory;
@@ -212,7 +211,7 @@ public sealed class PeopleSyncRunner(
             }
 
             stageTimer.Restart();
-            var upsertResult = await _sender.Send(
+            var upsertResult = await _dispatcher.Send(
                 new BulkUpsertEmployeesCommand(employees, matchBy: source.MatchBy, deactivateMissing: !incremental),
                 cancellationToken);
             upsertMs = stageTimer.ElapsedMilliseconds;

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkSyncRunner.cs
@@ -1,6 +1,4 @@
 ﻿using System.Text.Json;
-using MediatR;
-using Wayd.AppIntegration.Application.Connections.Dtos;
 using Wayd.AppIntegration.Application.Connections.Queries;
 using Wayd.AppIntegration.Application.Interfaces;
 using Wayd.Common.Application.Enums;
@@ -18,14 +16,14 @@ namespace Wayd.AppIntegration.Application.Connections.Managers;
 /// </summary>
 public sealed class WorkSyncRunner(
     ILogger<WorkSyncRunner> logger,
-    ISender sender,
+    IDispatcher dispatcher,
     IWorkItemSourceFactory sourceFactory,
     IAppIntegrationDbContext db,
     IDateTimeProvider clock,
     IEnumerable<ISyncableConnectionDescriptorBuilder> descriptorBuilders) : IWorkSyncRunner
 {
     private readonly ILogger<WorkSyncRunner> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IWorkItemSourceFactory _sourceFactory = sourceFactory;
     private readonly IAppIntegrationDbContext _db = db;
     private readonly IDateTimeProvider _clock = clock;
@@ -51,7 +49,7 @@ public sealed class WorkSyncRunner(
         {
             try
             {
-                var connections = await _sender.Send(
+                var connections = await _dispatcher.Send(
                     new GetConnectionsQuery(IncludeInactive: false, Capability: ConnectorCapability.WorkItems),
                     cancellationToken);
                 var active = connections
@@ -102,7 +100,7 @@ public sealed class WorkSyncRunner(
         var syncId = Guid.CreateVersion7();
         using (_logger.BeginScope(new Dictionary<string, object> { ["SyncId"] = syncId, ["ConnectionId"] = connectionId }))
         {
-            var connection = await _sender.Send(new GetConnectionQuery(connectionId), cancellationToken);
+            var connection = await _dispatcher.Send(new GetConnectionQuery(connectionId), cancellationToken);
             if (connection is null)
                 return Result.Failure($"Connection {connectionId} not found.");
 
@@ -194,7 +192,7 @@ public sealed class WorkSyncRunner(
                 }
             }
 
-            var dependenciesResult = await _sender.Send(new ProcessDependenciesCommand(descriptorResult.Value.SystemId!), cancellationToken);
+            var dependenciesResult = await _dispatcher.Send(new ProcessDependenciesCommand(descriptorResult.Value.SystemId!), cancellationToken);
             if (dependenciesResult.IsFailure)
             {
                 _logger.LogError("ProcessDependencies failed for connection {ConnectionId}: {Error}", connectionId, dependenciesResult.Error);

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkdayConnectionInitProbe.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/WorkdayConnectionInitProbe.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.AppIntegration.Application.Connections.Commands.Workday;
+﻿using Wayd.AppIntegration.Application.Connections.Commands.Workday;
 using Wayd.Common.Application.Interfaces.ExternalPeople;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 using Wayd.Integrations.Abstractions;
@@ -11,12 +10,12 @@ namespace Wayd.AppIntegration.Application.Connections.Managers;
 /// so the connections controller can dispatch probes by connector key instead of switching on
 /// connection types.
 /// </summary>
-public sealed class WorkdayConnectionInitProbe(ISender sender) : IConnectionInitProbe
+public sealed class WorkdayConnectionInitProbe(IDispatcher dispatcher) : IConnectionInitProbe
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     public Connector Connector => Connector.Workday;
 
     public Task<Result<ConnectionInitResult>> Run(Guid connectionId, CancellationToken cancellationToken) =>
-        _sender.Send(new InitWorkdayConnectionCommand(connectionId), cancellationToken);
+        _dispatcher.Send(new InitWorkdayConnectionCommand(connectionId), cancellationToken);
 }

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
@@ -1,5 +1,4 @@
 ﻿using FluentAssertions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
@@ -16,7 +15,7 @@ public class SyncAzureDevOpsConnectionConfigurationCommandHandlerTests
     private readonly FakeAppIntegrationDbContext _db = new();
     private readonly TestingDateTimeProvider _clock = new(new DateTime(2026, 5, 1, 12, 0, 0));
     private readonly Mock<IAzureDevOpsService> _azureDevOpsService = new();
-    private readonly Mock<ISender> _sender = new();
+    private readonly Mock<IDispatcher> _sender = new();
     private readonly SyncAzureDevOpsConnectionConfigurationCommandHandler _sut;
 
     public SyncAzureDevOpsConnectionConfigurationCommandHandlerTests()

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommandHandlerTests.cs
@@ -15,7 +15,7 @@ public class SyncAzureDevOpsConnectionConfigurationCommandHandlerTests
     private readonly FakeAppIntegrationDbContext _db = new();
     private readonly TestingDateTimeProvider _clock = new(new DateTime(2026, 5, 1, 12, 0, 0));
     private readonly Mock<IAzureDevOpsService> _azureDevOpsService = new();
-    private readonly Mock<IDispatcher> _sender = new();
+    private readonly Mock<IDispatcher> _dispatcher = new();
     private readonly SyncAzureDevOpsConnectionConfigurationCommandHandler _sut;
 
     public SyncAzureDevOpsConnectionConfigurationCommandHandlerTests()
@@ -25,7 +25,7 @@ public class SyncAzureDevOpsConnectionConfigurationCommandHandlerTests
             _clock,
             Mock.Of<ILogger<SyncAzureDevOpsConnectionConfigurationCommandHandler>>(),
             _azureDevOpsService.Object,
-            _sender.Object);
+            _dispatcher.Object);
     }
 
     private AzureDevOpsBoardsConnection CreateConnectionWithProcess(Guid externalId, Guid internalId, bool integrationIsActive = true)

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsInitManagerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsInitManagerTests.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
 using FluentAssertions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Wayd.AppIntegration.Application.Connections.Commands;
 using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
@@ -67,7 +66,7 @@ public class AzureDevOpsInitManagerTests
 
     private void SetupConnectionQuery(Guid connectionId, AzureDevOpsConnectionDetailsDto? details)
     {
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.Is<GetAzureDevOpsConnectionQuery>(q => q.ConnectionId == connectionId), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
     }
@@ -207,7 +206,7 @@ public class AzureDevOpsInitManagerTests
             .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace> { mockWorkspace.Object }));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
 
@@ -242,11 +241,11 @@ public class AzureDevOpsInitManagerTests
             .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncAzureDevOpsConnectionConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -255,7 +254,7 @@ public class AzureDevOpsInitManagerTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Verify(s => s.Send(It.IsAny<SyncAzureDevOpsConnectionConfigurationCommand>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
@@ -279,11 +278,11 @@ public class AzureDevOpsInitManagerTests
             .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncAzureDevOpsConnectionConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -410,19 +409,19 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         // ExternalWorkProcessExistsQuery - returns true (another connection has it)
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ExternalWorkProcessExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
         // GetIntegrationRegistrationsForWorkProcessesQuery - returns the existing registration
         var existingIntegrationState = IntegrationState<Guid>.Create(wpInternalId, true);
         var existingRegistration = new IntegrationRegistration<Guid, Guid>(wpExternalId, existingIntegrationState);
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.Is<GetIntegrationRegistrationsForWorkProcessesQuery>(q => q.ExternalId == wpExternalId), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>> { existingRegistration });
 
         // UpdateAzureDevOpsWorkProcessIntegrationStateCommand - links this connection
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<UpdateAzureDevOpsWorkProcessIntegrationStateCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -434,7 +433,7 @@ public class AzureDevOpsInitManagerTests
         result.Value.Should().Be(wpInternalId);
 
         // Should NOT create a new work process
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Verify(s => s.Send(It.IsAny<CreateExternalWorkProcessCommand>(), It.IsAny<CancellationToken>()), Times.Never);
 
         // Should NOT call Azure DevOps to get the process details (no need to sync types/statuses/workflows)
@@ -442,7 +441,7 @@ public class AzureDevOpsInitManagerTests
             .Verify(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
 
         // Should link this connection to the existing work process
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Verify(s => s.Send(It.Is<UpdateAzureDevOpsWorkProcessIntegrationStateCommand>(c =>
                 c.ConnectionId == connectionId), It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -460,7 +459,7 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         // ExternalWorkProcessExistsQuery
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ExternalWorkProcessExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
@@ -474,10 +473,10 @@ public class AzureDevOpsInitManagerTests
         _mocker.GetMock<IAzureDevOpsService>()
             .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncAzureDevOpsConnectionConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -492,12 +491,12 @@ public class AzureDevOpsInitManagerTests
 
         // CreateExternalWorkProcessCommand
         var integrationState = IntegrationState<Guid>.Create(wpInternalId, true);
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<CreateExternalWorkProcessCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(integrationState));
 
         // UpdateAzureDevOpsWorkProcessIntegrationStateCommand
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<UpdateAzureDevOpsWorkProcessIntegrationStateCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -561,7 +560,7 @@ public class AzureDevOpsInitManagerTests
             workspaces: [new AzureDevOpsWorkspaceDto { ExternalId = wsExternalId, Name = "TestProject", WorkProcessId = Guid.CreateVersion7() }]);
         SetupConnectionQuery(connectionId, details);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ExternalWorkspaceExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
@@ -583,11 +582,11 @@ public class AzureDevOpsInitManagerTests
             workspaces: [new AzureDevOpsWorkspaceDto { ExternalId = wsExternalId, Name = "TestProject", WorkProcessId = Guid.CreateVersion7() }]);
         SetupConnectionQuery(connectionId, details);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ExternalWorkspaceExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<WorkspaceKeyExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
@@ -609,10 +608,10 @@ public class AzureDevOpsInitManagerTests
             workspaces: [new AzureDevOpsWorkspaceDto { ExternalId = wsExternalId, Name = "TestProject", WorkProcessId = Guid.CreateVersion7() }]);
         SetupConnectionQuery(connectionId, details);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ExternalWorkspaceExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<WorkspaceKeyExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
@@ -626,10 +625,10 @@ public class AzureDevOpsInitManagerTests
         _mocker.GetMock<IAzureDevOpsService>()
             .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncAzureDevOpsConnectionConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -652,10 +651,10 @@ public class AzureDevOpsInitManagerTests
             workspaces: [new AzureDevOpsWorkspaceDto { ExternalId = wsExternalId, Name = "TestProject", WorkProcessId = Guid.CreateVersion7() }]);
         SetupConnectionQuery(connectionId, details);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ExternalWorkspaceExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<WorkspaceKeyExistsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(false);
 
@@ -669,10 +668,10 @@ public class AzureDevOpsInitManagerTests
         _mocker.GetMock<IAzureDevOpsService>()
             .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncAzureDevOpsConnectionConfigurationCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -684,12 +683,12 @@ public class AzureDevOpsInitManagerTests
 
         // CreateExternalWorkspaceCommand
         var integrationState = IntegrationState<Guid>.Create(wsInternalId, true);
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<CreateExternalWorkspaceCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(integrationState));
 
         // UpdateAzureDevOpsWorkspaceIntegrationStateCommand
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<UpdateAzureDevOpsWorkspaceIntegrationStateCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
 using FluentAssertions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.AutoMock;
@@ -117,11 +116,11 @@ public class AzureDevOpsWorkItemSourceTests
             .Setup(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(workProcessConfig.Object));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetWorkProcessSchemesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<IWorkProcessSchemeDto>().AsReadOnly() as IReadOnlyList<IWorkProcessSchemeDto>);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<UpdateExternalWorkProcessCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 
@@ -130,18 +129,18 @@ public class AzureDevOpsWorkItemSourceTests
             .Setup(s => s.GetWorkspace(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new Mock<IExternalWorkspaceConfiguration>().Object));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<UpdateExternalWorkspaceCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
     }
 
     private void StubWorkItemSubSteps()
     {
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetWorkspaceWorkTypesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IWorkTypeDto>().AsReadOnly() as IReadOnlyList<IWorkTypeDto>));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetWorkspaceMostRecentChangeDateQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success<Instant?>(null));
 
@@ -226,7 +225,7 @@ public class AzureDevOpsWorkItemSourceTests
             processes: [Process(externalId: processId)],
             workspaces: [Workspace(processId, externalId: workspaceId, name: "ProjectA")]);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.Is<GetAzureDevOpsConnectionQuery>(q => q.ConnectionId == descriptor.ConnectionId), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
@@ -254,7 +253,7 @@ public class AzureDevOpsWorkItemSourceTests
             processes: [Process(externalId: inactiveProcessId, isActive: false)],
             workspaces: [Workspace(inactiveProcessId)]);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
@@ -276,7 +275,7 @@ public class AzureDevOpsWorkItemSourceTests
             processes: [Process(externalId: processId)],
             workspaces: [Workspace(processId, isActive: false)]);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
@@ -311,7 +310,7 @@ public class AzureDevOpsWorkItemSourceTests
                 InternalTeamId = internalTeamId
             }]);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
@@ -330,7 +329,7 @@ public class AzureDevOpsWorkItemSourceTests
         var descriptor = BuildDescriptor();
         _sut.Bind(descriptor);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((AzureDevOpsConnectionDetailsDto?)null);
 
@@ -356,7 +355,7 @@ public class AzureDevOpsWorkItemSourceTests
                 Workspace(processId, name: "ProjectB")
             ]);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
@@ -391,7 +390,7 @@ public class AzureDevOpsWorkItemSourceTests
             processes: [Process(externalId: processId)],
             workspaces: [Workspace(processId)]);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetAzureDevOpsConnectionQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
 
@@ -476,10 +475,10 @@ public class AzureDevOpsWorkItemSourceTests
         var descriptor = BuildDescriptor();
         _sut.Bind(descriptor);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetWorkspaceWorkTypesQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IWorkTypeDto>().AsReadOnly() as IReadOnlyList<IWorkTypeDto>));
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetWorkspaceMostRecentChangeDateQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success<Instant?>(null));
 
@@ -506,19 +505,19 @@ public class AzureDevOpsWorkItemSourceTests
             .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new[] { 1, 2, 3, 4 }));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIterationMappingsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new Dictionary<string, Guid>());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncExternalWorkItemsCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncExternalWorkItemParentChangesCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<SyncExternalWorkItemDependencyChangesCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<DeleteExternalWorkItemsCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
 

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/PeopleSyncRunnerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/PeopleSyncRunnerTests.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
 using FluentAssertions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.AutoMock;
@@ -65,7 +64,7 @@ public class PeopleSyncRunnerTests
         };
         _mocker.Use<IEnumerable<ISyncableConnectionDescriptorBuilder>>(descriptorBuilders);
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<BulkUpsertEmployeesCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
         _mocker.GetMock<IUserService>()
@@ -170,7 +169,7 @@ public class PeopleSyncRunnerTests
 
         // Assert
         result.IsSuccess.Should().BeTrue();
-        _mocker.GetMock<ISender>().Verify(s => s.Send(
+        _mocker.GetMock<IDispatcher>().Verify(s => s.Send(
             It.Is<BulkUpsertEmployeesCommand>(c =>
                 c.MatchBy == EmployeeMatchProperty.EmployeeNumber && c.DeactivateMissing),
             It.IsAny<CancellationToken>()), Times.Once);
@@ -193,7 +192,7 @@ public class PeopleSyncRunnerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _source.Verify(s => s.GetEmployees(priorRun.FinishedAt, It.IsAny<CancellationToken>()), Times.Once);
-        _mocker.GetMock<ISender>().Verify(s => s.Send(
+        _mocker.GetMock<IDispatcher>().Verify(s => s.Send(
             It.Is<BulkUpsertEmployeesCommand>(c => !c.DeactivateMissing),
             It.IsAny<CancellationToken>()), Times.Once);
 
@@ -217,7 +216,7 @@ public class PeopleSyncRunnerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _source.Verify(s => s.GetEmployees(It.Is<Instant?>(i => i == null), It.IsAny<CancellationToken>()), Times.Once);
-        _mocker.GetMock<ISender>().Verify(s => s.Send(
+        _mocker.GetMock<IDispatcher>().Verify(s => s.Send(
             It.Is<BulkUpsertEmployeesCommand>(c => c.DeactivateMissing),
             It.IsAny<CancellationToken>()), Times.Once);
 

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/WorkSyncRunnerTests.cs
@@ -1,6 +1,5 @@
 ﻿using CSharpFunctionalExtensions;
 using FluentAssertions;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.AutoMock;
@@ -114,7 +113,7 @@ public class WorkSyncRunnerTests
             CanSync = e.CanSync
         }).ToList().AsReadOnly() as IReadOnlyList<ConnectionListDto>;
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetConnectionsQuery>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(dtos);
     }
@@ -141,7 +140,7 @@ public class WorkSyncRunnerTests
         _source.Setup(s => s.SyncWorkItems(It.IsAny<WorkspaceSyncTarget>(), It.IsAny<SyncType>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new WorkspaceItemsSyncResult(workItemsPerWorkspace, 0, 0, 0)));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ProcessDependenciesCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success());
     }
@@ -214,7 +213,7 @@ public class WorkSyncRunnerTests
             .Callback(() => sequence.Add(nameof(IWorkItemSource.SyncWorkItems)))
             .ReturnsAsync(Result.Success(WorkspaceItemsSyncResult.Zero));
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ProcessDependenciesCommand>(), It.IsAny<CancellationToken>()))
             .Callback(() => sequence.Add(nameof(ProcessDependenciesCommand)))
             .ReturnsAsync(Result.Success());
@@ -357,7 +356,7 @@ public class WorkSyncRunnerTests
         var connection = SeedActiveAzdoConnection();
         SetupConnectionsQuery(connection);
         StubHappyPathSource();
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<ProcessDependenciesCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure("Dependencies failed"));
 
@@ -447,7 +446,7 @@ public class WorkSyncRunnerTests
         // Critical invariant: the runner must only see WorkSync connectors. If this assertion
         // is changed to allow unfiltered queries, future People/AI-sync connectors will be
         // pulled into the work-sync pipeline.
-        _mocker.GetMock<ISender>().Verify(s => s.Send(
+        _mocker.GetMock<IDispatcher>().Verify(s => s.Send(
             It.Is<GetConnectionsQuery>(q =>
                 q.IncludeInactive == false
                 && q.Capability == ConnectorCapability.WorkItems),
@@ -499,7 +498,7 @@ public class WorkSyncRunnerTests
             },
         };
 
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.Is<GetConnectionQuery>(q => q.Id == connectionId), It.IsAny<CancellationToken>()))
             .ReturnsAsync(details);
     }
@@ -528,7 +527,7 @@ public class WorkSyncRunnerTests
         run.WorkItemsProcessed.Should().Be(4);
 
         // Org-wide query must not be used by the per-connection overload.
-        _mocker.GetMock<ISender>()
+        _mocker.GetMock<IDispatcher>()
             .Verify(s => s.Send(It.IsAny<GetConnectionsQuery>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/CreatePlanningIntervalObjectiveCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/CreatePlanningIntervalObjectiveCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.Common.Application.Models;
+﻿using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.Goals.Commands;
 using Wayd.Common.Domain.Enums.Goals;
 
@@ -55,12 +54,12 @@ public sealed class CreatePlanningIntervalObjectiveCommandValidator : CustomVali
     }
 }
 
-internal sealed class CreatePlanningIntervalObjectiveCommandHandler(IPlanningDbContext planningDbContext, ISender sender, ILogger<CreatePlanningIntervalObjectiveCommandHandler> logger) : ICommandHandler<CreatePlanningIntervalObjectiveCommand, ObjectIdAndKey>
+internal sealed class CreatePlanningIntervalObjectiveCommandHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher, ILogger<CreatePlanningIntervalObjectiveCommandHandler> logger) : ICommandHandler<CreatePlanningIntervalObjectiveCommand, ObjectIdAndKey>
 {
     private const string AppRequestName = nameof(CreatePlanningIntervalCommand);
 
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ILogger<CreatePlanningIntervalObjectiveCommandHandler> _logger = logger;
 
     public async Task<Result<ObjectIdAndKey>> Handle(CreatePlanningIntervalObjectiveCommand request, CancellationToken cancellationToken)
@@ -90,7 +89,7 @@ internal sealed class CreatePlanningIntervalObjectiveCommandHandler(IPlanningDbC
                 return Result.Failure<ObjectIdAndKey>("Team not found.");
             }
 
-            var objectiveResult = await _sender.Send(new CreateObjectiveCommand(
+            var objectiveResult = await _dispatcher.Send(new CreateObjectiveCommand(
                 request.Name,
                 request.Description,
                 ObjectiveType.PlanningInterval,
@@ -108,7 +107,7 @@ internal sealed class CreatePlanningIntervalObjectiveCommandHandler(IPlanningDbC
             var result = planningInterval.CreateObjective(team, objectiveResult.Value, request.IsStretch);
             if (result.IsFailure)
             {
-                var deleteResult = await _sender.Send(new DeleteObjectiveCommand(objectiveResult.Value), cancellationToken);
+                var deleteResult = await _dispatcher.Send(new DeleteObjectiveCommand(objectiveResult.Value), cancellationToken);
                 if (deleteResult.IsFailure)
                     _logger.LogError("Unable to delete objective.  Error: {Error}", deleteResult.Error);
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/DeletePlanningIntervalObjectiveCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/DeletePlanningIntervalObjectiveCommand.cs
@@ -1,15 +1,14 @@
-﻿using MediatR;
-using Wayd.Common.Application.Requests.Goals.Commands;
+﻿using Wayd.Common.Application.Requests.Goals.Commands;
 using Wayd.Common.Application.Requests.Goals.Queries;
 
 namespace Wayd.Planning.Application.PlanningIntervals.Commands;
 
 public sealed record DeletePlanningIntervalObjectiveCommand(Guid PlanningIntervalId, Guid PlanningIntervalObjectiveId) : ICommand;
 
-internal sealed class DeletePlanningIntervalObjectiveCommandHandler(IPlanningDbContext planningDbContext, ISender sender, ILogger<DeletePlanningIntervalObjectiveCommandHandler> logger) : ICommandHandler<DeletePlanningIntervalObjectiveCommand>
+internal sealed class DeletePlanningIntervalObjectiveCommandHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher, ILogger<DeletePlanningIntervalObjectiveCommandHandler> logger) : ICommandHandler<DeletePlanningIntervalObjectiveCommand>
 {
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ILogger<DeletePlanningIntervalObjectiveCommandHandler> _logger = logger;
 
     public async Task<Result> Handle(DeletePlanningIntervalObjectiveCommand request, CancellationToken cancellationToken)
@@ -32,7 +31,7 @@ internal sealed class DeletePlanningIntervalObjectiveCommandHandler(IPlanningDbC
                 return Result.Failure($"Planning Interval Objective {request.PlanningIntervalObjectiveId} not found.");
             }
 
-            var currentObjective = await _sender.Send(new GetObjectiveForPlanningIntervalQuery(piObjective.ObjectiveId, planningInterval.Id), cancellationToken);
+            var currentObjective = await _dispatcher.Send(new GetObjectiveForPlanningIntervalQuery(piObjective.ObjectiveId, planningInterval.Id), cancellationToken);
             if (currentObjective is null)
                 return Result.Failure<int>($"Objective {request.PlanningIntervalObjectiveId} not found.");
 
@@ -48,7 +47,7 @@ internal sealed class DeletePlanningIntervalObjectiveCommandHandler(IPlanningDbC
             await _planningDbContext.SaveChangesAsync(cancellationToken);
 
             // TODO: this the correct order?  pi objective first, then objective?
-            var deleteObjectiveResult = await _sender.Send(new DeleteObjectiveCommand(currentObjective.Id), cancellationToken);
+            var deleteObjectiveResult = await _dispatcher.Send(new DeleteObjectiveCommand(currentObjective.Id), cancellationToken);
             if (deleteObjectiveResult.IsFailure)
             {
                 _logger.LogError("Unable to delete objective {ObjectiveId}.  Error: {Error}", currentObjective.Id, deleteObjectiveResult.Error);

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/ImportPlanningIntervalObjectivesCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/ImportPlanningIntervalObjectivesCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.Common.Application.Requests.Goals.Commands;
+﻿using Wayd.Common.Application.Requests.Goals.Commands;
 using Wayd.Common.Domain.Enums.Goals;
 using Wayd.Planning.Application.PlanningIntervals.Dtos;
 using Wayd.Planning.Application.PlanningIntervals.Extensions;
@@ -32,10 +31,10 @@ public sealed class ImportPlanningIntervalObjectivesCommandValidator : CustomVal
     }
 }
 
-internal sealed class ImportPlanningIntervalObjectivesCommandHandler(IPlanningDbContext planningDbContext, ISender sender, ILogger<ImportPlanningIntervalObjectivesCommandHandler> logger) : ICommandHandler<ImportPlanningIntervalObjectivesCommand>
+internal sealed class ImportPlanningIntervalObjectivesCommandHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher, ILogger<ImportPlanningIntervalObjectivesCommandHandler> logger) : ICommandHandler<ImportPlanningIntervalObjectivesCommand>
 {
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ILogger<ImportPlanningIntervalObjectivesCommandHandler> _logger = logger;
 
     public async Task<Result> Handle(ImportPlanningIntervalObjectivesCommand request, CancellationToken cancellationToken)
@@ -66,7 +65,7 @@ internal sealed class ImportPlanningIntervalObjectivesCommandHandler(IPlanningDb
 
                 var mappedStatus = importedObjective.Status.ToGoalObjectiveStatus();
 
-                var objectiveResult = await _sender.Send(new ImportObjectiveCommand(
+                var objectiveResult = await _dispatcher.Send(new ImportObjectiveCommand(
                     importedObjective.Name,
                     importedObjective.Description,
                     ObjectiveType.PlanningInterval,
@@ -84,7 +83,7 @@ internal sealed class ImportPlanningIntervalObjectivesCommandHandler(IPlanningDb
                 var result = planningInterval.CreateObjective(team, objectiveResult.Value, importedObjective.IsStretch);
                 if (result.IsFailure)
                 {
-                    var deleteResult = await _sender.Send(new DeleteObjectiveCommand(objectiveResult.Value), cancellationToken);
+                    var deleteResult = await _dispatcher.Send(new DeleteObjectiveCommand(objectiveResult.Value), cancellationToken);
                     if (deleteResult.IsFailure)
                         _logger.LogError("Unable to delete objective. (Import Id: {ImportId}).  Error: {Error}", importedObjective.ImportId, deleteResult.Error);
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/UpdatePlanningIntervalObjectiveCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/UpdatePlanningIntervalObjectiveCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.Common.Application.Requests.Goals.Commands;
+﻿using Wayd.Common.Application.Requests.Goals.Commands;
 using Wayd.Common.Application.Requests.Goals.Queries;
 using Wayd.Planning.Application.PlanningIntervals.Extensions;
 using Wayd.Planning.Domain.Enums;
@@ -66,13 +65,13 @@ public sealed class UpdatePlanningIntervalObjectiveCommandValidator : CustomVali
 internal sealed class UpdatePlanningIntervalObjectiveCommandHandler : ICommandHandler<UpdatePlanningIntervalObjectiveCommand, int>
 {
     private readonly IPlanningDbContext _planningDbContext;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
     private readonly ILogger<UpdatePlanningIntervalObjectiveCommandHandler> _logger;
 
-    public UpdatePlanningIntervalObjectiveCommandHandler(IPlanningDbContext planningDbContext, ISender sender, ILogger<UpdatePlanningIntervalObjectiveCommandHandler> logger)
+    public UpdatePlanningIntervalObjectiveCommandHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher, ILogger<UpdatePlanningIntervalObjectiveCommandHandler> logger)
     {
         _planningDbContext = planningDbContext;
-        _sender = sender;
+        _dispatcher = dispatcher;
         _logger = logger;
     }
 
@@ -102,7 +101,7 @@ internal sealed class UpdatePlanningIntervalObjectiveCommandHandler : ICommandHa
             var objectiveName = request.Name;
             if (planningInterval.ObjectivesLocked)
             {
-                var currentObjective = await _sender.Send(new GetObjectiveForPlanningIntervalQuery(updatePiObjectiveResult.Value.ObjectiveId, planningInterval.Id), cancellationToken);
+                var currentObjective = await _dispatcher.Send(new GetObjectiveForPlanningIntervalQuery(updatePiObjectiveResult.Value.ObjectiveId, planningInterval.Id), cancellationToken);
                 if (currentObjective is null)
                     return Result.Failure<int>($"Objective {request.PlanningIntervalObjectiveId} not found.");
 
@@ -111,7 +110,7 @@ internal sealed class UpdatePlanningIntervalObjectiveCommandHandler : ICommandHa
 
             var mappedStatus = request.Status.ToGoalObjectiveStatus();
 
-            var objectiveResult = await _sender.Send(new UpdateObjectiveCommand(
+            var objectiveResult = await _dispatcher.Send(new UpdateObjectiveCommand(
                 updatePiObjectiveResult.Value.ObjectiveId,
                 objectiveName,
                 request.Description,

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/UpdatePlanningIntervalObjectivesOrderCommand.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Commands/UpdatePlanningIntervalObjectivesOrderCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.Common.Application.Requests.Goals.Commands;
+﻿using Wayd.Common.Application.Requests.Goals.Commands;
 
 namespace Wayd.Planning.Application.PlanningIntervals.Commands;
 
@@ -21,12 +20,12 @@ public sealed class UpdatePlanningIntervalObjectivesOrderCommandValidator : Cust
     }
 }
 
-internal sealed class UpdatePlanningIntervalObjectivesOrderCommandHandler(IPlanningDbContext planningDbContext, ISender sender, ILogger<UpdatePlanningIntervalObjectivesOrderCommandHandler> logger) : ICommandHandler<UpdatePlanningIntervalObjectivesOrderCommand>
+internal sealed class UpdatePlanningIntervalObjectivesOrderCommandHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher, ILogger<UpdatePlanningIntervalObjectivesOrderCommandHandler> logger) : ICommandHandler<UpdatePlanningIntervalObjectivesOrderCommand>
 {
     private const string AppRequestName = nameof(UpdatePlanningIntervalObjectivesOrderCommand);
 
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ILogger<UpdatePlanningIntervalObjectivesOrderCommandHandler> _logger = logger;
 
     public async Task<Result> Handle(UpdatePlanningIntervalObjectivesOrderCommand request, CancellationToken cancellationToken)
@@ -60,7 +59,7 @@ internal sealed class UpdatePlanningIntervalObjectivesOrderCommandHandler(IPlann
                 updatedGoalObjectives.Add(piObjective.ObjectiveId, request.Objectives[piObjective.Id]);
             }
 
-            var objectivResult = await _sender.Send(new UpdateObjectivesOrderCommand(updatedGoalObjectives), cancellationToken);
+            var objectivResult = await _dispatcher.Send(new UpdateObjectivesOrderCommand(updatedGoalObjectives), cancellationToken);
 
             return objectivResult.IsSuccess
                 ? Result.Success()

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetPlanningIntervalObjectiveQuery.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetPlanningIntervalObjectiveQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using MediatR;
 using Wayd.Common.Application.Dtos;
 using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.Goals.Queries;
@@ -22,11 +21,11 @@ public sealed record GetPlanningIntervalObjectiveQuery : IQuery<PlanningInterval
     public IdOrKey ObjectiveIdOrKey { get; }
 }
 
-internal sealed class GetPlanningIntervalObjectiveQueryHandler(IPlanningDbContext planningDbContext, ILogger<GetPlanningIntervalObjectiveQueryHandler> logger, ISender sender, IDateTimeProvider dateTimeProvider) : IQueryHandler<GetPlanningIntervalObjectiveQuery, PlanningIntervalObjectiveDetailsDto?>
+internal sealed class GetPlanningIntervalObjectiveQueryHandler(IPlanningDbContext planningDbContext, ILogger<GetPlanningIntervalObjectiveQueryHandler> logger, IDispatcher dispatcher, IDateTimeProvider dateTimeProvider) : IQueryHandler<GetPlanningIntervalObjectiveQuery, PlanningIntervalObjectiveDetailsDto?>
 {
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
     private readonly ILogger<GetPlanningIntervalObjectiveQueryHandler> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
 
     public async Task<PlanningIntervalObjectiveDetailsDto?> Handle(GetPlanningIntervalObjectiveQuery request, CancellationToken cancellationToken)
@@ -53,7 +52,7 @@ internal sealed class GetPlanningIntervalObjectiveQueryHandler(IPlanningDbContex
             return null;
 
         // call the objective query handler
-        var objective = await _sender.Send(new GetObjectiveForPlanningIntervalQuery(planningInterval.Objectives.First().ObjectiveId, planningInterval.Id), cancellationToken);
+        var objective = await _dispatcher.Send(new GetObjectiveForPlanningIntervalQuery(planningInterval.Objectives.First().ObjectiveId, planningInterval.Id), cancellationToken);
         if (objective is null)
             return null;
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetPlanningIntervalObjectivesQuery.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/PlanningIntervals/Queries/GetPlanningIntervalObjectivesQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using MediatR;
 using Wayd.Common.Application.Dtos;
 using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.Goals.Queries;
@@ -19,11 +18,11 @@ public sealed record GetPlanningIntervalObjectivesQuery : IQuery<IReadOnlyList<P
     public Guid? TeamId { get; set; }
 }
 
-internal sealed class GetPlanningIntervalObjectivesQueryHandler(IPlanningDbContext planningDbContext, ILogger<GetPlanningIntervalObjectivesQueryHandler> logger, ISender sender, IDateTimeProvider dateTimeProvider) : IQueryHandler<GetPlanningIntervalObjectivesQuery, IReadOnlyList<PlanningIntervalObjectiveListDto>>
+internal sealed class GetPlanningIntervalObjectivesQueryHandler(IPlanningDbContext planningDbContext, ILogger<GetPlanningIntervalObjectivesQueryHandler> logger, IDispatcher dispatcher, IDateTimeProvider dateTimeProvider) : IQueryHandler<GetPlanningIntervalObjectivesQuery, IReadOnlyList<PlanningIntervalObjectiveListDto>>
 {
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
     private readonly ILogger<GetPlanningIntervalObjectivesQueryHandler> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
 
     public async Task<IReadOnlyList<PlanningIntervalObjectiveListDto>> Handle(GetPlanningIntervalObjectivesQuery request, CancellationToken cancellationToken)
@@ -66,7 +65,7 @@ internal sealed class GetPlanningIntervalObjectivesQueryHandler(IPlanningDbConte
 
         // call the objective query handler
         var teamIds = request.TeamId.HasValue ? new Guid[] { request.TeamId.Value } : null;
-        var objectives = await _sender.Send(new GetObjectivesForPlanningIntervalsQuery([planningInterval.Id], teamIds), cancellationToken);
+        var objectives = await _dispatcher.Send(new GetObjectivesForPlanningIntervalsQuery([planningInterval.Id], teamIds), cancellationToken);
         if (!objectives.Any() || planningInterval.Objectives.Count != objectives.Count)
             ThrowAndLogException(request, $"Error mapping objectives for planning interval {planningInterval.Id}.");
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Risks/Queries/GetRisksByPlanningIntervalQuery.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Risks/Queries/GetRisksByPlanningIntervalQuery.cs
@@ -1,5 +1,4 @@
 ﻿using System.Linq.Expressions;
-using MediatR;
 using Wayd.Common.Application.Models;
 using Wayd.Common.Extensions;
 using Wayd.Planning.Application.PlanningIntervals.Queries;
@@ -24,14 +23,14 @@ public sealed record GetRisksByPlanningIntervalQuery : IQuery<IReadOnlyList<Risk
     public Guid? TeamId { get; }
 }
 
-internal sealed class GetRisksByPlanningIntervalQueryHandler(IPlanningDbContext planningDbContext, ISender sender) : IQueryHandler<GetRisksByPlanningIntervalQuery, IReadOnlyList<RiskListDto>>
+internal sealed class GetRisksByPlanningIntervalQueryHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher) : IQueryHandler<GetRisksByPlanningIntervalQuery, IReadOnlyList<RiskListDto>>
 {
     private readonly IPlanningDbContext _planningDbContext = planningDbContext;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     public async Task<IReadOnlyList<RiskListDto>> Handle(GetRisksByPlanningIntervalQuery request, CancellationToken cancellationToken)
     {
-        var teamIds = await _sender.Send(new GetPlanningIntervalTeamsQuery(request.IdOrKey), cancellationToken);
+        var teamIds = await _dispatcher.Send(new GetPlanningIntervalTeamsQuery(request.IdOrKey), cancellationToken);
         if (!teamIds.Any())
             return [];
 

--- a/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Search/SearchPlanningForGlobalSearchQueryHandler.cs
+++ b/Wayd.Services/Wayd.Planning/src/Wayd.Planning.Application/Search/SearchPlanningForGlobalSearchQueryHandler.cs
@@ -1,5 +1,4 @@
 ﻿using Ardalis.GuardClauses;
-using MediatR;
 using Wayd.Common.Application.Requests.Goals.Queries;
 using Wayd.Common.Application.Search;
 using Wayd.Common.Application.Search.Dtos;
@@ -10,7 +9,7 @@ using Wayd.Planning.Domain.Models.Roadmaps;
 
 namespace Wayd.Planning.Application.Search;
 
-internal sealed class SearchPlanningForGlobalSearchQueryHandler(IPlanningDbContext planningDbContext, ISender sender, IDateTimeProvider dateTimeProvider, ICurrentUser currentUser)
+internal sealed class SearchPlanningForGlobalSearchQueryHandler(IPlanningDbContext planningDbContext, IDispatcher dispatcher, IDateTimeProvider dateTimeProvider, ICurrentUser currentUser)
     : IQueryHandler<SearchPlanningForGlobalSearchQuery, ServiceSearchResponse>
 {
     public async Task<ServiceSearchResponse> Handle(SearchPlanningForGlobalSearchQuery request, CancellationToken cancellationToken)
@@ -167,7 +166,7 @@ internal sealed class SearchPlanningForGlobalSearchQueryHandler(IPlanningDbConte
     private async Task<GlobalSearchCategoryDto> SearchObjectives(string term, int max, CancellationToken cancellationToken)
     {
         // Search objective names via Goals service
-        var matchingObjectives = await sender.Send(
+        var matchingObjectives = await dispatcher.Send(
             new SearchObjectivesByNameQuery(term, max), cancellationToken);
 
         if (matchingObjectives.Count == 0)

--- a/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkTypeLevels/Commands/UpdateWorkTypeLevelsOrderCommand.cs
+++ b/Wayd.Services/Wayd.Work/src/Wayd.Work.Application/WorkTypeLevels/Commands/UpdateWorkTypeLevelsOrderCommand.cs
@@ -1,5 +1,4 @@
-﻿using MediatR;
-using Wayd.Work.Application.Persistence;
+﻿using Wayd.Work.Application.Persistence;
 
 namespace Wayd.Work.Application.WorkTypeLevels.Commands;
 
@@ -10,13 +9,13 @@ internal sealed class UpdateWorkTypeLevelsOrderCommandHandler : ICommandHandler<
     private const string AppRequestName = nameof(UpdateWorkTypeLevelsOrderCommand);
 
     private readonly IWorkDbContext _workDbContext;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
     private readonly ILogger<UpdateWorkTypeLevelsOrderCommandHandler> _logger;
 
-    public UpdateWorkTypeLevelsOrderCommandHandler(IWorkDbContext planningDbContext, ISender sender, ILogger<UpdateWorkTypeLevelsOrderCommandHandler> logger)
+    public UpdateWorkTypeLevelsOrderCommandHandler(IWorkDbContext planningDbContext, IDispatcher dispatcher, ILogger<UpdateWorkTypeLevelsOrderCommandHandler> logger)
     {
         _workDbContext = planningDbContext;
-        _sender = sender;
+        _dispatcher = dispatcher;
         _logger = logger;
     }
 

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/BackgroundJobsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/BackgroundJobsController.cs
@@ -11,11 +11,11 @@ namespace Wayd.Web.Api.Controllers.Admin;
 [Route("api/admin/background-jobs")]
 [ApiVersionNeutral]
 [ApiController]
-public class BackgroundJobsController(ILogger<BackgroundJobsController> logger, IJobService jobService, ISender sender) : ControllerBase
+public class BackgroundJobsController(ILogger<BackgroundJobsController> logger, IJobService jobService, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<BackgroundJobsController> _logger = logger;
     private readonly IJobService _jobService = jobService;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet("job-types")]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.BackgroundJobs)]
@@ -25,7 +25,7 @@ public class BackgroundJobsController(ILogger<BackgroundJobsController> logger, 
     public async Task<ActionResult<IReadOnlyList<BackgroundJobTypeDto>>> GetJobTypes(CancellationToken cancellationToken)
     {
         // TODO how do we determine what is active rather than returning all types
-        var types = await _sender.Send(new GetBackgroundJobTypesQuery(), cancellationToken);
+        var types = await _dispatcher.Send(new GetBackgroundJobTypesQuery(), cancellationToken);
         return Ok(types.OrderBy(c => c.Order));
     }
 

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/FeatureFlagsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/FeatureFlagsController.cs
@@ -9,9 +9,9 @@ namespace Wayd.Web.Api.Controllers.Admin;
 [Route("api/admin/feature-flags")]
 [ApiVersionNeutral]
 [ApiController]
-public class FeatureFlagsController(ISender sender) : ControllerBase
+public class FeatureFlagsController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.FeatureFlags)]
@@ -20,7 +20,7 @@ public class FeatureFlagsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<FeatureFlagListDto>>> FeatureFlags(CancellationToken cancellationToken, [FromQuery] bool includeArchived = false)
     {
-        var flags = await _sender.Send(new GetFeatureFlagsQuery(includeArchived), cancellationToken);
+        var flags = await _dispatcher.Send(new GetFeatureFlagsQuery(includeArchived), cancellationToken);
         return Ok(flags);
     }
 
@@ -31,7 +31,7 @@ public class FeatureFlagsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<FeatureFlagDto>> FeatureFlag(int id, CancellationToken cancellationToken)
     {
-        var flag = await _sender.Send(new GetFeatureFlagQuery(id), cancellationToken);
+        var flag = await _dispatcher.Send(new GetFeatureFlagQuery(id), cancellationToken);
         return flag is not null
             ? Ok(flag)
             : NotFound();
@@ -48,7 +48,7 @@ public class FeatureFlagsController(ISender sender) : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.Id), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateFeatureFlagCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateFeatureFlagCommand(), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -64,7 +64,7 @@ public class FeatureFlagsController(ISender sender) : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.Id), HttpContext));
 
-        var result = await _sender.Send(new ToggleFeatureFlagCommand(id, request.IsEnabled), cancellationToken);
+        var result = await _dispatcher.Send(new ToggleFeatureFlagCommand(id, request.IsEnabled), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -77,7 +77,7 @@ public class FeatureFlagsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Archive(int id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveFeatureFlagCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveFeatureFlagCommand(id), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/ScoringModelsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/ScoringModelsController.cs
@@ -10,10 +10,10 @@ namespace Wayd.Web.Api.Controllers.Admin;
 [Route("api/scoring-models")]
 [ApiVersionNeutral]
 [ApiController]
-public class ScoringModelsController(ILogger<ScoringModelsController> logger, ISender sender) : ControllerBase
+public class ScoringModelsController(ILogger<ScoringModelsController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ScoringModelsController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.ScoringModels)]
@@ -22,7 +22,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ScoringModelListDto>>> GetScoringModels([FromQuery] ScoringModelState? state, CancellationToken cancellationToken)
     {
-        var models = await _sender.Send(new GetScoringModelsQuery(state), cancellationToken);
+        var models = await _dispatcher.Send(new GetScoringModelsQuery(state), cancellationToken);
 
         return Ok(models);
     }
@@ -34,7 +34,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ScoringModelDetailsDto>> GetScoringModel(string idOrKey, CancellationToken cancellationToken)
     {
-        var model = await _sender.Send(new GetScoringModelQuery(idOrKey), cancellationToken);
+        var model = await _dispatcher.Send(new GetScoringModelQuery(idOrKey), cancellationToken);
 
         return model is not null
             ? Ok(model)
@@ -47,7 +47,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> Create([FromBody] CreateScoringModelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateScoringModelCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateScoringModelCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = result.Value }, result.Value)
@@ -62,7 +62,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Update(Guid id, [FromBody] UpdateScoringModelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateScoringModelCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateScoringModelCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -76,7 +76,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteScoringModelCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteScoringModelCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -91,7 +91,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateScoringModelCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateScoringModelCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -106,7 +106,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveScoringModelCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveScoringModelCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -121,7 +121,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult<ScoringModelEvaluationDto>> Evaluate(Guid id, [FromBody] EvaluateScoringModelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToQuery(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToQuery(id), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -136,7 +136,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> AddCriterion(Guid id, [FromBody] ScoringModelCriterionRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
@@ -151,7 +151,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdateCriterion(Guid id, Guid criterionId, [FromBody] ScoringModelCriterionRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateCommand(id, criterionId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateCommand(id, criterionId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -165,7 +165,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveCriterion(Guid id, Guid criterionId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveScoringModelCriterionCommand(id, criterionId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveScoringModelCriterionCommand(id, criterionId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -180,7 +180,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ReorderCriteria(Guid id, [FromBody] ReorderScoringModelCriteriaRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToReorderScoringModelCriteriaCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToReorderScoringModelCriteriaCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -197,7 +197,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> AddScale(Guid id, [FromBody] ScoringScaleRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
@@ -212,7 +212,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdateScale(Guid id, Guid scaleId, [FromBody] ScoringScaleRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateCommand(id, scaleId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateCommand(id, scaleId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -226,7 +226,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveScale(Guid id, Guid scaleId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveScoringScaleCommand(id, scaleId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveScoringScaleCommand(id, scaleId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -241,7 +241,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ReorderScales(Guid id, [FromBody] ReorderScoringScalesRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToReorderScoringScalesCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToReorderScoringScalesCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -258,7 +258,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> AddScaleLevel(Guid id, Guid scaleId, [FromBody] ScoringScaleLevelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToAddCommand(id, scaleId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddCommand(id, scaleId), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
@@ -273,7 +273,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdateScaleLevel(Guid id, Guid scaleId, Guid levelId, [FromBody] ScoringScaleLevelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateCommand(id, scaleId, levelId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateCommand(id, scaleId, levelId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -287,7 +287,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveScaleLevel(Guid id, Guid scaleId, Guid levelId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveScoringScaleLevelCommand(id, scaleId, levelId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveScoringScaleLevelCommand(id, scaleId, levelId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -302,7 +302,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ReorderScaleLevels(Guid id, Guid scaleId, [FromBody] ReorderScoringScaleLevelsRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToReorderScoringScaleLevelsCommand(id, scaleId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToReorderScoringScaleLevelsCommand(id, scaleId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -319,7 +319,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> AddOutput(Guid id, [FromBody] ScoringModelOutputRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScoringModel), new { idOrKey = id.ToString() }, result.Value)
@@ -334,7 +334,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdateOutput(Guid id, Guid outputId, [FromBody] ScoringModelOutputRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateCommand(id, outputId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateCommand(id, outputId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -348,7 +348,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveOutput(Guid id, Guid outputId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveScoringModelOutputCommand(id, outputId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveScoringModelOutputCommand(id, outputId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -363,7 +363,7 @@ public class ScoringModelsController(ILogger<ScoringModelsController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ReorderOutputs(Guid id, [FromBody] ReorderScoringModelOutputsRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToReorderScoringModelOutputsCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToReorderScoringModelOutputsCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/AzureDevOpsConnectionsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/AzureDevOpsConnectionsController.cs
@@ -13,9 +13,9 @@ namespace Wayd.Web.Api.Controllers.AppIntegrations;
 [Route("api/app-integrations/connections/azure-devops")]
 [ApiVersionNeutral]
 [ApiController]
-public class AzureDevOpsConnectionsController(ISender sender) : ControllerBase
+public class AzureDevOpsConnectionsController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpPost("{id}/sync-organization")]
     [MustHavePermission(ApplicationAction.Update, ApplicationResource.Connections)]
@@ -78,7 +78,7 @@ public class AzureDevOpsConnectionsController(ISender sender) : ControllerBase
     public async Task<ActionResult<IEnumerable<AzureDevOpsWorkspaceTeamDto>>> GetConnectionTeams(
         Guid id, Guid? workspaceId, CancellationToken cancellationToken)
     {
-        var teams = await _sender.Send(new GetAzureDevOpsConnectionTeamsQuery(id, workspaceId), cancellationToken);
+        var teams = await _dispatcher.Send(new GetAzureDevOpsConnectionTeamsQuery(id, workspaceId), cancellationToken);
         return Ok(teams);
     }
 
@@ -95,8 +95,8 @@ public class AzureDevOpsConnectionsController(ISender sender) : ControllerBase
         if (id != request.ConnectionId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.ConnectionId), HttpContext));
 
-        var teamIds = await _sender.Send(new GetValidBaseTeamIdsQuery(), cancellationToken);
-        var result = await _sender.Send(request.ToUpdateAzureDevOpsConnectionTeamMappingsCommand(teamIds), cancellationToken);
+        var teamIds = await _dispatcher.Send(new GetValidBaseTeamIdsQuery(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateAzureDevOpsConnectionTeamMappingsCommand(teamIds), cancellationToken);
 
         return result.IsSuccess ? NoContent() : BadRequest(result.ToBadRequestObject(HttpContext));
     }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/AzureOpenAIConnectionsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/AzureOpenAIConnectionsController.cs
@@ -6,9 +6,9 @@ namespace Wayd.Web.Api.Controllers.AppIntegrations;
 [Route("api/app-integrations/connections/azure-openai")]
 [ApiVersionNeutral]
 [ApiController]
-public class AzureOpenAIConnectionsController(ISender sender) : ControllerBase
+public class AzureOpenAIConnectionsController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpPost("test")]
     [MustHavePermission(ApplicationAction.Update, ApplicationResource.Connections)]

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/ConnectionsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/ConnectionsController.cs
@@ -23,9 +23,9 @@ namespace Wayd.Web.Api.Controllers.AppIntegrations;
 [Route("api/app-integrations/connections")]
 [ApiVersionNeutral]
 [ApiController]
-public class ConnectionsController(ISender sender) : ControllerBase
+public class ConnectionsController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Connections)]
@@ -35,7 +35,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
         CancellationToken cancellationToken,
         bool includeDisabled = false)
     {
-        var connections = await _sender.Send(new GetConnectionsQuery(includeDisabled), cancellationToken);
+        var connections = await _dispatcher.Send(new GetConnectionsQuery(includeDisabled), cancellationToken);
         return Ok(connections);
     }
 
@@ -45,7 +45,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<ConnectorListDto>>> GetConnectors(CancellationToken cancellationToken)
     {
-        var connectors = await _sender.Send(new GetConnectorsQuery(), cancellationToken);
+        var connectors = await _dispatcher.Send(new GetConnectorsQuery(), cancellationToken);
         return Ok(connectors.OrderBy(c => c.Name));
     }
 
@@ -56,7 +56,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ConnectionDetailsDto>> GetConnection(Guid id, CancellationToken cancellationToken)
     {
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
 
         if (connection is null)
             return NotFound();
@@ -93,13 +93,13 @@ public class ConnectionsController(ISender sender) : ControllerBase
         Result<Guid> result = request switch
         {
             CreateAzureDevOpsConnectionRequest azdo =>
-                await _sender.Send(azdo.ToCommand(), cancellationToken),
+                await _dispatcher.Send(azdo.ToCommand(), cancellationToken),
             CreateAzureOpenAIConnectionRequest aoai =>
-                await _sender.Send(aoai.ToCommand(), cancellationToken),
+                await _dispatcher.Send(aoai.ToCommand(), cancellationToken),
             CreateEntraConnectionRequest entra =>
-                await _sender.Send(entra.ToCommand(), cancellationToken),
+                await _dispatcher.Send(entra.ToCommand(), cancellationToken),
             CreateWorkdayConnectionRequest workday =>
-                await _sender.Send(workday.ToCommand(), cancellationToken),
+                await _dispatcher.Send(workday.ToCommand(), cancellationToken),
             _ => Result.Failure<Guid>($"Connector type not supported")
         };
 
@@ -124,13 +124,13 @@ public class ConnectionsController(ISender sender) : ControllerBase
         Result result = request switch
         {
             UpdateAzureDevOpsConnectionRequest azdo =>
-                await _sender.Send(azdo.ToCommand(), cancellationToken),
+                await _dispatcher.Send(azdo.ToCommand(), cancellationToken),
             UpdateAzureOpenAIConnectionRequest aoai =>
-                await _sender.Send(aoai.ToCommand(), cancellationToken),
+                await _dispatcher.Send(aoai.ToCommand(), cancellationToken),
             UpdateEntraConnectionRequest entra =>
-                await _sender.Send(entra.ToCommand(), cancellationToken),
+                await _dispatcher.Send(entra.ToCommand(), cancellationToken),
             UpdateWorkdayConnectionRequest workday =>
-                await _sender.Send(workday.ToCommand(), cancellationToken),
+                await _dispatcher.Send(workday.ToCommand(), cancellationToken),
             _ => Result.Failure($"Connector type not supported")
         };
 
@@ -148,11 +148,11 @@ public class ConnectionsController(ISender sender) : ControllerBase
     {
         // Pre-check existence so a missing connection surfaces as 404 rather than 400 — matches
         // the DeleteConnection pattern and the documented OpenAPI responses.
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
         if (connection is null)
             return NotFound();
 
-        var result = await _sender.Send(new ActivateConnectionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateConnectionCommand(id), cancellationToken);
         return result.IsSuccess ? NoContent() : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
@@ -167,11 +167,11 @@ public class ConnectionsController(ISender sender) : ControllerBase
     {
         // Pre-check existence so a missing connection surfaces as 404 rather than 400 — matches
         // the DeleteConnection pattern and the documented OpenAPI responses.
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
         if (connection is null)
             return NotFound();
 
-        var result = await _sender.Send(new DeactivateConnectionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeactivateConnectionCommand(id), cancellationToken);
         return result.IsSuccess ? NoContent() : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
@@ -188,7 +188,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
         CancellationToken cancellationToken,
         SyncType syncType = SyncType.Differential)
     {
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
         if (connection is null)
             return NotFound();
 
@@ -235,7 +235,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
         [FromServices] IServiceProvider serviceProvider,
         CancellationToken cancellationToken)
     {
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
         if (connection is null)
             return NotFound();
 
@@ -267,14 +267,14 @@ public class ConnectionsController(ISender sender) : ControllerBase
         if (string.IsNullOrWhiteSpace(typeId))
             return BadRequest(ProblemDetailsExtensions.ForBadRequest("typeId is required.", HttpContext));
 
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
         if (connection is null)
             return NotFound();
         if (connection is not WorkdayConnectionDetailsDto)
             return BadRequest(ProblemDetailsExtensions.ForBadRequest(
                 "This endpoint is only available for Workday connections.", HttpContext));
 
-        var result = await _sender.Send(new GetWorkdayOrgsByTypeCommand(id, typeId), cancellationToken);
+        var result = await _dispatcher.Send(new GetWorkdayOrgsByTypeCommand(id, typeId), cancellationToken);
         return result.IsSuccess ? Ok(result.Value) : BadRequest(result.ToBadRequestObject(HttpContext));
     }
 
@@ -296,7 +296,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
             sinceInstant = Instant.FromDateTimeUtc(s);
         }
 
-        var runs = await _sender.Send(new GetSyncRunsQuery(id, sinceInstant), cancellationToken);
+        var runs = await _dispatcher.Send(new GetSyncRunsQuery(id, sinceInstant), cancellationToken);
         return Ok(runs);
     }
 
@@ -307,7 +307,7 @@ public class ConnectionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<SyncRunDetailsDto>> GetSyncRun(Guid syncRunId, CancellationToken cancellationToken)
     {
-        var run = await _sender.Send(new GetSyncRunQuery(syncRunId), cancellationToken);
+        var run = await _dispatcher.Send(new GetSyncRunQuery(syncRunId), cancellationToken);
 
         return run is not null ? Ok(run) : NotFound();
     }
@@ -321,20 +321,20 @@ public class ConnectionsController(ISender sender) : ControllerBase
     public async Task<ActionResult> DeleteConnection(Guid id, CancellationToken cancellationToken)
     {
         // Determine connection type first to dispatch correct command
-        var connection = await _sender.Send(new GetConnectionQuery(id), cancellationToken);
+        var connection = await _dispatcher.Send(new GetConnectionQuery(id), cancellationToken);
         if (connection is null)
             return NotFound();
 
         Result result = connection switch
         {
             AzureDevOpsConnectionDetailsDto =>
-                await _sender.Send(new DeleteAzureDevOpsConnectionCommand(id), cancellationToken),
+                await _dispatcher.Send(new DeleteAzureDevOpsConnectionCommand(id), cancellationToken),
             AzureOpenAIConnectionDetailsDto =>
-                await _sender.Send(new DeleteAzureOpenAIConnectionCommand(id), cancellationToken),
+                await _dispatcher.Send(new DeleteAzureOpenAIConnectionCommand(id), cancellationToken),
             EntraConnectionDetailsDto =>
-                await _sender.Send(new DeleteEntraConnectionCommand(id), cancellationToken),
+                await _dispatcher.Send(new DeleteEntraConnectionCommand(id), cancellationToken),
             WorkdayConnectionDetailsDto =>
-                await _sender.Send(new DeleteWorkdayConnectionCommand(id), cancellationToken),
+                await _dispatcher.Send(new DeleteWorkdayConnectionCommand(id), cancellationToken),
             _ => Result.Failure($"Connector type not supported")
         };
 

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/FeatureFlagsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/FeatureFlagsController.cs
@@ -6,16 +6,16 @@ namespace Wayd.Web.Api.Controllers;
 [Route("api/feature-flags")]
 [ApiVersionNeutral]
 [ApiController]
-public class FeatureFlagsController(ISender sender) : ControllerBase
+public class FeatureFlagsController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [OpenApiOperation("Get all enabled feature flags for the current user.", "")]
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<ClientFeatureFlagDto>>> GetEnabledFeatureFlags(CancellationToken cancellationToken)
     {
-        var flags = await _sender.Send(new GetClientFeatureFlagsQuery(), cancellationToken);
+        var flags = await _dispatcher.Send(new GetClientFeatureFlagsQuery(), cancellationToken);
         return Ok(flags);
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/HealthChecks/HealthChecksController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/HealthChecks/HealthChecksController.cs
@@ -8,11 +8,11 @@ namespace Wayd.Web.Api.Controllers.HealthChecks;
 [ApiController]
 public class HealthChecksController : ControllerBase
 {
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public HealthChecksController(ISender sender)
+    public HealthChecksController(IDispatcher dispatcher)
     {
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet("statuses")]
@@ -21,7 +21,7 @@ public class HealthChecksController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<HealthStatusDto>>> GetStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetHealthStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetHealthStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Links/LinksController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Links/LinksController.cs
@@ -12,12 +12,12 @@ namespace Wayd.Web.Api.Controllers.Links;
 public class LinksController : ControllerBase
 {
     private readonly ILogger<LinksController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public LinksController(ILogger<LinksController> logger, ISender sender)
+    public LinksController(ILogger<LinksController> logger, IDispatcher dispatcher)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet("{objectId}/list")]
@@ -27,7 +27,7 @@ public class LinksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<LinkDto>>> GetList(Guid objectId, CancellationToken cancellationToken)
     {
-        var links = await _sender.Send(new GetLinksQuery(objectId), cancellationToken);
+        var links = await _dispatcher.Send(new GetLinksQuery(objectId), cancellationToken);
         return Ok(links);
     }
 
@@ -38,7 +38,7 @@ public class LinksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<LinkDto>> GetById(Guid id, CancellationToken cancellationToken)
     {
-        var link = await _sender.Send(new GetLinkQuery(id), cancellationToken);
+        var link = await _dispatcher.Send(new GetLinkQuery(id), cancellationToken);
         return link is not null
             ? Ok(link)
             : NotFound();
@@ -50,7 +50,7 @@ public class LinksController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult> Create([FromBody] CreateLinkRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateLinkCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateLinkCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value }, result.Value)
@@ -68,7 +68,7 @@ public class LinksController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateLinkCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateLinkCommand(), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -82,7 +82,7 @@ public class LinksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteLinkCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteLinkCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/EmployeesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/EmployeesController.cs
@@ -17,10 +17,10 @@ namespace Wayd.Web.Api.Controllers.Organizations;
 [Route("api/organization/employees")]
 [ApiVersionNeutral]
 [ApiController]
-public class EmployeesController(ILogger<EmployeesController> logger, ISender sender, ICsvService csvService) : ControllerBase
+public class EmployeesController(ILogger<EmployeesController> logger, IDispatcher dispatcher, ICsvService csvService) : ControllerBase
 {
     private readonly ILogger<EmployeesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ICsvService _csvService = csvService;
 
     [HttpGet]
@@ -30,7 +30,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<EmployeeListDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var employees = await _sender.Send(new GetEmployeesQuery(includeInactive), cancellationToken);
+        var employees = await _dispatcher.Send(new GetEmployeesQuery(includeInactive), cancellationToken);
         return Ok(employees.OrderBy(e => e.LastName));
     }
 
@@ -42,7 +42,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<EmployeeDetailsDto>> GetEmployee(string idOrKey, CancellationToken cancellationToken)
     {
-        var employee = await _sender.Send(new GetEmployeeQuery(idOrKey), cancellationToken);
+        var employee = await _dispatcher.Send(new GetEmployeeQuery(idOrKey), cancellationToken);
 
         return employee is not null
             ? Ok(employee)
@@ -55,7 +55,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create(CreateEmployeeRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateEmployeeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateEmployeeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetEmployee), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -95,7 +95,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
             if (employees.Count == 0)
                 return BadRequest(ProblemDetailsExtensions.ForBadRequest("No employees imported.", HttpContext));
 
-            var result = await _sender.Send(new ImportEmployeesCommand(employees), cancellationToken);
+            var result = await _dispatcher.Send(new ImportEmployeesCommand(employees), cancellationToken);
 
             return result.IsSuccess
                 ? NoContent()
@@ -117,7 +117,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateEmployeeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateEmployeeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -131,7 +131,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(string id)
     {
-        var result = await _sender.Send(new DeleteEmployeeCommand(Guid.Parse(id)));
+        var result = await _dispatcher.Send(new DeleteEmployeeCommand(Guid.Parse(id)));
 
         return result.IsSuccess
             ? NoContent()
@@ -145,7 +145,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<EmployeeListDto>>> GetDirectReports(Guid id, CancellationToken cancellationToken)
     {
-        var directReports = await _sender.Send(new GetDirectReportsQuery(id), cancellationToken);
+        var directReports = await _dispatcher.Send(new GetDirectReportsQuery(id), cancellationToken);
         return Ok(directReports.OrderBy(e => e.LastName));
     }
 
@@ -157,7 +157,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveInvalid(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveInvalidEmployeeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveInvalidEmployeeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -170,7 +170,7 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<TeamMemberDto>>> GetTeamMemberships(Guid id, CancellationToken cancellationToken)
     {
-        return Ok(await _sender.Send(new GetEmployeeTeamMembershipsQuery(id), cancellationToken));
+        return Ok(await _dispatcher.Send(new GetEmployeeTeamMembershipsQuery(id), cancellationToken));
     }
 
     [HttpGet("{id}/work-items")]
@@ -202,6 +202,6 @@ public class EmployeesController(ILogger<EmployeesController> logger, ISender se
             doneToInstant = Instant.FromDateTimeUtc(dt);
         }
 
-        return Ok(await _sender.Send(new GetEmployeeWorkItemsQuery(id, statusCategories, doneFromInstant, doneToInstant), cancellationToken));
+        return Ok(await _dispatcher.Send(new GetEmployeeWorkItemsQuery(id, statusCategories, doneFromInstant, doneToInstant), cancellationToken));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamMemberRolesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamMemberRolesController.cs
@@ -9,7 +9,7 @@ namespace Wayd.Web.Api.Controllers.Organizations;
 [Route("api/organization/team-member-roles")]
 [ApiVersionNeutral]
 [ApiController]
-public class TeamMemberRolesController(ISender sender) : ControllerBase
+public class TeamMemberRolesController(IDispatcher dispatcher) : ControllerBase
 {
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.TeamMemberRoles)]
@@ -17,7 +17,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<TeamMemberRoleDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var roles = await sender.Send(new GetTeamMemberRolesQuery(includeInactive), cancellationToken);
+        var roles = await dispatcher.Send(new GetTeamMemberRolesQuery(includeInactive), cancellationToken);
         return Ok(roles);
     }
 
@@ -28,7 +28,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TeamMemberRoleDto>> GetById(Guid id, CancellationToken cancellationToken)
     {
-        var role = await sender.Send(new GetTeamMemberRoleQuery(id), cancellationToken);
+        var role = await dispatcher.Send(new GetTeamMemberRoleQuery(id), cancellationToken);
         return role is not null ? Ok(role) : NotFound();
     }
 
@@ -38,7 +38,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult> Create([FromBody] CreateTeamMemberRoleRequest request, CancellationToken cancellationToken)
     {
-        var result = await sender.Send(new CreateTeamMemberRoleCommand(request.Name, request.Description), cancellationToken);
+        var result = await dispatcher.Send(new CreateTeamMemberRoleCommand(request.Name, request.Description), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value }, result.Value)
@@ -55,7 +55,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await sender.Send(new UpdateTeamMemberRoleCommand(request.Id, request.Name, request.Description), cancellationToken);
+        var result = await dispatcher.Send(new UpdateTeamMemberRoleCommand(request.Id, request.Name, request.Description), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -69,7 +69,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await sender.Send(new DeleteTeamMemberRoleCommand(id), cancellationToken);
+        var result = await dispatcher.Send(new DeleteTeamMemberRoleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -83,7 +83,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await sender.Send(new ActivateTeamMemberRoleCommand(id), cancellationToken);
+        var result = await dispatcher.Send(new ActivateTeamMemberRoleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -97,7 +97,7 @@ public class TeamMemberRolesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Deactivate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await sender.Send(new DeactivateTeamMemberRoleCommand(id), cancellationToken);
+        var result = await dispatcher.Send(new DeactivateTeamMemberRoleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamTypesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamTypesController.cs
@@ -8,11 +8,11 @@ namespace Wayd.Web.Api.Controllers.Work;
 [ApiController]
 public class TeamTypesController : ControllerBase
 {
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public TeamTypesController(ISender sender)
+    public TeamTypesController(IDispatcher dispatcher)
     {
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -22,7 +22,7 @@ public class TeamTypesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<TeamTypeDto>>> GetList(CancellationToken cancellationToken)
     {
-        var categories = await _sender.Send(new GetTeamTypesQuery(), cancellationToken);
+        var categories = await _dispatcher.Send(new GetTeamTypesQuery(), cancellationToken);
         return Ok(categories.OrderBy(c => c.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamsController.cs
@@ -23,10 +23,10 @@ namespace Wayd.Web.Api.Controllers.Organizations;
 [Route("api/organization/teams")]
 [ApiVersionNeutral]
 [ApiController]
-public class TeamsController(ILogger<TeamsController> logger, ISender sender, ICsvService csvService) : ControllerBase
+public class TeamsController(ILogger<TeamsController> logger, IDispatcher dispatcher, ICsvService csvService) : ControllerBase
 {
     private readonly ILogger<TeamsController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ICsvService _csvService = csvService;
 
     [HttpGet]
@@ -36,7 +36,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<TeamListDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var teams = await _sender.Send(new GetTeamsQuery(includeInactive), cancellationToken);
+        var teams = await _dispatcher.Send(new GetTeamsQuery(includeInactive), cancellationToken);
         return Ok(teams.OrderBy(e => e.Name));
     }
 
@@ -47,7 +47,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TeamDetailsDto>> GetById(int id)
     {
-        var team = await _sender.Send(new GetTeamQuery(id));
+        var team = await _dispatcher.Send(new GetTeamQuery(id));
 
         return team is not null
             ? Ok(team)
@@ -60,7 +60,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateTeamRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateTeamCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateTeamCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value.Key }, result.Value)
@@ -100,7 +100,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
             if (teams.Count == 0)
                 return BadRequest(ProblemDetailsExtensions.ForBadRequest("No teams imported.", HttpContext));
 
-            var result = await _sender.Send(new ImportTeamsCommand(teams), cancellationToken);
+            var result = await _dispatcher.Send(new ImportTeamsCommand(teams), cancellationToken);
 
             return result.IsSuccess
                 ? NoContent()
@@ -145,7 +145,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
             if (members.Count == 0)
                 return BadRequest(ProblemDetailsExtensions.ForBadRequest("No team members imported.", HttpContext));
 
-            var result = await _sender.Send(new ImportTeamMembersCommand(members), cancellationToken);
+            var result = await _dispatcher.Send(new ImportTeamMembersCommand(members), cancellationToken);
 
             return result.IsSuccess
                 ? NoContent()
@@ -190,7 +190,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
             if (memberships.Count == 0)
                 return BadRequest(ProblemDetailsExtensions.ForBadRequest("No team memberships imported.", HttpContext));
 
-            var result = await _sender.Send(new ImportTeamMembershipsCommand(memberships), cancellationToken);
+            var result = await _dispatcher.Send(new ImportTeamMembershipsCommand(memberships), cancellationToken);
 
             return result.IsSuccess
                 ? NoContent()
@@ -213,7 +213,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateTeamCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateTeamCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -231,7 +231,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToDeactivateTeamCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToDeactivateTeamCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -255,7 +255,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<TeamMembershipDto>>> GetTeamMemberships(Guid id, CancellationToken cancellationToken)
     {
-        return Ok(await _sender.Send(new GetTeamMembershipsQuery(id), cancellationToken));
+        return Ok(await _dispatcher.Send(new GetTeamMembershipsQuery(id), cancellationToken));
     }
 
     [HttpPost("{id}/team-memberships")]
@@ -269,7 +269,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         if (id != request.TeamId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.TeamId), HttpContext));
 
-        var result = await _sender.Send(request.ToTeamAddParentTeamMembershipCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToTeamAddParentTeamMembershipCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -289,7 +289,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         else if (teamMembershipId != request.TeamMembershipId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(teamMembershipId), nameof(request.TeamMembershipId), HttpContext));
 
-        var result = await _sender.Send(request.ToTeamUpdateTeamMembershipCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToTeamUpdateTeamMembershipCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -303,7 +303,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveTeamMembership(Guid id, Guid teamMembershipId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveTeamMembershipCommand(id, teamMembershipId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveTeamMembershipCommand(id, teamMembershipId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -322,7 +322,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<WorkItemBacklogItemDto>>> GetTeamBacklog(string idOrCode, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new GetTeamBacklogQuery(idOrCode), cancellationToken);
+        var result = await _dispatcher.Send(new GetTeamBacklogQuery(idOrCode), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -358,7 +358,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
             doneToInstant = Instant.FromDateTimeUtc(dt);
         }
 
-        var workItems = await _sender.Send(new GetTeamWorkItemsQuery(idOrCode, statusCategories, doneFromInstant, doneToInstant), cancellationToken);
+        var workItems = await _dispatcher.Send(new GetTeamWorkItemsQuery(idOrCode, statusCategories, doneFromInstant, doneToInstant), cancellationToken);
 
         return workItems is null
             ? NotFound()
@@ -373,7 +373,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<DependencyDto>>> GetTeamDependencies(Guid id, CancellationToken cancellationToken)
     {
-        var dependencies = await _sender.Send(new GetTeamDependenciesQuery(id, [DependencyState.ToDo, DependencyState.InProgress]), cancellationToken);
+        var dependencies = await _dispatcher.Send(new GetTeamDependenciesQuery(id, [DependencyState.ToDo, DependencyState.InProgress]), cancellationToken);
 
         return dependencies is null
             ? NotFound()
@@ -392,11 +392,11 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<RiskListDto>>> GetRisks(Guid id, CancellationToken cancellationToken, bool includeClosed = false)
     {
-        var teamExists = await _sender.Send(new TeamExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var risks = await _sender.Send(new GetRisksQuery(id, includeClosed), cancellationToken);
+        var risks = await _dispatcher.Send(new GetRisksQuery(id, includeClosed), cancellationToken);
 
         return Ok(risks);
     }
@@ -409,11 +409,11 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<RiskDetailsDto>> GetRiskById(Guid id, string riskIdOrKey, CancellationToken cancellationToken)
     {
-        var teamExists = await _sender.Send(new TeamExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var risk = await _sender.Send(new GetRiskQuery(riskIdOrKey), cancellationToken);
+        var risk = await _dispatcher.Send(new GetRiskQuery(riskIdOrKey), cancellationToken);
 
         return risk is not null && risk.Team?.Id == id
             ? Ok(risk)
@@ -432,11 +432,11 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         if (id != request.TeamId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.TeamId), HttpContext));
 
-        var teamExists = await _sender.Send(new TeamExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var result = await _sender.Send(request.ToCreateRiskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateRiskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetRiskById), new { id, riskId = result.Value }, result.Value)
@@ -456,7 +456,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         else if (riskId != request.RiskId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(riskId), nameof(request.RiskId), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateRiskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateRiskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -474,11 +474,11 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TeamOperatingModelDetailsDto>> GetOperatingModel(Guid id, Guid operatingModelId, CancellationToken cancellationToken)
     {
-        var teamExists = await _sender.Send(new TeamExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var operatingModel = await _sender.Send(new GetTeamOperatingModelQuery(id, operatingModelId), cancellationToken);
+        var operatingModel = await _dispatcher.Send(new GetTeamOperatingModelQuery(id, operatingModelId), cancellationToken);
 
         return operatingModel is not null
             ? Ok(operatingModel)
@@ -492,7 +492,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<TeamOperatingModelDetailsDto>>> GetOperatingModels(Guid id, CancellationToken cancellationToken)
     {
-        var history = await _sender.Send(new GetTeamOperatingModelsQuery(id), cancellationToken);
+        var history = await _dispatcher.Send(new GetTeamOperatingModelsQuery(id), cancellationToken);
 
         return history is not null
             ? Ok(history)
@@ -512,7 +512,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
             ? LocalDate.FromDateTime(asOfDate.Value)
             : null;
 
-        var operatingModel = await _sender.Send(new GetTeamOperatingModelAsOfQuery(id, localDate), cancellationToken);
+        var operatingModel = await _dispatcher.Send(new GetTeamOperatingModelAsOfQuery(id, localDate), cancellationToken);
 
         return operatingModel is not null
             ? Ok(operatingModel)
@@ -535,7 +535,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
             ? LocalDate.FromDateTime(asOfDate.Value)
             : null;
 
-        var operatingModels = await _sender.Send(new GetTeamOperatingModelsForTeamsQuery(teamIds, localDate), cancellationToken);
+        var operatingModels = await _dispatcher.Send(new GetTeamOperatingModelsForTeamsQuery(teamIds, localDate), cancellationToken);
 
         return Ok(operatingModels);
     }
@@ -547,7 +547,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<bool>> HasEverBeenScrum(Guid id, CancellationToken cancellationToken)
     {
-        var hasBeenScrum = await _sender.Send(new TeamHasEverBeenScrumQuery(id), cancellationToken);
+        var hasBeenScrum = await _dispatcher.Send(new TeamHasEverBeenScrumQuery(id), cancellationToken);
 
         return hasBeenScrum is not null
             ? Ok(hasBeenScrum)
@@ -563,11 +563,11 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> SetOperatingModel(Guid id, [FromBody] SetTeamOperatingModelRequest request, CancellationToken cancellationToken)
     {
-        var teamExists = await _sender.Send(new TeamExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var result = await _sender.Send(request.ToSetTeamOperatingModelCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToSetTeamOperatingModelCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetOperatingModel), new { id, operatingModelId = result.Value }, result.Value)
@@ -583,7 +583,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdateOperatingModel(Guid id, Guid operatingModelId, [FromBody] UpdateTeamOperatingModelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateTeamOperatingModelCommand(id, operatingModelId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateTeamOperatingModelCommand(id, operatingModelId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -598,7 +598,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteOperatingModel(Guid id, Guid operatingModelId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteTeamOperatingModelCommand(id, operatingModelId), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteTeamOperatingModelCommand(id, operatingModelId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -614,7 +614,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<SprintListDto>>> GetSprints(Guid id, CancellationToken cancellationToken)
     {
-        var sprints = await _sender.Send(new GetSprintsQuery(id), cancellationToken);
+        var sprints = await _dispatcher.Send(new GetSprintsQuery(id), cancellationToken);
 
         return Ok(sprints);
     }
@@ -626,7 +626,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<SprintDetailsDto>> GetActiveSprint(Guid id, CancellationToken cancellationToken)
     {
-        var sprint = await _sender.Send(new GetTeamActiveSprintQuery(id), cancellationToken);
+        var sprint = await _dispatcher.Send(new GetTeamActiveSprintQuery(id), cancellationToken);
 
         return Ok(sprint);
     }
@@ -642,7 +642,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
         LocalDate? dateOnlyAsOfDate = asOfDate.HasValue
             ? LocalDate.FromDateTime(asOfDate.Value)
             : null;
-        var orgChart = await _sender.Send(new GetFunctionalOrganizationChartQuery(dateOnlyAsOfDate), cancellationToken);
+        var orgChart = await _dispatcher.Send(new GetFunctionalOrganizationChartQuery(dateOnlyAsOfDate), cancellationToken);
 
         return Ok(orgChart);
     }
@@ -655,7 +655,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<TeamMemberDto>>> GetMembers(Guid id, CancellationToken cancellationToken)
     {
-        return Ok(await _sender.Send(new GetTeamMembersQuery(id), cancellationToken));
+        return Ok(await _dispatcher.Send(new GetTeamMembersQuery(id), cancellationToken));
     }
 
     [HttpPost("{id}/members")]
@@ -665,7 +665,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> AddMember(Guid id, [FromBody] AddTeamMemberRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new AddTeamMemberCommand(id, request.EmployeeId, request.RoleIds), cancellationToken);
+        var result = await _dispatcher.Send(new AddTeamMemberCommand(id, request.EmployeeId, request.RoleIds), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -679,7 +679,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> UpdateMember(Guid id, Guid employeeId, [FromBody] UpdateTeamMemberRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new UpdateTeamMemberCommand(id, employeeId, request.RoleIds), cancellationToken);
+        var result = await _dispatcher.Send(new UpdateTeamMemberCommand(id, employeeId, request.RoleIds), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -693,7 +693,7 @@ public class TeamsController(ILogger<TeamsController> logger, ISender sender, IC
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveMember(Guid id, Guid employeeId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveTeamMemberCommand(id, employeeId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveTeamMemberCommand(id, employeeId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamsOfTeamsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Organizations/TeamsOfTeamsController.cs
@@ -23,12 +23,12 @@ namespace Wayd.Web.Api.Controllers.Organizations;
 public class TeamsOfTeamsController : ControllerBase
 {
     private readonly ILogger<TeamsOfTeamsController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public TeamsOfTeamsController(ILogger<TeamsOfTeamsController> logger, ISender sender)
+    public TeamsOfTeamsController(ILogger<TeamsOfTeamsController> logger, IDispatcher dispatcher)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -38,7 +38,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<TeamOfTeamsListDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var teams = await _sender.Send(new GetTeamOfTeamsListQuery(includeInactive), cancellationToken);
+        var teams = await _dispatcher.Send(new GetTeamOfTeamsListQuery(includeInactive), cancellationToken);
         return Ok(teams.OrderBy(e => e.Name));
     }
 
@@ -49,7 +49,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<TeamOfTeamsDetailsDto>> GetById(int id)
     {
-        var team = await _sender.Send(new GetTeamOfTeamsQuery(id));
+        var team = await _dispatcher.Send(new GetTeamOfTeamsQuery(id));
 
         return team is not null
             ? Ok(team)
@@ -62,7 +62,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create(CreateTeamOfTeamsRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateTeamOfTeamsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateTeamOfTeamsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value.Key }, result.Value)
@@ -80,7 +80,7 @@ public class TeamsOfTeamsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateTeamOfTeamsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateTeamOfTeamsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -98,7 +98,7 @@ public class TeamsOfTeamsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToDeactivateTeamOfTeamsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToDeactivateTeamOfTeamsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -122,7 +122,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<TeamMembershipDto>>> GetTeamMemberships(Guid id, CancellationToken cancellationToken)
     {
-        var memberships = await _sender.Send(new GetTeamMembershipsQuery(id), cancellationToken);
+        var memberships = await _dispatcher.Send(new GetTeamMembershipsQuery(id), cancellationToken);
 
         return Ok(memberships);
     }
@@ -138,7 +138,7 @@ public class TeamsOfTeamsController : ControllerBase
         if (id != request.TeamId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToTeamOfTeamsAddParentTeamMembershipCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToTeamOfTeamsAddParentTeamMembershipCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -158,7 +158,7 @@ public class TeamsOfTeamsController : ControllerBase
         else if (teamMembershipId != request.TeamMembershipId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(teamMembershipId), nameof(request.TeamMembershipId), HttpContext));
 
-        var result = await _sender.Send(request.ToTeamOfTeamsUpdateTeamMembershipCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToTeamOfTeamsUpdateTeamMembershipCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -172,7 +172,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveTeamMembership(Guid id, Guid teamMembershipId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveTeamMembershipCommand(id, teamMembershipId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveTeamMembershipCommand(id, teamMembershipId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -191,11 +191,11 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IReadOnlyList<RiskListDto>>> GetRisks(Guid id, CancellationToken cancellationToken, bool includeClosed = false)
     {
-        var teamExists = await _sender.Send(new TeamOfTeamsExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamOfTeamsExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var risks = await _sender.Send(new GetRisksQuery(id, includeClosed), cancellationToken);
+        var risks = await _dispatcher.Send(new GetRisksQuery(id, includeClosed), cancellationToken);
 
         return Ok(risks);
     }
@@ -208,11 +208,11 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<RiskDetailsDto>> GetRiskById(Guid id, string riskIdOrKey, CancellationToken cancellationToken)
     {
-        var teamExists = await _sender.Send(new TeamOfTeamsExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamOfTeamsExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var risk = await _sender.Send(new GetRiskQuery(riskIdOrKey), cancellationToken);
+        var risk = await _dispatcher.Send(new GetRiskQuery(riskIdOrKey), cancellationToken);
 
         return risk is not null && risk.Team?.Id == id
             ? Ok(risk)
@@ -231,11 +231,11 @@ public class TeamsOfTeamsController : ControllerBase
         if (id != request.TeamId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.TeamId), HttpContext));
 
-        var teamExists = await _sender.Send(new TeamOfTeamsExistsQuery(id), cancellationToken);
+        var teamExists = await _dispatcher.Send(new TeamOfTeamsExistsQuery(id), cancellationToken);
         if (!teamExists)
             return NotFound();
 
-        var result = await _sender.Send(request.ToCreateRiskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateRiskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetRiskById), new { id, riskId = result.Value }, result.Value)
@@ -255,7 +255,7 @@ public class TeamsOfTeamsController : ControllerBase
         else if (riskId != request.RiskId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(riskId), nameof(request.RiskId), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateRiskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateRiskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -272,7 +272,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<TeamMemberDto>>> GetMembers(Guid id, CancellationToken cancellationToken)
     {
-        return Ok(await _sender.Send(new TeamsMemberQueries.GetTeamMembersQuery(id), cancellationToken));
+        return Ok(await _dispatcher.Send(new TeamsMemberQueries.GetTeamMembersQuery(id), cancellationToken));
     }
 
     [HttpPost("{id}/members")]
@@ -282,7 +282,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> AddMember(Guid id, [FromBody] AddTeamMemberRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new TeamsMemberCommands.AddTeamMemberCommand(id, request.EmployeeId, request.RoleIds), cancellationToken);
+        var result = await _dispatcher.Send(new TeamsMemberCommands.AddTeamMemberCommand(id, request.EmployeeId, request.RoleIds), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -296,7 +296,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> UpdateMember(Guid id, Guid employeeId, [FromBody] UpdateTeamMemberRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new TeamsMemberCommands.UpdateTeamMemberCommand(id, employeeId, request.RoleIds), cancellationToken);
+        var result = await _dispatcher.Send(new TeamsMemberCommands.UpdateTeamMemberCommand(id, employeeId, request.RoleIds), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -310,7 +310,7 @@ public class TeamsOfTeamsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveMember(Guid id, Guid employeeId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new TeamsMemberCommands.RemoveTeamMemberCommand(id, employeeId), cancellationToken);
+        var result = await _dispatcher.Send(new TeamsMemberCommands.RemoveTeamMemberCommand(id, employeeId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/EstimationScalesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/EstimationScalesController.cs
@@ -12,9 +12,9 @@ namespace Wayd.Web.Api.Controllers.Planning;
 [ApiVersionNeutral]
 [ApiController]
 [FeatureGate(FeatureFlags.Names.PlanningPoker)]
-public class EstimationScalesController(ISender sender) : ControllerBase
+public class EstimationScalesController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.EstimationScales)]
@@ -23,7 +23,7 @@ public class EstimationScalesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<EstimationScaleDto>>> GetScales(CancellationToken cancellationToken, [FromQuery] bool includeInactive = false)
     {
-        var scales = await _sender.Send(new GetEstimationScalesQuery(includeInactive), cancellationToken);
+        var scales = await _dispatcher.Send(new GetEstimationScalesQuery(includeInactive), cancellationToken);
         return Ok(scales.OrderBy(s => s.Name));
     }
 
@@ -34,7 +34,7 @@ public class EstimationScalesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<EstimationScaleDto>> GetScale(int id, CancellationToken cancellationToken)
     {
-        var scale = await _sender.Send(new GetEstimationScaleQuery(id), cancellationToken);
+        var scale = await _dispatcher.Send(new GetEstimationScaleQuery(id), cancellationToken);
         return scale is not null
             ? Ok(scale)
             : NotFound();
@@ -46,7 +46,7 @@ public class EstimationScalesController(ISender sender) : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Int))]
     public async Task<ActionResult<int>> Create([FromBody] CreateEstimationScaleRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateEstimationScaleCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateEstimationScaleCommand(), cancellationToken);
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScale), new { id = result.Value }, result.Value)
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -63,7 +63,7 @@ public class EstimationScalesController(ISender sender) : ControllerBase
         if (id != request.EstimationScaleId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.EstimationScaleId), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateEstimationScaleCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateEstimationScaleCommand(), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -79,7 +79,7 @@ public class EstimationScalesController(ISender sender) : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.Id), HttpContext));
 
-        var result = await _sender.Send(new SetEstimationScaleActiveStatusCommand(id, request.IsActive), cancellationToken);
+        var result = await _dispatcher.Send(new SetEstimationScaleActiveStatusCommand(id, request.IsActive), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -92,7 +92,7 @@ public class EstimationScalesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(int id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteEstimationScaleCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteEstimationScaleCommand(id), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/PlanningIntervalsController.cs
@@ -28,14 +28,14 @@ namespace Wayd.Web.Api.Controllers.Planning;
 public class PlanningIntervalsController : ControllerBase
 {
     private readonly ILogger<PlanningIntervalsController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly ICsvService _csvService;
 
-    public PlanningIntervalsController(ILogger<PlanningIntervalsController> logger, ISender sender, IDateTimeProvider dateTimeProvider, ICsvService csvService)
+    public PlanningIntervalsController(ILogger<PlanningIntervalsController> logger, IDispatcher dispatcher, IDateTimeProvider dateTimeProvider, ICsvService csvService)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
         _dateTimeProvider = dateTimeProvider;
         _csvService = csvService;
     }
@@ -47,7 +47,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalListDto>>> GetList(CancellationToken cancellationToken)
     {
-        var planningIntervals = await _sender.Send(new GetPlanningIntervalsQuery(), cancellationToken);
+        var planningIntervals = await _dispatcher.Send(new GetPlanningIntervalsQuery(), cancellationToken);
         return Ok(planningIntervals);
     }
 
@@ -58,7 +58,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PlanningIntervalDetailsDto>> GetPlanningInterval(string idOrKey, CancellationToken cancellationToken)
     {
-        var planningInterval = await _sender.Send(new GetPlanningIntervalQuery(idOrKey), cancellationToken);
+        var planningInterval = await _dispatcher.Send(new GetPlanningIntervalQuery(idOrKey), cancellationToken);
 
         return planningInterval is not null
             ? Ok(planningInterval)
@@ -73,7 +73,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PlanningIntervalCalendarDto>> GetCalendar(string idOrKey, CancellationToken cancellationToken)
     {
-        var calendar = await _sender.Send(new GetPlanningIntervalCalendarQuery(idOrKey), cancellationToken);
+        var calendar = await _dispatcher.Send(new GetPlanningIntervalCalendarQuery(idOrKey), cancellationToken);
 
         return calendar is not null
             ? Ok(calendar)
@@ -88,7 +88,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PlanningIntervalPredictabilityDto>> GetPredictability(string idOrKey, CancellationToken cancellationToken)
     {
-        var predictability = await _sender.Send(new GetPlanningIntervalPredictabilityQuery(idOrKey), cancellationToken);
+        var predictability = await _dispatcher.Send(new GetPlanningIntervalPredictabilityQuery(idOrKey), cancellationToken);
 
         return predictability is not null
             ? Ok(predictability)
@@ -101,7 +101,7 @@ public class PlanningIntervalsController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult> Create([FromBody] CreatePlanningIntervalRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreatePlanningIntervalCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreatePlanningIntervalCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetPlanningInterval), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -119,7 +119,7 @@ public class PlanningIntervalsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdatePlanningIntervalCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdatePlanningIntervalCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -134,12 +134,12 @@ public class PlanningIntervalsController : ControllerBase
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalTeamResponse>>> GetTeams(string idOrKey, CancellationToken cancellationToken)
     {
         List<PlanningIntervalTeamResponse> piTeams = [];
-        var teamIds = await _sender.Send(new GetPlanningIntervalTeamsQuery(idOrKey), cancellationToken);
+        var teamIds = await _dispatcher.Send(new GetPlanningIntervalTeamsQuery(idOrKey), cancellationToken);
 
         if (teamIds.Any())
         {
-            var teams = await _sender.Send(new GetTeamsQuery(true, teamIds), cancellationToken);
-            var teamOfTeams = await _sender.Send(new GetTeamOfTeamsListQuery(true, teamIds), cancellationToken);
+            var teams = await _dispatcher.Send(new GetTeamsQuery(true, teamIds), cancellationToken);
+            var teamOfTeams = await _dispatcher.Send(new GetTeamOfTeamsListQuery(true, teamIds), cancellationToken);
 
             piTeams.AddRange(teams.Adapt<List<PlanningIntervalTeamResponse>>());
             piTeams.AddRange(teamOfTeams.Adapt<List<PlanningIntervalTeamResponse>>());
@@ -155,7 +155,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<double?>> GetTeamPredictability(string idOrKey, Guid teamId, CancellationToken cancellationToken)
     {
-        var predictability = await _sender.Send(new GetTeamPlanningIntervalPredictabilityQuery(idOrKey, teamId), cancellationToken);
+        var predictability = await _dispatcher.Send(new GetTeamPlanningIntervalPredictabilityQuery(idOrKey, teamId), cancellationToken);
 
         return Ok(predictability);
     }
@@ -170,7 +170,7 @@ public class PlanningIntervalsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToManagePlanningIntervalDatesCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToManagePlanningIntervalDatesCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -187,7 +187,7 @@ public class PlanningIntervalsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToManagePlanningIntervalTeamsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToManagePlanningIntervalTeamsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -204,7 +204,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalIterationListDto>>> GetIterations(string idOrKey, CancellationToken cancellationToken)
     {
-        var iterations = await _sender.Send(new GetPlanningIntervalIterationsQuery(idOrKey), cancellationToken);
+        var iterations = await _dispatcher.Send(new GetPlanningIntervalIterationsQuery(idOrKey), cancellationToken);
 
         return iterations is not null
             ? Ok(iterations)
@@ -219,7 +219,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PlanningIntervalIterationDetailsDto?>> GetIteration(string idOrKey, string iterationIdOrKey, CancellationToken cancellationToken)
     {
-        var iteration = await _sender.Send(new GetPlanningIntervalIterationQuery(idOrKey, iterationIdOrKey), cancellationToken);
+        var iteration = await _dispatcher.Send(new GetPlanningIntervalIterationQuery(idOrKey, iterationIdOrKey), cancellationToken);
 
         return iteration is not null
             ? Ok(iteration)
@@ -233,7 +233,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<PlanningIntervalIterationCategoryDto>>> GetIterationCategories(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetPlanningIntervalIterationCategoriesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetPlanningIntervalIterationCategoriesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -245,7 +245,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalIterationSprintsDto>>> GetIterationSprints(string idOrKey, [FromQuery] Guid? iterationId, CancellationToken cancellationToken)
     {
-        var iterations = await _sender.Send(new GetPlanningIntervalIterationSprintsQuery(idOrKey, iterationId), cancellationToken);
+        var iterations = await _dispatcher.Send(new GetPlanningIntervalIterationSprintsQuery(idOrKey, iterationId), cancellationToken);
 
         return iterations is not null
             ? Ok(iterations)
@@ -266,7 +266,7 @@ public class PlanningIntervalsController : ControllerBase
         if (teamId != request.TeamId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(teamId), nameof(request.TeamId), HttpContext));
 
-        var result = await _sender.Send(request.ToMapPlanningIntervalSprintsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToMapPlanningIntervalSprintsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -282,7 +282,7 @@ public class PlanningIntervalsController : ControllerBase
     public async Task<ActionResult<PlanningIntervalMetricsResponse>> GetMetrics(string idOrKey, CancellationToken cancellationToken)
     {
         // Pull the PI itself for identity fields.
-        var planningInterval = await _sender.Send(
+        var planningInterval = await _dispatcher.Send(
             new GetPlanningIntervalQuery(idOrKey),
             cancellationToken);
 
@@ -290,7 +290,7 @@ public class PlanningIntervalsController : ControllerBase
             return NotFound();
 
         // Pull sprint mappings for every iteration in the PI in one shot.
-        var iterationSprints = await _sender.Send(
+        var iterationSprints = await _dispatcher.Send(
             new GetPlanningIntervalIterationSprintsQuery(idOrKey, null),
             cancellationToken);
 
@@ -300,7 +300,7 @@ public class PlanningIntervalsController : ControllerBase
         // Predictability is computed by the existing query and includes a
         // per-team breakdown — we surface those values here so the client only
         // needs one round-trip for the at-a-glance team cards.
-        var predictability = await _sender.Send(
+        var predictability = await _dispatcher.Send(
             new GetPlanningIntervalPredictabilityQuery(new IdOrKey(idOrKey)),
             cancellationToken);
 
@@ -329,7 +329,7 @@ public class PlanningIntervalsController : ControllerBase
             });
         }
 
-        var sprintMetrics = await _sender.Send(
+        var sprintMetrics = await _dispatcher.Send(
             new GetSprintsWorkItemMetricsQuery(sprintIds),
             cancellationToken);
 
@@ -337,7 +337,7 @@ public class PlanningIntervalsController : ControllerBase
         // the short code the plan-review tabs route on. The PlanningTeamNavigationDto
         // we already have via sprintToTeam doesn't expose Code.
         var participatingTeamIds = sprintToTeam.Values.Select(t => t.Id).Distinct().ToList();
-        var teamList = await _sender.Send(
+        var teamList = await _dispatcher.Send(
             new GetTeamsQuery(true, participatingTeamIds),
             cancellationToken);
         var codeByTeamId = teamList.ToDictionary(t => t.Id, t => t.Code);
@@ -402,7 +402,7 @@ public class PlanningIntervalsController : ControllerBase
     public async Task<ActionResult<PlanningIntervalIterationMetricsResponse>> GetIterationMetrics(string idOrKey, string iterationIdOrKey, CancellationToken cancellationToken)
     {
         // Get the iteration with its mapped sprints from Planning context
-        var iterationSprints = await _sender.Send(
+        var iterationSprints = await _dispatcher.Send(
             new GetPlanningIntervalIterationSprintsQuery(idOrKey, null),
             cancellationToken);
 
@@ -419,7 +419,7 @@ public class PlanningIntervalsController : ControllerBase
 
         // Get work item metrics from Work context
         var sprintIds = iteration.Sprints.Select(s => s.Id).ToList();
-        var sprintMetrics = await _sender.Send(
+        var sprintMetrics = await _dispatcher.Send(
             new GetSprintsWorkItemMetricsQuery(sprintIds),
             cancellationToken);
 
@@ -482,7 +482,7 @@ public class PlanningIntervalsController : ControllerBase
     public async Task<ActionResult<List<SprintBacklogItemDto>>> GetIterationBacklog(string idOrKey, string iterationIdOrKey, CancellationToken cancellationToken)
     {
         // Get the iteration with its mapped sprints from Planning context
-        var iterationSprints = await _sender.Send(
+        var iterationSprints = await _dispatcher.Send(
             new GetPlanningIntervalIterationSprintsQuery(idOrKey, null),
             cancellationToken);
 
@@ -499,7 +499,7 @@ public class PlanningIntervalsController : ControllerBase
 
         // Get combined backlog from Work context
         var sprintIds = iteration.Sprints.Select(s => s.Id).ToList();
-        var backlog = await _sender.Send(
+        var backlog = await _dispatcher.Send(
             new GetSprintsBacklogQuery(sprintIds),
             cancellationToken);
 
@@ -517,7 +517,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalObjectiveListDto>>> GetObjectives(string idOrKey, Guid? teamId, CancellationToken cancellationToken)
     {
-        var objectives = await _sender.Send(new GetPlanningIntervalObjectivesQuery(idOrKey, teamId), cancellationToken);
+        var objectives = await _dispatcher.Send(new GetPlanningIntervalObjectivesQuery(idOrKey, teamId), cancellationToken);
 
         return Ok(objectives);
     }
@@ -530,7 +530,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PlanningIntervalObjectiveDetailsDto>> GetObjective(string idOrKey, string objectiveIdOrKey, CancellationToken cancellationToken)
     {
-        var objective = await _sender.Send(new GetPlanningIntervalObjectiveQuery(idOrKey, objectiveIdOrKey), cancellationToken);
+        var objective = await _dispatcher.Send(new GetPlanningIntervalObjectiveQuery(idOrKey, objectiveIdOrKey), cancellationToken);
 
         return objective is not null
             ? Ok(objective)
@@ -549,7 +549,7 @@ public class PlanningIntervalsController : ControllerBase
         if (id != request.PlanningIntervalId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.PlanningIntervalId), HttpContext));
 
-        var result = await _sender.Send(request.ToCreatePlanningIntervalObjectiveCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreatePlanningIntervalObjectiveCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetObjective), new { idOrKey = id, objectiveIdOrKey = result.Value.Id.ToString() }, result.Value)
@@ -570,7 +570,7 @@ public class PlanningIntervalsController : ControllerBase
         else if (objectiveId != request.ObjectiveId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(objectiveId), nameof(request.ObjectiveId), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdatePlanningIntervalObjectiveCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdatePlanningIntervalObjectiveCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -589,7 +589,7 @@ public class PlanningIntervalsController : ControllerBase
         if (id != request.PlanningIntervalId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.PlanningIntervalId), HttpContext));
 
-        var result = await _sender.Send(new UpdatePlanningIntervalObjectivesOrderCommand(request.PlanningIntervalId, request.Objectives), cancellationToken);
+        var result = await _dispatcher.Send(new UpdatePlanningIntervalObjectivesOrderCommand(request.PlanningIntervalId, request.Objectives), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -603,7 +603,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalObjectiveHealthCheckDto>>> GetObjectivesHealthReport(string idOrKey, Guid? teamId, CancellationToken cancellationToken)
     {
-        var objectives = await _sender.Send(new GetPlanningIntervalObjectivesQuery(idOrKey, teamId), cancellationToken);
+        var objectives = await _dispatcher.Send(new GetPlanningIntervalObjectivesQuery(idOrKey, teamId), cancellationToken);
         if (objectives == null)
             return Ok(new List<PlanningIntervalObjectiveHealthCheckDto>());
 
@@ -620,11 +620,11 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<WorkItemsSummaryDto>> GetObjectiveWorkItems(string idOrKey, string objectiveIdOrKey, CancellationToken cancellationToken)
     {
-        var objectiveId = await _sender.Send(new CheckPlanningIntervalObjectiveExistsQuery(idOrKey, objectiveIdOrKey), cancellationToken);
+        var objectiveId = await _dispatcher.Send(new CheckPlanningIntervalObjectiveExistsQuery(idOrKey, objectiveIdOrKey), cancellationToken);
         if (objectiveId is null)
             return NotFound();
 
-        var workItemsSummary = await _sender.Send(new GetExternalObjectWorkItemsQuery(objectiveId.Value), cancellationToken);
+        var workItemsSummary = await _dispatcher.Send(new GetExternalObjectWorkItemsQuery(objectiveId.Value), cancellationToken);
 
         if (workItemsSummary is null)
             return NotFound();
@@ -643,18 +643,18 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<List<WorkItemProgressDailyRollupDto>>> GetObjectiveWorkItemMetrics(string idOrKey, string objectiveIdOrKey, CancellationToken cancellationToken)
     {
-        var objectiveId = await _sender.Send(new CheckPlanningIntervalObjectiveExistsQuery(idOrKey, objectiveIdOrKey), cancellationToken);
+        var objectiveId = await _dispatcher.Send(new CheckPlanningIntervalObjectiveExistsQuery(idOrKey, objectiveIdOrKey), cancellationToken);
         if (objectiveId is null)
             return NotFound();
 
-        var planningInterval = await _sender.Send(new GetPlanningIntervalQuery(idOrKey), cancellationToken);
+        var planningInterval = await _dispatcher.Send(new GetPlanningIntervalQuery(idOrKey), cancellationToken);
 
         var today = _dateTimeProvider.Now.ToDateOnly();
         var piEnd = planningInterval!.End.ToDateOnly();
         // get the min of today and the end of the PI
         var end = today < piEnd ? today : piEnd;
 
-        var dailyRollup = await _sender.Send(new GetExternalObjectWorkItemMetricsQuery(objectiveId.Value, planningInterval!.Start.ToDateOnly(), end), cancellationToken);
+        var dailyRollup = await _dispatcher.Send(new GetExternalObjectWorkItemMetricsQuery(objectiveId.Value, planningInterval!.Start.ToDateOnly(), end), cancellationToken);
 
         if (dailyRollup is null)
             return NotFound();
@@ -676,11 +676,11 @@ public class PlanningIntervalsController : ControllerBase
         else if (objectiveId != request.ObjectiveId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(objectiveId), nameof(request.ObjectiveId), HttpContext));
 
-        var confirmedObjectiveId = await _sender.Send(new CheckPlanningIntervalObjectiveExistsQuery(new IdOrKey(id), new IdOrKey(objectiveId)), cancellationToken);
+        var confirmedObjectiveId = await _dispatcher.Send(new CheckPlanningIntervalObjectiveExistsQuery(new IdOrKey(id), new IdOrKey(objectiveId)), cancellationToken);
         if (confirmedObjectiveId is null)
             return NotFound();
 
-        var result = await _sender.Send(request.ToManageExternalObjectWorkItemsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToManageExternalObjectWorkItemsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -729,7 +729,7 @@ public class PlanningIntervalsController : ControllerBase
             if (!objectives.Any())
                 return BadRequest("No PI objectives imported.");
 
-            var result = await _sender.Send(new ImportPlanningIntervalObjectivesCommand(objectives), cancellationToken);
+            var result = await _dispatcher.Send(new ImportPlanningIntervalObjectivesCommand(objectives), cancellationToken);
 
             return result.IsSuccess
                 ? NoContent()
@@ -749,7 +749,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteObjective(Guid id, Guid objectiveId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeletePlanningIntervalObjectiveCommand(id, objectiveId), cancellationToken);
+        var result = await _dispatcher.Send(new DeletePlanningIntervalObjectiveCommand(id, objectiveId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -763,7 +763,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalObjectiveStatusDto>>> GetObjectiveStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetPlanningIntervalObjectiveStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetPlanningIntervalObjectiveStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -778,7 +778,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<PlanningIntervalObjectiveHealthCheckDetailsDto>>> GetObjectiveHealthChecks(Guid id, Guid objectiveId, CancellationToken cancellationToken)
     {
-        var healthChecks = await _sender.Send(new GetPlanningIntervalObjectiveHealthChecksQuery(objectiveId), cancellationToken);
+        var healthChecks = await _dispatcher.Send(new GetPlanningIntervalObjectiveHealthChecksQuery(objectiveId), cancellationToken);
         return Ok(healthChecks);
     }
 
@@ -789,7 +789,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PlanningIntervalObjectiveHealthCheckDetailsDto>> GetObjectiveHealthCheck(Guid id, Guid objectiveId, Guid healthCheckId, CancellationToken cancellationToken)
     {
-        var healthCheck = await _sender.Send(new GetPlanningIntervalObjectiveHealthCheckQuery(objectiveId, healthCheckId), cancellationToken);
+        var healthCheck = await _dispatcher.Send(new GetPlanningIntervalObjectiveHealthCheckQuery(objectiveId, healthCheckId), cancellationToken);
 
         return healthCheck is not null
             ? Ok(healthCheck)
@@ -805,7 +805,7 @@ public class PlanningIntervalsController : ControllerBase
         if (objectiveId != request.PlanningIntervalObjectiveId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(objectiveId), nameof(request.PlanningIntervalObjectiveId), HttpContext));
 
-        var result = await _sender.Send(request.ToCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetObjectiveHealthCheck), new { id, objectiveId, healthCheckId = result.Value }, result.Value)
@@ -825,7 +825,7 @@ public class PlanningIntervalsController : ControllerBase
         else if (healthCheckId != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(healthCheckId), nameof(request.Id), HttpContext));
 
-        var result = await _sender.Send(request.ToCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -840,7 +840,7 @@ public class PlanningIntervalsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteObjectiveHealthCheck(Guid id, Guid objectiveId, Guid healthCheckId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeletePlanningIntervalObjectiveHealthCheckCommand(objectiveId, healthCheckId), cancellationToken);
+        var result = await _dispatcher.Send(new DeletePlanningIntervalObjectiveHealthCheckCommand(objectiveId, healthCheckId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -859,7 +859,7 @@ public class PlanningIntervalsController : ControllerBase
     public async Task<ActionResult<IReadOnlyList<RiskListDto>>> GetRisks(string idOrKey, bool? includeClosed, Guid? teamId, CancellationToken cancellationToken)
     {
         includeClosed ??= false;
-        var risks = await _sender.Send(new GetRisksByPlanningIntervalQuery(idOrKey, includeClosed.Value, teamId), cancellationToken);
+        var risks = await _dispatcher.Send(new GetRisksByPlanningIntervalQuery(idOrKey, includeClosed.Value, teamId), cancellationToken);
 
         return Ok(risks);
     }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/PokerSessionsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/PokerSessionsController.cs
@@ -14,9 +14,9 @@ namespace Wayd.Web.Api.Controllers.Planning;
 [ApiVersionNeutral]
 [ApiController]
 [FeatureGate(FeatureFlags.Names.PlanningPoker)]
-public class PokerSessionsController(ISender sender) : ControllerBase
+public class PokerSessionsController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.PokerSessions)]
@@ -25,7 +25,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<PokerSessionListDto>>> GetList(CancellationToken cancellationToken, [FromQuery] PokerSessionStatus? status = null)
     {
-        var sessions = await _sender.Send(new GetPokerSessionsQuery(status), cancellationToken);
+        var sessions = await _dispatcher.Send(new GetPokerSessionsQuery(status), cancellationToken);
         return Ok(sessions);
     }
 
@@ -36,7 +36,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PokerSessionDetailsDto>> GetSession(string idOrKey, CancellationToken cancellationToken)
     {
-        var session = await _sender.Send(new GetPokerSessionQuery(idOrKey), cancellationToken);
+        var session = await _dispatcher.Send(new GetPokerSessionQuery(idOrKey), cancellationToken);
         return session is not null
             ? Ok(session)
             : NotFound();
@@ -48,7 +48,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreatePokerSessionRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreatePokerSessionCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreatePokerSessionCommand(), cancellationToken);
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetSession), new { idOrKey = result.Value.Id.ToString() }, result.Value)
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -61,7 +61,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Update(Guid id, [FromBody] UpdatePokerSessionRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdatePokerSessionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdatePokerSessionCommand(id), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -74,7 +74,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeletePokerSessionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeletePokerSessionCommand(id), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -87,7 +87,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Complete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CompletePokerSessionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CompletePokerSessionCommand(id), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -100,7 +100,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<PokerRoundDto>> AddRound(Guid id, [FromBody] AddPokerRoundRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToAddPokerRoundCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddPokerRoundCommand(id), cancellationToken);
         return result.IsSuccess
             ? Ok(result.Value)
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -113,7 +113,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemoveRound(Guid id, Guid roundId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemovePokerRoundCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(new RemovePokerRoundCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -126,7 +126,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RevealRound(Guid id, Guid roundId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RevealPokerRoundCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(new RevealPokerRoundCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -139,7 +139,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> ResetRound(Guid id, Guid roundId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ResetPokerRoundCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(new ResetPokerRoundCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -152,7 +152,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> SetConsensus(Guid id, Guid roundId, [FromBody] SetConsensusRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToSetConsensusCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToSetConsensusCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -165,7 +165,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> UpdateRoundLabel(Guid id, Guid roundId, [FromBody] UpdatePokerRoundLabelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdatePokerRoundLabelCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdatePokerRoundLabelCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -178,7 +178,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> SubmitVote(Guid id, Guid roundId, [FromBody] SubmitVoteRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToSubmitVoteCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToSubmitVoteCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));
@@ -191,7 +191,7 @@ public class PokerSessionsController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> WithdrawVote(Guid id, Guid roundId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new WithdrawVoteCommand(id, roundId), cancellationToken);
+        var result = await _dispatcher.Send(new WithdrawVoteCommand(id, roundId), cancellationToken);
         return result.IsSuccess
             ? NoContent()
             : BadRequest(result.ToBadRequestObject(HttpContext));

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/RisksController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/RisksController.cs
@@ -1,5 +1,4 @@
 ﻿using CsvHelper;
-using Wayd.Common.Application.Interfaces;
 using Wayd.Common.Application.Models;
 using Wayd.Planning.Application.Risks.Commands;
 using Wayd.Planning.Application.Risks.Dtos;
@@ -14,13 +13,13 @@ namespace Wayd.Web.Api.Controllers.Planning;
 [ApiController]
 public class RisksController : ControllerBase
 {
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
     private readonly ICsvService _csvService;
     private readonly IDateTimeProvider _dateTimeProvider;
 
-    public RisksController(ISender sender, ICsvService csvService, IDateTimeProvider dateTimeProvider)
+    public RisksController(IDispatcher dispatcher, ICsvService csvService, IDateTimeProvider dateTimeProvider)
     {
-        _sender = sender;
+        _dispatcher = dispatcher;
         _csvService = csvService;
         _dateTimeProvider = dateTimeProvider;
     }
@@ -32,7 +31,7 @@ public class RisksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RiskListDto>>> GetList(CancellationToken cancellationToken, bool includeClosed = false)
     {
-        var risks = await _sender.Send(new GetRisksQuery(includeClosed), cancellationToken);
+        var risks = await _dispatcher.Send(new GetRisksQuery(includeClosed), cancellationToken);
         return Ok(risks);
     }
 
@@ -43,7 +42,7 @@ public class RisksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<RiskDetailsDto>> GetRisk(string idOrKey, CancellationToken cancellationToken)
     {
-        var risk = await _sender.Send(new GetRiskQuery(idOrKey), cancellationToken);
+        var risk = await _dispatcher.Send(new GetRiskQuery(idOrKey), cancellationToken);
 
         return risk is not null
             ? Ok(risk)
@@ -57,7 +56,7 @@ public class RisksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RiskListDto>>> GetMyRisks(CancellationToken cancellationToken)
     {
-        var risks = await _sender.Send(new GetMyRisksQuery(), cancellationToken);
+        var risks = await _dispatcher.Send(new GetMyRisksQuery(), cancellationToken);
         return Ok(risks);
     }
 
@@ -67,7 +66,7 @@ public class RisksController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateRiskRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateRiskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateRiskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetRisk), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -85,7 +84,7 @@ public class RisksController : ControllerBase
         if (id != request.RiskId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(id), nameof(request.RiskId), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateRiskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateRiskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -130,7 +129,7 @@ public class RisksController : ControllerBase
             if (risks.Count == 0)
                 return BadRequest(ProblemDetailsExtensions.ForBadRequest("No risks imported.", HttpContext));
 
-            var result = await _sender.Send(new ImportRisksCommand(risks), cancellationToken);
+            var result = await _dispatcher.Send(new ImportRisksCommand(risks), cancellationToken);
 
             return result.IsSuccess
                 ? NoContent()
@@ -150,7 +149,7 @@ public class RisksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RiskStatusDto>>> GetStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetRiskStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetRiskStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -161,7 +160,7 @@ public class RisksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RiskCategoryDto>>> GetCategories(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetRiskCategoriesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetRiskCategoriesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -172,7 +171,7 @@ public class RisksController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RiskGradeDto>>> GetGrades(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetRiskGradesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetRiskGradesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/RoadmapsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/RoadmapsController.cs
@@ -16,20 +16,20 @@ namespace Wayd.Web.Api.Controllers.Planning;
 public class RoadmapsController : ControllerBase
 {
     private readonly ILogger<RoadmapsController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
     private readonly IValidator<UpdateRoadmapActivityRequest> _updateActivityValidator;
     private readonly IValidator<UpdateRoadmapMilestoneRequest> _updateMilestoneValidator;
     private readonly IValidator<UpdateRoadmapTimeboxRequest> _updateTimeboxValidator;
 
     public RoadmapsController(
         ILogger<RoadmapsController> logger,
-        ISender sender,
+        IDispatcher dispatcher,
         IValidator<UpdateRoadmapActivityRequest> updateActivityValidator,
         IValidator<UpdateRoadmapMilestoneRequest> updateMilestoneValidator,
         IValidator<UpdateRoadmapTimeboxRequest> updateTimeboxValidator)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
         _updateActivityValidator = updateActivityValidator;
         _updateMilestoneValidator = updateMilestoneValidator;
         _updateTimeboxValidator = updateTimeboxValidator;
@@ -52,7 +52,7 @@ public class RoadmapsController : ControllerBase
             filter = [.. state.Select(s => (RoadmapState)s)];
         }
 
-        var roadmaps = await _sender.Send(new GetRoadmapsQuery(filter), cancellationToken);
+        var roadmaps = await _dispatcher.Send(new GetRoadmapsQuery(filter), cancellationToken);
         return Ok(roadmaps);
     }
 
@@ -63,7 +63,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<RoadmapDetailsDto>> GetRoadmap(string idOrKey, CancellationToken cancellationToken)
     {
-        var roadmap = await _sender.Send(new GetRoadmapQuery(idOrKey), cancellationToken);
+        var roadmap = await _dispatcher.Send(new GetRoadmapQuery(idOrKey), cancellationToken);
 
         return roadmap is not null
             ? Ok(roadmap)
@@ -76,7 +76,7 @@ public class RoadmapsController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateRoadmapRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateRoadmapCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateRoadmapCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetRoadmap), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -89,7 +89,7 @@ public class RoadmapsController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Copy([FromBody] CopyRoadmapRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCopyRoadmapCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCopyRoadmapCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetRoadmap), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -107,7 +107,7 @@ public class RoadmapsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateRoadmapCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateRoadmapCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -125,7 +125,7 @@ public class RoadmapsController : ControllerBase
         if (id != request.RoadmapId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateRoadmapColorsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateRoadmapColorsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -139,7 +139,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteRoadmapCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteRoadmapCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -153,7 +153,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveRoadmapCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveRoadmapCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -167,7 +167,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateRoadmapCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateRoadmapCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -183,7 +183,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RoadmapItemListDto>>> GetItems(string idOrKey, CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetRoadmapItemsQuery(idOrKey), cancellationToken);
+        var items = await _dispatcher.Send(new GetRoadmapItemsQuery(idOrKey), cancellationToken);
         return Ok(items);
     }
 
@@ -194,7 +194,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RoadmapActivityListDto>>> GetActivities(string idOrKey, CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetRoadmapActivitiesQuery(idOrKey), cancellationToken);
+        var items = await _dispatcher.Send(new GetRoadmapActivitiesQuery(idOrKey), cancellationToken);
         return Ok(items);
     }
 
@@ -205,7 +205,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<RoadmapItemDetailsDto>> GetItem(string roadmapIdOrKey, Guid itemId, CancellationToken cancellationToken)
     {
-        var item = await _sender.Send(new GetRoadmapItemQuery(roadmapIdOrKey, itemId), cancellationToken);
+        var item = await _dispatcher.Send(new GetRoadmapItemQuery(roadmapIdOrKey, itemId), cancellationToken);
         return Ok(item);
     }
 
@@ -226,7 +226,7 @@ public class RoadmapsController : ControllerBase
             _ => throw new ArgumentException("Invalid roadmap item type", nameof(request))
         };
 
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetItem), new { roadmapIdOrKey = roadmapId, itemId = result.Value.ToString() }, result.Value)
@@ -254,7 +254,7 @@ public class RoadmapsController : ControllerBase
             _ => throw new ArgumentException("Invalid roadmap item type", nameof(request))
         };
 
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -278,7 +278,7 @@ public class RoadmapsController : ControllerBase
             return BadRequest("Patch document cannot be null.");
 
         // Get the current item state
-        var itemDto = await _sender.Send(new GetRoadmapItemQuery(roadmapId.ToString(), itemId), cancellationToken);
+        var itemDto = await _dispatcher.Send(new GetRoadmapItemQuery(roadmapId.ToString(), itemId), cancellationToken);
         if (itemDto is null)
             return NotFound($"Roadmap item with ID '{itemId}' not found.");
 
@@ -328,7 +328,7 @@ public class RoadmapsController : ControllerBase
             _ => throw new ArgumentException("Invalid roadmap item type", nameof(updateRequest))
         };
 
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -356,7 +356,7 @@ public class RoadmapsController : ControllerBase
             _ => throw new ArgumentException("Invalid roadmap item type", nameof(request))
         };
 
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -375,7 +375,7 @@ public class RoadmapsController : ControllerBase
         else if (itemId != request.ItemId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(nameof(itemId), nameof(request.ItemId), HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateRoadmapActivityPlacementCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateRoadmapActivityPlacementCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -389,7 +389,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteItem(Guid roadmapId, Guid itemId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteRoadmapItemCommand(roadmapId, itemId), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteRoadmapItemCommand(roadmapId, itemId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -405,7 +405,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<VisibilityDto>>> GetVisibilityOptions(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetVisibilitiesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetVisibilitiesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -416,7 +416,7 @@ public class RoadmapsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<RoadmapStateDto>>> GetStateOptions(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetRoadmapStatesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetRoadmapStatesQuery(), cancellationToken);
         return Ok(items.OrderBy(s => s.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/SprintsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Planning/SprintsController.cs
@@ -9,10 +9,10 @@ namespace Wayd.Web.Api.Controllers.Planning;
 [Route("api/planning/[controller]")]
 [ApiVersionNeutral]
 [ApiController]
-public class SprintsController(ILogger<SprintsController> logger, ISender sender) : ControllerBase
+public class SprintsController(ILogger<SprintsController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<SprintsController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Iterations)]
@@ -21,7 +21,7 @@ public class SprintsController(ILogger<SprintsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<SprintListDto>>> GetSprints([FromQuery] Guid? teamId, CancellationToken cancellationToken)
     {
-        var sprints = await _sender.Send(new GetSprintsQuery(teamId), cancellationToken);
+        var sprints = await _dispatcher.Send(new GetSprintsQuery(teamId), cancellationToken);
 
         return Ok(sprints);
     }
@@ -33,7 +33,7 @@ public class SprintsController(ILogger<SprintsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<SprintDetailsDto>> GetSprint(string idOrKey, CancellationToken cancellationToken)
     {
-        var sprint = await _sender.Send(new GetSprintQuery(idOrKey), cancellationToken);
+        var sprint = await _dispatcher.Send(new GetSprintQuery(idOrKey), cancellationToken);
 
         return sprint is not null
             ? Ok(sprint)
@@ -48,7 +48,7 @@ public class SprintsController(ILogger<SprintsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<SprintBacklogItemDto>>> GetSprintBacklog(string idOrKey, CancellationToken cancellationToken)
     {
-        var backlogItems = await _sender.Send(new GetSprintBacklogQuery(idOrKey), cancellationToken);
+        var backlogItems = await _dispatcher.Send(new GetSprintBacklogQuery(idOrKey), cancellationToken);
 
         return backlogItems is not null
             ? Ok(backlogItems)
@@ -62,7 +62,7 @@ public class SprintsController(ILogger<SprintsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<SprintWorkItemMetricsDto>> GetSprintMetrics(string idOrKey, CancellationToken cancellationToken)
     {
-        var metrics = await _sender.Send(new GetSprintWorkItemMetricsQuery(idOrKey), cancellationToken);
+        var metrics = await _dispatcher.Send(new GetSprintWorkItemMetricsQuery(idOrKey), cancellationToken);
 
         return metrics is not null
             ? Ok(metrics)
@@ -75,7 +75,7 @@ public class SprintsController(ILogger<SprintsController> logger, ISender sender
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<NavigationDto>>> GetPlanningIntervals(int key, CancellationToken cancellationToken)
     {
-        var planningIntervals = await _sender.Send(new GetSprintPlanningIntervalsQuery(key), cancellationToken);
+        var planningIntervals = await _dispatcher.Send(new GetSprintPlanningIntervalsQuery(key), cancellationToken);
         return Ok(planningIntervals);
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ExpenditureCategoriesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ExpenditureCategoriesController.cs
@@ -9,10 +9,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/expenditure-categories")]
 [ApiVersionNeutral]
 [ApiController]
-public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesController> logger, ISender sender) : ControllerBase
+public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ExpenditureCategoriesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.ExpenditureCategories)]
@@ -21,7 +21,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ExpenditureCategoryListDto>>> GetExpenditureCategories(CancellationToken cancellationToken)
     {
-        var expenditures = await _sender.Send(new GetExpenditureCategoriesQuery(), cancellationToken);
+        var expenditures = await _dispatcher.Send(new GetExpenditureCategoriesQuery(), cancellationToken);
 
         return Ok(expenditures);
     }
@@ -33,7 +33,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ExpenditureCategoryDetailsDto>> GetExpenditureCategory(int id, CancellationToken cancellationToken)
     {
-        var expenditure = await _sender.Send(new GetExpenditureCategoryQuery(id), cancellationToken);
+        var expenditure = await _dispatcher.Send(new GetExpenditureCategoryQuery(id), cancellationToken);
 
         return expenditure is not null
             ? Ok(expenditure)
@@ -46,7 +46,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Int))]
     public async Task<ActionResult<int>> Create([FromBody] CreateExpenditureCategoryRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateExpenditureCategoryCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateExpenditureCategoryCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetExpenditureCategory), new { id = result.Value }, result.Value)
@@ -64,7 +64,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateExpenditureCategoryCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateExpenditureCategoryCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -79,7 +79,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(int id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateExpenditureCategoryCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateExpenditureCategoryCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -94,7 +94,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Archive(int id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveExpenditureCategoryCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveExpenditureCategoryCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -108,7 +108,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(int id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteExpenditureCategoryCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteExpenditureCategoryCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -122,7 +122,7 @@ public class ExpenditureCategoriesController(ILogger<ExpenditureCategoriesContro
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ExpenditureCategoryOptionDto>>> GetExpenditureCategoryOptions([FromQuery] bool? includeArchived, CancellationToken cancellationToken)
     {
-        var options = await _sender.Send(new GetExpenditureCategoryOptionsQuery(includeArchived), cancellationToken);
+        var options = await _dispatcher.Send(new GetExpenditureCategoryOptionsQuery(includeArchived), cancellationToken);
 
         return Ok(options);
     }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/PortfoliosController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/PortfoliosController.cs
@@ -21,11 +21,11 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/[controller]")]
 [ApiVersionNeutral]
 [ApiController]
-public class PortfoliosController(ILogger<PortfoliosController> logger, ISender sender)
+public class PortfoliosController(ILogger<PortfoliosController> logger, IDispatcher dispatcher)
     : ControllerBase
 {
     private readonly ILogger<PortfoliosController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.ProjectPortfolios)]
@@ -38,7 +38,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
             ? [.. status.Select(s => (ProjectPortfolioStatus)s)]
             : null;
 
-        var portfolios = await _sender.Send(new GetProjectPortfoliosQuery(filter), cancellationToken);
+        var portfolios = await _dispatcher.Send(new GetProjectPortfoliosQuery(filter), cancellationToken);
 
         return Ok(portfolios);
     }
@@ -50,7 +50,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectPortfolioDetailsDto>> GetPortfolio(string idOrKey, CancellationToken cancellationToken)
     {
-        var portfolio = await _sender.Send(new GetProjectPortfolioQuery(idOrKey), cancellationToken);
+        var portfolio = await _dispatcher.Send(new GetProjectPortfolioQuery(idOrKey), cancellationToken);
 
         return portfolio is not null
             ? Ok(portfolio)
@@ -63,7 +63,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreatePortfolioRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateProjectPortfolioCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateProjectPortfolioCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetPortfolio), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -81,7 +81,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateProjectPortfolioCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateProjectPortfolioCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -96,7 +96,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateProjectPortfolioCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateProjectPortfolioCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -111,7 +111,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Close(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CloseProjectPortfolioCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CloseProjectPortfolioCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -126,7 +126,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveProjectPortfolioCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveProjectPortfolioCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -140,7 +140,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteProjectPortfolioCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteProjectPortfolioCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -155,7 +155,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> AssignScoringModel(Guid id, [FromBody] AssignPortfolioScoringModelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new AssignPortfolioScoringModelCommand(id, request.ScoringModelId), cancellationToken);
+        var result = await _dispatcher.Send(new AssignPortfolioScoringModelCommand(id, request.ScoringModelId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -169,7 +169,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> ClearScoringModel(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ClearPortfolioScoringModelCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ClearPortfolioScoringModelCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -184,7 +184,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> MoveProjectRanks(Guid id, [FromBody] MoveProjectRanksRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -198,7 +198,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RebalanceProjectRanks(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RebalancePortfolioRanksCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new RebalancePortfolioRanksCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -212,7 +212,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PortfolioRankingScoreboardDto>> GetRankingScoreboard(Guid id, CancellationToken cancellationToken)
     {
-        var scoreboard = await _sender.Send(new GetPortfolioRankingScoreboardQuery(id), cancellationToken);
+        var scoreboard = await _dispatcher.Send(new GetPortfolioRankingScoreboardQuery(id), cancellationToken);
 
         return scoreboard is not null
             ? Ok(scoreboard)
@@ -231,7 +231,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
             ? [.. status.Select(s => (ProgramStatus)s)]
             : null;
 
-        var programs = await _sender.Send(new GetProgramsQuery(PortfolioIdOrKey: idOrKey, StatusFilter: filter), cancellationToken);
+        var programs = await _dispatcher.Send(new GetProgramsQuery(PortfolioIdOrKey: idOrKey, StatusFilter: filter), cancellationToken);
 
         return programs is not null
             ? Ok(programs)
@@ -250,7 +250,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
             ? [.. status.Select(s => (ProjectStatus)s)]
             : null;
 
-        var projects = await _sender.Send(new GetProjectsQuery(StatusFilter: filter, PortfolioIdOrKey: idOrKey), cancellationToken);
+        var projects = await _dispatcher.Send(new GetProjectsQuery(StatusFilter: filter, PortfolioIdOrKey: idOrKey), cancellationToken);
 
         return projects is not null
             ? Ok(projects)
@@ -268,7 +268,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
             ? [.. status.Select(s => (StrategicInitiativeStatus)s)]
             : null;
 
-        var initiatives = await _sender.Send(new GetStrategicInitiativesQuery(filter, idOrKey), cancellationToken);
+        var initiatives = await _dispatcher.Send(new GetStrategicInitiativesQuery(filter, idOrKey), cancellationToken);
 
         return Ok(initiatives);
     }
@@ -280,7 +280,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectPortfolioStatusDto>>> GetPortfolioStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetProjectPortfolioStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetProjectPortfolioStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -291,7 +291,7 @@ public class PortfoliosController(ILogger<PortfoliosController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectPortfolioOptionDto>>> GetPortfolioOptions(CancellationToken cancellationToken)
     {
-        var options = await _sender.Send(new GetProjectPortfolioOptionsQuery(), cancellationToken);
+        var options = await _dispatcher.Send(new GetProjectPortfolioOptionsQuery(), cancellationToken);
 
         return Ok(options);
     }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProgramsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProgramsController.cs
@@ -13,10 +13,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/[controller]")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProgramsController(ILogger<ProgramsController> logger, ISender sender) : ControllerBase
+public class ProgramsController(ILogger<ProgramsController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ProgramsController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Programs)]
@@ -35,7 +35,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
             ? new IdOrKey(portfolioId.Value)
             : null;
 
-        var programs = await _sender.Send(new GetProgramsQuery(StatusFilter: filter, PortfolioIdOrKey: portfolioIdOrKey), cancellationToken);
+        var programs = await _dispatcher.Send(new GetProgramsQuery(StatusFilter: filter, PortfolioIdOrKey: portfolioIdOrKey), cancellationToken);
 
         return programs is not null
             ? Ok(programs)
@@ -49,7 +49,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProgramDetailsDto>> GetProgram(string idOrKey, CancellationToken cancellationToken)
     {
-        var program = await _sender.Send(new GetProgramQuery(idOrKey), cancellationToken);
+        var program = await _dispatcher.Send(new GetProgramQuery(idOrKey), cancellationToken);
 
         return program is not null
             ? Ok(program)
@@ -62,7 +62,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateProgramRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateProgramCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateProgramCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetProgram), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -80,7 +80,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateProgramCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateProgramCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -95,7 +95,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateProgramCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateProgramCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -110,7 +110,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Complete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CompleteProgramCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CompleteProgramCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -125,7 +125,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Cancel(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CancelProgramCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CancelProgramCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -139,7 +139,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteProgramCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteProgramCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -155,7 +155,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProgramStatusDto>>> GetProgramStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetProgramStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetProgramStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -171,7 +171,7 @@ public class ProgramsController(ILogger<ProgramsController> logger, ISender send
             ? [.. status.Select(s => (ProjectStatus)s)]
             : null;
 
-        var projects = await _sender.Send(new GetProjectsQuery(StatusFilter: filter, ProgramIdOrKey: idOrKey), cancellationToken);
+        var projects = await _dispatcher.Send(new GetProjectsQuery(StatusFilter: filter, ProgramIdOrKey: idOrKey), cancellationToken);
 
         return projects is not null
             ? Ok(projects)

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectHealthChecksController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectHealthChecksController.cs
@@ -9,10 +9,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/projects")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController> logger, ISender sender) : ControllerBase
+public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ProjectHealthChecksController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet("{id}/health-checks")]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Projects)]
@@ -21,7 +21,7 @@ public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<ProjectHealthCheckDetailsDto>>> GetHealthChecks(Guid id, CancellationToken cancellationToken)
     {
-        var healthChecks = await _sender.Send(new GetProjectHealthChecksQuery(id), cancellationToken);
+        var healthChecks = await _dispatcher.Send(new GetProjectHealthChecksQuery(id), cancellationToken);
         return Ok(healthChecks);
     }
 
@@ -32,7 +32,7 @@ public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectHealthCheckDetailsDto>> GetHealthCheck(Guid id, Guid healthCheckId, CancellationToken cancellationToken)
     {
-        var healthCheck = await _sender.Send(new GetProjectHealthCheckQuery(id, healthCheckId), cancellationToken);
+        var healthCheck = await _dispatcher.Send(new GetProjectHealthCheckQuery(id, healthCheckId), cancellationToken);
 
         return healthCheck is not null
             ? Ok(healthCheck)
@@ -47,7 +47,7 @@ public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult<Guid>> CreateHealthCheck(Guid id, [FromBody] CreateProjectHealthCheckRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CreateProjectHealthCheckCommand(id, request.Status, request.Expiration, request.Note), cancellationToken);
+        var result = await _dispatcher.Send(new CreateProjectHealthCheckCommand(id, request.Status, request.Expiration, request.Note), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetHealthCheck), new { id, healthCheckId = result.Value }, result.Value)
@@ -62,7 +62,7 @@ public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult<ProjectHealthCheckDetailsDto>> UpdateHealthCheck(Guid id, Guid healthCheckId, [FromBody] UpdateProjectHealthCheckRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new UpdateProjectHealthCheckCommand(id, healthCheckId, request.Status, request.Expiration, request.Note), cancellationToken);
+        var result = await _dispatcher.Send(new UpdateProjectHealthCheckCommand(id, healthCheckId, request.Status, request.Expiration, request.Note), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -76,7 +76,7 @@ public class ProjectHealthChecksController(ILogger<ProjectHealthChecksController
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> DeleteHealthCheck(Guid id, Guid healthCheckId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteProjectHealthCheckCommand(id, healthCheckId), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteProjectHealthCheckCommand(id, healthCheckId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectLifecyclesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectLifecyclesController.cs
@@ -10,10 +10,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/project-lifecycles")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> logger, ISender sender) : ControllerBase
+public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ProjectLifecyclesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.ProjectLifecycles)]
@@ -22,7 +22,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectLifecycleListDto>>> GetProjectLifecycles([FromQuery] ProjectLifecycleState? state, CancellationToken cancellationToken)
     {
-        var lifecycles = await _sender.Send(new GetProjectLifecyclesQuery(state), cancellationToken);
+        var lifecycles = await _dispatcher.Send(new GetProjectLifecyclesQuery(state), cancellationToken);
 
         return Ok(lifecycles);
     }
@@ -34,7 +34,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectLifecycleDetailsDto>> GetProjectLifecycle(string idOrKey, CancellationToken cancellationToken)
     {
-        var lifecycle = await _sender.Send(new GetProjectLifecycleQuery(idOrKey), cancellationToken);
+        var lifecycle = await _dispatcher.Send(new GetProjectLifecycleQuery(idOrKey), cancellationToken);
 
         return lifecycle is not null
             ? Ok(lifecycle)
@@ -47,7 +47,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> Create([FromBody] CreateProjectLifecycleRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateProjectLifecycleCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateProjectLifecycleCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetProjectLifecycle), new { idOrKey = result.Value }, result.Value)
@@ -62,7 +62,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Update(Guid id, [FromBody] UpdateProjectLifecycleRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateProjectLifecycleCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateProjectLifecycleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -76,7 +76,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteProjectLifecycleCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteProjectLifecycleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -91,7 +91,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateProjectLifecycleCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateProjectLifecycleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -106,7 +106,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveProjectLifecycleCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveProjectLifecycleCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -119,7 +119,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Guid))]
     public async Task<ActionResult<Guid>> AddPhase(Guid id, [FromBody] ProjectLifecyclePhaseRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToAddCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetProjectLifecycle), new { idOrKey = id.ToString() }, result.Value)
@@ -134,7 +134,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdatePhase(Guid id, Guid phaseId, [FromBody] ProjectLifecyclePhaseRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToUpdateCommand(id, phaseId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateCommand(id, phaseId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -148,7 +148,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> RemovePhase(Guid id, Guid phaseId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveProjectLifecyclePhaseCommand(id, phaseId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveProjectLifecyclePhaseCommand(id, phaseId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -163,7 +163,7 @@ public class ProjectLifecyclesController(ILogger<ProjectLifecyclesController> lo
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ReorderPhases(Guid id, [FromBody] ReorderProjectLifecyclePhasesRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToReorderProjectLifecyclePhasesCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToReorderProjectLifecyclePhasesCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectScoresController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectScoresController.cs
@@ -8,10 +8,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/projects")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProjectScoresController(ILogger<ProjectScoresController> logger, ISender sender) : ControllerBase
+public class ProjectScoresController(ILogger<ProjectScoresController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ProjectScoresController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet("{id}/scoring-context")]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Projects)]
@@ -20,7 +20,7 @@ public class ProjectScoresController(ILogger<ProjectScoresController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectScoringContextDto>> GetScoringContext(Guid id, CancellationToken cancellationToken)
     {
-        var context = await _sender.Send(new GetProjectScoringContextQuery(id), cancellationToken);
+        var context = await _dispatcher.Send(new GetProjectScoringContextQuery(id), cancellationToken);
 
         return context is not null
             ? Ok(context)
@@ -33,7 +33,7 @@ public class ProjectScoresController(ILogger<ProjectScoresController> logger, IS
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IEnumerable<ProjectScoreSummaryDto>>> GetScores(Guid id, CancellationToken cancellationToken)
     {
-        var scores = await _sender.Send(new GetProjectScoresQuery(id), cancellationToken);
+        var scores = await _dispatcher.Send(new GetProjectScoresQuery(id), cancellationToken);
         return Ok(scores);
     }
 
@@ -44,7 +44,7 @@ public class ProjectScoresController(ILogger<ProjectScoresController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectScoreDetailsDto>> GetScore(Guid id, Guid scoreId, CancellationToken cancellationToken)
     {
-        var score = await _sender.Send(new GetProjectScoreQuery(id, scoreId), cancellationToken);
+        var score = await _dispatcher.Send(new GetProjectScoreQuery(id, scoreId), cancellationToken);
 
         return score is not null
             ? Ok(score)
@@ -59,7 +59,7 @@ public class ProjectScoresController(ILogger<ProjectScoresController> logger, IS
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult<Guid>> RecordScore(Guid id, [FromBody] RecordProjectScoreRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetScore), new { id, scoreId = result.Value }, result.Value)

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectTasksController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectTasksController.cs
@@ -14,10 +14,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/projects/{projectIdOrKey}/tasks")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISender sender, IValidator<UpdateProjectTaskRequest> updateProjectTaskValidator) : ControllerBase
+public class ProjectTasksController(ILogger<ProjectTasksController> logger, IDispatcher dispatcher, IValidator<UpdateProjectTaskRequest> updateProjectTaskValidator) : ControllerBase
 {
     private readonly ILogger<ProjectTasksController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IValidator<UpdateProjectTaskRequest> _updateProjectTaskValidator = updateProjectTaskValidator;
 
     [HttpGet]
@@ -33,7 +33,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
     {
         TaskStatus? statusFilter = status.HasValue ? (TaskStatus)status.Value : null;
 
-        var tasks = await _sender.Send(
+        var tasks = await _dispatcher.Send(
             new GetProjectTasksQuery(projectIdOrKey, statusFilter, parentId),
             cancellationToken);
 
@@ -50,7 +50,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         string taskIdOrKey,
         CancellationToken cancellationToken)
     {
-        var task = await _sender.Send(new GetProjectTaskQuery(taskIdOrKey), cancellationToken);
+        var task = await _dispatcher.Send(new GetProjectTaskQuery(taskIdOrKey), cancellationToken);
 
         return task is not null
             ? Ok(task)
@@ -73,7 +73,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         if (projectId is null)
             return NotFound($"Project with identifier '{projectIdOrKey}' not found.");
 
-        var result = await _sender.Send(request.ToCreateProjectTaskCommand(projectId.Value), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateProjectTaskCommand(projectId.Value), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(
@@ -98,7 +98,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateProjectTaskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateProjectTaskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -122,7 +122,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
             return BadRequest("Patch document cannot be null.");
 
         // Get the current task state
-        var taskDto = await _sender.Send(new GetProjectTaskQuery(id.ToString()), cancellationToken);
+        var taskDto = await _dispatcher.Send(new GetProjectTaskQuery(id.ToString()), cancellationToken);
         if (taskDto is null)
             return NotFound($"Project task with ID '{id}' not found.");
 
@@ -151,7 +151,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
                 modelStateDictionary: ModelState,
                 statusCode: StatusCodes.Status422UnprocessableEntity);
 
-        var result = await _sender.Send(updateRequest.ToUpdateProjectTaskCommand(), cancellationToken);
+        var result = await _dispatcher.Send(updateRequest.ToUpdateProjectTaskCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -169,7 +169,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         Guid id,
         CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteProjectTaskCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteProjectTaskCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -195,7 +195,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         if (projectId is null)
             return NotFound($"Project with identifier '{projectIdOrKey}' not found.");
 
-        var result = await _sender.Send(request.ToUpdateProjectTaskPlacementCommand(projectId.Value), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateProjectTaskPlacementCommand(projectId.Value), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -211,7 +211,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         string projectIdOrKey,
         CancellationToken cancellationToken)
     {
-        var criticalPath = await _sender.Send(new GetCriticalPathQuery(projectIdOrKey), cancellationToken);
+        var criticalPath = await _dispatcher.Send(new GetCriticalPathQuery(projectIdOrKey), cancellationToken);
 
         return Ok(criticalPath);
     }
@@ -235,7 +235,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         if (projectId is null)
             return NotFound($"Project with identifier '{projectIdOrKey}' not found.");
 
-        var result = await _sender.Send(new AddProjectTaskDependencyCommand(projectId.Value, request.PredecessorId, request.SuccessorId), cancellationToken);
+        var result = await _dispatcher.Send(new AddProjectTaskDependencyCommand(projectId.Value, request.PredecessorId, request.SuccessorId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -258,7 +258,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         if (projectId is null)
             return NotFound($"Project with identifier '{projectIdOrKey}' not found.");
 
-        var result = await _sender.Send(new RemoveProjectTaskDependencyCommand(projectId.Value, id, successorId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveProjectTaskDependencyCommand(projectId.Value, id, successorId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -272,7 +272,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectTaskTypeDto>>> GetTaskTypes(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetProjectTaskTypesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetProjectTaskTypesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -283,7 +283,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<TaskStatusDto>>> GetTaskStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetProjectTaskStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetProjectTaskStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -294,7 +294,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<TaskPriorityDto>>> GetTaskPriorities(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetProjectTaskPrioritiesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetProjectTaskPrioritiesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -308,7 +308,7 @@ public class ProjectTasksController(ILogger<ProjectTasksController> logger, ISen
         try
         {
             var key = new ProjectKey(projectIdOrKey);
-            return await _sender.Send(new GetProjectIdQuery(key), cancellationToken);
+            return await _dispatcher.Send(new GetProjectIdQuery(key), cancellationToken);
         }
         catch
         {

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/ProjectsController.cs
@@ -15,10 +15,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/[controller]")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProjectsController(ILogger<ProjectsController> logger, ISender sender) : ControllerBase
+public class ProjectsController(ILogger<ProjectsController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<ProjectsController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Projects)]
@@ -35,7 +35,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
             ? new IdOrKey(portfolioId.Value)
             : null;
 
-        var projects = await _sender.Send(new GetProjectsQuery(StatusFilter: filter, PortfolioIdOrKey: portfolioIdOrKey, RoleFilter: roleFilter), cancellationToken);
+        var projects = await _dispatcher.Send(new GetProjectsQuery(StatusFilter: filter, PortfolioIdOrKey: portfolioIdOrKey, RoleFilter: roleFilter), cancellationToken);
 
         return projects is not null
             ? Ok(projects)
@@ -50,7 +50,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     {
         var statusFilter = ParseStatusFilter(status);
 
-        var summary = await _sender.Send(new GetMyProjectsSummaryQuery(StatusFilter: statusFilter), cancellationToken);
+        var summary = await _dispatcher.Send(new GetMyProjectsSummaryQuery(StatusFilter: statusFilter), cancellationToken);
 
         return summary is not null
             ? Ok(summary)
@@ -66,7 +66,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
         var statusFilter = ParseStatusFilter(status);
         var roleFilter = ParseRoleFilter(role);
 
-        return Ok(await _sender.Send(new GetMyProjectsTaskMetricsQuery(StatusFilter: statusFilter, RoleFilter: roleFilter), cancellationToken));
+        return Ok(await _dispatcher.Send(new GetMyProjectsTaskMetricsQuery(StatusFilter: statusFilter, RoleFilter: roleFilter), cancellationToken));
     }
 
     [HttpGet("{idOrKey}")]
@@ -76,7 +76,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectDetailsDto>> GetProject(string idOrKey, CancellationToken cancellationToken)
     {
-        var project = await _sender.Send(new GetProjectQuery(idOrKey), cancellationToken);
+        var project = await _dispatcher.Send(new GetProjectQuery(idOrKey), cancellationToken);
 
         return project is not null
             ? Ok(project)
@@ -89,7 +89,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateProjectRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateProjectCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateProjectCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetProject), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -107,7 +107,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateProjectCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateProjectCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -123,7 +123,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ChangeProgram(Guid id, [FromBody] ChangeProjectProgramRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToChangeProjectProgramCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToChangeProjectProgramCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -138,7 +138,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ChangeKey(Guid id, [FromBody] ChangeProjectKeyRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToChangeProjectKeyCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToChangeProjectKeyCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -153,7 +153,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Approve(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ApproveProjectCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ApproveProjectCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -168,7 +168,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateProjectCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateProjectCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -183,7 +183,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Complete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CompleteProjectCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CompleteProjectCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -198,7 +198,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Cancel(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CancelProjectCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CancelProjectCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -212,7 +212,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteProjectCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteProjectCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -226,7 +226,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectStatusDto>>> GetProjectStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetProjectStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetProjectStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -237,7 +237,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<ProjectTeamMemberDto>>> GetProjectTeam(string idOrKey, CancellationToken cancellationToken)
     {
-        var team = await _sender.Send(new GetProjectTeamQuery(idOrKey), cancellationToken);
+        var team = await _dispatcher.Send(new GetProjectTeamQuery(idOrKey), cancellationToken);
 
         return team is not null
             ? Ok(team)
@@ -252,7 +252,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<WorkItemListDto>>> GetProjectWorkItems(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new GetProjectWorkItemsQuery(id), cancellationToken);
+        var result = await _dispatcher.Send(new GetProjectWorkItemsQuery(id), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value.OrderBy(w => w.StackRank))
@@ -266,7 +266,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> AssignLifecycle(Guid id, [FromBody] AssignProjectLifecycleRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -284,7 +284,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
         [FromBody] ChangeProjectLifecycleRequest request,
         CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -298,7 +298,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectPhaseListDto>>> GetProjectPhases(Guid id, CancellationToken cancellationToken)
     {
-        var phases = await _sender.Send(new GetProjectPhasesQuery(id), cancellationToken);
+        var phases = await _dispatcher.Send(new GetProjectPhasesQuery(id), cancellationToken);
 
         return Ok(phases);
     }
@@ -310,7 +310,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<ProjectPlanNodeDto>>> GetProjectPlanTree(string idOrKey, CancellationToken cancellationToken)
     {
-        var nodes = await _sender.Send(new GetProjectPlanTreeQuery(idOrKey), cancellationToken);
+        var nodes = await _dispatcher.Send(new GetProjectPlanTreeQuery(idOrKey), cancellationToken);
 
         return Ok(nodes);
     }
@@ -322,7 +322,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<ProjectPlanSummaryDto>> GetProjectPlanSummary(string idOrKey, [FromQuery] Guid? employeeId, CancellationToken cancellationToken)
     {
-        var summary = await _sender.Send(new GetProjectPlanSummaryQuery(idOrKey, employeeId), cancellationToken);
+        var summary = await _dispatcher.Send(new GetProjectPlanSummaryQuery(idOrKey, employeeId), cancellationToken);
 
         return Ok(summary);
     }
@@ -335,7 +335,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     {
         var roleFilter = ParseRoleFilter(role);
 
-        var summaries = await _sender.Send(new GetProjectsPlanSummariesQuery(projectId, roleFilter), cancellationToken);
+        var summaries = await _dispatcher.Send(new GetProjectsPlanSummariesQuery(projectId, roleFilter), cancellationToken);
 
         return Ok(summaries);
     }
@@ -347,7 +347,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<ProjectPhaseDetailsDto>> GetProjectPhase(Guid id, Guid phaseId, CancellationToken cancellationToken)
     {
-        var phase = await _sender.Send(new GetProjectPhaseQuery(id, phaseId), cancellationToken);
+        var phase = await _dispatcher.Send(new GetProjectPhaseQuery(id, phaseId), cancellationToken);
 
         return phase is not null
             ? Ok(phase)
@@ -361,7 +361,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> UpdateProjectPhase(Guid id, Guid phaseId, [FromBody] UpdateProjectPhaseRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCommand(id, phaseId), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCommand(id, phaseId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -385,7 +385,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
         if (patchDocument == null)
             return BadRequest("Patch document cannot be null.");
 
-        var phaseDto = await _sender.Send(new GetProjectPhaseQuery(id, phaseId), cancellationToken);
+        var phaseDto = await _dispatcher.Send(new GetProjectPhaseQuery(id, phaseId), cancellationToken);
         if (phaseDto is null)
             return NotFound($"Project phase with ID '{phaseId}' not found.");
 
@@ -402,7 +402,7 @@ public class ProjectsController(ILogger<ProjectsController> logger, ISender send
         if (!TryValidateModel(updateRequest))
             return ValidationProblem(ModelState);
 
-        var result = await _sender.Send(updateRequest.ToCommand(id, phaseId), cancellationToken);
+        var result = await _dispatcher.Send(updateRequest.ToCommand(id, phaseId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Ppm/StrategicInitiativesController.cs
@@ -13,10 +13,10 @@ namespace Wayd.Web.Api.Controllers.Ppm;
 [Route("api/ppm/strategic-initiatives")]
 [ApiVersionNeutral]
 [ApiController]
-public class StrategicInitiativesController(ILogger<StrategicInitiativesController> logger, ISender sender) : ControllerBase
+public class StrategicInitiativesController(ILogger<StrategicInitiativesController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<StrategicInitiativesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.StrategicInitiatives)]
@@ -33,7 +33,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
             ? new IdOrKey(portfolioId.Value)
             : null;
 
-        var initiatives = await _sender.Send(new GetStrategicInitiativesQuery(StatusFilter: filter, PortfolioIdOrKey: portfolioIdOrKey), cancellationToken);
+        var initiatives = await _dispatcher.Send(new GetStrategicInitiativesQuery(StatusFilter: filter, PortfolioIdOrKey: portfolioIdOrKey), cancellationToken);
 
         return Ok(initiatives);
     }
@@ -45,7 +45,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<StrategicInitiativeDetailsDto>> GetStrategicInitiative(string idOrKey, CancellationToken cancellationToken)
     {
-        var initiative = await _sender.Send(new GetStrategicInitiativeQuery(idOrKey), cancellationToken);
+        var initiative = await _dispatcher.Send(new GetStrategicInitiativeQuery(idOrKey), cancellationToken);
 
         return initiative is not null
             ? Ok(initiative)
@@ -58,7 +58,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateStrategicInitiativeRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateStrategicInitiativeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateStrategicInitiativeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetStrategicInitiative), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -76,7 +76,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateStrategicInitiativeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateStrategicInitiativeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -91,7 +91,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Approve(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ApproveStrategicInitiativeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ApproveStrategicInitiativeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -106,7 +106,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateStrategicInitiativeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateStrategicInitiativeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -121,7 +121,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Complete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CompleteStrategicInitiativeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CompleteStrategicInitiativeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -136,7 +136,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Cancel(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new CancelStrategicInitiativeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new CancelStrategicInitiativeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -150,7 +150,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteStrategicInitiativeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteStrategicInitiativeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -164,7 +164,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<StrategicInitiativeStatusDto>>> GetStrategicInitiativeStatuses(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetStrategicInitiativeStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetStrategicInitiativeStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(c => c.Order));
     }
 
@@ -177,7 +177,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<StrategicInitiativeKpiListDto>>> GetKpis(string id, CancellationToken cancellationToken)
     {
-        var kpis = await _sender.Send(new GetStrategicInitiativeKpisQuery(id), cancellationToken);
+        var kpis = await _dispatcher.Send(new GetStrategicInitiativeKpisQuery(id), cancellationToken);
 
         return kpis is not null
             ? Ok(kpis)
@@ -191,7 +191,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<StrategicInitiativeKpiDetailsDto>> GetKpi(string id, string kpiId, CancellationToken cancellationToken)
     {
-        var kpi = await _sender.Send(new GetStrategicInitiativeKpiQuery(id, kpiId), cancellationToken);
+        var kpi = await _dispatcher.Send(new GetStrategicInitiativeKpiQuery(id, kpiId), cancellationToken);
 
         return kpi is not null
             ? Ok(kpi)
@@ -207,7 +207,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         if (id != request.StrategicInitiativeId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToCreateStrategicInitiativeKpiCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateStrategicInitiativeKpiCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetKpi), new { id = id, kpiId = result.Value }, result.Value)
@@ -225,7 +225,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         if (id != request.StrategicInitiativeId || kpiId != request.KpiId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateStrategicInitiativeKpiCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateStrategicInitiativeKpiCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -240,7 +240,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult> DeleteKpi(Guid id, Guid kpiId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteStrategicInitiativeKpiCommand(id, kpiId), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteStrategicInitiativeKpiCommand(id, kpiId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -255,7 +255,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> ReorderKpis(Guid id, [FromBody] ReorderStrategicInitiativeKpisRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToReorderStrategicInitiativeKpisCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(request.ToReorderStrategicInitiativeKpisCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -269,7 +269,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<StrategicInitiativeKpiCheckpointDto>>> GetKpiCheckpoints(string id, string kpiId, CancellationToken cancellationToken)
     {
-        var checkpoints = await _sender.Send(new GetStrategicInitiativeKpiCheckpointsQuery(id, kpiId), cancellationToken);
+        var checkpoints = await _dispatcher.Send(new GetStrategicInitiativeKpiCheckpointsQuery(id, kpiId), cancellationToken);
 
         return checkpoints is not null
             ? Ok(checkpoints)
@@ -283,7 +283,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<StrategicInitiativeKpiCheckpointDetailsDto>>> GetKpiCheckpointPlan(string id, string kpiId, CancellationToken cancellationToken)
     {
-        var checkpointPlan = await _sender.Send(new GetStrategicInitiativeKpiCheckpointPlanQuery(id, kpiId), cancellationToken);
+        var checkpointPlan = await _dispatcher.Send(new GetStrategicInitiativeKpiCheckpointPlanQuery(id, kpiId), cancellationToken);
 
         return checkpointPlan is not null
             ? Ok(checkpointPlan)
@@ -301,7 +301,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         if (id != request.StrategicInitiativeId || kpiId != request.KpiId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToManageStrategicInitiativeKpiCheckpointPlanCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToManageStrategicInitiativeKpiCheckpointPlanCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -315,7 +315,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<StrategicInitiativeKpiMeasurementDto>>> GetKpiMeasurements(string id, string kpiId, CancellationToken cancellationToken)
     {
-        var measurements = await _sender.Send(new GetStrategicInitiativeKpiMeasurementsQuery(id, kpiId), cancellationToken);
+        var measurements = await _dispatcher.Send(new GetStrategicInitiativeKpiMeasurementsQuery(id, kpiId), cancellationToken);
 
         return measurements is not null
             ? Ok(measurements)
@@ -333,7 +333,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         if (id != request.StrategicInitiativeId || kpiId != request.KpiId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToAddStrategicInitiativeKpiMeasurementCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToAddStrategicInitiativeKpiMeasurementCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -348,7 +348,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> RemoveKpiMeasurement(Guid id, Guid kpiId, Guid measurementId, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RemoveStrategicInitiativeKpiMeasurementCommand(id, kpiId, measurementId), cancellationToken);
+        var result = await _dispatcher.Send(new RemoveStrategicInitiativeKpiMeasurementCommand(id, kpiId, measurementId), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -367,7 +367,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<IEnumerable<ProjectListDto>>> GetProjects(string idOrKey, CancellationToken cancellationToken)
     {
-        var projects = await _sender.Send(new GetStrategicInitiativeProjectsQuery(idOrKey), cancellationToken);
+        var projects = await _dispatcher.Send(new GetStrategicInitiativeProjectsQuery(idOrKey), cancellationToken);
 
         return projects is not null
             ? Ok(projects)
@@ -385,7 +385,7 @@ public class StrategicInitiativesController(ILogger<StrategicInitiativesControll
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToManageStrategicInitiativeProjectsCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToManageStrategicInitiativeProjectsCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/SearchController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/SearchController.cs
@@ -9,9 +9,9 @@ namespace Wayd.Web.Api.Controllers;
 [ApiVersionNeutral]
 [ApiController]
 [Authorize]
-public class SearchController(ISender sender) : ControllerBase
+public class SearchController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [OpenApiOperation("Global search across all modules.", "")]
@@ -20,7 +20,7 @@ public class SearchController(ISender sender) : ControllerBase
     public async Task<ActionResult<GlobalSearchResultDto>> Search(
         [FromQuery] string query, CancellationToken cancellationToken, [FromQuery] int maxResultsPerCategory = 5)
     {
-        var result = await _sender.Send(
+        var result = await _dispatcher.Send(
             new GlobalSearchQuery(query, maxResultsPerCategory), cancellationToken);
 
         return result.IsSuccess

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/StrategicManagement/StrategicThemesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/StrategicManagement/StrategicThemesController.cs
@@ -11,10 +11,10 @@ namespace Wayd.Web.Api.Controllers.StrategicManagement;
 [Route("api/strategic-management/strategic-themes")]
 [ApiVersionNeutral]
 [ApiController]
-public class StrategicThemesController(ILogger<StrategicThemesController> logger, ISender sender) : ControllerBase
+public class StrategicThemesController(ILogger<StrategicThemesController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<StrategicThemesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.StrategicThemes)]
@@ -27,7 +27,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
             ? [.. state.Select(s => (StrategicThemeState)s)]
             : null;
 
-        var themes = await _sender.Send(new GetStrategicThemesQuery(filter), cancellationToken);
+        var themes = await _dispatcher.Send(new GetStrategicThemesQuery(filter), cancellationToken);
 
         return Ok(themes);
     }
@@ -39,7 +39,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<StrategicThemeDetailsDto>> GetStrategicTheme(string idOrKey, CancellationToken cancellationToken)
     {
-        var theme = await _sender.Send(new GetStrategicThemeQuery(idOrKey), cancellationToken);
+        var theme = await _dispatcher.Send(new GetStrategicThemeQuery(idOrKey), cancellationToken);
 
         return theme is not null
             ? Ok(theme)
@@ -52,7 +52,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateStrategicThemeRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateStrategicThemeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateStrategicThemeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetStrategicTheme), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -70,7 +70,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateStrategicThemeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateStrategicThemeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -85,7 +85,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateStrategicThemeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateStrategicThemeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -100,7 +100,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveStrategicThemeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveStrategicThemeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -114,7 +114,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteStrategicThemeCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteStrategicThemeCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -128,7 +128,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<StrategicThemeOptionDto>>> GetStrategicThemeOptions([FromQuery] bool? includeArchived, CancellationToken cancellationToken)
     {
-        var options = await _sender.Send(new GetStrategicThemeOptionsQuery(includeArchived), cancellationToken);
+        var options = await _dispatcher.Send(new GetStrategicThemeOptionsQuery(includeArchived), cancellationToken);
 
         return Ok(options);
     }
@@ -140,7 +140,7 @@ public class StrategicThemesController(ILogger<StrategicThemesController> logger
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<StrategicThemeStateDto>>> GetStateOptions(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetStrategicThemeStatesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetStrategicThemeStatesQuery(), cancellationToken);
         return Ok(items.OrderBy(s => s.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/StrategicManagement/StrategiesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/StrategicManagement/StrategiesController.cs
@@ -11,10 +11,10 @@ namespace Wayd.Web.Api.Controllers.StrategicManagement;
 [Route("api/strategic-management/[controller]")]
 [ApiVersionNeutral]
 [ApiController]
-public class StrategiesController(ILogger<StrategiesController> logger, ISender sender) : ControllerBase
+public class StrategiesController(ILogger<StrategiesController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<StrategiesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Strategies)]
@@ -25,7 +25,7 @@ public class StrategiesController(ILogger<StrategiesController> logger, ISender 
     {
         StrategyStatus? filter = status.HasValue ? (StrategyStatus)status.Value : null;
 
-        var strategies = await _sender.Send(new GetStrategiesQuery(filter), cancellationToken);
+        var strategies = await _dispatcher.Send(new GetStrategiesQuery(filter), cancellationToken);
 
         return Ok(strategies);
     }
@@ -37,7 +37,7 @@ public class StrategiesController(ILogger<StrategiesController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<StrategyDetailsDto>> GetStrategy(string idOrKey, CancellationToken cancellationToken)
     {
-        var strategy = await _sender.Send(new GetStrategyQuery(idOrKey), cancellationToken);
+        var strategy = await _dispatcher.Send(new GetStrategyQuery(idOrKey), cancellationToken);
 
         return strategy is not null
             ? Ok(strategy)
@@ -50,7 +50,7 @@ public class StrategiesController(ILogger<StrategiesController> logger, ISender 
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateStrategyRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateStrategyCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateStrategyCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetStrategy), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -68,7 +68,7 @@ public class StrategiesController(ILogger<StrategiesController> logger, ISender 
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateStrategyCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateStrategyCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -82,7 +82,7 @@ public class StrategiesController(ILogger<StrategiesController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteStrategyCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteStrategyCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -96,7 +96,7 @@ public class StrategiesController(ILogger<StrategiesController> logger, ISender 
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<StrategyStatusDto>>> GetStatusOptions(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetStrategyStatusesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetStrategyStatusesQuery(), cancellationToken);
         return Ok(items.OrderBy(s => s.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/StrategicManagement/VisionsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/StrategicManagement/VisionsController.cs
@@ -11,10 +11,10 @@ namespace Wayd.Web.Api.Controllers.StrategicManagement;
 [Route("api/strategic-management/[controller]")]
 [ApiVersionNeutral]
 [ApiController]
-public class VisionsController(ILogger<VisionsController> logger, ISender sender) : ControllerBase
+public class VisionsController(ILogger<VisionsController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<VisionsController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Visions)]
@@ -25,7 +25,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     {
         VisionState? filter = state.HasValue ? (VisionState)state.Value : null;
 
-        var visions = await _sender.Send(new GetVisionsQuery(filter), cancellationToken);
+        var visions = await _dispatcher.Send(new GetVisionsQuery(filter), cancellationToken);
 
         return Ok(visions);
     }
@@ -37,7 +37,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<VisionDto>> GetVision(string idOrKey, CancellationToken cancellationToken)
     {
-        var vision = await _sender.Send(new GetVisionQuery(idOrKey), cancellationToken);
+        var vision = await _dispatcher.Send(new GetVisionQuery(idOrKey), cancellationToken);
 
         return vision is not null
             ? Ok(vision)
@@ -50,7 +50,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201IdAndKey))]
     public async Task<ActionResult<ObjectIdAndKey>> Create([FromBody] CreateVisionRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateVisionCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateVisionCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetVision), new { idOrKey = result.Value.Id.ToString() }, result.Value)
@@ -68,7 +68,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateVisionCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateVisionCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -83,7 +83,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateVisionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateVisionCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -98,7 +98,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> Archive(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ArchiveVisionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ArchiveVisionCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -112,7 +112,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteVisionCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteVisionCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -126,7 +126,7 @@ public class VisionsController(ILogger<VisionsController> logger, ISender sender
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<VisionStateDto>>> GetStateOptions(CancellationToken cancellationToken)
     {
-        var items = await _sender.Send(new GetVisionStatesQuery(), cancellationToken);
+        var items = await _dispatcher.Send(new GetVisionStatesQuery(), cancellationToken);
         return Ok(items.OrderBy(s => s.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/OidcProvidersController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/OidcProvidersController.cs
@@ -17,9 +17,9 @@ namespace Wayd.Web.Api.Controllers.UserManagement;
 [Route("api/user-management/oidc-providers")]
 [ApiVersionNeutral]
 [ApiController]
-public class OidcProvidersController(ISender sender, IUserService userService) : ControllerBase
+public class OidcProvidersController(IDispatcher dispatcher, IUserService userService) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly IUserService _userService = userService;
 
     [HttpGet]
@@ -28,7 +28,7 @@ public class OidcProvidersController(ISender sender, IUserService userService) :
     [ProducesResponseType(StatusCodes.Status200OK)]
     public async Task<ActionResult<IReadOnlyList<OidcProviderListItemDto>>> GetList(CancellationToken cancellationToken)
     {
-        var providers = await _sender.Send(new GetOidcProvidersQuery(), cancellationToken);
+        var providers = await _dispatcher.Send(new GetOidcProvidersQuery(), cancellationToken);
         return Ok(providers);
     }
 
@@ -39,7 +39,7 @@ public class OidcProvidersController(ISender sender, IUserService userService) :
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<OidcProviderDto>> GetById(Guid id, CancellationToken cancellationToken)
     {
-        var provider = await _sender.Send(new GetOidcProviderQuery(id), cancellationToken);
+        var provider = await _dispatcher.Send(new GetOidcProviderQuery(id), cancellationToken);
         return provider is not null ? Ok(provider) : NotFound();
     }
 
@@ -65,7 +65,7 @@ public class OidcProvidersController(ISender sender, IUserService userService) :
             request.RequireEmployeeRecord,
             request.DefaultRoleId);
 
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value.Id }, result.Value)
@@ -96,7 +96,7 @@ public class OidcProvidersController(ISender sender, IUserService userService) :
             request.RequireEmployeeRecord,
             request.DefaultRoleId);
 
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -111,7 +111,7 @@ public class OidcProvidersController(ISender sender, IUserService userService) :
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeleteOidcProviderCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeleteOidcProviderCommand(id), cancellationToken);
 
         if (result.IsFailure)
         {
@@ -134,7 +134,7 @@ public class OidcProvidersController(ISender sender, IUserService userService) :
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<TestOidcProviderDiscoveryResult>> TestDiscovery(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new TestOidcProviderDiscoveryCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new TestOidcProviderDiscoveryCommand(id), cancellationToken);
 
         // Note: a discovery failure (timeout, 404, bad JSON) returns 200 OK
         // with Success=false. The 400 path is reserved for the request being

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/PersonalAccessTokensController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/PersonalAccessTokensController.cs
@@ -11,11 +11,11 @@ namespace Wayd.Web.Api.Controllers.UserManagement;
 [ApiController]
 public class PersonalAccessTokensController : ControllerBase
 {
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public PersonalAccessTokensController(ISender sender)
+    public PersonalAccessTokensController(IDispatcher dispatcher)
     {
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -24,7 +24,7 @@ public class PersonalAccessTokensController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<List<PersonalAccessTokenDto>>> GetMyTokens(CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new GetMyPersonalAccessTokensQuery(), cancellationToken);
+        var result = await _dispatcher.Send(new GetMyPersonalAccessTokensQuery(), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -38,7 +38,7 @@ public class PersonalAccessTokensController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<PersonalAccessTokenDto>> GetById(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new GetPersonalAccessTokenQuery(id), cancellationToken);
+        var result = await _dispatcher.Send(new GetPersonalAccessTokenQuery(id), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -53,7 +53,7 @@ public class PersonalAccessTokensController : ControllerBase
     public async Task<ActionResult<CreatePersonalAccessTokenResult>> Create(CreatePersonalAccessTokenRequest request, CancellationToken cancellationToken)
     {
         var command = request.ToCreatePersonalAccessTokenCommand();
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value.Id }, result.Value)
@@ -69,7 +69,7 @@ public class PersonalAccessTokensController : ControllerBase
     public async Task<ActionResult> Update(Guid id, UpdatePersonalAccessTokenRequest request, CancellationToken cancellationToken)
     {
         var command = request.ToUpdatePersonalAccessTokenCommand(id);
-        var result = await _sender.Send(command, cancellationToken);
+        var result = await _dispatcher.Send(command, cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -83,7 +83,7 @@ public class PersonalAccessTokensController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Revoke(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new RevokePersonalAccessTokenCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new RevokePersonalAccessTokenCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -97,7 +97,7 @@ public class PersonalAccessTokensController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult> Delete(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeletePersonalAccessTokenCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeletePersonalAccessTokenCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/ProfileController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/UserManagement/ProfileController.cs
@@ -8,10 +8,10 @@ namespace Wayd.Web.Api.Controllers.UserManagement;
 [Route("api/user-management/profiles")]
 [ApiVersionNeutral]
 [ApiController]
-public class ProfileController(IUserService userService, ISender sender, ICurrentUser currentUser) : ControllerBase
+public class ProfileController(IUserService userService, IDispatcher dispatcher, ICurrentUser currentUser) : ControllerBase
 {
     private readonly IUserService _userService = userService;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
     private readonly ICurrentUser _currentUser = currentUser;
 
     [HttpGet]
@@ -129,6 +129,6 @@ public class ProfileController(IUserService userService, ISender sender, ICurren
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public Task<List<AuditDto>> GetLogs(CancellationToken cancellationToken)
     {
-        return _sender.Send(new GetMyAuditLogsQuery(), cancellationToken);
+        return _dispatcher.Send(new GetMyAuditLogsQuery(), cancellationToken);
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkProcessesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkProcessesController.cs
@@ -9,10 +9,10 @@ namespace Wayd.Web.Api.Controllers.Work;
 [Route("api/work/work-processes")]
 [ApiVersionNeutral]
 [ApiController]
-public class WorkProcessesController(ILogger<WorkProcessesController> logger, ISender sender) : ControllerBase
+public class WorkProcessesController(ILogger<WorkProcessesController> logger, IDispatcher dispatcher) : ControllerBase
 {
     private readonly ILogger<WorkProcessesController> _logger = logger;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.WorkProcesses)]
@@ -21,7 +21,7 @@ public class WorkProcessesController(ILogger<WorkProcessesController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkProcessListDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var workProcesses = await _sender.Send(new GetWorkProcessesQuery(includeInactive), cancellationToken);
+        var workProcesses = await _dispatcher.Send(new GetWorkProcessesQuery(includeInactive), cancellationToken);
         return Ok(workProcesses.OrderBy(s => s.Name));
     }
 
@@ -47,7 +47,7 @@ public class WorkProcessesController(ILogger<WorkProcessesController> logger, IS
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsFailure
             ? BadRequest(result.ToBadRequestObject(HttpContext))
@@ -63,7 +63,7 @@ public class WorkProcessesController(ILogger<WorkProcessesController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Activate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new ActivateWorkProcessCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new ActivateWorkProcessCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -77,7 +77,7 @@ public class WorkProcessesController(ILogger<WorkProcessesController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> Deactivate(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new DeactivateWorkProcessCommand(id), cancellationToken);
+        var result = await _dispatcher.Send(new DeactivateWorkProcessCommand(id), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -93,7 +93,7 @@ public class WorkProcessesController(ILogger<WorkProcessesController> logger, IS
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkProcessSchemeDto>>> GetSchemes(Guid id, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new GetWorkProcessSchemesQuery(id), cancellationToken);
+        var result = await _dispatcher.Send(new GetWorkProcessSchemesQuery(id), cancellationToken);
 
         return result is not null
                 ? Ok(result)

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkStatusCategoriesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkStatusCategoriesController.cs
@@ -8,11 +8,11 @@ namespace Wayd.Web.Api.Controllers.Work;
 [ApiController]
 public class WorkStatusCategoriesController : ControllerBase
 {
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public WorkStatusCategoriesController(ISender sender)
+    public WorkStatusCategoriesController(IDispatcher dispatcher)
     {
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -22,7 +22,7 @@ public class WorkStatusCategoriesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkStatusCategoryListDto>>> GetList(CancellationToken cancellationToken)
     {
-        var categories = await _sender.Send(new GetWorkStatusCategoriesQuery(), cancellationToken);
+        var categories = await _dispatcher.Send(new GetWorkStatusCategoriesQuery(), cancellationToken);
         return Ok(categories.OrderBy(c => c.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkStatusesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkStatusesController.cs
@@ -11,12 +11,12 @@ namespace Wayd.Web.Api.Controllers.Work;
 public class WorkStatusesController : ControllerBase
 {
     private readonly ILogger<WorkStatusesController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public WorkStatusesController(ILogger<WorkStatusesController> logger, ISender sender)
+    public WorkStatusesController(ILogger<WorkStatusesController> logger, IDispatcher dispatcher)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -26,7 +26,7 @@ public class WorkStatusesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkStatusDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var workStatuses = await _sender.Send(new GetWorkStatusesQuery(includeInactive), cancellationToken);
+        var workStatuses = await _dispatcher.Send(new GetWorkStatusesQuery(includeInactive), cancellationToken);
         return Ok(workStatuses.OrderBy(s => s.Name));
     }
 
@@ -38,7 +38,7 @@ public class WorkStatusesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<WorkStatusDto>> GetById(int id)
     {
-        var workStatus = await _sender.Send(new GetWorkStatusQuery(id));
+        var workStatus = await _dispatcher.Send(new GetWorkStatusQuery(id));
 
         return workStatus is not null
             ? Ok(workStatus)
@@ -51,7 +51,7 @@ public class WorkStatusesController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Int))]
     public async Task<ActionResult> Create(CreateWorkStatusRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateWorkStatusCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateWorkStatusCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value }, result.Value)
@@ -69,7 +69,7 @@ public class WorkStatusesController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateWorkStatusCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateWorkStatusCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkTypeLevelsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkTypeLevelsController.cs
@@ -13,12 +13,12 @@ namespace Wayd.Web.Api.Controllers.Work;
 public class WorkTypeLevelsController : ControllerBase
 {
     private readonly ILogger<WorkTypeLevelsController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public WorkTypeLevelsController(ILogger<WorkTypeLevelsController> logger, ISender sender)
+    public WorkTypeLevelsController(ILogger<WorkTypeLevelsController> logger, IDispatcher dispatcher)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -28,7 +28,7 @@ public class WorkTypeLevelsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkTypeLevelDto>>> GetList(CancellationToken cancellationToken)
     {
-        var levels = await _sender.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
+        var levels = await _dispatcher.Send(new GetWorkTypeLevelsQuery(), cancellationToken);
 
         return Ok(levels.OrderBy(l => l.Tier.Id).ThenByDescending(s => s.Order));
     }
@@ -41,7 +41,7 @@ public class WorkTypeLevelsController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<WorkTypeLevelDto>> GetById(int id)
     {
-        var backlogLevel = await _sender.Send(new GetWorkTypeLevelQuery(id));
+        var backlogLevel = await _dispatcher.Send(new GetWorkTypeLevelQuery(id));
 
         return backlogLevel is not null
             ? Ok(backlogLevel)
@@ -54,7 +54,7 @@ public class WorkTypeLevelsController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Int))]
     public async Task<ActionResult> Create(CreateWorkTypeLevelRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateWorkTypeLevelCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateWorkTypeLevelCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value }, result.Value)
@@ -72,7 +72,7 @@ public class WorkTypeLevelsController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateWorkTypeLevelCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateWorkTypeLevelCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -88,7 +88,7 @@ public class WorkTypeLevelsController : ControllerBase
     [ProducesResponseType(typeof(HttpValidationProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<ActionResult> UpdateOrder([FromBody] UpdateWorkTypeLevelsOrderRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new UpdateWorkTypeLevelsOrderCommand(request.Levels), cancellationToken);
+        var result = await _dispatcher.Send(new UpdateWorkTypeLevelsOrderCommand(request.Levels), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkTypeTiersController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkTypeTiersController.cs
@@ -8,11 +8,11 @@ namespace Wayd.Web.Api.Controllers.Work;
 [ApiController]
 public class WorkTypeTiersController : ControllerBase
 {
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public WorkTypeTiersController(ISender sender)
+    public WorkTypeTiersController(IDispatcher dispatcher)
     {
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -22,7 +22,7 @@ public class WorkTypeTiersController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkTypeTierDto>>> GetList(CancellationToken cancellationToken)
     {
-        var tiers = await _sender.Send(new GetWorkTypeTiersQuery(), cancellationToken);
+        var tiers = await _dispatcher.Send(new GetWorkTypeTiersQuery(), cancellationToken);
         return Ok(tiers.OrderBy(c => c.Order));
     }
 }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkTypesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkTypesController.cs
@@ -11,12 +11,12 @@ namespace Wayd.Web.Api.Controllers.Work;
 public class WorkTypesController : ControllerBase
 {
     private readonly ILogger<WorkTypesController> _logger;
-    private readonly ISender _sender;
+    private readonly IDispatcher _dispatcher;
 
-    public WorkTypesController(ILogger<WorkTypesController> logger, ISender sender)
+    public WorkTypesController(ILogger<WorkTypesController> logger, IDispatcher dispatcher)
     {
         _logger = logger;
-        _sender = sender;
+        _dispatcher = dispatcher;
     }
 
     [HttpGet]
@@ -26,7 +26,7 @@ public class WorkTypesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IReadOnlyList<WorkTypeDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var workTypes = await _sender.Send(new GetWorkTypesQuery(includeInactive), cancellationToken);
+        var workTypes = await _dispatcher.Send(new GetWorkTypesQuery(includeInactive), cancellationToken);
         return Ok(workTypes.OrderBy(s => s.Name));
     }
 
@@ -38,7 +38,7 @@ public class WorkTypesController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     public async Task<ActionResult<WorkTypeDto>> GetById(int id, CancellationToken cancellationToken)
     {
-        var workType = await _sender.Send(new GetWorkTypeQuery(id), cancellationToken);
+        var workType = await _dispatcher.Send(new GetWorkTypeQuery(id), cancellationToken);
 
         return workType is not null
             ? Ok(workType)
@@ -51,7 +51,7 @@ public class WorkTypesController : ControllerBase
     [ApiConventionMethod(typeof(WaydApiConventions), nameof(WaydApiConventions.CreateReturn201Int))]
     public async Task<ActionResult> Create(CreateWorkTypeRequest request, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(request.ToCreateWorkTypeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToCreateWorkTypeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? CreatedAtAction(nameof(GetById), new { id = result.Value }, result.Value)
@@ -69,7 +69,7 @@ public class WorkTypesController : ControllerBase
         if (id != request.Id)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateWorkTypeCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateWorkTypeCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkspacesController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Work/WorkspacesController.cs
@@ -14,9 +14,9 @@ namespace Wayd.Web.Api.Controllers.Work;
 [Route("api/work/workspaces")]
 [ApiVersionNeutral]
 [ApiController]
-public class WorkspacesController(ISender sender) : ControllerBase
+public class WorkspacesController(IDispatcher dispatcher) : ControllerBase
 {
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [HttpGet]
     [MustHavePermission(ApplicationAction.View, ApplicationResource.Workspaces)]
@@ -25,7 +25,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<WorkspaceListDto>>> GetList(CancellationToken cancellationToken, bool includeInactive = false)
     {
-        var workspaces = await _sender.Send(new GetWorkspacesQuery(includeInactive), cancellationToken);
+        var workspaces = await _dispatcher.Send(new GetWorkspacesQuery(includeInactive), cancellationToken);
         return Ok(workspaces);
     }
 
@@ -51,7 +51,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsFailure
             ? BadRequest(result.ToBadRequestObject(HttpContext))
@@ -67,7 +67,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult> SetExternalUrlTemplates(Guid id, [FromBody] SetExternalUrlTemplatesRequest dto, CancellationToken cancellationToken)
     {
-        var result = await _sender.Send(new SetExternalViewWorkItemUrlTemplateCommand(id, dto.ExternalViewWorkItemUrlTemplate), cancellationToken);
+        var result = await _dispatcher.Send(new SetExternalViewWorkItemUrlTemplateCommand(id, dto.ExternalViewWorkItemUrlTemplate), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -97,7 +97,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value.OrderByKey(true))
@@ -128,7 +128,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsFailure
             ? BadRequest(result.ToBadRequestObject(HttpContext))
@@ -161,7 +161,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsFailure
             ? BadRequest(result.ToBadRequestObject(HttpContext))
@@ -180,7 +180,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
         if (workItemId != request.WorkItemId)
             return BadRequest(ProblemDetailsExtensions.ForRouteParamMismatch(HttpContext));
 
-        var result = await _sender.Send(request.ToUpdateWorkItemProjectCommand(), cancellationToken);
+        var result = await _dispatcher.Send(request.ToUpdateWorkItemProjectCommand(), cancellationToken);
 
         return result.IsSuccess
             ? NoContent()
@@ -210,7 +210,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value.OrderBy(w => w.StackRank))
@@ -227,7 +227,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
     {
         var key = new WorkItemKey(workItemKey);
 
-        var result = await _sender.Send(new GetWorkItemDependenciesQuery(idOrKey, key), cancellationToken);
+        var result = await _dispatcher.Send(new GetWorkItemDependenciesQuery(idOrKey, key), cancellationToken);
 
 
         return result.IsFailure
@@ -260,7 +260,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
             return BadRequest(ProblemDetailsExtensions.ForUnknownIdOrKeyType(HttpContext));
         }
 
-        var result = await _sender.Send(query, cancellationToken);
+        var result = await _dispatcher.Send(query, cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value)
@@ -274,7 +274,7 @@ public class WorkspacesController(ISender sender) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<ActionResult<IEnumerable<WorkItemListDto>>> SearchWorkItems(string query, CancellationToken cancellationToken, int top = 50)
     {
-        var result = await _sender.Send(new SearchWorkItemsQuery(query, top), cancellationToken);
+        var result = await _dispatcher.Send(new SearchWorkItemsQuery(query, top), cancellationToken);
 
         return result.IsSuccess
             ? Ok(result.Value.OrderByKey(true))

--- a/Wayd.Web/src/Wayd.Web.Api/GlobalUsings.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/GlobalUsings.cs
@@ -1,6 +1,5 @@
 ﻿global using Asp.Versioning;
 global using FluentValidation;
-global using MediatR;
 global using Microsoft.AspNetCore.Mvc;
 global using Wayd.AppIntegration.Application.Connections.Commands;
 global using Wayd.AppIntegration.Application.Connections.Dtos;
@@ -10,6 +9,7 @@ global using Wayd.AppIntegration.Application.Connectors.Queries;
 global using Wayd.Common.Application.Auditing;
 global using Wayd.Common.Application.Identity.Roles;
 global using Wayd.Common.Application.Identity.Users;
+global using Wayd.Common.Application.Interfaces;
 global using Wayd.Common.Application.Validation;
 global using Wayd.Common.Domain.Authorization;
 global using Wayd.Common.Models;

--- a/Wayd.Web/src/Wayd.Web.Api/Services/JobManager.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Services/JobManager.cs
@@ -24,7 +24,7 @@ public class JobManager(
     ILogger<JobManager> logger,
     IWorkSyncRunner workSyncRunner,
     IPeopleSyncRunner peopleSyncRunner,
-    ISender sender)
+    IDispatcher dispatcher)
     : IJobManager
 {
     // TODO: does this belong in JobService/HangfireService?
@@ -32,7 +32,7 @@ public class JobManager(
     private readonly ILogger<JobManager> _logger = logger;
     private readonly IWorkSyncRunner _workSyncRunner = workSyncRunner;
     private readonly IPeopleSyncRunner _peopleSyncRunner = peopleSyncRunner;
-    private readonly ISender _sender = sender;
+    private readonly IDispatcher _dispatcher = dispatcher;
 
     [DisableConcurrentExecution(60 * 3)]
     [AutomaticRetry(Attempts = 3, DelaysInSeconds = [30, 60, 120])]
@@ -75,13 +75,13 @@ public class JobManager(
     {
         _logger.LogInformation("Running {BackgroundJob} job", nameof(RunSyncTeamsWithGraphTables));
 
-        var teamNodesresult = await _sender.Send(new SyncTeamNodesCommand(), cancellationToken);
+        var teamNodesresult = await _dispatcher.Send(new SyncTeamNodesCommand(), cancellationToken);
         if (teamNodesresult.IsFailure)
         {
             _logger.LogError("Failed to sync teams with graph tables: {Error}", teamNodesresult.Error);
         }
 
-        var teamMembershipEdgesResult = await _sender.Send(new SyncTeamMembershipEdgesCommand(), cancellationToken);
+        var teamMembershipEdgesResult = await _dispatcher.Send(new SyncTeamMembershipEdgesCommand(), cancellationToken);
         if (teamMembershipEdgesResult.IsFailure)
         {
             _logger.LogError("Failed to sync team memberships with graph tables: {Error}", teamMembershipEdgesResult.Error);
@@ -95,9 +95,9 @@ public class JobManager(
     {
         _logger.LogInformation("Running {BackgroundJob} job", nameof(RunSyncIterations));
 
-        var iterations = await _sender.Send(new GetSimpleIterationsQuery(), cancellationToken);
+        var iterations = await _dispatcher.Send(new GetSimpleIterationsQuery(), cancellationToken);
 
-        var result = await _sender.Send(new SyncWorkIterationsCommand(iterations), cancellationToken);
+        var result = await _dispatcher.Send(new SyncWorkIterationsCommand(iterations), cancellationToken);
         if (result.IsFailure)
         {
             _logger.LogError("Failed to sync iterations: {Error}", result.Error);
@@ -112,9 +112,9 @@ public class JobManager(
     {
         _logger.LogInformation("Running {BackgroundJob} job", nameof(RunSyncStrategicThemes));
 
-        var strategicThemes = await _sender.Send(new GetStrategicThemesDataQuery(), cancellationToken);
+        var strategicThemes = await _dispatcher.Send(new GetStrategicThemesDataQuery(), cancellationToken);
 
-        var result = await _sender.Send(new PpmSyncStrategicThemesCommand(strategicThemes), cancellationToken);
+        var result = await _dispatcher.Send(new PpmSyncStrategicThemesCommand(strategicThemes), cancellationToken);
         if (result.IsFailure)
         {
             _logger.LogError("Failed to sync strategic themes: {Error}", result.Error);
@@ -128,9 +128,9 @@ public class JobManager(
     {
         _logger.LogInformation("Running {BackgroundJob} job", nameof(RunSyncProjects));
 
-        var projects = await _sender.Send(new GetSimpleProjectsQuery(), cancellationToken);
+        var projects = await _dispatcher.Send(new GetSimpleProjectsQuery(), cancellationToken);
 
-        var result = await _sender.Send(new SyncWorkProjectsCommand(projects), cancellationToken);
+        var result = await _dispatcher.Send(new SyncWorkProjectsCommand(projects), cancellationToken);
         if (result.IsFailure)
         {
             _logger.LogError("Failed to sync projects: {Error}", result.Error);
@@ -145,21 +145,21 @@ public class JobManager(
     {
         _logger.LogInformation("Running {BackgroundJob} job", nameof(RunSyncTeams));
 
-        var teams = await _sender.Send(new GetSimpleTeamsQuery(), cancellationToken);
+        var teams = await _dispatcher.Send(new GetSimpleTeamsQuery(), cancellationToken);
 
-        var planningSyncResult = await _sender.Send(new SyncPlanningTeamsCommand(teams), cancellationToken);
+        var planningSyncResult = await _dispatcher.Send(new SyncPlanningTeamsCommand(teams), cancellationToken);
         if (planningSyncResult.IsFailure)
         {
             _logger.LogError("Failed to sync planning teams: {Error}", planningSyncResult.Error);
         }
 
-        var ppmSyncResult = await _sender.Send(new SyncPpmTeamsCommand(teams), cancellationToken);
+        var ppmSyncResult = await _dispatcher.Send(new SyncPpmTeamsCommand(teams), cancellationToken);
         if (ppmSyncResult.IsFailure)
         {
             _logger.LogError("Failed to sync PPM teams: {Error}", ppmSyncResult.Error);
         }
 
-        var workSyncResult = await _sender.Send(new SyncWorkTeamsCommand(teams), cancellationToken);
+        var workSyncResult = await _dispatcher.Send(new SyncWorkTeamsCommand(teams), cancellationToken);
         if (workSyncResult.IsFailure)
         {
             _logger.LogError("Failed to sync work teams: {Error}", workSyncResult.Error);
@@ -176,11 +176,11 @@ public class JobManager(
 
         // Runs as the system identity (set by the Hangfire activator), so the rebalance command
         // bypasses the per-actor Owner/Manager check for this maintenance pass.
-        var portfolioIds = await _sender.Send(new GetPortfolioIdsToRebalanceQuery(), cancellationToken);
+        var portfolioIds = await _dispatcher.Send(new GetPortfolioIdsToRebalanceQuery(), cancellationToken);
 
         foreach (var portfolioId in portfolioIds)
         {
-            var result = await _sender.Send(new RebalancePortfolioRanksCommand(portfolioId), cancellationToken);
+            var result = await _dispatcher.Send(new RebalancePortfolioRanksCommand(portfolioId), cancellationToken);
             if (result.IsFailure)
             {
                 _logger.LogWarning("Failed to rebalance ranks for portfolio {PortfolioId}: {Error}", portfolioId, result.Error);

--- a/docs/contributing/specs/mediatr-to-wolverine-migration.md
+++ b/docs/contributing/specs/mediatr-to-wolverine-migration.md
@@ -1,0 +1,165 @@
+---
+title: "Spec: MediatR to Wolverine Migration"
+description: Investigation, decision record, and phased migration plan for replacing MediatR with Wolverine.
+audience: [developer, agent]
+---
+
+# MediatR → Wolverine Migration
+
+| | |
+|---|---|
+| **Status** | Approved direction — planning complete, implementation not started |
+| **Date** | 2026-07-16 |
+| **Decision** | Migrate from MediatR 12.5.0 to Wolverine 6.x using a facade-first, phased approach |
+
+## Motivation
+
+Two drivers, both required to justify the churn:
+
+1. **MediatR is a dead end for us.** MediatR v13+ moved to a commercial license. We are pinned at 12.5.0 (Apache-2.0), which is safe to run indefinitely but receives no new features or bug fixes. Staying pinned means carrying frozen infrastructure forever.
+2. **We want the in-process → messaging evolution path.** Wolverine offers a smooth progression from in-process events (what we have) to a durable transactional outbox, scheduled messages, and eventually external transports if modules are ever split out — without rewriting handler code at each step. MediatR has no equivalent path.
+
+An in-house dispatcher (~150 LOC, viable because we own the `ICommand`/`IQuery` abstractions) was considered and rejected: it solves the license driver but rebuilds MediatR's ceiling rather than raising it.
+
+## Current MediatR footprint (as of 2026-07-16)
+
+| Surface | Scale |
+|---|---|
+| Command/query handler implementations | ~890 (`ICommandHandler` ~500, `IQueryHandler` ~390), all `internal sealed` |
+| `Send()` call sites | ~1,000 across ~65 files (45 controllers, sync runners, `JobManager`, `UserService`, some handler-to-handler) |
+| Active pipeline behaviors | 2 — `ValidationBehavior`, `PerformanceBehavior` (in `Wayd.Common.Application/Behaviors/`); `LoggingBehavior` and `UnhandledExceptionBehavior` exist but are not registered |
+| Domain events | Published after `SaveChanges` in `BaseDbContext.SendDomainEvents()` via `EventPublisher` → `IPublisher.Publish(EventNotification<TEvent>)`; 7 concrete event handlers (cross-domain replication) |
+| MediatR features NOT used | Streaming, pre/post processors, exception handlers — none |
+| Registration | 9 per-module `AddMediatR` calls (one per Application assembly); behaviors registered once in `Wayd.Common.Application` |
+| Test coupling | Very low — 372 direct `handler.Handle(...)` calls; only ~5 test files mock `ISender` |
+
+Incidental findings to clean up regardless of migration:
+
+- `Wayd.Common.Domain.csproj` references `MediatR.Contracts` but no source in that project uses it (vestigial).
+- `Wayd.Web.Api/GlobalUsings.cs` has `global using MediatR;`.
+- The generic entity events (`EntityCreatedEvent<T>`, `EntityUpdatedEvent<T>`, `EntityDeletedEvent<T>`, etc.) are published but have **zero subscribers** — they are published into the void today.
+
+## Target
+
+**Wolverine 6.x** (verified July 2026: supports .NET 9/10; core is open source; JasperFx sells support plans, not the library). Controllers stay plain MVC + NSwag — Wolverine.HTTP is not in scope.
+
+Key packages: `WolverineFx`, `WolverineFx.FluentValidation`, and at Stage B `WolverineFx.SqlServer` + `WolverineFx.EntityFrameworkCore`.
+
+## Migration phases
+
+### Phase 0 — Retire the generic entity events (standalone cleanup, independent of the migration) ✅ Complete (PR #659)
+
+The `EntityCreatedEvent<T>` / `EntityUpdatedEvent<T>` / `EntityDeletedEvent<T>` / `EntityActivatedEvent<T>` / `EntityDeactivatedEvent<T>` pattern is being removed as a pattern, regardless of the migration: the events have zero subscribers, they wrap live EF entity instances (never serializable, so incompatible with any future durable messaging), and they add log noise. Measured surface (2026-07-16):
+
+- 66 raise sites (`Wayd.Work` 38, `Wayd.AppIntegration` 16, `Wayd.Common` 12) — delete the `AddDomainEvent(...)` calls.
+- 5 event records + `IGenericDomainEvent` in `Wayd.Common.Domain/Events/` — delete.
+- The `IGenericDomainEvent` special-case logging branch in `EventPublisher` — delete.
+- 1 test file references them (`OidcProviderTests`) — update assertions.
+
+When a real subscriber need appears later, define a concrete, serializable event (id + payload, like `TeamCreatedEvent`) — that is the Wolverine-compatible shape.
+
+Doing this first shrinks the migration: Phase 2 loses a task, the "no-route log noise" question disappears, and the inline-only carve-out at Stage B is no longer needed.
+
+### Phase 1 — Seam prep ✅ Complete (safe now, still on MediatR)
+
+Independently valuable; reduces MediatR's blast radius to one project.
+
+1. **Done.** Introduced the `IDispatcher` facade (injected interface — see "Open decisions" for the resolved shape and rationale) over `ISender` and migrated all ~60 injection sites (45 controllers, the sync runners, `JobManager`, `UserService`, and the handful of application-layer classes that inject a dispatcher) to it. The facade infers the response type from the marker interfaces, so all call sites stayed syntactically unchanged apart from the injected type name.
+2. **Done.** Removed `global using MediatR;` from `Wayd.Web.Api` (added `global using Wayd.Common.Application.Interfaces;` so controllers resolve `IDispatcher`); removed now-unused file-level `using MediatR;` across the migrated files.
+3. **Done.** Removed the vestigial `MediatR.Contracts` reference from `Wayd.Common.Domain`.
+
+After Phase 1, `using MediatR;` appears only inside `Wayd.Common.Application` (markers + behaviors + facade impl + the `EventNotification`/`IEventNotificationHandler` wrappers) and in `EventPublisher` (the `IPublisher` path, untouched until Phase 2). The MediatR **package** references still exist per-module because the markers extend `IRequest`; that drops out in Phase 2 (see the note under "Open decisions").
+
+### Phase 2 — The swap, at behavior parity ("Stage A", ~3–5 days + regression bake)
+
+Events remain in-process, inline, synchronous. No outbox yet.
+
+1. Decouple `ICommand`/`ICommand<T>`/`IQuery<T>` from `IRequest<T>` (they become pure markers; message records stay `public sealed record`).
+2. Replace the 9 `AddMediatR` calls with a single `UseWolverine()` on the host builder, with explicit `Discovery.IncludeAssembly(...)` per Application assembly and discovery filters so non-CQRS `*Handler` classes are not scooped up.
+3. Make handlers `public` (Wolverine's code generation cannot call internal types) and flip the `Handlers_ShouldBeInternal` architecture test.
+4. Reimplement the Phase 1 facade over `IMessageBus.InvokeAsync<T>`.
+5. Validation: adopt `WolverineFx.FluentValidation` with `RegistrationBehavior.ExplicitRegistration` (we keep our `AddValidatorsFromAssembly` registrations — the default discovery mode would double-register and duplicate every failure) and a custom `IFailureAction<T>` that throws our `Wayd.Common.Application.Exceptions.ValidationException`, preserving the exact `ExceptionMiddleware` HTTP contract. Fallback if the hook proves too rigid: port `ValidationBehavior` as custom middleware (~30 lines).
+6. Port `PerformanceBehavior` as Wolverine middleware, keeping the `ILongRunningRequest` opt-out.
+7. **Identity propagation middleware (required in this phase, not later):** stamp the current user ID into the message envelope headers on send; on execution, restore it via `ICurrentUserInitializer.SetCurrentUser` in the handler's scope. See "Identity and DI scoping" below for why.
+8. Retarget `EventPublisher` from `IPublisher` to `IMessageBus.PublishAsync`, publishing the concrete event type directly. Delete the `EventNotification<TEvent>` wrapper and its `Activator.CreateInstance` reflection; event handlers implement plain `Handle(TEvent, CancellationToken)`.
+9. Architecture tests: update reflection to the new shapes; **add a test asserting exactly one handler per command/query** (Wolverine silently *combines* multiple handlers for the same message — MediatR gave us this safety implicitly).
+10. Register Wolverine's OpenTelemetry activity sources in the OTel configuration.
+11. Codegen workflow: `TypeLoadMode.Auto` in dev; pre-generated types + `AssertWolverineConfigurationIsValid` startup assertion in CI/prod.
+12. Delete MediatR packages.
+
+### Stage B — Durable outbox (~1–2 days after Phase 2 is stable)
+
+1. Add `PersistMessagesWithSqlServer(...)` and `AddDbContextWithWolverineIntegration<WaydDbContext>()`.
+2. Rework `BaseDbContext.SendDomainEvents()`: instead of publishing **after** `SaveChanges` returns (today a crash between commit and publish silently drops events), enlist events with the Wolverine-integrated `IMessageBus` **during the transaction** so envelopes commit atomically with entity changes, and delivery happens post-commit via Wolverine's durability agent.
+3. Wolverine's envelope tables are provisioned by Weasel at startup, parallel to (not inside) our EF migrations. Pick a dedicated schema (do not land in `dbo`). Testcontainers integration tests will auto-provision.
+4. Configure System.Text.Json NodaTime serialization for durable event payloads.
+
+### Stage C — Selective async routing (incremental, ongoing)
+
+Move handlers from inline to durable local queues **per event type**, not globally:
+
+- **Must stay inline:** cross-domain replication events (same-Id projections) that in-request reads or subsequent commands depend on. Going async breaks read-your-writes for those flows. The replication map is the input to this classification.
+- **Go durable/async first:** genuinely fire-and-forget handlers — audit trails, notifications, search-index updates.
+
+Once queued, failures no longer reach `ExceptionMiddleware` — they are governed by Wolverine **failure policies** (retry/backoff, requeue, dead-letter queue). This is a new design surface with no MediatR equivalent; budget a deliberate design session rather than accepting defaults. Reconcile with the Hangfire `[AutomaticRetry]` semantics if/when job consolidation happens (out of scope for this spec).
+
+### Phase 4 — Documentation
+
+Update: `CLAUDE.md`, `AGENTS.md`, `docs/contributing/architecture.mdx`, `api.mdx`, `adding-a-feature.mdx`, `docs/reference/technology-stack.mdx`, `attribution.mdx`.
+
+## Identity and DI scoping (the biggest behavioral difference)
+
+MediatR resolves handlers from the **caller's** DI scope. Wolverine executes every message in a **fresh scope**. Consequences:
+
+- **HTTP → handler: unaffected.** `CurrentUser` lazily reads `IHttpContextAccessor` (AsyncLocal-backed), which flows with the async call chain regardless of scope. Inline `InvokeAsync` from a controller sees the same user; `BaseDbContext` auditing keeps working.
+- **Hangfire jobs: breaks silently at Phase 2 without the identity middleware.** `SetCurrentUser` sets fields on one scope's `CurrentUser` instance; the Wolverine handler's fresh scope has a different instance and no `HttpContext` → blank user, silent audit-attribution loss. Hence the envelope-header middleware is a Phase 2 requirement.
+- **Durable handlers (Stage B+):** run later, on agent threads, possibly after the originating request completed — there is fundamentally no ambient user; identity must travel on the envelope. Same middleware covers it.
+- **Nested sends get isolated DbContexts.** Today nested `Send` calls share the caller's scoped `WaydDbContext`; under Wolverine each gets its own. Each command already does its own `SaveChanges`, so this is mostly safer — but audit sync-runner flows for reliance on shared change-tracker state.
+- **Event handlers stop sharing the publisher's DbContext.** Today they run synchronously inside the publisher's `SaveChanges` call, in the same scope (an accident of `EventPublisher` being injected into `BaseDbContext`). Under Wolverine they get fresh contexts reading just-committed data — cleaner, but verify the 7 replication handlers against this change.
+
+## Other trade-offs and gotchas
+
+| Trade-off | Impact / mitigation |
+|---|---|
+| Handlers must be `public` | ~890 classes flip from `internal sealed` to `public sealed`; architecture test inverted. Deliberate loss of encapsulation — accepted. |
+| Return values become cascaded messages under `Publish` | All handlers return `Result`/`Result<T>`. Fine via `InvokeAsync`; guard against `Publish` misuse with an architecture test or policy. |
+| Multiple handlers for one message are combined, not rejected | New architecture test enforces exactly one handler per command/query. |
+| Routing is by concrete type — no open-generic handler patterns | Only closed-generic usage exists today (`IntegrationStateChangedEvent<Guid>` — fine). Constrains future "one handler for all entity events" patterns. |
+| Generic entity events carry live EF entities | Not serializable — can never be routed durable. Removed as a pattern in Phase 0 (subscriber-less today). |
+| Validators run sequentially, not `Task.WhenAll` | Improvement: the current parallel run is a latent EF Core concurrency bug when two validators for one request share the scoped DbContext. |
+| Validation overhead per message | Improvement: Wolverine codegen bakes validation only into pipelines of message types that have validators; MediatR resolved an (often empty) `IEnumerable<IValidator<T>>` on every Result-returning request. |
+| Cold-start code generation | Affects dev inner loop, NSwag Debug-build boot, integration tests. Mitigate with `TypeLoadMode.Auto` (dev) and pre-generated types (CI/prod). |
+| Debugging character changes | Stack traces route through generated types; generated code can be dumped and read. |
+| Trace shape changes | Wolverine emits its own OTel activities/metrics — register sources, tune log noise. |
+| Smaller ecosystem than MediatR | Accepted; commercial support available from JasperFx, which aligns with the maintenance driver. |
+
+## What we don't lose
+
+- No MediatR features in use beyond `Send`/`Publish` + 2 behaviors — nothing exotic to replace.
+- Unit tests are almost untouched (direct `Handle` calls); only ~5 `ISender` mock sites move to the facade.
+- Controllers, NSwag client generation, and the frontend are unaffected.
+- Two current behaviors the migration "changes" were latent bugs it fixes: parallel validators sharing a DbContext, and events published after commit with no durability.
+
+## Open decisions
+
+- [x] Facade shape and name — **resolved (Phase 1 implemented):** an injected interface, `IDispatcher`, in `Wayd.Common.Application.Interfaces`, replacing every `ISender` injection site. It exposes three response-inferring overloads that mirror the marker interfaces so call sites stay identical (`_dispatcher.Send(cmd, ct)`):
+  - `Task<Result> Send(ICommand command, CancellationToken ct = default)`
+  - `Task<Result<TResponse>> Send<TResponse>(ICommand<TResponse> command, CancellationToken ct = default)`
+  - `Task<TResponse> Send<TResponse>(IQuery<TResponse> query, CancellationToken ct = default)`
+
+  The three overloads are unambiguous because `ICommand`, `ICommand<T>`, and `IQuery<T>` are disjoint hierarchies (none extends another). No MediatR types appear in the contract, so it re-implements cleanly over `IMessageBus.InvokeAsync<T>(object)` in Phase 2. The Phase 1 implementation, `MediatRDispatcher` (`internal sealed`, in `Wayd.Common.Application/Dispatching/`), is a thin pass-through to `ISender.Send` and is the only non-behavior/non-marker type in the codebase that still names an MediatR dispatch type. Chosen over `IMessageBus` extension methods because an injected interface is the minimal rename (`ISender sender` → `IDispatcher dispatcher`) and is trivially mockable — the ~5 `Mock<ISender>`/`GetMock<ISender>()` test sites became `IDispatcher` with no other change.
+
+  Note: `ICommand`/`ICommand<T>`/`IQuery<T>` still extend `IRequest<…>` in Phase 1, so the per-module MediatR **package** references remain (the markers transitively need them); only file-level `using MediatR;` statements and the `ISender` indirection were confined. Decoupling the markers from `IRequest` — which lets the package references drop out of every project except `Wayd.Common.Application` — is Phase 2, task 1.
+- [ ] Schema name for Wolverine envelope tables.
+- [x] Fate of the subscriber-less generic entity events — **resolved: remove the pattern entirely (Phase 0)**.
+- [ ] Failure-policy design for Stage C (retry/backoff/DLQ per exception type).
+- [ ] Event classification (inline vs. durable) — requires the cross-domain replication map as input.
+- [ ] Whether/when to consolidate Hangfire jobs onto Wolverine scheduling (explicitly out of scope here).
+
+## References
+
+- [Wolverine documentation](https://wolverinefx.net/)
+- [Handler discovery and public-type requirement](https://wolverinefx.net/guide/handlers/)
+- [FluentValidation middleware](https://wolverinefx.net/guide/handlers/fluent-validation.html)
+- [EF Core durable outbox integration](https://wolverinefx.net/guide/durability/efcore.html)
+- [Wolverine releases](https://github.com/JasperFx/wolverine/releases)


### PR DESCRIPTION
## MediatR → Wolverine migration: Phase 1 (seam prep)

Introduces a dispatcher facade and migrates every injection site to it, shrinking MediatR's blast radius from ~65 files to one project. **Zero behavior change** — this phase stays entirely on MediatR 12.5.0.

The point is to make the later Wolverine swap (or any other dispatcher) a change behind a seam rather than a ~65-file churn. Phase 0 (removing the generic `Entity*Event` pattern) landed in #659.

Full plan: `docs/contributing/specs/mediatr-to-wolverine-migration.md`

### The facade

`IDispatcher` in `Wayd.Common.Application.Interfaces`, implemented by `MediatRDispatcher` (`internal sealed`, in `Dispatching/`) as a thin pass-through to `ISender`. Three overloads infer the response type from the existing markers, so call sites are unchanged apart from the injected type name:

| Marker | Overload | Returns |
|---|---|---|
| `ICommand` | `Send(ICommand, CancellationToken = default)` | `Task<Result>` |
| `ICommand<T>` | `Send<T>(ICommand<T>, CancellationToken = default)` | `Task<Result<T>>` |
| `IQuery<T>` | `Send<T>(IQuery<T>, CancellationToken = default)` | `Task<T>` |

The overloads are unambiguous because `ICommand`, `ICommand<T>`, and `IQuery<T>` are disjoint hierarchies — none extends another. No MediatR type appears in the contract, so it re-implements cleanly over Wolverine's `IMessageBus.InvokeAsync<T>(object)` in Phase 2.

Chosen over `IMessageBus` extension methods because an injected interface is the minimal rename (`ISender sender` → `IDispatcher dispatcher`) and is trivially mockable — the test sites moved over with no change beyond the type name.

### Changes

- **Facade** — `IDispatcher.cs`, `MediatRDispatcher.cs`; registered scoped in `AddCommonApplication`.
- **~63 injection sites migrated** — 45 controllers, the sync runners, `JobManager`, `UserService` (both partials), and the application-layer classes that inject a dispatcher. Pure rename; unused file-level `using MediatR;` removed throughout.
- **`Wayd.Web.Api/GlobalUsings.cs`** — dropped `global using MediatR;`, added `global using Wayd.Common.Application.Interfaces;`.
- **`Wayd.Common.Domain.csproj`** — removed the vestigial `MediatR.Contracts` PackageReference (nothing in that project used it).
- **Tests** — 6 files swapped `Mock<ISender>` / `GetMock<ISender>()` to `IDispatcher`; setups and return values transferred 1:1.
- **Spec** — Phase 0 and Phase 1 marked complete; facade shape recorded under "Open decisions".

Handlers, `IPublisher`/`EventPublisher`, and the `ICommand`/`IQuery` interfaces themselves are untouched. The internal-handler convention stays intact.

### Two things worth a look during review

**`GetMyAuditLogsQuery` marker swap.** It used raw `IRequest<List<AuditDto>>` instead of the `IQuery<T>` marker, so it couldn't flow through a leak-free facade. Changed the query record to `IQuery<List<AuditDto>>`; the handler declaration is untouched. This is the only handler-adjacent change and it's a marker swap, not a restructure. (The two `OidcProvider` query handlers also use `IRequestHandler` directly, but their query *records* already implement `IQuery<T>`, so they needed nothing.)

**MediatR package references still exist per-module.** File-level `using MediatR;` and the `ISender` indirection are now confined, but the package references can't drop yet: the `ICommand`/`IQuery` markers still extend `IRequest`. Decoupling them is Phase 2, task 1. `EventPublisher.cs` also retains `using MediatR;` for the `IPublisher` path, which is scoped out of this phase. Both are noted in the spec.

After this PR, `using MediatR;` appears only in `Wayd.Common.Application` (markers, behaviors, facade impl, `EventNotification` wrappers) and in `EventPublisher`.

### Verification

- `dotnet build Wayd.slnx` — 0 warnings, 0 errors
- `Wayd.ArchitectureTests` — 65/65 pass
- Full suite — 23 test assemblies, 0 failures
