### PR TITLE
Feature/setup jasperfx aspire

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
     <PackageVersion Include="Hangfire" Version="1.8.23" />
+    <PackageVersion Include="JasperFx.Aspire" Version="2.29.1" />
     <PackageVersion Include="Hangfire.Console.Extensions" Version="2.1.2" />
     <PackageVersion Include="Hangfire.Console.Extensions.Serilog" Version="2.1.2" />
     <PackageVersion Include="Hangfire.Dashboard.BasicAuthorization" Version="1.0.2" />

--- a/Wayd.AppHost/AppHost.cs
+++ b/Wayd.AppHost/AppHost.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Data.SqlClient;
+﻿using JasperFx.Aspire;
+using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,7 +29,20 @@ var waydDb = builder.AddConnectionString("WaydDb");
 var waydApi = builder.AddProject<Projects.Wayd_Web_Api>("wayd-api")
     .WithReference(waydDb)
     .WaitFor(waydDb)
-    .WithHttpHealthCheck(global::Wayd.Infrastructure.ServiceEndpoints.HealthEndpointPath);
+    .WithHttpHealthCheck(global::Wayd.Infrastructure.ServiceEndpoints.HealthEndpointPath)
+    // JasperFx startup gate: run `resources setup` as a separate, short-lived invocation of the API
+    // (via RunJasperFxCommands in Program.cs) BEFORE the long-running API boots. It provisions the
+    // Wolverine durable-outbox tables in the dedicated `wolverine` schema — the orchestrated-environment
+    // equivalent of the AddResourceSetupOnStartup() call that keeps a plain `dotnet run`/Testcontainers
+    // boot self-sufficient. Placed after WithReference/WaitFor so the gate inherits them (it must reach
+    // the same database). The gate reads its connection string exactly as the API does — from
+    // database.json's DatabaseSettings:ConnectionString, the same value mirrored into ConnectionStrings:WaydDb
+    // above — so it provisions into the API's real database. `codegen write` is intentionally NOT run here:
+    // we remain on runtime codegen (Dynamic/Auto + WolverineFx.RuntimeCompilation), so pre-generating into
+    // an uncommitted tree each boot would only add startup cost without being the compiled source of truth.
+    // Flipping to TypeLoadMode.Static (with committed generated code) and adding the codegen gate is a
+    // deferred follow-up.
+    .WithJasperFxStartup(c => c.Run("resources", "setup"));
 
 // "Reset Database" command in the Aspire dashboard. Destruction lives here — in the orchestrator, out
 // of band from the running app — so it is never reachable via an HTTP request and simply does not exist

--- a/Wayd.AppHost/AppHost.cs
+++ b/Wayd.AppHost/AppHost.cs
@@ -42,7 +42,23 @@ var waydApi = builder.AddProject<Projects.Wayd_Web_Api>("wayd-api")
     // an uncommitted tree each boot would only add startup cost without being the compiled source of truth.
     // Flipping to TypeLoadMode.Static (with committed generated code) and adding the codegen gate is a
     // deferred follow-up.
-    .WithJasperFxStartup(c => c.Run("resources", "setup"));
+    //
+    // ConfigureGate strips the gate's HTTP/HTTPS endpoints. JasperFx.Aspire builds the gate as a second
+    // AddProject on the SAME csproj, so it inherits the API's launch-profile endpoints — but it is a
+    // run-to-completion process that never listens, so Aspire logs "service '/wayd-api-resources-setup-https'
+    // ... is not produced by this Executable" / "service-producer annotation is invalid" and the phantom
+    // service tangles the API's own endpoint allocation (leaving wayd-api stuck Running-Unhealthy). Removing
+    // the gate's EndpointAnnotations makes it a pure provisioning executable with no service to expose.
+    .WithJasperFxStartup(c => c.Run("resources", "setup", gate =>
+        gate.ConfigureGate = g =>
+        {
+            foreach (var endpoint in g.Resource.Annotations
+                         .OfType<Aspire.Hosting.ApplicationModel.EndpointAnnotation>()
+                         .ToArray())
+            {
+                g.Resource.Annotations.Remove(endpoint);
+            }
+        }));
 
 // "Reset Database" command in the Aspire dashboard. Destruction lives here — in the orchestrator, out
 // of band from the running app — so it is never reachable via an HTTP request and simply does not exist

--- a/Wayd.AppHost/AppHost.cs
+++ b/Wayd.AppHost/AppHost.cs
@@ -30,6 +30,13 @@ var waydApi = builder.AddProject<Projects.Wayd_Web_Api>("wayd-api")
     .WithReference(waydDb)
     .WaitFor(waydDb)
     .WithHttpHealthCheck(global::Wayd.Infrastructure.ServiceEndpoints.HealthEndpointPath)
+    // Surface the JasperFx/Wolverine CLI verbs as one-click buttons on the wayd-api dashboard tile.
+    // Default (no options) adds only the READ-ONLY verbs — `check-env`, `describe`, `codegen` (preview) —
+    // so an operator can run an environment check or inspect the generated handler code / Wolverine config
+    // against the running service without a terminal, and with no confirmation prompts. The mutating verbs
+    // (`resources`, `codegen write`, `projections`) are intentionally NOT added: `resources setup` already
+    // runs as the startup gate below, and mutating buttons would need IncludeMutatingCommands = true.
+    .WithJasperFxCommands()
     // JasperFx startup gate: run `resources setup` as a separate, short-lived invocation of the API
     // (via RunJasperFxCommands in Program.cs) BEFORE the long-running API boots. It provisions the
     // Wolverine durable-outbox tables in the dedicated `wolverine` schema — the orchestrated-environment

--- a/Wayd.AppHost/Wayd.AppHost.csproj
+++ b/Wayd.AppHost/Wayd.AppHost.csproj
@@ -10,6 +10,7 @@
       <PackageReference Include="Aspire.Hosting.AppHost" />
       <PackageReference Include="Aspire.Hosting.JavaScript" />
       <PackageReference Include="Aspire.Hosting.SqlServer" />
+      <PackageReference Include="JasperFx.Aspire" />
       <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
     </ItemGroup>
 

--- a/Wayd.Web/src/Wayd.Web.Api/Configurations/logger.json
+++ b/Wayd.Web/src/Wayd.Web.Api/Configurations/logger.json
@@ -32,6 +32,7 @@
                 "Microsoft.Hosting.Lifetime": "Information",
                 "Microsoft.IdentityModel": "Fatal",
                 "System": "Information",
+                "Wolverine": "Information",
                 "ZymLabs.NSwag.FluentValidation": "Warning"
             }
         },

--- a/Wayd.Web/src/Wayd.Web.Api/Program.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Reflection;
 using System.Text.Json.Serialization;
 using FluentValidation.AspNetCore;
+using JasperFx;
 using Wayd.AppIntegration.Application;
 using Wayd.Common.Application;
 using Wayd.Common.Application.Interfaces;
@@ -113,7 +114,29 @@ try
 
     app.UseInfrastructure(builder.Configuration);
     app.MapDefaultEndpoints();
-    app.Run();
+
+    // Expose the JasperFx/Wolverine CLI verbs (`resources setup`, `codegen write`, `check-env`, …) when
+    // the process is launched WITH a verb in args — this is what the Aspire AppHost's .WithJasperFxStartup
+    // gate invokes (`wayd-api resources setup`) to provision the durable-outbox tables before the API
+    // takes its first message. RunJasperFxCommands runs that verb and exits with its status code; propagate
+    // it so a failed provisioning gate fails fast (non-zero) rather than being swallowed.
+    //
+    // With NO verb (a normal boot), fall through to the plain app.Run() path exactly as before. This split
+    // is deliberate: routing a verbless boot through RunJasperFxCommands breaks WebApplicationFactory when
+    // more than one factory boots the host in a single test process (the second host reports "entry point
+    // exited without ever building an IHost"), and a verbless boot has no reason to enter the CLI machinery.
+    // A leading '-' is never a verb — it is a host flag (Kestrel's --urls, the ASP.NET Core switches, etc.),
+    // which JasperFx itself would just pass through to "run the host"; treat only a non-flag first arg as a verb.
+    var hasJasperFxVerb = args.Length > 0 && !args[0].StartsWith('-');
+
+    if (hasJasperFxVerb)
+    {
+        Environment.ExitCode = await app.RunJasperFxCommands(args);
+    }
+    else
+    {
+        app.Run();
+    }
 }
 catch (Exception ex) when (!ex.GetType().Name.Equals("HostAbortedException", StringComparison.Ordinal))
 {


### PR DESCRIPTION
## Wolverine → Aspire integration (JasperFx.Aspire) + log-noise fix

Deferred Stage B follow-up from the MediatR→Wolverine migration (#664). Wires
JasperFx.Aspire into the AppHost and quiets the durability-agent log spam.

### Changes

**1. Wolverine log-noise fix** (`logger.json`)
The durable outbox's durability agent polls `wolverine_control_queue` ~1/sec and
logs each batch at Debug (`Received DatabaseOperationBatch#… at dbcontrol://…`),
flooding logs whenever the effective level is Debug. Added a `"Wolverine": "Information"`
Serilog override. Started at Information (not Warning) so the useful boot lines
survive ("Starting Wolverine messaging", "Ran Setup() on resource Envelope Storage",
"Now listening"). Verified by booting the real host at Debug: the per-second spam is
gone, the Information boot lines remain. Config-only; applies in all environments.

**2. JasperFx.Aspire wiring** (AppHost-side)
- Added `JasperFx.Aspire` 2.29.1 to `Directory.Packages.props` + `Wayd.AppHost` (not
  the service project). Compatible with the WolverineFx 6.19.0 pin and .NET 10 / Aspire
  13.4.6 (its only dependency is `Aspire.Hosting ≥ 13.3.1`).
- `Program.cs`: wired `RunJasperFxCommands(args)` to expose the JasperFx/Wolverine CLI
  verbs, **gated on args** — an explicit verb routes through the CLI machinery; a verbless
  boot falls through to plain `app.Run()` exactly as before. This split is required:
  routing a verbless boot through `RunJasperFxCommands` breaks `WebApplicationFactory`
  when more than one factory boots the host in a single test process (the second host
  reports "entry point exited without ever building an IHost"). The existing
  try/catch/finally + StaticLogger + skipDbInit boot sequence is preserved.
- `AppHost.cs`:
  - `.WithJasperFxCommands()` — surfaces the read-only verbs (`check-env`, `describe`,
    `codegen` preview) as one-click buttons on the wayd-api dashboard tile. Verified:
    `check-env` → "All environment checks are good!"; `describe` runs clean.
  - `.WithJasperFxStartup(c => c.Run("resources", "setup"))` — a run-to-completion
    startup gate that provisions the Wolverine outbox tables (`wolverine` schema) before
    the API boots; the orchestrated-environment equivalent of the in-process
    `AddResourceSetupOnStartup()`. Verified end-to-end: dropped the schema, ran the
    AppHost, watched the gate recreate all 8 envelope tables.

**3. Startup-gate health fix** (`AppHost.cs`)
JasperFx.Aspire builds the gate as a second `AddProject` on the same csproj, so it
inherited the API's HTTP/HTTPS launch-profile endpoints despite never listening —
producing `service '/wayd-api-resources-setup-https' … is not produced by this
Executable` errors that tangled the API's endpoint allocation and left wayd-api stuck
"Running (Unhealthy)". Strip the gate's `EndpointAnnotation`s via the `ConfigureGate`
escape hatch so it's a pure provisioning executable. After the fix the errors are gone
and wayd-api is healthy (`/api/health` → 200).

### Deferred (explicitly)
`codegen write` gate + `TypeLoadMode.Static` + dropping the `WolverineFx.RuntimeCompilation`
reference. `codegen write` emits ~890 generated handler files into
`Internal/Generated/WolverineHandlers`; committing and keeping that tree in sync (a stale
tree silently breaks dispatch under Static) is a CI-gating decision that warrants its own
change. The Aspire wiring here is the prerequisite; the Static flip is the follow-up.

### Verification
- `dotnet build Wayd.slnx` — 0 warnings, 0 errors
- ArchitectureTests — 68/68 · Web.Api integration tests — 7/7 (Docker/Testcontainers)
- Real host boots clean; `resources setup` / `check-env` / `describe` verbs run and exit 0
- AppHost run: gate provisions the outbox schema, no endpoint errors, wayd-api healthy
