### PR TITLE
Feature/messaging UI

### DIFF
--- a/Wayd.Common/src/Wayd.Common.Domain/Authorization/ApplicationPermissions.cs
+++ b/Wayd.Common/src/Wayd.Common.Domain/Authorization/ApplicationPermissions.cs
@@ -27,6 +27,8 @@ public static class ApplicationResource
     public const string Hangfire = nameof(Hangfire);
     public const string BackgroundJobs = nameof(BackgroundJobs);
 
+    public const string Messaging = nameof(Messaging);
+
     public const string Users = nameof(Users);
     public const string UserRoles = nameof(UserRoles);
     public const string Roles = nameof(Roles);
@@ -104,6 +106,14 @@ public static class ApplicationPermissions
         new("View Background Jobs", ApplicationAction.View, ApplicationResource.BackgroundJobs, BackgroundJobsCategory),
         new("Create Background Jobs", ApplicationAction.Create, ApplicationResource.BackgroundJobs, BackgroundJobsCategory),
         new("Run Background Jobs", ApplicationAction.Run, ApplicationResource.BackgroundJobs, BackgroundJobsCategory)
+    ];
+
+    private const string MessagingCategory = "Messaging";
+    private static readonly ApplicationPermission[] _messaging =
+    [
+        new("View Messaging. This includes the outbox, incoming envelopes, and dead letter queue.", ApplicationAction.View, ApplicationResource.Messaging, MessagingCategory),
+        new("Replay Dead Letter Messages", ApplicationAction.Run, ApplicationResource.Messaging, MessagingCategory),
+        new("Discard Dead Letter Messages", ApplicationAction.Delete, ApplicationResource.Messaging, MessagingCategory),
     ];
 
     private const string IdentityCategory = "Identity";
@@ -318,6 +328,7 @@ public static class ApplicationPermissions
     private static readonly ApplicationPermission[] _all = [.. _common
         .Union(_application)
         .Union(_backgroundJobs)
+        .Union(_messaging)
         .Union(_identity)
         .Union(_appIntegration)
         .Union(_healthChecks)

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/Messaging/WolverineConfiguration.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/Messaging/WolverineConfiguration.cs
@@ -108,6 +108,19 @@ public static class WolverineConfiguration
         opts.PersistMessagesWithSqlServer(connectionString, Persistence.ConfigureServices.WolverineSchemaName);
         opts.UseEntityFrameworkCoreTransactions();
 
+        // REQUIRED for the outbox to actually be durable: Wolverine's outbox only persists envelopes
+        // destined for DURABLE endpoints. The durable events route to per-message-type LOCAL queues,
+        // which default to BufferedInMemory — in that mode the "outbox" merely defers an in-memory
+        // publish until post-commit, and a crash between commit and dispatch silently loses the event
+        // (verified 2026-07-19: zero envelope rows were ever written). This policy flips every local
+        // queue to durable so the envelope is written to wolverine_incoming_envelopes inside the same
+        // transaction as the entity change and recovered by the durability agent after a crash.
+        // Wolverine's internal system queues (agents) are not affected. Consequence: durable delivery
+        // is at-least-once for real now — durable-event handlers must stay idempotent (see
+        // DurableEventRoutes), and handled envelopes remain visible to the messaging dashboard for
+        // DurabilitySettings.KeepAfterMessageHandling (default 5 minutes) before cleanup.
+        opts.Policies.UseDurableLocalQueues();
+
         // Provision the envelope tables on startup. BOTH settings are required, and each is silently a no-op
         // without the other:
         //   - AutoBuildMessageStorageOnStartup must be set explicitly. JasperFx overrides Wolverine's own

--- a/Wayd.Tools/DataGeneration/src/Wayd.Tools.DataGeneration.Cli.Client/Generated/WaydApiClient.g.cs
+++ b/Wayd.Tools/DataGeneration/src/Wayd.Tools.DataGeneration.Cli.Client/Generated/WaydApiClient.g.cs
@@ -50574,6 +50574,651 @@ namespace Wayd.Tools.DataGeneration.Cli.Client
     }
 
     [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial interface IMessagingClient
+    {
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get counts of persisted message envelopes by lifecycle state.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<MessagingCountsResponse> GetCountsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get a page of dead-lettered messages, optionally filtered by message type, exception type, and time range.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<DeadLetterMessagesResponse> GetDeadLettersAsync(string? messageType = null, string? exceptionType = null, System.DateTimeOffset? from = null, System.DateTimeOffset? to = null, int? pageNumber = null, int? pageSize = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get the full detail of a dead-lettered message, including its serialized body.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task<DeadLetterMessageDetailsResponse> GetDeadLetterByIdAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Mark dead-lettered messages as replayable. The durability agent moves them back to the incoming queue on its next pass, so replay is asynchronous.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task ReplayDeadLettersAsync(DeadLetterMessagesRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Permanently delete dead-lettered messages.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        System.Threading.Tasks.Task DiscardDeadLettersAsync(DeadLetterMessagesRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MessagingClient : IMessagingClient
+    {
+        #pragma warning disable 8618
+        private string _baseUrl;
+        #pragma warning restore 8618
+
+        private System.Net.Http.HttpClient _httpClient;
+        private static System.Lazy<System.Text.Json.JsonSerializerOptions> _settings = new System.Lazy<System.Text.Json.JsonSerializerOptions>(CreateSerializerSettings, true);
+        private System.Text.Json.JsonSerializerOptions _instanceSettings;
+
+    #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        public MessagingClient(string baseUrl, System.Net.Http.HttpClient httpClient)
+    #pragma warning restore CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
+        {
+            BaseUrl = baseUrl;
+            _httpClient = httpClient;
+            Initialize();
+        }
+
+        private static System.Text.Json.JsonSerializerOptions CreateSerializerSettings()
+        {
+            var settings = new System.Text.Json.JsonSerializerOptions();
+            UpdateJsonSerializerSettings(settings);
+            return settings;
+        }
+
+        public string BaseUrl
+        {
+            get { return _baseUrl; }
+            set
+            {
+                _baseUrl = value;
+                if (!string.IsNullOrEmpty(_baseUrl) && !_baseUrl.EndsWith("/"))
+                    _baseUrl += '/';
+            }
+        }
+
+        protected System.Text.Json.JsonSerializerOptions JsonSerializerSettings { get { return _instanceSettings ?? _settings.Value; } }
+
+        static partial void UpdateJsonSerializerSettings(System.Text.Json.JsonSerializerOptions settings);
+
+        partial void Initialize();
+
+        partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, string url);
+        partial void PrepareRequest(System.Net.Http.HttpClient client, System.Net.Http.HttpRequestMessage request, System.Text.StringBuilder urlBuilder);
+        partial void ProcessResponse(System.Net.Http.HttpClient client, System.Net.Http.HttpResponseMessage response);
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get counts of persisted message envelopes by lifecycle state.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<MessagingCountsResponse> GetCountsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/admin/messaging/counts"
+                    urlBuilder_.Append("api/admin/messaging/counts");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<MessagingCountsResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new WaydApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new WaydApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get a page of dead-lettered messages, optionally filtered by message type, exception type, and time range.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<DeadLetterMessagesResponse> GetDeadLettersAsync(string? messageType = null, string? exceptionType = null, System.DateTimeOffset? from = null, System.DateTimeOffset? to = null, int? pageNumber = null, int? pageSize = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/admin/messaging/dead-letters"
+                    urlBuilder_.Append("api/admin/messaging/dead-letters");
+                    urlBuilder_.Append('?');
+                    if (messageType != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("messageType")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(messageType, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (exceptionType != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("exceptionType")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(exceptionType, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (from != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("from")).Append('=').Append(System.Uri.EscapeDataString(from.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (to != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("to")).Append('=').Append(System.Uri.EscapeDataString(to.Value.ToString("s", System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (pageNumber != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("pageNumber")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageNumber, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    if (pageSize != null)
+                    {
+                        urlBuilder_.Append(System.Uri.EscapeDataString("pageSize")).Append('=').Append(System.Uri.EscapeDataString(ConvertToString(pageSize, System.Globalization.CultureInfo.InvariantCulture))).Append('&');
+                    }
+                    urlBuilder_.Length--;
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<DeadLetterMessagesResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new WaydApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new WaydApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Get the full detail of a dead-lettered message, including its serialized body.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task<DeadLetterMessageDetailsResponse> GetDeadLetterByIdAsync(System.Guid id, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (id == null)
+                throw new System.ArgumentNullException("id");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    request_.Method = new System.Net.Http.HttpMethod("GET");
+                    request_.Headers.Accept.Add(System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/admin/messaging/dead-letters/{id}"
+                    urlBuilder_.Append("api/admin/messaging/dead-letters/");
+                    urlBuilder_.Append(System.Uri.EscapeDataString(ConvertToString(id, System.Globalization.CultureInfo.InvariantCulture)));
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 200)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<DeadLetterMessageDetailsResponse>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new WaydApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            return objectResponse_.Object;
+                        }
+                        else
+                        if (status_ == 404)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new WaydApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new WaydApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new WaydApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Mark dead-lettered messages as replayable. The durability agent moves them back to the incoming queue on its next pass, so replay is asynchronous.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task ReplayDeadLettersAsync(DeadLetterMessagesRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(request, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/admin/messaging/dead-letters/replay"
+                    urlBuilder_.Append("api/admin/messaging/dead-letters/replay");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 202)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new WaydApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new WaydApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new WaydApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        /// <param name="cancellationToken">A cancellation token that can be used by other objects or threads to receive notice of cancellation.</param>
+        /// <summary>
+        /// Permanently delete dead-lettered messages.
+        /// </summary>
+        /// <exception cref="WaydApiException">A server side error occurred.</exception>
+        public virtual async System.Threading.Tasks.Task DiscardDeadLettersAsync(DeadLetterMessagesRequest request, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        {
+            if (request == null)
+                throw new System.ArgumentNullException("request");
+
+            var client_ = _httpClient;
+            var disposeClient_ = false;
+            try
+            {
+                using (var request_ = new System.Net.Http.HttpRequestMessage())
+                {
+                    var json_ = System.Text.Json.JsonSerializer.SerializeToUtf8Bytes(request, JsonSerializerSettings);
+                    var content_ = new System.Net.Http.ByteArrayContent(json_);
+                    content_.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
+                    request_.Content = content_;
+                    request_.Method = new System.Net.Http.HttpMethod("POST");
+
+                    var urlBuilder_ = new System.Text.StringBuilder();
+                    if (!string.IsNullOrEmpty(_baseUrl)) urlBuilder_.Append(_baseUrl);
+                    // Operation Path: "api/admin/messaging/dead-letters/discard"
+                    urlBuilder_.Append("api/admin/messaging/dead-letters/discard");
+
+                    PrepareRequest(client_, request_, urlBuilder_);
+
+                    var url_ = urlBuilder_.ToString();
+                    request_.RequestUri = new System.Uri(url_, System.UriKind.RelativeOrAbsolute);
+
+                    PrepareRequest(client_, request_, url_);
+
+                    var response_ = await client_.SendAsync(request_, System.Net.Http.HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+                    var disposeResponse_ = true;
+                    try
+                    {
+                        var headers_ = new System.Collections.Generic.Dictionary<string, System.Collections.Generic.IEnumerable<string>>();
+                        foreach (var item_ in response_.Headers)
+                            headers_[item_.Key] = item_.Value;
+                        if (response_.Content != null && response_.Content.Headers != null)
+                        {
+                            foreach (var item_ in response_.Content.Headers)
+                                headers_[item_.Key] = item_.Value;
+                        }
+
+                        ProcessResponse(client_, response_);
+
+                        var status_ = (int)response_.StatusCode;
+                        if (status_ == 204)
+                        {
+                            return;
+                        }
+                        else
+                        if (status_ == 400)
+                        {
+                            var objectResponse_ = await ReadObjectResponseAsync<ProblemDetails>(response_, headers_, cancellationToken).ConfigureAwait(false);
+                            if (objectResponse_.Object == null)
+                            {
+                                throw new WaydApiException("Response was null which was not expected.", status_, objectResponse_.Text, headers_, null);
+                            }
+                            throw new WaydApiException<ProblemDetails>("A server side error occurred.", status_, objectResponse_.Text, headers_, objectResponse_.Object, null);
+                        }
+                        else
+                        {
+                            var responseData_ = response_.Content == null ? null : await ReadAsStringAsync(response_.Content, cancellationToken).ConfigureAwait(false);
+                            throw new WaydApiException("The HTTP status code of the response was not expected (" + status_ + ").", status_, responseData_, headers_, null);
+                        }
+                    }
+                    finally
+                    {
+                        if (disposeResponse_)
+                            response_.Dispose();
+                    }
+                }
+            }
+            finally
+            {
+                if (disposeClient_)
+                    client_.Dispose();
+            }
+        }
+
+        protected struct ObjectResponseResult<T>
+        {
+            public ObjectResponseResult(T responseObject, string responseText)
+            {
+                this.Object = responseObject;
+                this.Text = responseText;
+            }
+
+            public T Object { get; }
+
+            public string Text { get; }
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static System.Threading.Tasks.Task<string> ReadAsStringAsync(System.Net.Http.HttpContent content, System.Threading.CancellationToken cancellationToken)
+        {
+    #if NET5_0_OR_GREATER
+            return content.ReadAsStringAsync(cancellationToken);
+    #else
+            return content.ReadAsStringAsync();
+    #endif
+        }
+
+        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        private static System.Threading.Tasks.Task<System.IO.Stream> ReadAsStreamAsync(System.Net.Http.HttpContent content, System.Threading.CancellationToken cancellationToken)
+        {
+    #if NET5_0_OR_GREATER
+            return content.ReadAsStreamAsync(cancellationToken);
+    #else
+            return content.ReadAsStreamAsync();
+    #endif
+        }
+
+        public bool ReadResponseAsString { get; set; }
+
+        protected virtual async System.Threading.Tasks.Task<ObjectResponseResult<T>> ReadObjectResponseAsync<T>(System.Net.Http.HttpResponseMessage response, System.Collections.Generic.IReadOnlyDictionary<string, System.Collections.Generic.IEnumerable<string>> headers, System.Threading.CancellationToken cancellationToken)
+        {
+            if (response == null || response.Content == null)
+            {
+                return new ObjectResponseResult<T>(default(T)!, string.Empty);
+            }
+
+            if (ReadResponseAsString)
+            {
+                var responseText = await ReadAsStringAsync(response.Content, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    var typedBody = System.Text.Json.JsonSerializer.Deserialize<T>(responseText, JsonSerializerSettings);
+                    return new ObjectResponseResult<T>(typedBody!, responseText);
+                }
+                catch (System.Text.Json.JsonException exception)
+                {
+                    var message = "Could not deserialize the response body string as " + typeof(T).FullName + ".";
+                    throw new WaydApiException(message, (int)response.StatusCode, responseText, headers, exception);
+                }
+            }
+            else
+            {
+                try
+                {
+                    using (var responseStream = await ReadAsStreamAsync(response.Content, cancellationToken).ConfigureAwait(false))
+                    {
+                        var typedBody = await System.Text.Json.JsonSerializer.DeserializeAsync<T>(responseStream, JsonSerializerSettings, cancellationToken).ConfigureAwait(false);
+                        return new ObjectResponseResult<T>(typedBody!, string.Empty);
+                    }
+                }
+                catch (System.Text.Json.JsonException exception)
+                {
+                    var message = "Could not deserialize the response body stream as " + typeof(T).FullName + ".";
+                    throw new WaydApiException(message, (int)response.StatusCode, string.Empty, headers, exception);
+                }
+            }
+        }
+
+        private string ConvertToString(object? value, System.Globalization.CultureInfo cultureInfo)
+        {
+            if (value == null)
+            {
+                return "";
+            }
+
+            if (value is System.Enum)
+            {
+                var name = System.Enum.GetName(value.GetType(), value);
+                if (name != null)
+                {
+                    var field_ = System.Reflection.IntrospectionExtensions.GetTypeInfo(value.GetType()).GetDeclaredField(name);
+                    if (field_ != null)
+                    {
+                        var attribute = System.Reflection.CustomAttributeExtensions.GetCustomAttribute(field_, typeof(System.Runtime.Serialization.EnumMemberAttribute)) 
+                            as System.Runtime.Serialization.EnumMemberAttribute;
+                        if (attribute != null)
+                        {
+                            return attribute.Value != null ? attribute.Value : name;
+                        }
+                    }
+
+                    var converted = System.Convert.ToString(System.Convert.ChangeType(value, System.Enum.GetUnderlyingType(value.GetType()), cultureInfo));
+                    return converted == null ? string.Empty : converted;
+                }
+            }
+            else if (value is bool) 
+            {
+                return System.Convert.ToString((bool)value, cultureInfo).ToLowerInvariant();
+            }
+            else if (value is byte[])
+            {
+                return System.Convert.ToBase64String((byte[]) value);
+            }
+            else if (value is string[])
+            {
+                return string.Join(",", (string[])value);
+            }
+            else if (value.GetType().IsArray)
+            {
+                var valueArray = (System.Array)value;
+                var valueTextArray = new string[valueArray.Length];
+                for (var i = 0; i < valueArray.Length; i++)
+                {
+                    valueTextArray[i] = ConvertToString(valueArray.GetValue(i), cultureInfo);
+                }
+                return string.Join(",", valueTextArray);
+            }
+
+            var result = System.Convert.ToString(value, cultureInfo);
+            return result == null ? "" : result;
+        }
+    }
+
+    [System.CodeDom.Compiler.GeneratedCode("NSwag", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
     public partial interface IScoringModelsClient
     {
 
@@ -64534,6 +65179,141 @@ namespace Wayd.Tools.DataGeneration.Cli.Client
 
         [System.Text.Json.Serialization.JsonPropertyName("isEnabled")]
         public bool IsEnabled { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// Snapshot of the Wolverine durable message store: how many envelopes are currently persisted in
+    /// <br/>each lifecycle bucket. In a healthy system incoming/outgoing hover near zero — envelopes only
+    /// <br/>linger during backlog, scheduled delivery, or after an unclean shutdown.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class MessagingCountsResponse
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("incoming")]
+        public int Incoming { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("scheduled")]
+        public int Scheduled { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("outgoing")]
+        public int Outgoing { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("handled")]
+        public int Handled { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("deadLetter")]
+        public int DeadLetter { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// A page of dead-lettered messages. PageNumber is 0-based, mirroring Wolverine's
+    /// <br/>DeadLetterEnvelopeQuery paging.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeadLetterMessagesResponse
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("totalCount")]
+        public int TotalCount { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("pageNumber")]
+        public int PageNumber { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("pageSize")]
+        public int PageSize { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("items")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<DeadLetterMessageResponse> Items { get; set; } = new System.Collections.ObjectModel.Collection<DeadLetterMessageResponse>();
+
+    }
+
+    /// <summary>
+    /// A single dead-lettered message envelope: what failed, where, and why.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeadLetterMessageResponse
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("id")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.Guid Id { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("messageType")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public string MessageType { get; set; } = default!;
+
+        /// <summary>
+        /// The listener/queue URI the message was received at (e.g. local://durable/).
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("receivedAt")]
+        public string? ReceivedAt { get; set; } = default!;
+
+        /// <summary>
+        /// The service that originally sent the message.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("source")]
+        public string? Source { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("exceptionType")]
+        public string? ExceptionType { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("exceptionMessage")]
+        public string? ExceptionMessage { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("sentAt")]
+        [System.ComponentModel.DataAnnotations.Required(AllowEmptyStrings = true)]
+        public System.DateTimeOffset SentAt { get; set; } = default!;
+
+        /// <summary>
+        /// Whether the durability agent is set to move this envelope back to incoming for another attempt.
+        /// </summary>
+        [System.Text.Json.Serialization.JsonPropertyName("replayable")]
+        public bool Replayable { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("attempts")]
+        public int Attempts { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// Full detail for a single dead-lettered message, including the serialized message body
+    /// <br/>(System.Text.Json per the Wolverine host configuration, so it renders as JSON).
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeadLetterMessageDetailsResponse : DeadLetterMessageResponse
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("body")]
+        public string? Body { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("contentType")]
+        public string? ContentType { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("correlationId")]
+        public string? CorrelationId { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("destination")]
+        public string? Destination { get; set; } = default!;
+
+        [System.Text.Json.Serialization.JsonPropertyName("executionTime")]
+        public System.DateTimeOffset? ExecutionTime { get; set; } = default!;
+
+    }
+
+    /// <summary>
+    /// Identifies the dead-lettered messages a replay or discard operation targets.
+    /// </summary>
+    [System.CodeDom.Compiler.GeneratedCode("NJsonSchema", "14.7.1.0 (NJsonSchema v11.6.1.0 (Newtonsoft.Json v13.0.0.0))")]
+    public partial class DeadLetterMessagesRequest
+    {
+
+        [System.Text.Json.Serialization.JsonPropertyName("ids")]
+        [System.ComponentModel.DataAnnotations.Required]
+        public System.Collections.Generic.ICollection<System.Guid> Ids { get; set; } = new System.Collections.ObjectModel.Collection<System.Guid>();
 
     }
 

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/MessagingController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/MessagingController.cs
@@ -92,7 +92,8 @@ public class MessagingController(IMessageStore messageStore) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> ReplayDeadLetters([FromBody] DeadLetterMessagesRequest request, CancellationToken cancellationToken)
     {
-        if (request.Ids.Count == 0)
+        // is null: the property initializer doesn't survive an explicit {"ids": null} payload.
+        if (request.Ids is null || request.Ids.Count == 0)
         {
             return BadRequest(ProblemDetailsExtensions.ForBadRequest("At least one dead letter message id is required.", HttpContext));
         }
@@ -108,7 +109,8 @@ public class MessagingController(IMessageStore messageStore) : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     public async Task<IActionResult> DiscardDeadLetters([FromBody] DeadLetterMessagesRequest request, CancellationToken cancellationToken)
     {
-        if (request.Ids.Count == 0)
+        // is null: the property initializer doesn't survive an explicit {"ids": null} payload.
+        if (request.Ids is null || request.Ids.Count == 0)
         {
             return BadRequest(ProblemDetailsExtensions.ForBadRequest("At least one dead letter message id is required.", HttpContext));
         }

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/MessagingController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/Admin/MessagingController.cs
@@ -1,0 +1,119 @@
+using JasperFx.Core;
+using Wayd.Web.Api.Extensions;
+using Wayd.Web.Api.Models.Admin.Messaging;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
+
+namespace Wayd.Web.Api.Controllers.Admin;
+
+/// <summary>
+/// Operational visibility into the Wolverine durable message store (outbox/inbox counts and the
+/// dead letter queue). Injects <see cref="IMessageStore"/> directly rather than going through the
+/// Wolverine handler pipeline: this is host-plumbing introspection (the same category as
+/// <see cref="BackgroundJobsController"/> over Hangfire), and keeping it out of the pipeline keeps
+/// the committed handler codegen tree untouched.
+/// </summary>
+[Route("api/admin/messaging")]
+[ApiVersionNeutral]
+[ApiController]
+public class MessagingController(IMessageStore messageStore) : ControllerBase
+{
+    private readonly IMessageStore _messageStore = messageStore;
+
+    [HttpGet("counts")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.Messaging)]
+    [OpenApiOperation("Get counts of persisted message envelopes by lifecycle state.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<MessagingCountsResponse>> GetCounts()
+    {
+        var counts = await _messageStore.Admin.FetchCountsAsync();
+        return Ok(new MessagingCountsResponse
+        {
+            Incoming = counts.Incoming,
+            Scheduled = counts.Scheduled,
+            Outgoing = counts.Outgoing,
+            Handled = counts.Handled,
+            DeadLetter = counts.DeadLetter,
+        });
+    }
+
+    [HttpGet("dead-letters")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.Messaging)]
+    [OpenApiOperation("Get a page of dead-lettered messages, optionally filtered by message type, exception type, and time range.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    public async Task<ActionResult<DeadLetterMessagesResponse>> GetDeadLetters(
+        CancellationToken cancellationToken,
+        [FromQuery] string? messageType = null,
+        [FromQuery] string? exceptionType = null,
+        [FromQuery] DateTimeOffset? from = null,
+        [FromQuery] DateTimeOffset? to = null,
+        [FromQuery] int pageNumber = 0,
+        [FromQuery] int pageSize = 100)
+    {
+        var query = new DeadLetterEnvelopeQuery(new TimeRange(from, to))
+        {
+            MessageType = messageType,
+            ExceptionType = exceptionType,
+            PageNumber = Math.Max(pageNumber, 0),
+            PageSize = Math.Clamp(pageSize, 1, 500),
+        };
+
+        var results = await _messageStore.DeadLetters.QueryAsync(query, cancellationToken);
+
+        return Ok(new DeadLetterMessagesResponse
+        {
+            TotalCount = results.TotalCount,
+            PageNumber = results.PageNumber,
+            PageSize = query.PageSize,
+            Items = [.. results.Envelopes.Select(DeadLetterMessageResponse.From)],
+        });
+    }
+
+    [HttpGet("dead-letters/{id:guid}")]
+    [MustHavePermission(ApplicationAction.View, ApplicationResource.Messaging)]
+    [OpenApiOperation("Get the full detail of a dead-lettered message, including its serialized body.", "")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<DeadLetterMessageDetailsResponse>> GetDeadLetterById(Guid id)
+    {
+        var envelope = await _messageStore.DeadLetters.DeadLetterEnvelopeByIdAsync(id, null);
+        if (envelope is null)
+        {
+            return NotFound();
+        }
+
+        return Ok(DeadLetterMessageDetailsResponse.From(envelope, DeadLetterMessageResponse.From(envelope)));
+    }
+
+    [HttpPost("dead-letters/replay")]
+    [MustHavePermission(ApplicationAction.Run, ApplicationResource.Messaging)]
+    [OpenApiOperation("Mark dead-lettered messages as replayable. The durability agent moves them back to the incoming queue on its next pass, so replay is asynchronous.", "")]
+    [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> ReplayDeadLetters([FromBody] DeadLetterMessagesRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Ids.Count == 0)
+        {
+            return BadRequest(ProblemDetailsExtensions.ForBadRequest("At least one dead letter message id is required.", HttpContext));
+        }
+
+        await _messageStore.DeadLetters.ReplayAsync(new DeadLetterEnvelopeQuery([.. request.Ids]), cancellationToken);
+        return Accepted();
+    }
+
+    [HttpPost("dead-letters/discard")]
+    [MustHavePermission(ApplicationAction.Delete, ApplicationResource.Messaging)]
+    [OpenApiOperation("Permanently delete dead-lettered messages.", "")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> DiscardDeadLetters([FromBody] DeadLetterMessagesRequest request, CancellationToken cancellationToken)
+    {
+        if (request.Ids.Count == 0)
+        {
+            return BadRequest(ProblemDetailsExtensions.ForBadRequest("At least one dead letter message id is required.", HttpContext));
+        }
+
+        await _messageStore.DeadLetters.DiscardAsync(new DeadLetterEnvelopeQuery([.. request.Ids]), cancellationToken);
+        return NoContent();
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateConnectionCommandHandler458722511.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateConnectionCommandHandler458722511.cs
@@ -46,7 +46,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -56,6 +55,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var activateConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.ActivateConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateExpenditureCategoryCommandHandler1981682729.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateExpenditureCategoryCommandHandler1981682729.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var activateExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.ActivateExpenditureCategoryCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var activateExpenditureCategoryCommand = (Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.ActivateExpenditureCategoryCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateProgramCommandHandler1094317256.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateProgramCommandHandler1094317256.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var activateProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.ActivateProgramCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var activateProgramCommand = (Wayd.ProjectPortfolioManagement.Application.Programs.Commands.ActivateProgramCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateProjectCommandHandler756998488.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateProjectCommandHandler756998488.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var activateProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ActivateProjectCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateProjectLifecycleCommandHandler610684326.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateProjectLifecycleCommandHandler610684326.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var activateProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.ActivateProjectLifecycleCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var activateProjectLifecycleCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.ActivateProjectLifecycleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateStrategicInitiativeCommandHandler319155464.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateStrategicInitiativeCommandHandler319155464.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var activateStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ActivateStrategicInitiativeCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateStrategicThemeCommandHandler2125457767.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateStrategicThemeCommandHandler2125457767.cs
@@ -50,12 +50,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateTeamMemberRoleCommandHandler65890531.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateTeamMemberRoleCommandHandler65890531.cs
@@ -49,6 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var activateTeamMemberRoleCommandValidator = new Wayd.Organization.Application.TeamMemberRoles.Commands.ActivateTeamMemberRoleCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,8 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var activateTeamMemberRoleCommandValidator = new Wayd.Organization.Application.TeamMemberRoles.Commands.ActivateTeamMemberRoleCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var activateTeamMemberRoleCommand = (Wayd.Organization.Application.TeamMemberRoles.Commands.ActivateTeamMemberRoleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateWorkProcessCommandHandler1259935962.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ActivateWorkProcessCommandHandler1259935962.cs
@@ -47,12 +47,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddPokerRoundCommandHandler576612291.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddPokerRoundCommandHandler576612291.cs
@@ -49,15 +49,15 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var addPokerRoundCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.AddPokerRoundCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var addPokerRoundCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.AddPokerRoundCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddProjectLifecyclePhaseCommandHandler1519546691.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddProjectLifecyclePhaseCommandHandler1519546691.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var addProjectLifecyclePhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.AddProjectLifecyclePhaseCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var addProjectLifecyclePhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.AddProjectLifecyclePhaseCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var addProjectLifecyclePhaseCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.AddProjectLifecyclePhaseCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddProjectTaskDependencyCommandHandler1836852351.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddProjectTaskDependencyCommandHandler1836852351.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var addProjectTaskDependencyCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.AddProjectTaskDependencyCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var addProjectTaskDependencyCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.AddProjectTaskDependencyCommandValidator();
             // The actual message body
             var addProjectTaskDependencyCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.AddProjectTaskDependencyCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringModelCriterionCommandHandler1997247613.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringModelCriterionCommandHandler1997247613.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var addScoringModelCriterionCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringModelCriterionCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var addScoringModelCriterionCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringModelCriterionCommandValidator();
             // The actual message body
             var addScoringModelCriterionCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringModelCriterionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringModelOutputCommandHandler133156099.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringModelOutputCommandHandler133156099.cs
@@ -50,13 +50,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var addScoringModelOutputCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringModelOutputCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringScaleCommandHandler670185553.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringScaleCommandHandler670185553.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var addScoringScaleCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringScaleCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var addScoringScaleCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringScaleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringScaleLevelCommandHandler1535976123.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddScoringScaleLevelCommandHandler1535976123.cs
@@ -50,6 +50,7 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var addScoringScaleLevelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringScaleLevelCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var addScoringScaleLevelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringScaleLevelCommandValidator();
             // The actual message body
             var addScoringScaleLevelCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.AddScoringScaleLevelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddStrategicInitiativeKpiMeasurementCommandHandler1561301665.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddStrategicInitiativeKpiMeasurementCommandHandler1561301665.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var addStrategicInitiativeKpiMeasurementCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.AddStrategicInitiativeKpiMeasurementCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var addStrategicInitiativeKpiMeasurementCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.AddStrategicInitiativeKpiMeasurementCommandValidator();
             // The actual message body
             var addStrategicInitiativeKpiMeasurementCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.AddStrategicInitiativeKpiMeasurementCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddTeamMemberCommandHandler39526975.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddTeamMemberCommandHandler39526975.cs
@@ -55,8 +55,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var addTeamMemberCommandValidator = new Wayd.Organization.Application.Teams.Commands.AddTeamMemberCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddTeamMembershipCommandHandler193099804.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddTeamMembershipCommandHandler193099804.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var addTeamMembershipCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.AddTeamMembershipCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var addTeamMembershipCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.AddTeamMembershipCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddTeamMembershipCommandHandler504178351.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AddTeamMembershipCommandHandler504178351.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var addTeamMembershipCommandValidator = new Wayd.Organization.Application.Teams.Commands.AddTeamMembershipCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var addTeamMembershipCommandValidator = new Wayd.Organization.Application.Teams.Commands.AddTeamMembershipCommandValidator();
             // The actual message body
             var addTeamMembershipCommand = (Wayd.Organization.Application.Teams.Commands.AddTeamMembershipCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ApproveProjectCommandHandler238674914.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ApproveProjectCommandHandler238674914.cs
@@ -49,15 +49,15 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var approveProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ApproveProjectCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var approveProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ApproveProjectCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ApproveStrategicInitiativeCommandHandler312828936.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ApproveStrategicInitiativeCommandHandler312828936.cs
@@ -50,6 +50,7 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var approveStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ApproveStrategicInitiativeCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var approveStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ApproveStrategicInitiativeCommandValidator();
             // The actual message body
             var approveStrategicInitiativeCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ApproveStrategicInitiativeCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveExpenditureCategoryCommandHandler201025370.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveExpenditureCategoryCommandHandler201025370.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var archiveExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.ArchiveExpenditureCategoryCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var archiveExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.ArchiveExpenditureCategoryCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveFeatureFlagCommandHandler1167510142.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveFeatureFlagCommandHandler1167510142.cs
@@ -52,17 +52,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var archiveFeatureFlagCommandValidator = new Wayd.Common.Application.FeatureManagement.Commands.ArchiveFeatureFlagCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var archiveFeatureFlagCommand = (Wayd.Common.Application.FeatureManagement.Commands.ArchiveFeatureFlagCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveProjectPortfolioCommandHandler1136533725.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveProjectPortfolioCommandHandler1136533725.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var archiveProjectPortfolioCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.ArchiveProjectPortfolioCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var archiveProjectPortfolioCommand = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.ArchiveProjectPortfolioCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveRoadmapCommandHandler1378534742.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveRoadmapCommandHandler1378534742.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var archiveRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.ArchiveRoadmapCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var archiveRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.ArchiveRoadmapCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var archiveRoadmapCommand = (Wayd.Planning.Application.Roadmaps.Commands.ArchiveRoadmapCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveScoringModelCommandHandler1800429257.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveScoringModelCommandHandler1800429257.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var archiveScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ArchiveScoringModelCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var archiveScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ArchiveScoringModelCommandValidator();
             // The actual message body
             var archiveScoringModelCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.ArchiveScoringModelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveVisionCommandHandler559310046.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ArchiveVisionCommandHandler559310046.cs
@@ -51,12 +51,12 @@ namespace Internal.Generated.WolverineHandlers
         {
             var archiveVisionCommandValidator = new Wayd.StrategicManagement.Application.Visions.Commands.ArchiveVisionCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AssignPortfolioScoringModelCommandHandler778937935.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AssignPortfolioScoringModelCommandHandler778937935.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var assignPortfolioScoringModelCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Scoring.Commands.AssignPortfolioScoringModelCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AssignProjectLifecycleCommandHandler937364294.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/AssignProjectLifecycleCommandHandler937364294.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var assignProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.AssignProjectLifecycleCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var assignProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.AssignProjectLifecycleCommandValidator();
             // The actual message body
             var assignProjectLifecycleCommand = (Wayd.ProjectPortfolioManagement.Application.Projects.Commands.AssignProjectLifecycleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/BulkUpsertEmployeesCommandHandler608472054.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/BulkUpsertEmployeesCommandHandler608472054.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var bulkUpsertEmployeesCommandValidator = new Wayd.Common.Application.Employees.Commands.BulkUpsertEmployeesCommandValidator();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var bulkUpsertEmployeesCommand = (Wayd.Common.Application.Employees.Commands.BulkUpsertEmployeesCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CancelProgramCommandHandler1292109013.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CancelProgramCommandHandler1292109013.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var cancelProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CancelProgramCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var cancelProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CancelProgramCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CancelProjectCommandHandler1071545707.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CancelProjectCommandHandler1071545707.cs
@@ -51,13 +51,13 @@ namespace Internal.Generated.WolverineHandlers
         {
             var cancelProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.CancelProjectCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CancelStrategicInitiativeCommandHandler559386453.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CancelStrategicInitiativeCommandHandler559386453.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var cancelStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.CancelStrategicInitiativeCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var cancelStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.CancelStrategicInitiativeCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ChangeExternalWorkspaceWorkProcessCommandHandler2142615925.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ChangeExternalWorkspaceWorkProcessCommandHandler2142615925.cs
@@ -47,12 +47,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ChangeProjectLifecycleCommandHandler222626381.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ChangeProjectLifecycleCommandHandler222626381.cs
@@ -49,16 +49,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var changeProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ChangeProjectLifecycleCommandValidator();
             // The actual message body
             var changeProjectLifecycleCommand = (Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ChangeProjectLifecycleCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ChangeProjectProgramCommandHandler1217111995.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ChangeProjectProgramCommandHandler1217111995.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var changeProjectProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ChangeProjectProgramCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var changeProjectProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ChangeProjectProgramCommandValidator();
             // The actual message body
             var changeProjectProgramCommand = (Wayd.ProjectPortfolioManagement.Application.Projects.Commands.ChangeProjectProgramCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ClearPortfolioScoringModelCommandHandler1718380489.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ClearPortfolioScoringModelCommandHandler1718380489.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,7 +59,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var clearPortfolioScoringModelCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Scoring.Commands.ClearPortfolioScoringModelCommandValidator();
             // The actual message body
             var clearPortfolioScoringModelCommand = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Scoring.Commands.ClearPortfolioScoringModelCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompletePokerSessionCommandHandler649121443.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompletePokerSessionCommandHandler649121443.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var completePokerSessionCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.CompletePokerSessionCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -61,7 +62,6 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var pokerSessionNotifier = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Planning.Application.PokerSessions.Interfaces.IPokerSessionNotifier>(serviceScope.ServiceProvider);
-            var completePokerSessionCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.CompletePokerSessionCommandValidator();
             // The actual message body
             var completePokerSessionCommand = (Wayd.Planning.Application.PokerSessions.Commands.CompletePokerSessionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompleteProgramCommandHandler580583246.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompleteProgramCommandHandler580583246.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var completeProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CompleteProgramCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var completeProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CompleteProgramCommandValidator();
             // The actual message body
             var completeProgramCommand = (Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CompleteProgramCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompleteProjectCommandHandler1542647726.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompleteProjectCommandHandler1542647726.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var completeProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.CompleteProjectCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var completeProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.CompleteProjectCommandValidator();
             // The actual message body
             var completeProjectCommand = (Wayd.ProjectPortfolioManagement.Application.Projects.Commands.CompleteProjectCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompleteStrategicInitiativeCommandHandler1794615282.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CompleteStrategicInitiativeCommandHandler1794615282.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var completeStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.CompleteStrategicInitiativeCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var completeStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.CompleteStrategicInitiativeCommandValidator();
             // The actual message body
             var completeStrategicInitiativeCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.CompleteStrategicInitiativeCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CopyRoadmapCommandHandler1499945519.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CopyRoadmapCommandHandler1499945519.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var copyRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.CopyRoadmapCommandValidator(currentUser);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var copyRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.CopyRoadmapCommandValidator(currentUser);
             // The actual message body
             var copyRoadmapCommand = (Wayd.Planning.Application.Roadmaps.Commands.CopyRoadmapCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateAzureDevOpsConnectionCommandHandler1559412378.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateAzureDevOpsConnectionCommandHandler1559412378.cs
@@ -59,9 +59,9 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createAzureDevOpsConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.CreateAzureDevOpsConnectionCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var azureDevOpsService = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IAzureDevOpsService>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createAzureDevOpsConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.CreateAzureDevOpsConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateAzureOpenAIConnectionCommandHandler715032746.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateAzureOpenAIConnectionCommandHandler715032746.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createAzureOpenAIConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI.CreateAzureOpenAIConnectionCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createAzureOpenAIConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI.CreateAzureOpenAIConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateEmployeeCommandHandler626939204.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateEmployeeCommandHandler626939204.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createEmployeeCommandValidator = new Wayd.Common.Application.Employees.Commands.CreateEmployeeCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createEmployeeCommand = (Wayd.Common.Application.Employees.Commands.CreateEmployeeCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateEntraConnectionCommandHandler1596991542.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateEntraConnectionCommandHandler1596991542.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var createEntraConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.Entra.CreateEntraConnectionCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var createEntraConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.Entra.CreateEntraConnectionCommandValidator();
             // The actual message body
             var createEntraConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.Entra.CreateEntraConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateEstimationScaleCommandHandler863847122.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateEstimationScaleCommandHandler863847122.cs
@@ -49,7 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var createEstimationScaleCommandValidator = new Wayd.Planning.Application.EstimationScales.Commands.CreateEstimationScaleCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -59,7 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var createEstimationScaleCommandValidator = new Wayd.Planning.Application.EstimationScales.Commands.CreateEstimationScaleCommandValidator();
             // The actual message body
             var createEstimationScaleCommand = (Wayd.Planning.Application.EstimationScales.Commands.CreateEstimationScaleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateExpenditureCategoryCommandHandler1400387064.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateExpenditureCategoryCommandHandler1400387064.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var createExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.CreateExpenditureCategoryCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var createExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.CreateExpenditureCategoryCommandValidator();
             // The actual message body
             var createExpenditureCategoryCommand = (Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.CreateExpenditureCategoryCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateExternalWorkflowCommandHandler1114163367.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateExternalWorkflowCommandHandler1114163367.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var createExternalWorkflowCommandValidator = new Wayd.Common.Application.Requests.WorkManagement.Commands.CreateExternalWorkflowCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createExternalWorkflowCommand = (Wayd.Common.Application.Requests.WorkManagement.Commands.CreateExternalWorkflowCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateOidcProviderCommandHandler1132867236.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateOidcProviderCommandHandler1132867236.cs
@@ -52,7 +52,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var roleService = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Identity.Roles.IRoleService>(serviceScope.ServiceProvider);
@@ -65,6 +64,7 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createOidcProviderCommandValidator = new Wayd.Common.Application.Identity.OidcProviders.Commands.CreateOidcProviderCommandValidator(waydDbContext, roleService);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createOidcProviderCommand = (Wayd.Common.Application.Identity.OidcProviders.Commands.CreateOidcProviderCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePersonalAccessTokenCommandHandler1446657422.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePersonalAccessTokenCommandHandler1446657422.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createPersonalAccessTokenCommandValidator = new Wayd.Common.Application.Identity.PersonalAccessTokens.Commands.CreatePersonalAccessTokenCommandValidator(waydDbContext, currentUser, dateTimeProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var tokenHashingService = new Wayd.Infrastructure.Common.Services.TokenHashingService();
             // The actual message body
             var createPersonalAccessTokenCommand = (Wayd.Common.Application.Identity.PersonalAccessTokens.Commands.CreatePersonalAccessTokenCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePlanningIntervalCommandHandler2082769748.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePlanningIntervalCommandHandler2082769748.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createPlanningIntervalCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.CreatePlanningIntervalCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createPlanningIntervalCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.CreatePlanningIntervalCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePlanningIntervalObjectiveCommandHandler176607051.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePlanningIntervalObjectiveCommandHandler176607051.cs
@@ -49,19 +49,19 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createPlanningIntervalObjectiveCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.CreatePlanningIntervalObjectiveCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
             // The actual message body
             var createPlanningIntervalObjectiveCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.CreatePlanningIntervalObjectiveCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePlanningIntervalObjectiveHealthCheckCommandHandler1954206780.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePlanningIntervalObjectiveHealthCheckCommandHandler1954206780.cs
@@ -49,6 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var createPlanningIntervalObjectiveHealthCheckCommandValidator = new Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.CreatePlanningIntervalObjectiveHealthCheckCommandValidator(dateTimeProvider);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -56,10 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var createPlanningIntervalObjectiveHealthCheckCommandValidator = new Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.CreatePlanningIntervalObjectiveHealthCheckCommandValidator(dateTimeProvider);
             // The actual message body
             var createPlanningIntervalObjectiveHealthCheckCommand = (Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.CreatePlanningIntervalObjectiveHealthCheckCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePokerSessionCommandHandler2054535418.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreatePokerSessionCommandHandler2054535418.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var createPokerSessionCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.CreatePokerSessionCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var createPokerSessionCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.CreatePokerSessionCommandValidator();
             // The actual message body
             var createPokerSessionCommand = (Wayd.Planning.Application.PokerSessions.Commands.CreatePokerSessionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProgramCommandHandler2053081469.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProgramCommandHandler2053081469.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var createProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CreateProgramCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var createProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CreateProgramCommandValidator();
             // The actual message body
             var createProgramCommand = (Wayd.ProjectPortfolioManagement.Application.Programs.Commands.CreateProgramCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectHealthCheckCommandHandler164992882.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectHealthCheckCommandHandler164992882.cs
@@ -50,6 +50,8 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var createProjectHealthCheckCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.HealthChecks.Commands.CreateProjectHealthCheckCommandValidator(dateTimeProvider);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -57,9 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var createProjectHealthCheckCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.HealthChecks.Commands.CreateProjectHealthCheckCommandValidator(dateTimeProvider);
             // The actual message body
             var createProjectHealthCheckCommand = (Wayd.ProjectPortfolioManagement.Application.Projects.HealthChecks.Commands.CreateProjectHealthCheckCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectLifecycleCommandHandler1560753533.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectLifecycleCommandHandler1560753533.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var createProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.CreateProjectLifecycleCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var createProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.CreateProjectLifecycleCommandValidator();
             // The actual message body
             var createProjectLifecycleCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.CreateProjectLifecycleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectPortfolioCommandHandler1892724039.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectPortfolioCommandHandler1892724039.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var createProjectPortfolioCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.CreateProjectPortfolioCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createProjectPortfolioCommand = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.CreateProjectPortfolioCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectTaskCommandHandler181865277.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateProjectTaskCommandHandler181865277.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var createProjectTaskCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.CreateProjectTaskCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,7 +59,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var createProjectTaskCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.CreateProjectTaskCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createProjectTaskCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.CreateProjectTaskCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateRiskCommandHandler549788622.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateRiskCommandHandler549788622.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var createRiskCommandValidator = new Wayd.Planning.Application.Risks.Commands.CreateRiskCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var createRiskCommandValidator = new Wayd.Planning.Application.Risks.Commands.CreateRiskCommandValidator();
             // The actual message body
             var createRiskCommand = (Wayd.Planning.Application.Risks.Commands.CreateRiskCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateRoadmapCommandHandler1848518546.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateRoadmapCommandHandler1848518546.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var createRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.CreateRoadmapCommandValidator(currentUser);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var createRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.CreateRoadmapCommandValidator(currentUser);
             // The actual message body
             var createRoadmapCommand = (Wayd.Planning.Application.Roadmaps.Commands.CreateRoadmapCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateScoringModelCommandHandler1712364289.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateScoringModelCommandHandler1712364289.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var createScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.CreateScoringModelCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var createScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.CreateScoringModelCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createScoringModelCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.CreateScoringModelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateStrategicInitiativeCommandHandler1945367555.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateStrategicInitiativeCommandHandler1945367555.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var createStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.CreateStrategicInitiativeCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateStrategyCommandHandler1687672785.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateStrategyCommandHandler1687672785.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var createStrategyCommandValidator = new Wayd.StrategicManagement.Application.Strategies.Commands.CreateStrategyCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var createStrategyCommandValidator = new Wayd.StrategicManagement.Application.Strategies.Commands.CreateStrategyCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateTeamCommandHandler249812508.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateTeamCommandHandler249812508.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createTeamCommandValidator = new Wayd.Organization.Application.Teams.Commands.CreateTeamCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createTeamCommand = (Wayd.Organization.Application.Teams.Commands.CreateTeamCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateTeamOfTeamsCommandHandler1213285832.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateTeamOfTeamsCommandHandler1213285832.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createTeamOfTeamsCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.CreateTeamOfTeamsCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createTeamOfTeamsCommand = (Wayd.Organization.Application.TeamsOfTeams.Commands.CreateTeamOfTeamsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateVisionCommandHandler1400568526.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateVisionCommandHandler1400568526.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var createVisionCommandValidator = new Wayd.StrategicManagement.Application.Visions.Commands.CreateVisionCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var createVisionCommandValidator = new Wayd.StrategicManagement.Application.Visions.Commands.CreateVisionCommandValidator();
             // The actual message body
             var createVisionCommand = (Wayd.StrategicManagement.Application.Visions.Commands.CreateVisionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateWorkStatusCommandHandler405794893.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateWorkStatusCommandHandler405794893.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createWorkStatusCommandValidator = new Wayd.Work.Application.WorkStatuses.Commands.CreateWorkStatusCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createWorkStatusCommand = (Wayd.Work.Application.WorkStatuses.Commands.CreateWorkStatusCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateWorkTypeLevelCommandHandler1259366366.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateWorkTypeLevelCommandHandler1259366366.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var createWorkTypeLevelCommandValidator = new Wayd.Work.Application.WorkTypeLevels.Commands.CreateWorkTypeLevelCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var createWorkTypeLevelCommand = (Wayd.Work.Application.WorkTypeLevels.Commands.CreateWorkTypeLevelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateWorkdayConnectionCommandHandler970569258.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/CreateWorkdayConnectionCommandHandler970569258.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var createWorkdayConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.Workday.CreateWorkdayConnectionCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateTeamCommandHandler1981407490.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateTeamCommandHandler1981407490.cs
@@ -49,14 +49,14 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var deactivateTeamCommandValidator = new Wayd.Organization.Application.Teams.Commands.DeactivateTeamCommandValidator();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateTeamMemberRoleCommandHandler1297118514.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateTeamMemberRoleCommandHandler1297118514.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var deactivateTeamMemberRoleCommandValidator = new Wayd.Organization.Application.TeamMemberRoles.Commands.DeactivateTeamMemberRoleCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var deactivateTeamMemberRoleCommandValidator = new Wayd.Organization.Application.TeamMemberRoles.Commands.DeactivateTeamMemberRoleCommandValidator();
             // The actual message body
             var deactivateTeamMemberRoleCommand = (Wayd.Organization.Application.TeamMemberRoles.Commands.DeactivateTeamMemberRoleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateTeamOfTeamsCommandHandler1709588418.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateTeamOfTeamsCommandHandler1709588418.cs
@@ -49,14 +49,14 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var deactivateTeamOfTeamsCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.DeactivateTeamOfTeamsCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateWorkProcessCommandHandler1001045283.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeactivateWorkProcessCommandHandler1001045283.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deactivateWorkProcessCommand = (Wayd.Work.Application.WorkProcesses.Commands.DeactivateWorkProcessCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteAzureDevOpsConnectionCommandHandler1472309967.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteAzureDevOpsConnectionCommandHandler1472309967.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteAzureOpenAIConnectionCommandHandler1731715345.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteAzureOpenAIConnectionCommandHandler1731715345.cs
@@ -46,6 +46,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -55,7 +56,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteAzureOpenAIConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI.DeleteAzureOpenAIConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteEmployeeCommandHandler1845032495.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteEmployeeCommandHandler1845032495.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var deleteEmployeeCommandValidator = new Wayd.Common.Application.Employees.Commands.DeleteEmployeeCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,7 +59,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var deleteEmployeeCommandValidator = new Wayd.Common.Application.Employees.Commands.DeleteEmployeeCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteEmployeeCommand = (Wayd.Common.Application.Employees.Commands.DeleteEmployeeCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteEntraConnectionCommandHandler1396856303.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteEntraConnectionCommandHandler1396856303.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteEntraConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.Entra.DeleteEntraConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteEstimationScaleCommandHandler451674121.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteEstimationScaleCommandHandler451674121.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var deleteEstimationScaleCommandValidator = new Wayd.Planning.Application.EstimationScales.Commands.DeleteEstimationScaleCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var deleteEstimationScaleCommandValidator = new Wayd.Planning.Application.EstimationScales.Commands.DeleteEstimationScaleCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteEstimationScaleCommand = (Wayd.Planning.Application.EstimationScales.Commands.DeleteEstimationScaleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteExpenditureCategoryCommandHandler1462133523.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteExpenditureCategoryCommandHandler1462133523.cs
@@ -50,6 +50,7 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var deleteExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.DeleteExpenditureCategoryCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var deleteExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.DeleteExpenditureCategoryCommandValidator();
             // The actual message body
             var deleteExpenditureCategoryCommand = (Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.DeleteExpenditureCategoryCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteExternalWorkItemsCommandHandler1995417256.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteExternalWorkItemsCommandHandler1995417256.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteOidcProviderCommandHandler1006940691.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteOidcProviderCommandHandler1006940691.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,7 +61,6 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var userIdentityStore = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Identity.IUserIdentityStore>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteOidcProviderCommand = (Wayd.Common.Application.Identity.OidcProviders.Commands.DeleteOidcProviderCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeletePersonalAccessTokenCommandHandler151641923.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeletePersonalAccessTokenCommandHandler151641923.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var deletePersonalAccessTokenCommandValidator = new Wayd.Common.Application.Identity.PersonalAccessTokens.Commands.DeletePersonalAccessTokenCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeletePlanningIntervalObjectiveCommandHandler1620536396.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeletePlanningIntervalObjectiveCommandHandler1620536396.cs
@@ -46,6 +46,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -57,7 +58,6 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deletePlanningIntervalObjectiveCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.DeletePlanningIntervalObjectiveCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeletePlanningIntervalObjectiveHealthCheckCommandHandler1469198457.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeletePlanningIntervalObjectiveHealthCheckCommandHandler1469198457.cs
@@ -49,7 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var deletePlanningIntervalObjectiveHealthCheckCommandValidator = new Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.DeletePlanningIntervalObjectiveHealthCheckCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var deletePlanningIntervalObjectiveHealthCheckCommandValidator = new Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.DeletePlanningIntervalObjectiveHealthCheckCommandValidator();
             // The actual message body
             var deletePlanningIntervalObjectiveHealthCheckCommand = (Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.DeletePlanningIntervalObjectiveHealthCheckCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteProjectCommandHandler748925434.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteProjectCommandHandler748925434.cs
@@ -51,12 +51,12 @@ namespace Internal.Generated.WolverineHandlers
         {
             var deleteProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.DeleteProjectCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteProjectPortfolioCommandHandler863994530.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteProjectPortfolioCommandHandler863994530.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var deleteProjectPortfolioCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.DeleteProjectPortfolioCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var deleteProjectPortfolioCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.DeleteProjectPortfolioCommandValidator();
             // The actual message body
             var deleteProjectPortfolioCommand = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.DeleteProjectPortfolioCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteRoadmapItemCommandHandler1917404180.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteRoadmapItemCommandHandler1917404180.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var deleteRoadmapItemCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.DeleteRoadmapItemCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var deleteRoadmapItemCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.DeleteRoadmapItemCommandValidator();
             // The actual message body
             var deleteRoadmapItemCommand = (Wayd.Planning.Application.Roadmaps.Commands.DeleteRoadmapItemCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteScoringModelCommandHandler484944072.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteScoringModelCommandHandler484944072.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var deleteScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.DeleteScoringModelCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var deleteScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.DeleteScoringModelCommandValidator();
             // The actual message body
             var deleteScoringModelCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.DeleteScoringModelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteStrategicThemeCommandHandler861098417.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteStrategicThemeCommandHandler861098417.cs
@@ -51,8 +51,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var deleteStrategicThemeCommandValidator = new Wayd.StrategicManagement.Application.StrategicThemes.Commands.DeleteStrategicThemeCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var deleteStrategicThemeCommandValidator = new Wayd.StrategicManagement.Application.StrategicThemes.Commands.DeleteStrategicThemeCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteStrategyCommandHandler912308968.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteStrategyCommandHandler912308968.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var deleteStrategyCommandValidator = new Wayd.StrategicManagement.Application.Strategies.Commands.DeleteStrategyCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteStrategyCommand = (Wayd.StrategicManagement.Application.Strategies.Commands.DeleteStrategyCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteTeamMemberRoleCommandHandler2102106541.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteTeamMemberRoleCommandHandler2102106541.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var deleteTeamMemberRoleCommandValidator = new Wayd.Organization.Application.TeamMemberRoles.Commands.DeleteTeamMemberRoleCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var deleteTeamMemberRoleCommandValidator = new Wayd.Organization.Application.TeamMemberRoles.Commands.DeleteTeamMemberRoleCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteTeamMemberRoleCommand = (Wayd.Organization.Application.TeamMemberRoles.Commands.DeleteTeamMemberRoleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteTeamOperatingModelCommandHandler1589701941.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteTeamOperatingModelCommandHandler1589701941.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var deleteTeamOperatingModelCommandValidator = new Wayd.Organization.Application.Teams.Commands.DeleteTeamOperatingModelCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var deleteTeamOperatingModelCommandValidator = new Wayd.Organization.Application.Teams.Commands.DeleteTeamOperatingModelCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteTeamOperatingModelCommand = (Wayd.Organization.Application.Teams.Commands.DeleteTeamOperatingModelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteVisionCommandHandler598652707.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/DeleteVisionCommandHandler598652707.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var deleteVisionCommandValidator = new Wayd.StrategicManagement.Application.Visions.Commands.DeleteVisionCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var deleteVisionCommand = (Wayd.StrategicManagement.Application.Visions.Commands.DeleteVisionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ExternalWorkspaceExistsQueryHandler148588578.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ExternalWorkspaceExistsQueryHandler148588578.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var externalWorkspaceExistsQuery = (Wayd.Common.Application.Requests.WorkManagement.Queries.ExternalWorkspaceExistsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetAIConnectionQueryHandler1965122887.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetAIConnectionQueryHandler1965122887.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getAIConnectionQuery = (Wayd.Common.Application.Requests.AppIntegration.GetAIConnectionQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetAzureDevOpsConnectionTeamsQueryHandler33017111.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetAzureDevOpsConnectionTeamsQueryHandler33017111.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getAzureDevOpsConnectionTeamsQuery = (Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps.GetAzureDevOpsConnectionTeamsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetChildWorkItemsQueryHandler1791337146.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetChildWorkItemsQueryHandler1791337146.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetClientFeatureFlagsQueryHandler1528406493.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetClientFeatureFlagsQueryHandler1528406493.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getClientFeatureFlagsQuery = (Wayd.Common.Application.FeatureManagement.Queries.GetClientFeatureFlagsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetConnectionQueryHandler1128332545.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetConnectionQueryHandler1128332545.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getConnectionQuery = (Wayd.AppIntegration.Application.Connections.Queries.GetConnectionQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetDirectReportsQueryHandler1045390611.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetDirectReportsQueryHandler1045390611.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeeByEmailQueryHandler360746612.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeeByEmailQueryHandler360746612.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeeByEmployeeNumberQueryHandler140357739.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeeByEmployeeNumberQueryHandler140357739.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getEmployeeByEmployeeNumberQuery = (Wayd.Common.Application.Employees.Queries.GetEmployeeByEmployeeNumberQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeeQueryHandler1907450717.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeeQueryHandler1907450717.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getEmployeeQuery = (Wayd.Common.Application.Employees.Queries.GetEmployeeQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeesQueryHandler288739750.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEmployeesQueryHandler288739750.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getEmployeesQuery = (Wayd.Common.Application.Employees.Queries.GetEmployeesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEstimationScalesQueryHandler1856956424.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetEstimationScalesQueryHandler1856956424.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getEstimationScalesQuery = (Wayd.Planning.Application.EstimationScales.Queries.GetEstimationScalesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetExpenditureCategoriesQueryHandler207076911.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetExpenditureCategoriesQueryHandler207076911.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getExpenditureCategoriesQuery = (Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Queries.GetExpenditureCategoriesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetExpenditureCategoryOptionsQueryHandler1775244345.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetExpenditureCategoryOptionsQueryHandler1775244345.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getExpenditureCategoryOptionsQuery = (Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Queries.GetExpenditureCategoryOptionsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetExpenditureCategoryQueryHandler619306235.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetExpenditureCategoryQueryHandler619306235.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetFeatureFlagQueryHandler1774560753.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetFeatureFlagQueryHandler1774560753.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getFeatureFlagQuery = (Wayd.Common.Application.FeatureManagement.Queries.GetFeatureFlagQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetFunctionalOrganizationChartQueryHandler676001362.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetFunctionalOrganizationChartQueryHandler676001362.cs
@@ -47,12 +47,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetHealthStatusesQueryHandler1871674955.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetHealthStatusesQueryHandler1871674955.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getHealthStatusesQuery = (Wayd.Common.Application.HealthChecks.Queries.GetHealthStatusesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetIntegrationRegistrationsForWorkProcessesQueryHandler163258345.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetIntegrationRegistrationsForWorkProcessesQueryHandler163258345.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getIntegrationRegistrationsForWorkProcessesQuery = (Wayd.Common.Application.Requests.WorkManagement.Queries.GetIntegrationRegistrationsForWorkProcessesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetIterationMappingsQueryHandler1907064875.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetIterationMappingsQueryHandler1907064875.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var getIterationMappingsQueryValidator = new Wayd.Common.Application.Requests.Planning.Iterations.GetIterationMappingsQueryValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var getIterationMappingsQueryValidator = new Wayd.Common.Application.Requests.Planning.Iterations.GetIterationMappingsQueryValidator();
             // The actual message body
             var getIterationMappingsQuery = (Wayd.Common.Application.Requests.Planning.Iterations.GetIterationMappingsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetLinkQueryHandler1037944580.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetLinkQueryHandler1037944580.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetLinksQueryHandler1982048645.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetLinksQueryHandler1982048645.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getLinksQuery = (Wayd.Links.Queries.GetLinksQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyAuditLogsQueryHandler2006597625.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyAuditLogsQueryHandler2006597625.cs
@@ -25,14 +25,14 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var waydDbContext = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Persistence.Context.WaydDbContext>(serviceScope.ServiceProvider);
+            var auditService = new Wayd.Infrastructure.Auditing.AuditService(waydDbContext);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var auditService = new Wayd.Infrastructure.Auditing.AuditService(waydDbContext);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor, ambientUserId);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getMyAuditLogsQuery = (Wayd.Common.Application.Auditing.GetMyAuditLogsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyPersonalAccessTokensQueryHandler611158994.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyPersonalAccessTokensQueryHandler611158994.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getMyPersonalAccessTokensQuery = (Wayd.Common.Application.Identity.PersonalAccessTokens.Queries.GetMyPersonalAccessTokensQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyProjectsSummaryQueryHandler25861975.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyProjectsSummaryQueryHandler25861975.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getMyProjectsSummaryQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Queries.GetMyProjectsSummaryQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyRisksQueryHandler1251392374.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetMyRisksQueryHandler1251392374.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getMyRisksQuery = (Wayd.Planning.Application.Risks.Queries.GetMyRisksQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetObjectivesForPlanningIntervalsQueryHandler706258420.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetObjectivesForPlanningIntervalsQueryHandler706258420.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetOidcProvidersQueryHandler1920258446.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetOidcProvidersQueryHandler1920258446.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getOidcProvidersQuery = (Wayd.Common.Application.Identity.OidcProviders.Queries.GetOidcProvidersQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPersonalAccessTokenQueryHandler1557260079.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPersonalAccessTokenQueryHandler1557260079.cs
@@ -47,7 +47,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var getPersonalAccessTokenQueryValidator = new Wayd.Common.Application.Identity.PersonalAccessTokens.Queries.GetPersonalAccessTokenQueryValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -58,6 +57,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPersonalAccessTokenQuery = (Wayd.Common.Application.Identity.PersonalAccessTokens.Queries.GetPersonalAccessTokenQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalCalendarQueryHandler24606911.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalCalendarQueryHandler24606911.cs
@@ -46,6 +46,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -55,7 +56,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalCalendarQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalCalendarQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalIterationCategoriesQueryHandler820089704.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalIterationCategoriesQueryHandler820089704.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalIterationCategoriesQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalIterationCategoriesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalIterationQueryHandler1509814428.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalIterationQueryHandler1509814428.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalIterationQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalIterationQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalIterationsQueryHandler1118914971.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalIterationsQueryHandler1118914971.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalIterationsQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalIterationsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveHealthCheckQueryHandler1157446687.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveHealthCheckQueryHandler1157446687.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalObjectiveHealthCheckQuery = (Wayd.Planning.Application.PlanningIntervals.HealthChecks.Queries.GetPlanningIntervalObjectiveHealthCheckQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveHealthChecksQueryHandler1771019914.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveHealthChecksQueryHandler1771019914.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalObjectiveHealthChecksQuery = (Wayd.Planning.Application.PlanningIntervals.HealthChecks.Queries.GetPlanningIntervalObjectiveHealthChecksQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveQueryHandler2040531140.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveQueryHandler2040531140.cs
@@ -47,12 +47,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveStatusesQueryHandler1966763650.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalObjectiveStatusesQueryHandler1966763650.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalObjectiveStatusesQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalObjectiveStatusesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalPredictabilityQueryHandler1386169020.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalPredictabilityQueryHandler1386169020.cs
@@ -46,6 +46,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -55,7 +56,6 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalPredictabilityQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalPredictabilityQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalQueryHandler2102712659.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalQueryHandler2102712659.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalTeamsQueryHandler123932397.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalTeamsQueryHandler123932397.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalTeamsQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalTeamsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalsQueryHandler860364342.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPlanningIntervalsQueryHandler860364342.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPlanningIntervalsQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetPlanningIntervalsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPokerSessionQueryHandler1132615533.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPokerSessionQueryHandler1132615533.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPokerSessionQuery = (Wayd.Planning.Application.PokerSessions.Queries.GetPokerSessionQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPortfolioIdsToRebalanceQueryHandler930440408.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetPortfolioIdsToRebalanceQueryHandler930440408.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getPortfolioIdsToRebalanceQuery = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Ranking.Queries.GetPortfolioIdsToRebalanceQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProgramQueryHandler1080224494.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProgramQueryHandler1080224494.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProgramsQueryHandler2085439189.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProgramsQueryHandler2085439189.cs
@@ -44,13 +44,13 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectHealthChecksQueryHandler958591092.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectHealthChecksQueryHandler958591092.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectHealthChecksQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.HealthChecks.Queries.GetProjectHealthChecksQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPhasesQueryHandler996350338.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPhasesQueryHandler996350338.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectPhasesQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Queries.GetProjectPhasesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPlanTreeQueryHandler1983237253.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPlanTreeQueryHandler1983237253.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectPlanTreeQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Queries.GetProjectPlanTreeQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPortfolioQueryHandler433419899.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPortfolioQueryHandler433419899.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectPortfolioQuery = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Queries.GetProjectPortfolioQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPortfolioStatusesQueryHandler1213971065.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectPortfolioStatusesQueryHandler1213971065.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectPortfolioStatusesQuery = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Queries.GetProjectPortfolioStatusesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectScoreQueryHandler1632769389.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectScoreQueryHandler1632769389.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectScoreQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Scoring.Queries.GetProjectScoreQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectScoresQueryHandler1757559768.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectScoresQueryHandler1757559768.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectScoresQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Scoring.Queries.GetProjectScoresQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectScoringContextQueryHandler1468311887.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectScoringContextQueryHandler1468311887.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectScoringContextQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Scoring.Queries.GetProjectScoringContextQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectTaskPrioritiesQueryHandler446178774.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectTaskPrioritiesQueryHandler446178774.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectTaskPrioritiesQuery = (Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Queries.GetProjectTaskPrioritiesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectsPlanSummariesQueryHandler1370525160.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetProjectsPlanSummariesQueryHandler1370525160.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getProjectsPlanSummariesQuery = (Wayd.ProjectPortfolioManagement.Application.Projects.Queries.GetProjectsPlanSummariesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRiskGradesQueryHandler1045328083.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRiskGradesQueryHandler1045328083.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getRiskGradesQuery = (Wayd.Planning.Application.Risks.Queries.GetRiskGradesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRiskQueryHandler694157545.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRiskQueryHandler694157545.cs
@@ -46,6 +46,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -55,7 +56,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getRiskQuery = (Wayd.Planning.Application.Risks.Queries.GetRiskQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapActivitiesQueryHandler1649316866.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapActivitiesQueryHandler1649316866.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapItemQueryHandler1062250704.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapItemQueryHandler1062250704.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getRoadmapItemQuery = (Wayd.Planning.Application.Roadmaps.Queries.GetRoadmapItemQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapItemsQueryHandler1383149011.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapItemsQueryHandler1383149011.cs
@@ -44,13 +44,13 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapQueryHandler2077945691.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapQueryHandler2077945691.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapStatesQueryHandler234386423.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapStatesQueryHandler234386423.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getRoadmapStatesQuery = (Wayd.Planning.Application.Roadmaps.Queries.GetRoadmapStatesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapsQueryHandler1725325960.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetRoadmapsQueryHandler1725325960.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getRoadmapsQuery = (Wayd.Planning.Application.Roadmaps.Queries.GetRoadmapsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetScoringModelsQueryHandler1346065757.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetScoringModelsQueryHandler1346065757.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSimpleIterationsQueryHandler632905138.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSimpleIterationsQueryHandler632905138.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintBacklogQueryHandler1613927750.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintBacklogQueryHandler1613927750.cs
@@ -46,13 +46,13 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintPlanningIntervalsQueryHandler1047396827.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintPlanningIntervalsQueryHandler1047396827.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintWorkItemMetricsQueryHandler1224825778.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintWorkItemMetricsQueryHandler1224825778.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintsBacklogQueryHandler1981851357.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintsBacklogQueryHandler1981851357.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintsWorkItemMetricsQueryHandler1705844729.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSprintsWorkItemMetricsQueryHandler1705844729.cs
@@ -46,7 +46,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -56,6 +55,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getSprintsWorkItemMetricsQuery = (Wayd.Work.Application.WorkItems.Queries.GetSprintsWorkItemMetricsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpiCheckpointPlanQueryHandler257267825.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpiCheckpointPlanQueryHandler257267825.cs
@@ -44,13 +44,13 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpiCheckpointsQueryHandler1798189873.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpiCheckpointsQueryHandler1798189873.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicInitiativeKpiCheckpointsQuery = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Queries.GetStrategicInitiativeKpiCheckpointsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpiMeasurementsQueryHandler347857103.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpiMeasurementsQueryHandler347857103.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicInitiativeKpiMeasurementsQuery = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Queries.GetStrategicInitiativeKpiMeasurementsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpisQueryHandler366534085.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeKpisQueryHandler366534085.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeProjectsQueryHandler195331756.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeProjectsQueryHandler195331756.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicInitiativeProjectsQuery = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Queries.GetStrategicInitiativeProjectsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeQueryHandler498564526.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativeQueryHandler498564526.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicInitiativeQuery = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Queries.GetStrategicInitiativeQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativesQueryHandler1228423445.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicInitiativesQueryHandler1228423445.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicInitiativesQuery = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Queries.GetStrategicInitiativesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicThemeQueryHandler2019767389.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicThemeQueryHandler2019767389.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicThemeQuery = (Wayd.StrategicManagement.Application.StrategicThemes.Queries.GetStrategicThemeQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicThemeStatesQueryHandler474526163.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicThemeStatesQueryHandler474526163.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicThemeStatesQuery = (Wayd.StrategicManagement.Application.StrategicThemes.Queries.GetStrategicThemeStatesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicThemesDataQueryHandler754760534.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategicThemesDataQueryHandler754760534.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategicThemesDataQuery = (Wayd.StrategicManagement.Application.StrategicThemes.Queries.GetStrategicThemesDataQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategyQueryHandler301498954.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategyQueryHandler301498954.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategyStatusesQueryHandler688323604.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetStrategyStatusesQueryHandler688323604.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getStrategyStatusesQuery = (Wayd.StrategicManagement.Application.Strategies.Queries.GetStrategyStatusesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSyncRunQueryHandler1543580473.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSyncRunQueryHandler1543580473.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getSyncRunQuery = (Wayd.AppIntegration.Application.Connections.Queries.GetSyncRunQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSyncRunsQueryHandler1620900146.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetSyncRunsQueryHandler1620900146.cs
@@ -45,12 +45,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamActiveSprintQueryHandler400317883.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamActiveSprintQueryHandler400317883.cs
@@ -47,8 +47,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var getTeamActiveSprintQueryValidator = new Wayd.Planning.Application.Iterations.Queries.GetTeamActiveSprintQueryValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var getTeamActiveSprintQueryValidator = new Wayd.Planning.Application.Iterations.Queries.GetTeamActiveSprintQueryValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamDependenciesQueryHandler353257207.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamDependenciesQueryHandler353257207.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamMembersQueryHandler1209725364.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamMembersQueryHandler1209725364.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamOperatingModelAsOfQueryHandler416742084.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamOperatingModelAsOfQueryHandler416742084.cs
@@ -44,7 +44,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -54,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getTeamOperatingModelAsOfQuery = (Wayd.Organization.Application.Teams.Queries.GetTeamOperatingModelAsOfQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamOperatingModelQueryHandler74649579.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamOperatingModelQueryHandler74649579.cs
@@ -45,12 +45,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamOperatingModelsForTeamsQueryHandler1687542255.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamOperatingModelsForTeamsQueryHandler1687542255.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getTeamOperatingModelsForTeamsQuery = (Wayd.Organization.Application.Teams.Queries.GetTeamOperatingModelsForTeamsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamPlanningIntervalPredictabilityQueryHandler1719899813.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamPlanningIntervalPredictabilityQueryHandler1719899813.cs
@@ -46,7 +46,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -56,6 +55,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getTeamPlanningIntervalPredictabilityQuery = (Wayd.Planning.Application.PlanningIntervals.Queries.GetTeamPlanningIntervalPredictabilityQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamQueryHandler442932023.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamQueryHandler442932023.cs
@@ -46,12 +46,12 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamTypesQueryHandler228675606.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamTypesQueryHandler228675606.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getTeamTypesQuery = (Wayd.Organization.Application.TeamTypes.Queries.GetTeamTypesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamWorkItemsQueryHandler122895199.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetTeamWorkItemsQueryHandler122895199.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisibilitiesQueryHandler58676832.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisibilitiesQueryHandler58676832.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getVisibilitiesQuery = (Wayd.Common.Application.Requests.GetVisibilitiesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisionQueryHandler678207553.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisionQueryHandler678207553.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getVisionQuery = (Wayd.StrategicManagement.Application.Visions.Queries.GetVisionQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisionStatesQueryHandler329056127.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisionStatesQueryHandler329056127.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getVisionStatesQuery = (Wayd.StrategicManagement.Application.Visions.Queries.GetVisionStatesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisionsQueryHandler986070740.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetVisionsQueryHandler986070740.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getVisionsQuery = (Wayd.StrategicManagement.Application.Visions.Queries.GetVisionsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkItemDependenciesQueryHandler685808336.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkItemDependenciesQueryHandler685808336.cs
@@ -46,7 +46,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -56,6 +55,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkItemDependenciesQuery = (Wayd.Work.Application.WorkItems.Queries.GetWorkItemDependenciesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkItemQueryHandler752782397.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkItemQueryHandler752782397.cs
@@ -46,13 +46,13 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkProcessSchemesQueryHandler394688068.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkProcessSchemesQueryHandler394688068.cs
@@ -51,13 +51,13 @@ namespace Internal.Generated.WolverineHandlers
         {
             var getWorkProcessSchemesQueryValidator = new Wayd.Common.Application.Requests.WorkManagement.Queries.GetWorkProcessSchemesQueryValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkProcessesQueryHandler1821370780.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkProcessesQueryHandler1821370780.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkStatusCategoriesQueryHandler2057359524.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkStatusCategoriesQueryHandler2057359524.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkStatusCategoriesQuery = (Wayd.Work.Application.WorkStatusCategories.Queries.GetWorkStatusCategoriesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkStatusQueryHandler177358024.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkStatusQueryHandler177358024.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkStatusQuery = (Wayd.Work.Application.WorkStatuses.Queries.GetWorkStatusQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeLevelQueryHandler2063771095.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeLevelQueryHandler2063771095.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkTypeLevelQuery = (Wayd.Work.Application.WorkTypeLevels.Queries.GetWorkTypeLevelQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeLevelsQueryHandler649181916.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeLevelsQueryHandler649181916.cs
@@ -44,16 +44,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkTypeLevelsQuery = (Wayd.Common.Application.Requests.WorkManagement.Queries.GetWorkTypeLevelsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeQueryHandler1260453257.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeQueryHandler1260453257.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkTypeQuery = (Wayd.Work.Application.WorkTypes.Queries.GetWorkTypeQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeTiersQueryHandler1499946476.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypeTiersQueryHandler1499946476.cs
@@ -22,10 +22,10 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkTypeTiersQuery = (Wayd.Work.Application.WorkTypeTiers.Queries.GetWorkTypeTiersQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypesQueryHandler678749852.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkTypesQueryHandler678749852.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkdayOrgsByTypeCommandHandler2143001452.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkdayOrgsByTypeCommandHandler2143001452.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkspaceWorkTypesQueryHandler1011490601.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkspaceWorkTypesQueryHandler1011490601.cs
@@ -46,6 +46,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -55,7 +56,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkspaceWorkTypesQuery = (Wayd.Common.Application.Requests.WorkManagement.Queries.GetWorkspaceWorkTypesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkspacesQueryHandler1823374172.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GetWorkspacesQueryHandler1823374172.cs
@@ -44,6 +44,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -53,7 +54,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var getWorkspacesQuery = (Wayd.Work.Application.Workspaces.Queries.GetWorkspacesQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GlobalSearchQueryHandler1336425949.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/GlobalSearchQueryHandler1336425949.cs
@@ -27,15 +27,15 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var globalSearchQueryValidator = new Wayd.Common.Application.Search.GlobalSearchQueryValidator();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var currentPrincipal = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.ICurrentPrincipal>(serviceScope.ServiceProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var globalSearchQueryValidator = new Wayd.Common.Application.Search.GlobalSearchQueryValidator();
             // The actual message body
             var globalSearchQuery = (Wayd.Common.Application.Search.GlobalSearchQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportEmployeesCommandHandler300696232.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportEmployeesCommandHandler300696232.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var importEmployeesCommandValidator = new Wayd.Common.Application.Employees.Commands.ImportEmployeesCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var importEmployeesCommand = (Wayd.Common.Application.Employees.Commands.ImportEmployeesCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportObjectiveCommandHandler1904338085.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportObjectiveCommandHandler1904338085.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var importObjectiveCommandValidator = new Wayd.Common.Application.Requests.Goals.Commands.ImportObjectiveCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportPlanningIntervalObjectivesCommandHandler1238549771.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportPlanningIntervalObjectivesCommandHandler1238549771.cs
@@ -50,18 +50,18 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var importPlanningIntervalObjectivesCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.ImportPlanningIntervalObjectivesCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var importPlanningIntervalObjectivesCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.ImportPlanningIntervalObjectivesCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportRisksCommandHandler993951646.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportRisksCommandHandler993951646.cs
@@ -50,12 +50,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportTeamMembersCommandHandler807382886.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportTeamMembersCommandHandler807382886.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var importTeamMembersCommandValidator = new Wayd.Organization.Application.Teams.Commands.ImportTeamMembersCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var importTeamMembersCommandValidator = new Wayd.Organization.Application.Teams.Commands.ImportTeamMembersCommandValidator();
             // The actual message body
             var importTeamMembersCommand = (Wayd.Organization.Application.Teams.Commands.ImportTeamMembersCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportTeamMembershipsCommandHandler68222640.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportTeamMembershipsCommandHandler68222640.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var importTeamMembershipsCommandValidator = new Wayd.Organization.Application.Teams.Commands.ImportTeamMembershipsCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var importTeamMembershipsCommand = (Wayd.Organization.Application.Teams.Commands.ImportTeamMembershipsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportTeamsCommandHandler1817596408.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ImportTeamsCommandHandler1817596408.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var importTeamsCommandValidator = new Wayd.Organization.Application.Teams.Commands.ImportTeamsCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var importTeamsCommand = (Wayd.Organization.Application.Teams.Commands.ImportTeamsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/IterationDeletedEventHandler468798458.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/IterationDeletedEventHandler468798458.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var iterationDeletedEvent = (Wayd.Common.Domain.Events.Planning.Iterations.IterationDeletedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManageExternalObjectWorkItemsCommandHandler273596422.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManageExternalObjectWorkItemsCommandHandler273596422.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManagePlanningIntervalDatesCommandHandler473723498.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManagePlanningIntervalDatesCommandHandler473723498.cs
@@ -50,6 +50,7 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var managePlanningIntervalDatesCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.ManagePlanningIntervalDatesCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var managePlanningIntervalDatesCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.ManagePlanningIntervalDatesCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManagePlanningIntervalTeamsCommandHandler947006867.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManagePlanningIntervalTeamsCommandHandler947006867.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var managePlanningIntervalTeamsCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.ManagePlanningIntervalTeamsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManageStrategicInitiativeKpiCheckpointPlanCommandHandler1045974836.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManageStrategicInitiativeKpiCheckpointPlanCommandHandler1045974836.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var manageStrategicInitiativeKpiCheckpointPlanCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.ManageStrategicInitiativeKpiCheckpointPlanCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var manageStrategicInitiativeKpiCheckpointPlanCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.ManageStrategicInitiativeKpiCheckpointPlanCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManageStrategicInitiativeProjectsCommandHandler1999003584.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ManageStrategicInitiativeProjectsCommandHandler1999003584.cs
@@ -49,6 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var manageStrategicInitiativeProjectsCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ManageStrategicInitiativeProjectsCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,8 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var manageStrategicInitiativeProjectsCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ManageStrategicInitiativeProjectsCommandValidator();
             // The actual message body
             var manageStrategicInitiativeProjectsCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.ManageStrategicInitiativeProjectsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/MoveProjectRanksCommandHandler1616562338.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/MoveProjectRanksCommandHandler1616562338.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var moveProjectRanksCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Ranking.Commands.MoveProjectRanksCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var moveProjectRanksCommand = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Ranking.Commands.MoveProjectRanksCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ProjectCreatedEventHandler1121440168.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ProjectCreatedEventHandler1121440168.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var projectCreatedEvent = (Wayd.Common.Domain.Events.ProjectPortfolioManagement.ProjectCreatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ProjectDeletedEventHandler630214583.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ProjectDeletedEventHandler630214583.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var projectDeletedEvent = (Wayd.Common.Domain.Events.ProjectPortfolioManagement.ProjectDeletedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ProjectDetailsUpdatedEventHandler1990993425.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ProjectDetailsUpdatedEventHandler1990993425.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RebalancePortfolioRanksCommandHandler475183917.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RebalancePortfolioRanksCommandHandler475183917.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var rebalancePortfolioRanksCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Ranking.Commands.RebalancePortfolioRanksCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemovePokerRoundCommandHandler1501955926.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemovePokerRoundCommandHandler1501955926.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var removePokerRoundCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.RemovePokerRoundCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -62,6 +61,7 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var pokerSessionNotifier = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Planning.Application.PokerSessions.Interfaces.IPokerSessionNotifier>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var removePokerRoundCommand = (Wayd.Planning.Application.PokerSessions.Commands.RemovePokerRoundCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveProjectLifecyclePhaseCommandHandler1957893192.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveProjectLifecyclePhaseCommandHandler1957893192.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var removeProjectLifecyclePhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.RemoveProjectLifecyclePhaseCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var removeProjectLifecyclePhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.RemoveProjectLifecyclePhaseCommandValidator();
             // The actual message body
             var removeProjectLifecyclePhaseCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.RemoveProjectLifecyclePhaseCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveProjectTaskDependencyCommandHandler635473750.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveProjectTaskDependencyCommandHandler635473750.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var removeProjectTaskDependencyCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.RemoveProjectTaskDependencyCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var removeProjectTaskDependencyCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.RemoveProjectTaskDependencyCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var removeProjectTaskDependencyCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.RemoveProjectTaskDependencyCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringModelCriterionCommandHandler1556883904.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringModelCriterionCommandHandler1556883904.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var removeScoringModelCriterionCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringModelCriterionCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var removeScoringModelCriterionCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringModelCriterionCommandValidator();
             // The actual message body
             var removeScoringModelCriterionCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringModelCriterionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringModelOutputCommandHandler562446822.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringModelOutputCommandHandler562446822.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var removeScoringModelOutputCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringModelOutputCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var removeScoringModelOutputCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringModelOutputCommandValidator();
             // The actual message body
             var removeScoringModelOutputCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringModelOutputCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringScaleCommandHandler15441056.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringScaleCommandHandler15441056.cs
@@ -49,15 +49,15 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var removeScoringScaleCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringScaleCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringScaleLevelCommandHandler906054340.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveScoringScaleLevelCommandHandler906054340.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var removeScoringScaleLevelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringScaleLevelCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var removeScoringScaleLevelCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.RemoveScoringScaleLevelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveTeamMemberCommandHandler788264834.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveTeamMemberCommandHandler788264834.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var removeTeamMemberCommandValidator = new Wayd.Organization.Application.Teams.Commands.RemoveTeamMemberCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var removeTeamMemberCommand = (Wayd.Organization.Application.Teams.Commands.RemoveTeamMemberCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveTeamMembershipCommandHandler1305844476.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveTeamMembershipCommandHandler1305844476.cs
@@ -49,7 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var removeTeamMembershipCommandValidator = new Wayd.Organization.Application.Teams.Commands.RemoveTeamMembershipCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var removeTeamMembershipCommandValidator = new Wayd.Organization.Application.Teams.Commands.RemoveTeamMembershipCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var removeTeamMembershipCommand = (Wayd.Organization.Application.Teams.Commands.RemoveTeamMembershipCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveTeamMembershipCommandHandler822691589.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RemoveTeamMembershipCommandHandler822691589.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var removeTeamMembershipCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.RemoveTeamMembershipCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var removeTeamMembershipCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.RemoveTeamMembershipCommandValidator();
             // The actual message body
             var removeTeamMembershipCommand = (Wayd.Organization.Application.TeamsOfTeams.Commands.RemoveTeamMembershipCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderProjectLifecyclePhasesCommandHandler1324712846.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderProjectLifecyclePhasesCommandHandler1324712846.cs
@@ -49,7 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var reorderProjectLifecyclePhasesCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.ReorderProjectLifecyclePhasesCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var reorderProjectLifecyclePhasesCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.ReorderProjectLifecyclePhasesCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var reorderProjectLifecyclePhasesCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.ReorderProjectLifecyclePhasesCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderScoringModelOutputsCommandHandler131283596.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderScoringModelOutputsCommandHandler131283596.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var reorderScoringModelOutputsCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringModelOutputsCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var reorderScoringModelOutputsCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringModelOutputsCommandValidator();
             // The actual message body
             var reorderScoringModelOutputsCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringModelOutputsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderScoringScaleLevelsCommandHandler1838697416.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderScoringScaleLevelsCommandHandler1838697416.cs
@@ -49,16 +49,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var reorderScoringScaleLevelsCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringScaleLevelsCommandValidator();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var reorderScoringScaleLevelsCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringScaleLevelsCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var reorderScoringScaleLevelsCommand = (Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringScaleLevelsCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderScoringScalesCommandHandler6304462.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderScoringScalesCommandHandler6304462.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var reorderScoringScalesCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.ReorderScoringScalesCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderStrategicInitiativeKpisCommandHandler1814268150.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ReorderStrategicInitiativeKpisCommandHandler1814268150.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var reorderStrategicInitiativeKpisCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.ReorderStrategicInitiativeKpisCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var reorderStrategicInitiativeKpisCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.ReorderStrategicInitiativeKpisCommandValidator();
             // The actual message body
             var reorderStrategicInitiativeKpisCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.ReorderStrategicInitiativeKpisCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ResetPokerRoundCommandHandler1704225775.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ResetPokerRoundCommandHandler1704225775.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var resetPokerRoundCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.ResetPokerRoundCommandValidator();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
@@ -62,6 +61,7 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var pokerSessionNotifier = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Planning.Application.PokerSessions.Interfaces.IPokerSessionNotifier>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var resetPokerRoundCommand = (Wayd.Planning.Application.PokerSessions.Commands.ResetPokerRoundCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RevealPokerRoundCommandHandler531998915.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RevealPokerRoundCommandHandler531998915.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var revealPokerRoundCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.RevealPokerRoundCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RevokePersonalAccessTokenCommandHandler2105689816.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/RevokePersonalAccessTokenCommandHandler2105689816.cs
@@ -50,13 +50,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var revokePersonalAccessTokenCommandValidator = new Wayd.Common.Application.Identity.PersonalAccessTokens.Commands.RevokePersonalAccessTokenCommandValidator();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchObjectivesByNameQueryHandler307522614.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchObjectivesByNameQueryHandler307522614.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchPlanningForGlobalSearchQueryHandler1446301605.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchPlanningForGlobalSearchQueryHandler1446301605.cs
@@ -44,18 +44,18 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var searchPlanningForGlobalSearchQuery = (Wayd.Common.Application.Search.SearchPlanningForGlobalSearchQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchWorkForGlobalSearchQueryHandler1279108201.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchWorkForGlobalSearchQueryHandler1279108201.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchWorkItemsQueryHandler991056516.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SearchWorkItemsQueryHandler991056516.cs
@@ -46,7 +46,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -56,6 +55,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var searchWorkItemsQuery = (Wayd.Work.Application.WorkItems.Queries.SearchWorkItemsQuery)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetConsensusCommandHandler1101261818.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetConsensusCommandHandler1101261818.cs
@@ -51,13 +51,13 @@ namespace Internal.Generated.WolverineHandlers
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var setConsensusCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.SetConsensusCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetEstimationScaleActiveStatusCommandHandler736291114.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetEstimationScaleActiveStatusCommandHandler736291114.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var setEstimationScaleActiveStatusCommandValidator = new Wayd.Planning.Application.EstimationScales.Commands.SetEstimationScaleActiveStatusCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var setEstimationScaleActiveStatusCommand = (Wayd.Planning.Application.EstimationScales.Commands.SetEstimationScaleActiveStatusCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetExternalViewWorkItemUrlTemplateCommandHandler842944644.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetExternalViewWorkItemUrlTemplateCommandHandler842944644.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var setExternalViewWorkItemUrlTemplateCommand = (Wayd.Work.Application.Workspaces.Commands.SetExternalViewWorkItemUrlTemplateCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetTeamOperatingModelCommandHandler1825502212.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SetTeamOperatingModelCommandHandler1825502212.cs
@@ -49,16 +49,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var setTeamOperatingModelCommandValidator = new Wayd.Organization.Application.Teams.Commands.SetTeamOperatingModelCommandValidator();
             // The actual message body
             var setTeamOperatingModelCommand = (Wayd.Organization.Application.Teams.Commands.SetTeamOperatingModelCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/StrategicThemeCreatedEventHandler1242217029.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/StrategicThemeCreatedEventHandler1242217029.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var strategicThemeCreatedEvent = (Wayd.Common.Domain.Events.StrategicManagement.StrategicThemeCreatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/StrategicThemeDeletedEventHandler1869874618.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/StrategicThemeDeletedEventHandler1869874618.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/StrategicThemeUpdatedEventHandler397719276.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/StrategicThemeUpdatedEventHandler397719276.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var strategicThemeUpdatedEvent = (Wayd.Common.Domain.Events.StrategicManagement.StrategicThemeUpdatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SubmitVoteCommandHandler2132954093.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SubmitVoteCommandHandler2132954093.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var submitVoteCommandValidator = new Wayd.Planning.Application.PokerSessions.Commands.SubmitVoteCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -62,6 +61,7 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var pokerSessionNotifier = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Planning.Application.PokerSessions.Interfaces.IPokerSessionNotifier>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var submitVoteCommand = (Wayd.Planning.Application.PokerSessions.Commands.SubmitVoteCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncAzureDevOpsConnectionConfigurationCommandHandler2023797951.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncAzureDevOpsConnectionConfigurationCommandHandler2023797951.cs
@@ -47,12 +47,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncAzureDevOpsIterationsCommandHandler781422545.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncAzureDevOpsIterationsCommandHandler781422545.cs
@@ -51,14 +51,14 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var syncAzureDevOpsIterationsCommandValidator = new Wayd.Common.Application.Requests.Planning.Iterations.SyncAzureDevOpsIterationsCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
+            var syncAzureDevOpsIterationsCommandValidator = new Wayd.Common.Application.Requests.Planning.Iterations.SyncAzureDevOpsIterationsCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncExternalWorkItemDependencyChangesCommandHandler1193955285.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncExternalWorkItemDependencyChangesCommandHandler1193955285.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var syncExternalWorkItemDependencyChangesCommandValidator = new Wayd.Common.Application.Requests.WorkManagement.Commands.SyncExternalWorkItemDependencyChangesCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncExternalWorkItemsCommandHandler438486360.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncExternalWorkItemsCommandHandler438486360.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var syncExternalWorkItemsCommandValidator = new Wayd.Common.Application.Requests.WorkManagement.Commands.SyncExternalWorkItemsCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var syncExternalWorkItemsCommandValidator = new Wayd.Common.Application.Requests.WorkManagement.Commands.SyncExternalWorkItemsCommandValidator();
             // The actual message body
             var syncExternalWorkItemsCommand = (Wayd.Common.Application.Requests.WorkManagement.Commands.SyncExternalWorkItemsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncPlanningTeamsCommandHandler1965372878.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncPlanningTeamsCommandHandler1965372878.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncPpmTeamsCommandHandler1643562877.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncPpmTeamsCommandHandler1643562877.cs
@@ -47,13 +47,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncStrategicThemesCommandHandler1053941423.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/SyncStrategicThemesCommandHandler1053941423.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var syncStrategicThemesCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicThemes.Commands.SyncStrategicThemesCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamActivatedEventHandler1461625622.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamActivatedEventHandler1461625622.cs
@@ -62,7 +62,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -72,10 +71,11 @@ namespace Internal.Generated.WolverineHandlers
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
-            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
-            await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
             var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
             await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
+            await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body
             var teamActivatedEvent = (Wayd.Common.Domain.Events.Organization.TeamActivatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamCreatedEventHandler1916019145.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamCreatedEventHandler1916019145.cs
@@ -62,7 +62,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -72,10 +71,11 @@ namespace Internal.Generated.WolverineHandlers
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
-            var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
-            await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
             var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
             await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
+            var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
+            await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var teamCreatedEvent = (Wayd.Common.Domain.Events.Organization.TeamCreatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamDeactivatedEventHandler752439151.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamDeactivatedEventHandler752439151.cs
@@ -62,8 +62,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
+            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -71,11 +70,12 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
-            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
             await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
             await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
+            var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
+            await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body
             var teamDeactivatedEvent = (Wayd.Common.Domain.Events.Organization.TeamDeactivatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamDeletedEventHandler2098980936.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamDeletedEventHandler2098980936.cs
@@ -62,7 +62,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
+            var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -70,12 +70,12 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
             await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
             await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
+            var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
+            await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body
             var teamDeletedEvent = (Wayd.Common.Domain.Events.Organization.TeamDeletedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamHasEverBeenScrumQueryHandler1277161937.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamHasEverBeenScrumQueryHandler1277161937.cs
@@ -45,13 +45,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamUpdatedEventHandler1469245990.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TeamUpdatedEventHandler1469245990.cs
@@ -62,8 +62,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
+            var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -71,11 +70,12 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
+            await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
             await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
-            var eventPublisher3 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher3, context);
-            await using var waydDbContext3 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions3, currentUser, dateTimeProvider, _optionsOfDatabaseSettings3, eventPublisher3, dbContextOutbox, requestCorrelationIdProvider);
+            var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
+            await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body
             var teamUpdatedEvent = (Wayd.Common.Domain.Events.Organization.TeamUpdatedEvent)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TestOidcProviderDiscoveryCommandHandler1142594044.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/TestOidcProviderDiscoveryCommandHandler1142594044.cs
@@ -50,13 +50,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ToggleFeatureFlagCommandHandler2111748114.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/ToggleFeatureFlagCommandHandler2111748114.cs
@@ -52,17 +52,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var toggleFeatureFlagCommandValidator = new Wayd.Common.Application.FeatureManagement.Commands.ToggleFeatureFlagCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var toggleFeatureFlagCommandValidator = new Wayd.Common.Application.FeatureManagement.Commands.ToggleFeatureFlagCommandValidator();
             // The actual message body
             var toggleFeatureFlagCommand = (Wayd.Common.Application.FeatureManagement.Commands.ToggleFeatureFlagCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureDevOpsConnectionCommandHandler398973221.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureDevOpsConnectionCommandHandler398973221.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateAzureDevOpsConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps.UpdateAzureDevOpsConnectionCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var azureDevOpsService = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IAzureDevOpsService>(serviceScope.ServiceProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureDevOpsConnectionTeamMappingsCommandHandler913188001.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureDevOpsConnectionTeamMappingsCommandHandler913188001.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var azdoConnectionTeamMappingsRequestValidator = new Wayd.AppIntegration.Application.Connections.Commands.AzdoConnectionTeamMappingsRequestValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var azdoConnectionTeamMappingsRequestValidator = new Wayd.AppIntegration.Application.Connections.Commands.AzdoConnectionTeamMappingsRequestValidator();
             // The actual message body
             var updateAzureDevOpsConnectionTeamMappingsCommand = (Wayd.AppIntegration.Application.Connections.Commands.UpdateAzureDevOpsConnectionTeamMappingsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureDevOpsWorkspaceIntegrationStateCommandHandler2110296205.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureDevOpsWorkspaceIntegrationStateCommandHandler2110296205.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateAzureDevOpsWorkspaceIntegrationStateCommand = (Wayd.AppIntegration.Application.Connections.Commands.UpdateAzureDevOpsWorkspaceIntegrationStateCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureOpenAIConnectionCommandHandler1156399941.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateAzureOpenAIConnectionCommandHandler1156399941.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateAzureOpenAIConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI.UpdateAzureOpenAIConnectionCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateAzureOpenAIConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI.UpdateAzureOpenAIConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateEmployeeCommandHandler338932557.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateEmployeeCommandHandler338932557.cs
@@ -53,11 +53,11 @@ namespace Internal.Generated.WolverineHandlers
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateEmployeeCommandValidator = new Wayd.Common.Application.Employees.Commands.UpdateEmployeeCommandValidator(waydDbContext);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateEntraConnectionCommandHandler458139781.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateEntraConnectionCommandHandler458139781.cs
@@ -49,6 +49,7 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateEntraConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.Entra.UpdateEntraConnectionCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateEntraConnectionCommand = (Wayd.AppIntegration.Application.Connections.Commands.Entra.UpdateEntraConnectionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateEstimationScaleCommandHandler1702661029.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateEstimationScaleCommandHandler1702661029.cs
@@ -51,13 +51,13 @@ namespace Internal.Generated.WolverineHandlers
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateEstimationScaleCommandValidator = new Wayd.Planning.Application.EstimationScales.Commands.UpdateEstimationScaleCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateExpenditureCategoryCommandHandler1198953305.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateExpenditureCategoryCommandHandler1198953305.cs
@@ -49,8 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var updateExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.UpdateExpenditureCategoryCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +58,8 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var updateExpenditureCategoryCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.UpdateExpenditureCategoryCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateExpenditureCategoryCommand = (Wayd.ProjectPortfolioManagement.Application.ExpenditureCategories.Commands.UpdateExpenditureCategoryCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateExternalWorkflowCommandHandler1710507484.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateExternalWorkflowCommandHandler1710507484.cs
@@ -49,14 +49,14 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateExternalWorkflowCommandValidator = new Wayd.Common.Application.Requests.WorkManagement.Commands.UpdateExternalWorkflowCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var updateExternalWorkflowCommandValidator = new Wayd.Common.Application.Requests.WorkManagement.Commands.UpdateExternalWorkflowCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateFeatureFlagCommandHandler1786218659.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateFeatureFlagCommandHandler1786218659.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateFeatureFlagCommandValidator = new Wayd.Common.Application.FeatureManagement.Commands.UpdateFeatureFlagCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateLinkCommandHandler880070496.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateLinkCommandHandler880070496.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateLinkCommandValidator = new Wayd.Links.Commands.UpdateLinkCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateLinkCommandValidator = new Wayd.Links.Commands.UpdateLinkCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateObjectiveCommandHandler1835690997.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateObjectiveCommandHandler1835690997.cs
@@ -49,6 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateObjectiveCommandValidator = new Wayd.Common.Application.Requests.Goals.Commands.UpdateObjectiveCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,8 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var updateObjectiveCommandValidator = new Wayd.Common.Application.Requests.Goals.Commands.UpdateObjectiveCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateObjectiveCommand = (Wayd.Common.Application.Requests.Goals.Commands.UpdateObjectiveCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateObjectivesOrderCommandHandler927327542.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateObjectivesOrderCommandHandler927327542.cs
@@ -46,16 +46,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateObjectivesOrderCommand = (Wayd.Common.Application.Requests.Goals.Commands.UpdateObjectivesOrderCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateOidcProviderCommandHandler47202785.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateOidcProviderCommandHandler47202785.cs
@@ -53,18 +53,18 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var roleService = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Identity.Roles.IRoleService>(serviceScope.ServiceProvider);
-            var updateOidcProviderCommandValidator = new Wayd.Common.Application.Identity.OidcProviders.Commands.UpdateOidcProviderCommandValidator(roleService);
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var roleService = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Identity.Roles.IRoleService>(serviceScope.ServiceProvider);
+            var updateOidcProviderCommandValidator = new Wayd.Common.Application.Identity.OidcProviders.Commands.UpdateOidcProviderCommandValidator(roleService);
             // The actual message body
             var updateOidcProviderCommand = (Wayd.Common.Application.Identity.OidcProviders.Commands.UpdateOidcProviderCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePersonalAccessTokenCommandHandler1791677823.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePersonalAccessTokenCommandHandler1791677823.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updatePersonalAccessTokenCommandValidator = new Wayd.Common.Application.Identity.PersonalAccessTokens.Commands.UpdatePersonalAccessTokenCommandValidator(waydDbContext, currentUser, dateTimeProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updatePersonalAccessTokenCommand = (Wayd.Common.Application.Identity.PersonalAccessTokens.Commands.UpdatePersonalAccessTokenCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalCommandHandler1352569315.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalCommandHandler1352569315.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updatePlanningIntervalCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalCommandValidator(waydDbContext);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updatePlanningIntervalCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalObjectiveCommandHandler656141042.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalObjectiveCommandHandler656141042.cs
@@ -52,16 +52,16 @@ namespace Internal.Generated.WolverineHandlers
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updatePlanningIntervalObjectiveCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalObjectiveCommandValidator(waydDbContext);
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
             // The actual message body
             var updatePlanningIntervalObjectiveCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalObjectiveCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalObjectiveHealthCheckCommandHandler54696291.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalObjectiveHealthCheckCommandHandler54696291.cs
@@ -49,9 +49,9 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var updatePlanningIntervalObjectiveHealthCheckCommandValidator = new Wayd.Planning.Application.PlanningIntervals.HealthChecks.Commands.UpdatePlanningIntervalObjectiveHealthCheckCommandValidator(dateTimeProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalObjectivesOrderCommandHandler578113577.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdatePlanningIntervalObjectivesOrderCommandHandler578113577.cs
@@ -49,19 +49,19 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updatePlanningIntervalObjectivesOrderCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalObjectivesOrderCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
+            var updatePlanningIntervalObjectivesOrderCommandValidator = new Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalObjectivesOrderCommandValidator();
             // The actual message body
             var updatePlanningIntervalObjectivesOrderCommand = (Wayd.Planning.Application.PlanningIntervals.Commands.UpdatePlanningIntervalObjectivesOrderCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProgramCommandHandler738782744.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProgramCommandHandler738782744.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.UpdateProgramCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateProgramCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Programs.Commands.UpdateProgramCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectCommandHandler802462056.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectCommandHandler802462056.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateProjectCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.UpdateProjectCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateProjectCommand = (Wayd.ProjectPortfolioManagement.Application.Projects.Commands.UpdateProjectCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectHealthCheckCommandHandler29845861.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectHealthCheckCommandHandler29845861.cs
@@ -50,12 +50,12 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectLifecycleCommandHandler1442208442.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectLifecycleCommandHandler1442208442.cs
@@ -50,6 +50,7 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.UpdateProjectLifecycleCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -59,7 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var updateProjectLifecycleCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.UpdateProjectLifecycleCommandValidator();
             // The actual message body
             var updateProjectLifecycleCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.UpdateProjectLifecycleCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectLifecyclePhaseCommandHandler1404423165.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectLifecyclePhaseCommandHandler1404423165.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var updateProjectLifecyclePhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.UpdateProjectLifecyclePhaseCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateProjectLifecyclePhaseCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectLifecycles.Commands.UpdateProjectLifecyclePhaseCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectPhaseCommandHandler1100498313.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectPhaseCommandHandler1100498313.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateProjectPhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.UpdateProjectPhaseCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateProjectPhaseCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Projects.Commands.UpdateProjectPhaseCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectPortfolioCommandHandler371938628.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectPortfolioCommandHandler371938628.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var updateProjectPortfolioCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.UpdateProjectPortfolioCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var updateProjectPortfolioCommandValidator = new Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.UpdateProjectPortfolioCommandValidator();
             // The actual message body
             var updateProjectPortfolioCommand = (Wayd.ProjectPortfolioManagement.Application.Portfolios.Command.UpdateProjectPortfolioCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectTaskCommandHandler1799338840.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectTaskCommandHandler1799338840.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var updateProjectTaskCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.UpdateProjectTaskCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateProjectTaskCommand = (Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.UpdateProjectTaskCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectTaskPlacementCommandHandler692316167.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateProjectTaskPlacementCommandHandler692316167.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateProjectTaskPlacementCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.UpdateProjectTaskPlacementCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateProjectTaskPlacementCommandValidator = new Wayd.ProjectPortfolioManagement.Application.ProjectTasks.Commands.UpdateProjectTaskPlacementCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapActivityPlacementCommandHandler210392011.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapActivityPlacementCommandHandler210392011.cs
@@ -53,11 +53,11 @@ namespace Internal.Generated.WolverineHandlers
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateRoadmapActivityPlacementCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapActivityPlacementCommandValidator(waydDbContext);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapColorsCommandHandler164317857.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapColorsCommandHandler164317857.cs
@@ -49,7 +49,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateRoadmapColorsCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapColorsCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateRoadmapColorsCommand = (Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapColorsCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapCommandHandler1741118437.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapCommandHandler1741118437.cs
@@ -54,12 +54,12 @@ namespace Internal.Generated.WolverineHandlers
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var updateRoadmapCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapCommandValidator(currentUser);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateRoadmapCommand = (Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapItemCommandHandler400348998.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapItemCommandHandler400348998.cs
@@ -53,6 +53,7 @@ namespace Internal.Generated.WolverineHandlers
             var iUpsertRoadmapMilestoneValidator = new Wayd.Planning.Application.Roadmaps.Validators.IUpsertRoadmapMilestoneValidator();
             var iUpsertRoadmapActivityValidator = new Wayd.Planning.Application.Roadmaps.Validators.IUpsertRoadmapActivityValidator();
             var updateRoadmapItemCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapItemCommandValidator(iUpsertRoadmapActivityValidator, iUpsertRoadmapMilestoneValidator, iUpsertRoadmapTimeboxValidator);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -62,7 +63,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateRoadmapItemCommand = (Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapItemCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapRootActivitiesOrderCommandHandler92693982.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapRootActivitiesOrderCommandHandler92693982.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateRoadmapRootActivitiesOrderCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapRootActivitiesOrderCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapRootActivityOrderCommandHandler439651782.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateRoadmapRootActivityOrderCommandHandler439651782.cs
@@ -50,13 +50,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateRoadmapRootActivityOrderCommandValidator = new Wayd.Planning.Application.Roadmaps.Commands.UpdateRoadmapRootActivityOrderCommandValidator();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringModelCommandHandler661460522.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringModelCommandHandler661460522.cs
@@ -50,13 +50,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateScoringModelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.UpdateScoringModelCommandValidator();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringModelCriterionCommandHandler1763462803.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringModelCriterionCommandHandler1763462803.cs
@@ -51,13 +51,13 @@ namespace Internal.Generated.WolverineHandlers
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateScoringModelCriterionCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.UpdateScoringModelCriterionCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringScaleCommandHandler907902217.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringScaleCommandHandler907902217.cs
@@ -51,13 +51,13 @@ namespace Internal.Generated.WolverineHandlers
         {
             var updateScoringScaleCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.UpdateScoringScaleCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // The actual message body

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringScaleLevelCommandHandler1471061101.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateScoringScaleLevelCommandHandler1471061101.cs
@@ -50,13 +50,13 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateScoringScaleLevelCommandValidator = new Wayd.Common.Application.Scoring.ScoringModels.Commands.UpdateScoringScaleLevelCommandValidator();

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategicInitiativeCommandHandler1756548056.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategicInitiativeCommandHandler1756548056.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var updateStrategicInitiativeCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.UpdateStrategicInitiativeCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateStrategicInitiativeCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.UpdateStrategicInitiativeCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategicInitiativeKpiCommandHandler2026415061.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategicInitiativeKpiCommandHandler2026415061.cs
@@ -50,16 +50,16 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var updateStrategicInitiativeKpiCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.UpdateStrategicInitiativeKpiCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var updateStrategicInitiativeKpiCommandValidator = new Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.UpdateStrategicInitiativeKpiCommandValidator();
             // The actual message body
             var updateStrategicInitiativeKpiCommand = (Wayd.ProjectPortfolioManagement.Application.StrategicInitiatives.Commands.Kpis.UpdateStrategicInitiativeKpiCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategicThemeCommandHandler1160815605.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategicThemeCommandHandler1160815605.cs
@@ -49,16 +49,16 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateStrategicThemeCommandValidator = new Wayd.StrategicManagement.Application.StrategicThemes.Commands.UpdateStrategicThemeCommandValidator();
             // The actual message body
             var updateStrategicThemeCommand = (Wayd.StrategicManagement.Application.StrategicThemes.Commands.UpdateStrategicThemeCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategyCommandHandler1503902042.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateStrategyCommandHandler1503902042.cs
@@ -49,6 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var updateStrategyCommandValidator = new Wayd.StrategicManagement.Application.Strategies.Commands.UpdateStrategyCommandValidator();
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,8 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var updateStrategyCommandValidator = new Wayd.StrategicManagement.Application.Strategies.Commands.UpdateStrategyCommandValidator();
             // The actual message body
             var updateStrategyCommand = (Wayd.StrategicManagement.Application.Strategies.Commands.UpdateStrategyCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamCommandHandler1482938567.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamCommandHandler1482938567.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
-            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
-            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
-            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
-            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
+            var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
+            var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
+            var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             var updateTeamCommandValidator = new Wayd.Organization.Application.Teams.Commands.UpdateTeamCommandValidator(waydDbContext);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateTeamCommand = (Wayd.Organization.Application.Teams.Commands.UpdateTeamCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamMemberCommandHandler1001428917.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamMemberCommandHandler1001428917.cs
@@ -55,18 +55,18 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var eventPublisher2 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher2, context);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher1 = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher1, context);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext2 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions2, currentUser, dateTimeProvider, _optionsOfDatabaseSettings2, eventPublisher2, dbContextOutbox, requestCorrelationIdProvider);
             await using var waydDbContext1 = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions1, currentUser, dateTimeProvider, _optionsOfDatabaseSettings1, eventPublisher1, dbContextOutbox, requestCorrelationIdProvider);
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var updateTeamMemberCommandValidator = new Wayd.Organization.Application.Teams.Commands.UpdateTeamMemberCommandValidator();
             // The actual message body
             var updateTeamMemberCommand = (Wayd.Organization.Application.Teams.Commands.UpdateTeamMemberCommand)context.Envelope.Message;

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamMembershipCommandHandler2133774895.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamMembershipCommandHandler2133774895.cs
@@ -49,17 +49,17 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var updateTeamMembershipCommandValidator = new Wayd.Organization.Application.Teams.Commands.UpdateTeamMembershipCommandValidator();
-            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
-            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
-            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
+            await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
+            // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
+            var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateTeamMembershipCommandValidator = new Wayd.Organization.Application.Teams.Commands.UpdateTeamMembershipCommandValidator();
             // The actual message body
             var updateTeamMembershipCommand = (Wayd.Organization.Application.Teams.Commands.UpdateTeamMembershipCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamMembershipCommandHandler520564548.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamMembershipCommandHandler520564548.cs
@@ -49,6 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateTeamMembershipCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.UpdateTeamMembershipCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -58,8 +60,6 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
-            var updateTeamMembershipCommandValidator = new Wayd.Organization.Application.TeamsOfTeams.Commands.UpdateTeamMembershipCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateTeamMembershipCommand = (Wayd.Organization.Application.TeamsOfTeams.Commands.UpdateTeamMembershipCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamOperatingModelCommandHandler319180495.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateTeamOperatingModelCommandHandler319180495.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var updateTeamOperatingModelCommandValidator = new Wayd.Organization.Application.Teams.Commands.UpdateTeamOperatingModelCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateTeamOperatingModelCommand = (Wayd.Organization.Application.Teams.Commands.UpdateTeamOperatingModelCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateVisionCommandHandler800396569.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateVisionCommandHandler800396569.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
-            var updateVisionCommandValidator = new Wayd.StrategicManagement.Application.Visions.Commands.UpdateVisionCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var updateVisionCommandValidator = new Wayd.StrategicManagement.Application.Visions.Commands.UpdateVisionCommandValidator();
             // The actual message body
             var updateVisionCommand = (Wayd.StrategicManagement.Application.Visions.Commands.UpdateVisionCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkStatusCommandHandler1213171504.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkStatusCommandHandler1213171504.cs
@@ -50,7 +50,6 @@ namespace Internal.Generated.WolverineHandlers
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
             var updateWorkStatusCommandValidator = new Wayd.Work.Application.WorkStatuses.Commands.UpdateWorkStatusCommandValidator();
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -60,6 +59,7 @@ namespace Internal.Generated.WolverineHandlers
             var currentUser = new Wayd.Infrastructure.Auth.CurrentUser(_httpContextAccessor1, ambientUserId);
             var dateTimeProvider = new Wayd.Infrastructure.Common.Services.DateTimeProvider(_timeProvider);
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateWorkStatusCommand = (Wayd.Work.Application.WorkStatuses.Commands.UpdateWorkStatusCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkTypeCommandHandler1054296683.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkTypeCommandHandler1054296683.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateWorkTypeCommandValidator = new Wayd.Work.Application.WorkTypes.Commands.UpdateWorkTypeCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateWorkTypeCommandValidator = new Wayd.Work.Application.WorkTypes.Commands.UpdateWorkTypeCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkTypeLevelsOrderCommandHandler720109914.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkTypeLevelsOrderCommandHandler720109914.cs
@@ -46,7 +46,6 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             var requestCorrelationIdProvider = new Wayd.Infrastructure.Common.Services.RequestCorrelationIdProvider(_httpContextAccessor2);
             var dbContextOutbox = new Wolverine.EntityFrameworkCore.DbContextOutbox(_wolverineRuntime, _domainEventScraperIEnumerable);
             var eventPublisher = new Wayd.Infrastructure.Common.Services.EventPublisher(_loggerOfEventPublisher, context);
@@ -58,6 +57,7 @@ namespace Internal.Generated.WolverineHandlers
             await using var waydDbContext = new Wayd.Infrastructure.Persistence.Context.WaydDbContext(_dbContextOptions, currentUser, dateTimeProvider, _optionsOfDatabaseSettings, eventPublisher, dbContextOutbox, requestCorrelationIdProvider);
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var dispatcher = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Common.Application.Interfaces.IDispatcher>(serviceScope.ServiceProvider);
+            var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
             // The actual message body
             var updateWorkTypeLevelsOrderCommand = (Wayd.Work.Application.WorkTypeLevels.Commands.UpdateWorkTypeLevelsOrderCommand)context.Envelope.Message;
 

--- a/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkdayConnectionCommandHandler99682107.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Internal/Generated/WolverineHandlers/UpdateWorkdayConnectionCommandHandler99682107.cs
@@ -49,8 +49,8 @@ namespace Internal.Generated.WolverineHandlers
 
         public override async System.Threading.Tasks.Task HandleAsync(Wolverine.Runtime.MessageContext context, System.Threading.CancellationToken cancellation)
         {
-            var updateWorkdayConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.Workday.UpdateWorkdayConnectionCommandValidator();
             var systemTextJsonService = new Wayd.Infrastructure.Common.Services.SystemTextJsonService();
+            var updateWorkdayConnectionCommandValidator = new Wayd.AppIntegration.Application.Connections.Commands.Workday.UpdateWorkdayConnectionCommandValidator();
             await using var serviceScope = _serviceScopeFactory.CreateAsyncScope();
             // This service has been marked as requiring service location independent of Wolverine's ability to use constructor injection of everything else
             var ambientUserId = Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService<Wayd.Infrastructure.Auth.AmbientUserId>(serviceScope.ServiceProvider);

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessageDetailsResponse.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessageDetailsResponse.cs
@@ -1,0 +1,38 @@
+using System.Text;
+using Wolverine.Persistence.Durability;
+
+namespace Wayd.Web.Api.Models.Admin.Messaging;
+
+/// <summary>
+/// Full detail for a single dead-lettered message, including the serialized message body
+/// (System.Text.Json per the Wolverine host configuration, so it renders as JSON).
+/// </summary>
+public class DeadLetterMessageDetailsResponse : DeadLetterMessageResponse
+{
+    public string? Body { get; set; }
+    public string? ContentType { get; set; }
+    public string? CorrelationId { get; set; }
+    public string? Destination { get; set; }
+    public DateTimeOffset? ExecutionTime { get; set; }
+
+    internal static DeadLetterMessageDetailsResponse From(DeadLetterEnvelope envelope, DeadLetterMessageResponse summary)
+    {
+        return new DeadLetterMessageDetailsResponse
+        {
+            Id = summary.Id,
+            MessageType = summary.MessageType,
+            ReceivedAt = summary.ReceivedAt,
+            Source = summary.Source,
+            ExceptionType = summary.ExceptionType,
+            ExceptionMessage = summary.ExceptionMessage,
+            SentAt = summary.SentAt,
+            Replayable = summary.Replayable,
+            Attempts = summary.Attempts,
+            Body = envelope.Envelope.Data is { Length: > 0 } data ? Encoding.UTF8.GetString(data) : null,
+            ContentType = envelope.Envelope.ContentType,
+            CorrelationId = envelope.Envelope.CorrelationId,
+            Destination = envelope.Envelope.Destination?.ToString(),
+            ExecutionTime = envelope.ExecutionTime,
+        };
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessageResponse.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessageResponse.cs
@@ -1,0 +1,43 @@
+using Wolverine.Persistence.Durability;
+
+namespace Wayd.Web.Api.Models.Admin.Messaging;
+
+/// <summary>
+/// A single dead-lettered message envelope: what failed, where, and why.
+/// </summary>
+public class DeadLetterMessageResponse
+{
+    public Guid Id { get; set; }
+    public string MessageType { get; set; } = default!;
+
+    /// <summary>The listener/queue URI the message was received at (e.g. local://durable/).</summary>
+    public string? ReceivedAt { get; set; }
+
+    /// <summary>The service that originally sent the message.</summary>
+    public string? Source { get; set; }
+
+    public string? ExceptionType { get; set; }
+    public string? ExceptionMessage { get; set; }
+    public DateTimeOffset SentAt { get; set; }
+
+    /// <summary>Whether the durability agent is set to move this envelope back to incoming for another attempt.</summary>
+    public bool Replayable { get; set; }
+
+    public int Attempts { get; set; }
+
+    internal static DeadLetterMessageResponse From(DeadLetterEnvelope envelope)
+    {
+        return new DeadLetterMessageResponse
+        {
+            Id = envelope.Id,
+            MessageType = envelope.MessageType,
+            ReceivedAt = envelope.ReceivedAt,
+            Source = envelope.Source,
+            ExceptionType = envelope.ExceptionType,
+            ExceptionMessage = envelope.ExceptionMessage,
+            SentAt = envelope.SentAt,
+            Replayable = envelope.Replayable,
+            Attempts = envelope.Envelope.Attempts,
+        };
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessagesRequest.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessagesRequest.cs
@@ -1,0 +1,9 @@
+namespace Wayd.Web.Api.Models.Admin.Messaging;
+
+/// <summary>
+/// Identifies the dead-lettered messages a replay or discard operation targets.
+/// </summary>
+public class DeadLetterMessagesRequest
+{
+    public List<Guid> Ids { get; set; } = [];
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessagesResponse.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/DeadLetterMessagesResponse.cs
@@ -1,0 +1,13 @@
+namespace Wayd.Web.Api.Models.Admin.Messaging;
+
+/// <summary>
+/// A page of dead-lettered messages. <see cref="PageNumber"/> is 0-based, mirroring Wolverine's
+/// DeadLetterEnvelopeQuery paging.
+/// </summary>
+public class DeadLetterMessagesResponse
+{
+    public int TotalCount { get; set; }
+    public int PageNumber { get; set; }
+    public int PageSize { get; set; }
+    public List<DeadLetterMessageResponse> Items { get; set; } = [];
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/MessagingCountsResponse.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Models/Admin/Messaging/MessagingCountsResponse.cs
@@ -1,0 +1,15 @@
+namespace Wayd.Web.Api.Models.Admin.Messaging;
+
+/// <summary>
+/// Snapshot of the Wolverine durable message store: how many envelopes are currently persisted in
+/// each lifecycle bucket. In a healthy system incoming/outgoing hover near zero — envelopes only
+/// linger during backlog, scheduled delivery, or after an unclean shutdown.
+/// </summary>
+public class MessagingCountsResponse
+{
+    public int Incoming { get; set; }
+    public int Scheduled { get; set; }
+    public int Outgoing { get; set; }
+    public int Handled { get; set; }
+    public int DeadLetter { get; set; }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
+++ b/Wayd.Web/src/Wayd.Web.Api/wwwroot/api/v1/specification.json
@@ -23333,6 +23333,250 @@
         ]
       }
     },
+    "/api/admin/messaging/counts": {
+      "get": {
+        "tags": [
+          "Messaging"
+        ],
+        "summary": "Get counts of persisted message envelopes by lifecycle state.",
+        "operationId": "Messaging_GetCounts",
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MessagingCountsResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/admin/messaging/dead-letters": {
+      "get": {
+        "tags": [
+          "Messaging"
+        ],
+        "summary": "Get a page of dead-lettered messages, optionally filtered by message type, exception type, and time range.",
+        "operationId": "Messaging_GetDeadLetters",
+        "parameters": [
+          {
+            "name": "messageType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 1
+          },
+          {
+            "name": "exceptionType",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "nullable": true
+            },
+            "x-position": 2
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "x-position": 3
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "nullable": true
+            },
+            "x-position": 4
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            },
+            "x-position": 5
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 100
+            },
+            "x-position": 6
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeadLetterMessagesResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/admin/messaging/dead-letters/{id}": {
+      "get": {
+        "tags": [
+          "Messaging"
+        ],
+        "summary": "Get the full detail of a dead-lettered message, including its serialized body.",
+        "operationId": "Messaging_GetDeadLetterById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            },
+            "x-position": 1
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeadLetterMessageDetailsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/admin/messaging/dead-letters/replay": {
+      "post": {
+        "tags": [
+          "Messaging"
+        ],
+        "summary": "Mark dead-lettered messages as replayable. The durability agent moves them back to the incoming queue on its next pass, so replay is asynchronous.",
+        "operationId": "Messaging_ReplayDeadLetters",
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeadLetterMessagesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
+    "/api/admin/messaging/dead-letters/discard": {
+      "post": {
+        "tags": [
+          "Messaging"
+        ],
+        "summary": "Permanently delete dead-lettered messages.",
+        "operationId": "Messaging_DiscardDeadLetters",
+        "requestBody": {
+          "x-name": "request",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeadLetterMessagesRequest"
+              }
+            }
+          },
+          "required": true,
+          "x-position": 1
+        },
+        "responses": {
+          "204": {
+            "description": ""
+          },
+          "400": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ]
+      }
+    },
     "/api/scoring-models": {
       "get": {
         "tags": [
@@ -39876,6 +40120,178 @@
           },
           "isEnabled": {
             "type": "boolean"
+          }
+        }
+      },
+      "MessagingCountsResponse": {
+        "type": "object",
+        "description": "Snapshot of the Wolverine durable message store: how many envelopes are currently persisted in\neach lifecycle bucket. In a healthy system incoming/outgoing hover near zero — envelopes only\nlinger during backlog, scheduled delivery, or after an unclean shutdown.",
+        "additionalProperties": false,
+        "required": [
+          "incoming",
+          "scheduled",
+          "outgoing",
+          "handled",
+          "deadLetter"
+        ],
+        "properties": {
+          "incoming": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "scheduled": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "outgoing": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "handled": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "deadLetter": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "DeadLetterMessagesResponse": {
+        "type": "object",
+        "description": "A page of dead-lettered messages. PageNumber is 0-based, mirroring Wolverine's\nDeadLetterEnvelopeQuery paging.",
+        "additionalProperties": false,
+        "required": [
+          "totalCount",
+          "pageNumber",
+          "pageSize",
+          "items"
+        ],
+        "properties": {
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DeadLetterMessageResponse"
+            }
+          }
+        }
+      },
+      "DeadLetterMessageResponse": {
+        "type": "object",
+        "description": "A single dead-lettered message envelope: what failed, where, and why.",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "messageType",
+          "sentAt",
+          "replayable",
+          "attempts"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "guid",
+            "nullable": false,
+            "example": "00000000-0000-0000-0000-000000000000"
+          },
+          "messageType": {
+            "type": "string"
+          },
+          "receivedAt": {
+            "type": "string",
+            "description": "The listener/queue URI the message was received at (e.g. local://durable/).",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "description": "The service that originally sent the message.",
+            "nullable": true
+          },
+          "exceptionType": {
+            "type": "string",
+            "nullable": true
+          },
+          "exceptionMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "sentAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "replayable": {
+            "type": "boolean",
+            "description": "Whether the durability agent is set to move this envelope back to incoming for another attempt."
+          },
+          "attempts": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "DeadLetterMessageDetailsResponse": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/DeadLetterMessageResponse"
+          },
+          {
+            "type": "object",
+            "description": "Full detail for a single dead-lettered message, including the serialized message body\n(System.Text.Json per the Wolverine host configuration, so it renders as JSON).",
+            "additionalProperties": false,
+            "properties": {
+              "body": {
+                "type": "string",
+                "nullable": true
+              },
+              "contentType": {
+                "type": "string",
+                "nullable": true
+              },
+              "correlationId": {
+                "type": "string",
+                "nullable": true
+              },
+              "destination": {
+                "type": "string",
+                "nullable": true
+              },
+              "executionTime": {
+                "type": "string",
+                "format": "date-time",
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
+      "DeadLetterMessagesRequest": {
+        "type": "object",
+        "description": "Identifies the dead-lettered messages a replay or discard operation targets.",
+        "additionalProperties": false,
+        "required": [
+          "ids"
+        ],
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "guid",
+              "nullable": false,
+              "example": "00000000-0000-0000-0000-000000000000"
+            }
           }
         }
       },

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/_components/settings-menu.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/_components/settings-menu.tsx
@@ -41,6 +41,7 @@ enum SettingsTab {
 
   // other
   BackgroundJobs = 'background-jobs',
+  Messaging = 'messaging',
 }
 
 type RestrictedMenuItem = SubMenuType & {
@@ -232,6 +233,12 @@ const buildSettingsMenuItems = (featureFlags: {
       'Background Jobs',
       SettingsTab.BackgroundJobs,
       '/settings/background-jobs',
+    ),
+    getRestrictedMenuItem(
+      'Permissions.Messaging.View',
+      'Messaging',
+      SettingsTab.Messaging,
+      '/settings/messaging',
     ),
   ]),
 ]

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/_components/dead-letter-details-drawer.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/_components/dead-letter-details-drawer.tsx
@@ -1,0 +1,151 @@
+'use client'
+
+import { useGetDeadLetterByIdQuery } from '@/src/store/features/admin/messaging-api'
+import useAuth from '@/src/components/contexts/auth'
+import { useMessage } from '@/src/components/contexts/messaging'
+import { getDrawerWidthPixels } from '@/src/utils'
+import { Button, Drawer, Flex, Space } from 'antd'
+import { FC, useEffect, useState } from 'react'
+import { LabeledContent } from '@/src/components/common/content'
+import useDeadLetterActions, { shortTypeName } from './use-dead-letter-actions'
+
+export interface DeadLetterDetailsDrawerProps {
+  deadLetterId: string
+  drawerOpen: boolean
+  onDrawerClose: () => void
+}
+
+/** Pretty-prints the envelope body when it is valid JSON; falls back to the raw text. */
+const formatBody = (body?: string | null): string | undefined => {
+  if (!body) return undefined
+  try {
+    return JSON.stringify(JSON.parse(body), null, 2)
+  } catch {
+    return body
+  }
+}
+
+const DeadLetterDetailsDrawer: FC<DeadLetterDetailsDrawerProps> = ({
+  deadLetterId,
+  drawerOpen,
+  onDrawerClose,
+}) => {
+  const [size, setSize] = useState(() => getDrawerWidthPixels())
+  const messageApi = useMessage()
+  const { hasPermissionClaim } = useAuth()
+
+  const canReplay = hasPermissionClaim('Permissions.Messaging.Run')
+  const canDiscard = hasPermissionClaim('Permissions.Messaging.Delete')
+
+  const {
+    data: deadLetter,
+    isLoading,
+    error,
+  } = useGetDeadLetterByIdQuery(deadLetterId)
+
+  const { handleReplay, handleDiscard } = useDeadLetterActions()
+
+  useEffect(() => {
+    if (error) {
+      messageApi.error(
+        'An error occurred while loading the dead letter message. Please try again.',
+      )
+    }
+  }, [error, messageApi])
+
+  const body = formatBody(deadLetter?.body)
+
+  const extraActions =
+    deadLetter && (canReplay || canDiscard) ? (
+      <Space>
+        {canReplay && (
+          <Button onClick={() => handleReplay(deadLetter, onDrawerClose)}>
+            Replay
+          </Button>
+        )}
+        {canDiscard && (
+          <Button
+            danger
+            onClick={() => handleDiscard(deadLetter, onDrawerClose)}
+          >
+            Discard
+          </Button>
+        )}
+      </Space>
+    ) : undefined
+
+  return (
+    <Drawer
+      title={
+        deadLetter
+          ? shortTypeName(deadLetter.messageType)
+          : 'Dead Letter Message'
+      }
+      placement="right"
+      onClose={onDrawerClose}
+      open={drawerOpen}
+      loading={isLoading}
+      size={size}
+      resizable={{
+        onResize: (newSize) => setSize(newSize),
+      }}
+      destroyOnHidden={true}
+      extra={extraActions}
+    >
+      <Flex vertical gap={10}>
+        <LabeledContent label="Message Type">
+          {deadLetter?.messageType}
+        </LabeledContent>
+        <LabeledContent label="Exception Type">
+          {deadLetter?.exceptionType}
+        </LabeledContent>
+        <LabeledContent label="Exception Message">
+          {deadLetter?.exceptionMessage}
+        </LabeledContent>
+        <LabeledContent label="Sent At">
+          {deadLetter?.sentAt ? deadLetter.sentAt.toLocaleString() : undefined}
+        </LabeledContent>
+        <LabeledContent label="Attempts">{deadLetter?.attempts}</LabeledContent>
+        <LabeledContent label="Queued for Replay">
+          {deadLetter?.replayable ? 'Yes' : 'No'}
+        </LabeledContent>
+        {deadLetter?.source && (
+          <LabeledContent label="Source">{deadLetter.source}</LabeledContent>
+        )}
+        {deadLetter?.receivedAt && (
+          <LabeledContent label="Received At (Queue)">
+            {deadLetter.receivedAt}
+          </LabeledContent>
+        )}
+        {deadLetter?.destination && (
+          <LabeledContent label="Destination">
+            {deadLetter.destination}
+          </LabeledContent>
+        )}
+        {deadLetter?.correlationId && (
+          <LabeledContent label="Correlation Id">
+            {deadLetter.correlationId}
+          </LabeledContent>
+        )}
+        {body && (
+          <LabeledContent label="Message Body">
+            <pre
+              style={{
+                margin: 0,
+                padding: '8px 12px',
+                borderRadius: 'var(--ant-border-radius)',
+                backgroundColor: 'var(--ant-color-fill-quaternary)',
+                overflowX: 'auto',
+                fontSize: 'var(--ant-font-size-sm)',
+              }}
+            >
+              {body}
+            </pre>
+          </LabeledContent>
+        )}
+      </Flex>
+    </Drawer>
+  )
+}
+
+export default DeadLetterDetailsDrawer

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/_components/dead-letter-details-drawer.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/_components/dead-letter-details-drawer.tsx
@@ -103,7 +103,12 @@ const DeadLetterDetailsDrawer: FC<DeadLetterDetailsDrawerProps> = ({
           {deadLetter?.exceptionMessage}
         </LabeledContent>
         <LabeledContent label="Sent At">
-          {deadLetter?.sentAt ? deadLetter.sentAt.toLocaleString() : undefined}
+          {deadLetter?.sentAt
+            ? // The NSwag axios client doesn't revive date strings into Date
+              // instances, so sentAt is an ISO string at runtime despite the
+              // typed Date — convert before formatting.
+              new Date(deadLetter.sentAt).toLocaleString()
+            : undefined}
         </LabeledContent>
         <LabeledContent label="Attempts">{deadLetter?.attempts}</LabeledContent>
         <LabeledContent label="Queued for Replay">

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/_components/use-dead-letter-actions.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/_components/use-dead-letter-actions.ts
@@ -1,0 +1,65 @@
+'use client'
+
+import { App } from 'antd'
+import {
+  useDiscardDeadLettersMutation,
+  useReplayDeadLettersMutation,
+} from '@/src/store/features/admin/messaging-api'
+import { useMessage } from '@/src/components/contexts/messaging'
+
+interface DeadLetterInfo {
+  id: string
+  messageType: string
+}
+
+const useDeadLetterActions = () => {
+  const messageApi = useMessage()
+  const { modal } = App.useApp()
+  const [replayDeadLetters] = useReplayDeadLettersMutation()
+  const [discardDeadLetters] = useDiscardDeadLettersMutation()
+
+  const handleReplay = async (
+    deadLetter: DeadLetterInfo,
+    onSuccess?: () => void,
+  ) => {
+    try {
+      await replayDeadLetters([deadLetter.id]).unwrap()
+      // Replay is asynchronous: the API marks the envelope replayable and the
+      // durability agent moves it back to incoming on its next pass.
+      messageApi.success('Message queued for replay.')
+      onSuccess?.()
+    } catch {
+      messageApi.error('Failed to queue message for replay.')
+    }
+  }
+
+  const handleDiscard = (deadLetter: DeadLetterInfo, onSuccess?: () => void) => {
+    modal.confirm({
+      title: 'Discard Dead Letter Message',
+      content: `Are you sure you want to permanently delete this "${shortTypeName(deadLetter.messageType)}" message? This cannot be undone.`,
+      okText: 'Discard',
+      okButtonProps: { danger: true },
+      onOk: async () => {
+        try {
+          await discardDeadLetters([deadLetter.id]).unwrap()
+          messageApi.success('Message discarded.')
+          onSuccess?.()
+        } catch {
+          messageApi.error('Failed to discard message.')
+        }
+      },
+    })
+  }
+
+  return { handleReplay, handleDiscard }
+}
+
+/** Trims an assembly-qualified or namespaced .NET type name down to the class name. */
+export const shortTypeName = (typeName?: string | null): string => {
+  if (!typeName) return ''
+  const withoutAssembly = typeName.split(',')[0].trim()
+  const segments = withoutAssembly.split('.')
+  return segments[segments.length - 1]
+}
+
+export default useDeadLetterActions

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/loading.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/loading.tsx
@@ -1,0 +1,13 @@
+'use client'
+
+import PageTitle from '@/src/components/common/page-title'
+import { Skeleton } from 'antd'
+
+export default function MessagingLoading() {
+  return (
+    <>
+      <PageTitle title="Messaging" />
+      <Skeleton active />
+    </>
+  )
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/settings/messaging/page.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import PageTitle from '@/src/components/common/page-title'
+import {
+  WaydGrid,
+  createActionsColumn,
+} from '@/src/components/common/wayd-grid'
+import MetricCard from '@/src/components/common/metrics/metric-card'
+import { useMemo, useState } from 'react'
+import { Button, Flex, Typography } from 'antd'
+import type { ColumnDef } from '@tanstack/react-table'
+import type { ItemType } from 'antd/es/menu/interface'
+import { authorizePage } from '../../../components/hoc'
+import useAuth from '../../../components/contexts/auth'
+import { useDocumentTitle } from '../../../hooks'
+import { DeadLetterMessageResponse } from '@/src/services/wayd-api'
+import {
+  useGetDeadLettersQuery,
+  useGetMessagingCountsQuery,
+} from '@/src/store/features/admin/messaging-api'
+import DeadLetterDetailsDrawer from './_components/dead-letter-details-drawer'
+import useDeadLetterActions, {
+  shortTypeName,
+} from './_components/use-dead-letter-actions'
+
+// The server caps a dead letter query page at 500. Fetch one max-size page and
+// let the grid filter/sort client-side; the tile + overflow note carry the true
+// total when the queue is (pathologically) deeper than that.
+const DEAD_LETTER_PAGE_SIZE = 500
+
+const MessagingPage = () => {
+  useDocumentTitle('Messaging')
+  const [viewingDeadLetterId, setViewingDeadLetterId] = useState<string | null>(
+    null,
+  )
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  const { hasPermissionClaim } = useAuth()
+  const canReplay = hasPermissionClaim('Permissions.Messaging.Run')
+  const canDiscard = hasPermissionClaim('Permissions.Messaging.Delete')
+  const showRowActions = canReplay || canDiscard
+
+  const {
+    data: counts,
+    isLoading: countsLoading,
+    refetch: refetchCounts,
+  } = useGetMessagingCountsQuery()
+
+  const {
+    data: deadLetters,
+    isLoading: deadLettersLoading,
+    refetch: refetchDeadLetters,
+  } = useGetDeadLettersQuery({ pageSize: DEAD_LETTER_PAGE_SIZE })
+
+  const { handleReplay, handleDiscard } = useDeadLetterActions()
+
+  const refresh = () => {
+    refetchCounts()
+    refetchDeadLetters()
+  }
+
+  const closeDetailsDrawer = () => {
+    setDrawerOpen(false)
+    setViewingDeadLetterId(null)
+  }
+
+  const columns = useMemo<ColumnDef<DeadLetterMessageResponse, any>[]>(() => {
+    const openDetailsDrawer = (id: string) => {
+      setViewingDeadLetterId(id)
+      setDrawerOpen(true)
+    }
+
+    return [
+      createActionsColumn<DeadLetterMessageResponse>({
+        hide: !showRowActions,
+        ariaLabel: 'Dead letter message actions',
+        getItems: (deadLetter) => {
+          const items: ItemType[] = []
+
+          if (canReplay) {
+            items.push({
+              key: 'replay',
+              label: 'Replay',
+              onClick: () => handleReplay(deadLetter),
+            })
+          }
+
+          if (canDiscard) {
+            if (items.length > 0) {
+              items.push({ key: 'divider', type: 'divider' })
+            }
+            items.push({
+              key: 'discard',
+              label: 'Discard',
+              danger: true,
+              onClick: () => handleDiscard(deadLetter),
+            })
+          }
+
+          return items
+        },
+      }),
+      {
+        id: 'messageType',
+        accessorFn: (row) => shortTypeName(row.messageType),
+        header: 'Message Type',
+        size: 220,
+        meta: { filterType: 'set' },
+        cell: ({ row }) => (
+          <Button
+            type="link"
+            style={{ padding: 0, height: 'auto', fontSize: 'inherit' }}
+            onClick={() => openDetailsDrawer(row.original.id)}
+          >
+            {shortTypeName(row.original.messageType)}
+          </Button>
+        ),
+      },
+      {
+        id: 'exceptionType',
+        accessorFn: (row) => shortTypeName(row.exceptionType),
+        header: 'Exception Type',
+        size: 200,
+        meta: { filterType: 'set' },
+      },
+      {
+        id: 'exceptionMessage',
+        accessorKey: 'exceptionMessage',
+        header: 'Exception Message',
+        size: 320,
+      },
+      {
+        id: 'sentAt',
+        accessorKey: 'sentAt',
+        header: 'Sent At',
+        meta: { columnType: 'dateTime' },
+      },
+      {
+        id: 'attempts',
+        accessorKey: 'attempts',
+        header: 'Attempts',
+        size: 100,
+      },
+      {
+        id: 'replayable',
+        accessorKey: 'replayable',
+        header: 'Queued for Replay',
+        size: 150,
+        meta: { columnType: 'yesNo' },
+      },
+      {
+        id: 'receivedAt',
+        accessorKey: 'receivedAt',
+        header: 'Queue',
+        size: 180,
+        meta: { filterType: 'set' },
+      },
+    ]
+  }, [showRowActions, canReplay, canDiscard, handleReplay, handleDiscard])
+
+  const deadLetterOverflow =
+    deadLetters && deadLetters.totalCount > deadLetters.items.length
+
+  return (
+    <>
+      <PageTitle title="Messaging" />
+      <Flex gap={12} wrap style={{ marginBottom: 16 }}>
+        <MetricCard
+          title="Incoming"
+          value={counts?.incoming ?? 0}
+          loading={countsLoading}
+          tooltip="Durably persisted messages waiting to be processed. Only appears when delivery backs up — a burst of messages, database latency, or messages recovered after an unclean shutdown. Zero is the healthy state; successfully processed messages pass through too quickly to see."
+        />
+        <MetricCard
+          title="Scheduled"
+          value={counts?.scheduled ?? 0}
+          loading={countsLoading}
+          tooltip="Messages scheduled for a future time — mostly failed messages waiting out a retry cooldown (1s / 5s / 15s between attempts). Visible for the ~20 seconds a message spends retrying before it either succeeds or dead-letters."
+        />
+        <MetricCard
+          title="Outbox"
+          value={counts?.outgoing ?? 0}
+          loading={countsLoading}
+          tooltip="Outgoing messages committed with a transaction but not yet dispatched. Only appears during a dispatch backlog or after an unclean shutdown. Zero is the healthy state."
+        />
+        <MetricCard
+          title="Dead Letters"
+          value={counts?.deadLetter ?? 0}
+          loading={countsLoading}
+          valueStyle={
+            counts?.deadLetter
+              ? { color: 'var(--ant-color-error)' }
+              : undefined
+          }
+          tooltip="Messages that failed every retry attempt. Unlike the other buckets, these persist until you replay or discard them below — this is the tile to watch."
+        />
+        <MetricCard
+          title="Handled"
+          value={counts?.handled ?? 0}
+          loading={countsLoading}
+          tooltip="Successfully processed messages kept briefly (5 minutes) for duplicate detection, then purged. Messages executed in-memory are never persisted at all, so this is usually zero — successful work leaves no trace here. See the application logs for message history."
+        />
+      </Flex>
+      <WaydGrid
+        columns={columns}
+        data={deadLetters?.items}
+        onRefresh={refresh}
+        isLoading={deadLettersLoading}
+        persistStateKey="settings-messaging-dead-letters"
+        csvFileName="dead-letter-messages"
+        initialSorting={[{ id: 'sentAt', desc: true }]}
+        emptyMessage="The dead letter queue is empty."
+        leftSlot={
+          deadLetterOverflow ? (
+            <Typography.Text type="warning">
+              {`Showing the first ${deadLetters.items.length} of ${deadLetters.totalCount} dead letter messages.`}
+            </Typography.Text>
+          ) : undefined
+        }
+      />
+      {viewingDeadLetterId !== null && (
+        <DeadLetterDetailsDrawer
+          deadLetterId={viewingDeadLetterId}
+          drawerOpen={drawerOpen}
+          onDrawerClose={closeDetailsDrawer}
+        />
+      )}
+    </>
+  )
+}
+
+const PageWithAuthorization = authorizePage(
+  MessagingPage,
+  'Permission',
+  'Permissions.Messaging.View',
+)
+
+export default PageWithAuthorization

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/clients.ts
@@ -39,6 +39,7 @@ import {
   ConnectionsClient,
   AzureDevOpsConnectionsClient,
   FeatureFlagsClient,
+  MessagingClient,
   PersonalAccessTokensClient,
   SearchClient,
   TokenResponse,
@@ -362,6 +363,8 @@ export const getAzureDevOpsConnectionsClient = () =>
 
 export const getBackgroundJobsClient = () =>
   new BackgroundJobsClient('', axiosClient)
+
+export const getMessagingClient = () => new MessagingClient('', axiosClient)
 
 export const getHealthChecksClient = () =>
   new HealthChecksClient('', axiosClient)

--- a/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/services/wayd-api.ts
@@ -27680,6 +27680,321 @@ export class BackgroundJobsClient {
     }
 }
 
+export class MessagingClient {
+    protected instance: AxiosInstance;
+    protected baseUrl: string;
+    protected jsonParseReviver: ((key: string, value: any) => any) | undefined = undefined;
+
+    constructor(baseUrl?: string, instance?: AxiosInstance) {
+
+        this.instance = instance || axios.create();
+
+        this.baseUrl = baseUrl ?? "";
+
+    }
+
+    /**
+     * Get counts of persisted message envelopes by lifecycle state.
+     */
+    getCounts( cancelToken?: CancelToken): Promise<MessagingCountsResponse> {
+        let url_ = this.baseUrl + "/api/admin/messaging/counts";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetCounts(_response);
+        });
+    }
+
+    protected processGetCounts(response: AxiosResponse): Promise<MessagingCountsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<MessagingCountsResponse>(result200);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<MessagingCountsResponse>(null as any);
+    }
+
+    /**
+     * Get a page of dead-lettered messages, optionally filtered by message type, exception type, and time range.
+     * @param messageType (optional) 
+     * @param exceptionType (optional) 
+     * @param from (optional) 
+     * @param to (optional) 
+     * @param pageNumber (optional) 
+     * @param pageSize (optional) 
+     */
+    getDeadLetters(messageType?: string | null | undefined, exceptionType?: string | null | undefined, from?: Date | null | undefined, to?: Date | null | undefined, pageNumber?: number | undefined, pageSize?: number | undefined, cancelToken?: CancelToken): Promise<DeadLetterMessagesResponse> {
+        let url_ = this.baseUrl + "/api/admin/messaging/dead-letters?";
+        if (messageType !== undefined && messageType !== null)
+            url_ += "messageType=" + encodeURIComponent("" + messageType) + "&";
+        if (exceptionType !== undefined && exceptionType !== null)
+            url_ += "exceptionType=" + encodeURIComponent("" + exceptionType) + "&";
+        if (from !== undefined && from !== null)
+            url_ += "from=" + encodeURIComponent(from ? "" + from.toISOString() : "") + "&";
+        if (to !== undefined && to !== null)
+            url_ += "to=" + encodeURIComponent(to ? "" + to.toISOString() : "") + "&";
+        if (pageNumber === null)
+            throw new globalThis.Error("The parameter 'pageNumber' cannot be null.");
+        else if (pageNumber !== undefined)
+            url_ += "pageNumber=" + encodeURIComponent("" + pageNumber) + "&";
+        if (pageSize === null)
+            throw new globalThis.Error("The parameter 'pageSize' cannot be null.");
+        else if (pageSize !== undefined)
+            url_ += "pageSize=" + encodeURIComponent("" + pageSize) + "&";
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetDeadLetters(_response);
+        });
+    }
+
+    protected processGetDeadLetters(response: AxiosResponse): Promise<DeadLetterMessagesResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<DeadLetterMessagesResponse>(result200);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<DeadLetterMessagesResponse>(null as any);
+    }
+
+    /**
+     * Get the full detail of a dead-lettered message, including its serialized body.
+     */
+    getDeadLetterById(id: string, cancelToken?: CancelToken): Promise<DeadLetterMessageDetailsResponse> {
+        let url_ = this.baseUrl + "/api/admin/messaging/dead-letters/{id}";
+        if (id === undefined || id === null)
+            throw new globalThis.Error("The parameter 'id' must be defined.");
+        url_ = url_.replace("{id}", encodeURIComponent("" + id));
+        url_ = url_.replace(/[?&]$/, "");
+
+        let options_: AxiosRequestConfig = {
+            method: "GET",
+            url: url_,
+            headers: {
+                "Accept": "application/json"
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processGetDeadLetterById(_response);
+        });
+    }
+
+    protected processGetDeadLetterById(response: AxiosResponse): Promise<DeadLetterMessageDetailsResponse> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 200) {
+            const _responseText = response.data;
+            let result200: any = null;
+            let resultData200  = _responseText;
+            result200 = resultData200;
+            return Promise.resolve<DeadLetterMessageDetailsResponse>(result200);
+
+        } else if (status === 404) {
+            const _responseText = response.data;
+            let result404: any = null;
+            let resultData404  = _responseText;
+            result404 = resultData404;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result404);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<DeadLetterMessageDetailsResponse>(null as any);
+    }
+
+    /**
+     * Mark dead-lettered messages as replayable. The durability agent moves them back to the incoming queue on its next pass, so replay is asynchronous.
+     */
+    replayDeadLetters(request: DeadLetterMessagesRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/admin/messaging/dead-letters/replay";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processReplayDeadLetters(_response);
+        });
+    }
+
+    protected processReplayDeadLetters(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 202) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+
+    /**
+     * Permanently delete dead-lettered messages.
+     */
+    discardDeadLetters(request: DeadLetterMessagesRequest, cancelToken?: CancelToken): Promise<void> {
+        let url_ = this.baseUrl + "/api/admin/messaging/dead-letters/discard";
+        url_ = url_.replace(/[?&]$/, "");
+
+        const content_ = JSON.stringify(request);
+
+        let options_: AxiosRequestConfig = {
+            data: content_,
+            method: "POST",
+            url: url_,
+            headers: {
+                "Content-Type": "application/json",
+            },
+            cancelToken
+        };
+
+        return this.instance.request(options_).catch((_error: any) => {
+            if (isAxiosError(_error) && _error.response) {
+                return _error.response;
+            } else {
+                throw _error;
+            }
+        }).then((_response: AxiosResponse) => {
+            return this.processDiscardDeadLetters(_response);
+        });
+    }
+
+    protected processDiscardDeadLetters(response: AxiosResponse): Promise<void> {
+        const status = response.status;
+        let _headers: any = {};
+        if (response.headers && typeof response.headers === "object") {
+            for (const k in response.headers) {
+                if (response.headers.hasOwnProperty(k)) {
+                    _headers[k] = response.headers[k];
+                }
+            }
+        }
+        if (status === 204) {
+            const _responseText = response.data;
+            return Promise.resolve<void>(null as any);
+
+        } else if (status === 400) {
+            const _responseText = response.data;
+            let result400: any = null;
+            let resultData400  = _responseText;
+            result400 = resultData400;
+            return throwException("A server side error occurred.", status, _responseText, _headers, result400);
+
+        } else if (status !== 200 && status !== 204) {
+            const _responseText = response.data;
+            return throwException("An unexpected server error occurred.", status, _responseText, _headers);
+        }
+        return Promise.resolve<void>(null as any);
+    }
+}
+
 export class ScoringModelsClient {
     protected instance: AxiosInstance;
     protected baseUrl: string;
@@ -32991,6 +33306,53 @@ export interface UpdateFeatureFlagRequest {
 export interface ToggleFeatureFlagRequest {
     id: number;
     isEnabled: boolean;
+}
+
+/** Snapshot of the Wolverine durable message store: how many envelopes are currently persisted in each lifecycle bucket. In a healthy system incoming/outgoing hover near zero — envelopes only linger during backlog, scheduled delivery, or after an unclean shutdown. */
+export interface MessagingCountsResponse {
+    incoming: number;
+    scheduled: number;
+    outgoing: number;
+    handled: number;
+    deadLetter: number;
+}
+
+/** A page of dead-lettered messages. PageNumber is 0-based, mirroring Wolverine's DeadLetterEnvelopeQuery paging. */
+export interface DeadLetterMessagesResponse {
+    totalCount: number;
+    pageNumber: number;
+    pageSize: number;
+    items: DeadLetterMessageResponse[];
+}
+
+/** A single dead-lettered message envelope: what failed, where, and why. */
+export interface DeadLetterMessageResponse {
+    id: string;
+    messageType: string;
+    /** The listener/queue URI the message was received at (e.g. local://durable/). */
+    receivedAt?: string | undefined;
+    /** The service that originally sent the message. */
+    source?: string | undefined;
+    exceptionType?: string | undefined;
+    exceptionMessage?: string | undefined;
+    sentAt: Date;
+    /** Whether the durability agent is set to move this envelope back to incoming for another attempt. */
+    replayable: boolean;
+    attempts: number;
+}
+
+/** Full detail for a single dead-lettered message, including the serialized message body (System.Text.Json per the Wolverine host configuration, so it renders as JSON). */
+export interface DeadLetterMessageDetailsResponse extends DeadLetterMessageResponse {
+    body?: string | undefined;
+    contentType?: string | undefined;
+    correlationId?: string | undefined;
+    destination?: string | undefined;
+    executionTime?: Date | undefined;
+}
+
+/** Identifies the dead-lettered messages a replay or discard operation targets. */
+export interface DeadLetterMessagesRequest {
+    ids: string[];
 }
 
 export interface ScoringModelListDto {

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/admin/messaging-api.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/admin/messaging-api.ts
@@ -1,0 +1,108 @@
+import {
+  DeadLetterMessageDetailsResponse,
+  DeadLetterMessagesResponse,
+  MessagingCountsResponse,
+} from '@/src/services/wayd-api'
+import { apiSlice } from '../apiSlice'
+import { QueryTags } from '../query-tags'
+import { getMessagingClient } from '@/src/services/clients'
+
+export interface GetDeadLettersRequest {
+  messageType?: string
+  exceptionType?: string
+  from?: Date
+  to?: Date
+  /** 0-based, mirroring Wolverine's dead letter query paging. */
+  pageNumber?: number
+  pageSize?: number
+}
+
+export const messagingApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    getMessagingCounts: builder.query<MessagingCountsResponse, void>({
+      queryFn: async () => {
+        try {
+          const data = await getMessagingClient().getCounts()
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: [QueryTags.MessagingCounts],
+    }),
+    getDeadLetters: builder.query<DeadLetterMessagesResponse, GetDeadLettersRequest>(
+      {
+        queryFn: async (request) => {
+          try {
+            const data = await getMessagingClient().getDeadLetters(
+              request.messageType,
+              request.exceptionType,
+              request.from,
+              request.to,
+              request.pageNumber,
+              request.pageSize,
+            )
+            return { data }
+          } catch (error) {
+            console.error('API Error:', error)
+            return { error }
+          }
+        },
+        providesTags: (result) => [
+          QueryTags.DeadLetterMessage,
+          ...(result?.items?.map(({ id }) => ({
+            type: QueryTags.DeadLetterMessage,
+            id,
+          })) ?? []),
+        ],
+      },
+    ),
+    getDeadLetterById: builder.query<DeadLetterMessageDetailsResponse, string>({
+      queryFn: async (id) => {
+        try {
+          const data = await getMessagingClient().getDeadLetterById(id)
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      providesTags: (result, error, id) => [
+        { type: QueryTags.DeadLetterMessage, id },
+      ],
+    }),
+    replayDeadLetters: builder.mutation<void, string[]>({
+      queryFn: async (ids) => {
+        try {
+          const data = await getMessagingClient().replayDeadLetters({ ids })
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: [QueryTags.DeadLetterMessage, QueryTags.MessagingCounts],
+    }),
+    discardDeadLetters: builder.mutation<void, string[]>({
+      queryFn: async (ids) => {
+        try {
+          const data = await getMessagingClient().discardDeadLetters({ ids })
+          return { data }
+        } catch (error) {
+          console.error('API Error:', error)
+          return { error }
+        }
+      },
+      invalidatesTags: [QueryTags.DeadLetterMessage, QueryTags.MessagingCounts],
+    }),
+  }),
+})
+
+export const {
+  useGetMessagingCountsQuery,
+  useGetDeadLettersQuery,
+  useGetDeadLetterByIdQuery,
+  useReplayDeadLettersMutation,
+  useDiscardDeadLettersMutation,
+} = messagingApi

--- a/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/store/features/query-tags.ts
@@ -3,6 +3,8 @@ export enum QueryTags {
   BackgroundJob = 'Admin.BackgroundJob',
   BackgroundJobType = 'Admin.BackgroundJobType',
   FeatureFlag = 'Admin.FeatureFlag',
+  MessagingCounts = 'Admin.MessagingCounts',
+  DeadLetterMessage = 'Admin.DeadLetterMessage',
 
   // CLIENT FEATURE FLAGS
   ClientFeatureFlag = 'Client.FeatureFlag',

--- a/Wayd.Web/tests/Wayd.Web.Api.IntegrationTests/Sut/DurableEventRoutingTests.cs
+++ b/Wayd.Web/tests/Wayd.Web.Api.IntegrationTests/Sut/DurableEventRoutingTests.cs
@@ -13,9 +13,14 @@ using Wayd.Organization.Application.Teams.Commands;
 using Wayd.ProjectPortfolioManagement.Application;
 using Wayd.ProjectPortfolioManagement.Application.Projects.Commands;
 using Wayd.ProjectPortfolioManagement.Domain.Models;
+using Wayd.Common.Domain.Enums.Organization;
 using Wayd.Web.Api.IntegrationTests.Infrastructure;
 using Wayd.Work.Application.Persistence;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+using Wolverine.Persistence.Durability.DeadLetterManagement;
 using Wolverine.Runtime;
+using Wolverine.Runtime.Routing;
 
 namespace Wayd.Web.Api.IntegrationTests.Sut;
 
@@ -124,6 +129,107 @@ public sealed class DurableEventRoutingTests(WaydSqlServerApiFactory factory)
         var controlChain = runtime.Handlers.ChainFor(typeof(CreateTeamCommand));
         Assert.NotNull(controlChain);
         Assert.Empty(controlChain!.Failures);
+    }
+
+    [Fact]
+    public void DurableEventChains_RouteToDurableLocalQueues()
+    {
+        // Arrange — the outbox only persists envelopes destined for DURABLE endpoints. Without
+        // UseDurableLocalQueues (WolverineConfiguration) the per-message-type local queues default to
+        // BufferedInMemory and the "durable" events are never written to the envelope store at all — a
+        // crash between commit and dispatch silently loses the event. This pins the queue mode so that
+        // regression can't return silently (it is invisible to delivery-based tests: in-memory delivery
+        // also "arrives eventually").
+        _ = _factory.CreateClient();
+        var runtime = (WolverineRuntime)_factory.Services.GetRequiredService<IWolverineRuntime>();
+
+        Type[] durableEventTypes =
+        [
+            typeof(ProjectCreatedEvent),
+            typeof(IterationCreatedEvent),
+            typeof(StrategicThemeCreatedEvent),
+            typeof(IntegrationStateChangedEvent<Guid>),
+            typeof(TeamCreatedEvent),
+        ];
+
+        foreach (var durableEventType in durableEventTypes)
+        {
+            // Act — resolve the routes exactly the way a publish does.
+            var routes = runtime.RoutingFor(durableEventType).Routes;
+
+            // Assert
+            Assert.NotEmpty(routes);
+            foreach (var route in routes)
+            {
+                var messageRoute = Assert.IsType<MessageRoute>(route, exactMatch: false);
+                Assert.True(
+                    messageRoute.Sender.IsDurable,
+                    $"{durableEventType.Name} routes to non-durable endpoint {messageRoute.Sender.Destination} — its envelopes would never be persisted");
+            }
+        }
+    }
+
+    [Fact]
+    public async Task DurableEvent_WhoseHandlerFailsPersistently_LandsInDeadLetterStore()
+    {
+        // Arrange — a TeamCreatedEvent whose Name exceeds the PlanningTeam projection's 128-char column,
+        // so the replication handler's SaveChanges fails deterministically on every attempt (a
+        // non-transient failure). Per DurableEventFailurePolicy the chain retries with cooldowns
+        // (1s/5s/15s) and then dead-letters — this proves a real handler failure ends up in the durable
+        // dead letter store, where the messaging dashboard (and replay) can see it.
+        _ = _factory.CreateClient();
+        var ct = TestContext.Current.CancellationToken;
+
+        var poisonedId = Guid.NewGuid();
+        var poisonedEvent = new TeamCreatedEvent(
+            id: poisonedId,
+            key: 999999,
+            code: new TeamCode("DLQTEST"),
+            name: new string('x', 200),
+            description: "Poisoned event for the failure-to-dead-letter pipeline test.",
+            type: TeamType.Team,
+            activeDate: new LocalDate(2026, 1, 1),
+            inactiveDate: null,
+            isActive: true,
+            timestamp: Now);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var bus = scope.ServiceProvider.GetRequiredService<IMessageBus>();
+
+            // Act — publish through Wolverine so the envelope takes the real durable local queue path.
+            await bus.PublishAsync(poisonedEvent);
+        }
+
+        // Assert — the envelope lands in the dead letter store after the retry schedule (~21s of
+        // cooldowns), so poll generously. Query by the poisoned envelope's message type and match on Id.
+        var store = _factory.Services.GetRequiredService<IMessageStore>();
+        DeadLetterEnvelope? deadLetter = null;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(90);
+        while (DateTime.UtcNow < deadline)
+        {
+            var results = await store.DeadLetters.QueryAsync(
+                new DeadLetterEnvelopeQuery { MessageType = typeof(TeamCreatedEvent).FullName },
+                ct);
+            // This test class owns its SQL container, so any TeamCreatedEvent dead letter is ours; the
+            // serialized body containing the poisoned id double-checks that when the body is available.
+            deadLetter = results.Envelopes.FirstOrDefault(e =>
+                e.Envelope.Data is null
+                || System.Text.Encoding.UTF8.GetString(e.Envelope.Data).Contains(poisonedId.ToString(), StringComparison.OrdinalIgnoreCase));
+            if (deadLetter is not null)
+            {
+                break;
+            }
+
+            await Task.Delay(1000, ct);
+        }
+
+        Assert.True(deadLetter is not null, "Poisoned TeamCreatedEvent should have been moved to the durable dead letter store after exhausting retries");
+        Assert.False(deadLetter!.Replayable);
+        Assert.NotNull(deadLetter.ExceptionType);
+
+        // Cleanup — discard so the poisoned envelope can't bleed into other assertions on this store.
+        await store.DeadLetters.DiscardAsync(new DeadLetterEnvelopeQuery([deadLetter.Id]), ct);
     }
 
     private async Task<(int ExpenditureCategoryId, Guid PortfolioId)> SeedProjectPrerequisites(CancellationToken ct)

--- a/Wayd.Web/tests/Wayd.Web.Api.IntegrationTests/Sut/MessagingControllerTests.cs
+++ b/Wayd.Web/tests/Wayd.Web.Api.IntegrationTests/Sut/MessagingControllerTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Wayd.Web.Api.Controllers.Admin;
@@ -122,6 +123,28 @@ public sealed class MessagingControllerTests(WaydSqlServerApiFactory factory)
         Assert.IsType<NotFoundResult>(detailResponse.Result);
     }
 
+    [Fact]
+    public async Task ReplayAndDiscard_WithNullOrEmptyIds_ReturnBadRequest()
+    {
+        // Arrange — the Ids property initializer does not survive an explicit {"ids": null} payload,
+        // so both action guards must handle null as well as empty.
+        _ = _factory.CreateClient();
+        var ct = TestContext.Current.CancellationToken;
+        var controller = CreateController();
+
+        // Act
+        var replayNull = await controller.ReplayDeadLetters(new DeadLetterMessagesRequest { Ids = null! }, ct);
+        var replayEmpty = await controller.ReplayDeadLetters(new DeadLetterMessagesRequest(), ct);
+        var discardNull = await controller.DiscardDeadLetters(new DeadLetterMessagesRequest { Ids = null! }, ct);
+        var discardEmpty = await controller.DiscardDeadLetters(new DeadLetterMessagesRequest(), ct);
+
+        // Assert
+        Assert.IsType<BadRequestObjectResult>(replayNull);
+        Assert.IsType<BadRequestObjectResult>(replayEmpty);
+        Assert.IsType<BadRequestObjectResult>(discardNull);
+        Assert.IsType<BadRequestObjectResult>(discardEmpty);
+    }
+
     /// <summary>
     /// A fictional, handler-less message type. Wolverine stores the dead letter regardless of whether
     /// the type resolves, and a replay of it can never dispatch into real application code.
@@ -131,7 +154,11 @@ public sealed class MessagingControllerTests(WaydSqlServerApiFactory factory)
     private MessagingController CreateController()
     {
         var store = _factory.Services.GetRequiredService<IMessageStore>();
-        return new MessagingController(store);
+        return new MessagingController(store)
+        {
+            // ProblemDetailsExtensions.ForBadRequest reads the request/trace info off HttpContext.
+            ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() },
+        };
     }
 
     private async Task<Guid> SeedDeadLetter(CancellationToken ct)

--- a/Wayd.Web/tests/Wayd.Web.Api.IntegrationTests/Sut/MessagingControllerTests.cs
+++ b/Wayd.Web/tests/Wayd.Web.Api.IntegrationTests/Sut/MessagingControllerTests.cs
@@ -1,0 +1,158 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Wayd.Web.Api.Controllers.Admin;
+using Wayd.Web.Api.Models.Admin.Messaging;
+using Wayd.Web.Api.IntegrationTests.Infrastructure;
+using Wolverine;
+using Wolverine.Persistence.Durability;
+
+namespace Wayd.Web.Api.IntegrationTests.Sut;
+
+/// <summary>
+/// MessagingController against the real Wolverine SQL Server message store: counts, dead-letter
+/// query/detail, replay, and discard. Dead letters are seeded through Wolverine's own
+/// <see cref="IMessageInbox.MoveToDeadLetterStorageAsync"/> (the same path a real handler failure takes
+/// after the retry policy is exhausted) rather than raw SQL, so the tests do not pin the envelope table
+/// schema. The seeded envelopes use a fictional message type with no handler, so a replayed envelope
+/// that the durability agent picks up cannot trigger real application handlers.
+/// </summary>
+[Trait("Category", "Docker")]
+public sealed class MessagingControllerTests(WaydSqlServerApiFactory factory)
+    : IClassFixture<WaydSqlServerApiFactory>
+{
+    private readonly WaydSqlServerApiFactory _factory = factory;
+
+    [Fact]
+    public async Task GetCounts_ReturnsPersistedCountsSnapshot()
+    {
+        // Arrange — boot the real host so the wolverine schema is provisioned.
+        _ = _factory.CreateClient();
+        var controller = CreateController();
+
+        // Act
+        var response = await controller.GetCounts();
+
+        // Assert
+        var counts = Assert.IsType<MessagingCountsResponse>(Assert.IsType<OkObjectResult>(response.Result).Value);
+        Assert.True(counts.Incoming >= 0);
+        Assert.True(counts.DeadLetter >= 0);
+    }
+
+    [Fact]
+    public async Task GetDeadLetters_ReturnsSeededEnvelope_AndDetailExposesBody()
+    {
+        // Arrange
+        _ = _factory.CreateClient();
+        var ct = TestContext.Current.CancellationToken;
+        var controller = CreateController();
+        var envelopeId = await SeedDeadLetter(ct);
+
+        // Act
+        var listResponse = await controller.GetDeadLetters(ct, pageSize: 500);
+        var detailResponse = await controller.GetDeadLetterById(envelopeId);
+
+        // Assert — the seeded envelope shows up in the page with its failure metadata...
+        var page = Assert.IsType<DeadLetterMessagesResponse>(Assert.IsType<OkObjectResult>(listResponse.Result).Value);
+        Assert.True(page.TotalCount >= 1);
+        var summary = Assert.Single(page.Items, i => i.Id == envelopeId);
+        Assert.Equal(FakeMessageType, summary.MessageType);
+        Assert.Equal(typeof(InvalidOperationException).FullName, summary.ExceptionType);
+        Assert.Equal("Simulated handler failure", summary.ExceptionMessage);
+
+        // ...and the detail endpoint surfaces the serialized JSON body.
+        var detail = Assert.IsType<DeadLetterMessageDetailsResponse>(Assert.IsType<OkObjectResult>(detailResponse.Result).Value);
+        Assert.Equal(envelopeId, detail.Id);
+        Assert.NotNull(detail.Body);
+        Assert.Contains("\"marker\"", detail.Body);
+    }
+
+    [Fact]
+    public async Task GetDeadLetterById_UnknownId_ReturnsNotFound()
+    {
+        // Arrange
+        _ = _factory.CreateClient();
+        var controller = CreateController();
+
+        // Act
+        var response = await controller.GetDeadLetterById(Guid.NewGuid());
+
+        // Assert
+        Assert.IsType<NotFoundResult>(response.Result);
+    }
+
+    [Fact]
+    public async Task ReplayDeadLetters_MarksEnvelopeReplayable()
+    {
+        // Arrange
+        _ = _factory.CreateClient();
+        var ct = TestContext.Current.CancellationToken;
+        var controller = CreateController();
+        var envelopeId = await SeedDeadLetter(ct);
+
+        // Act
+        var response = await controller.ReplayDeadLetters(
+            new DeadLetterMessagesRequest { Ids = [envelopeId] }, ct);
+
+        // Assert — accepted, and the envelope is now marked replayable OR already swept back to the
+        // incoming queue by the durability agent (a race we tolerate rather than flake on: both states
+        // are the successful outcome of a replay).
+        Assert.IsType<AcceptedResult>(response);
+        var store = _factory.Services.GetRequiredService<IMessageStore>();
+        var envelope = await store.DeadLetters.DeadLetterEnvelopeByIdAsync(envelopeId, null);
+        Assert.True(envelope is null || envelope.Replayable);
+    }
+
+    [Fact]
+    public async Task DiscardDeadLetters_DeletesEnvelope()
+    {
+        // Arrange
+        _ = _factory.CreateClient();
+        var ct = TestContext.Current.CancellationToken;
+        var controller = CreateController();
+        var envelopeId = await SeedDeadLetter(ct);
+
+        // Act
+        var response = await controller.DiscardDeadLetters(
+            new DeadLetterMessagesRequest { Ids = [envelopeId] }, ct);
+
+        // Assert — gone from the store entirely.
+        Assert.IsType<NoContentResult>(response);
+        var detailResponse = await controller.GetDeadLetterById(envelopeId);
+        Assert.IsType<NotFoundResult>(detailResponse.Result);
+    }
+
+    /// <summary>
+    /// A fictional, handler-less message type. Wolverine stores the dead letter regardless of whether
+    /// the type resolves, and a replay of it can never dispatch into real application code.
+    /// </summary>
+    private const string FakeMessageType = "Wayd.Web.Api.IntegrationTests.FakeDeadLetterMessage";
+
+    private MessagingController CreateController()
+    {
+        var store = _factory.Services.GetRequiredService<IMessageStore>();
+        return new MessagingController(store);
+    }
+
+    private async Task<Guid> SeedDeadLetter(CancellationToken ct)
+    {
+        _ = ct; // MoveToDeadLetterStorageAsync has no cancellable overload.
+
+        var store = _factory.Services.GetRequiredService<IMessageStore>();
+
+        var envelope = new Envelope
+        {
+            Id = Guid.NewGuid(),
+            MessageType = FakeMessageType,
+            Data = JsonSerializer.SerializeToUtf8Bytes(new { marker = "dead-letter-integration-test" }),
+            ContentType = "application/json",
+            Destination = new Uri("local://durable/"),
+            SentAt = DateTimeOffset.UtcNow,
+        };
+
+        await store.Inbox.MoveToDeadLetterStorageAsync(
+            envelope, new InvalidOperationException("Simulated handler failure"));
+
+        return envelope.Id;
+    }
+}


### PR DESCRIPTION
## Messaging Dashboard + Durable Local Queues Fix

### Summary

Adds a **Settings → Messaging** dashboard for operational visibility into Wolverine's durable messaging (outbox/inbox counts and full dead-letter management), and fixes a latent durability gap it uncovered: the "durable" event queues were buffered in-memory, meaning the transactional outbox was never actually crash-safe.

### Messaging Dashboard (Settings → Other → Messaging)

**Backend** — new `MessagingController` (`api/admin/messaging`) wrapping Wolverine's own admin surface (`IMessageStore.Admin` / `IMessageStore.DeadLetters`) — no raw SQL against the `wolverine` schema:

- `GET counts` — persisted envelope counts by lifecycle state (Incoming / Scheduled / Outgoing / Handled / Dead Letter)
- `GET dead-letters` — paged, filterable by message type, exception type, and time range
- `GET dead-letters/{id}` — full detail including the serialized JSON message body
- `POST dead-letters/replay` / `POST dead-letters/discard`

The controller injects `IMessageStore` directly (same pattern as `BackgroundJobsController`/Hangfire) rather than going through the handler pipeline — this is host-plumbing introspection, and it keeps the change out of the Wolverine codegen graph.

**Permissions** — new `Messaging` resource: `View` (all reads), `Run` (replay), `Delete` (discard). ⚠️ **Post-deploy:** an admin must grant these to a role before the menu item appears.

**Frontend** — `/settings/messaging`: count tiles (dead-letter tile highlights red when non-zero) with tooltips explaining exactly when each bucket populates, a WaydGrid of dead letters (newest first, set filters, CSV export, persisted layout), a details drawer with envelope metadata + pretty-printed body, and permission-gated Replay/Discard actions (row menu + drawer, confirm on discard). Replay is surfaced as asynchronous ("queued for replay") because Wolverine's durability agent sweeps replayable envelopes back to incoming on its next pass.

### Durable Local Queues Fix

Building the dashboard exposed that the envelope tables were **always empty**: nothing called `UseDurableLocalQueues()`, so the per-message-type local queues the `DurableEventRoutes` events ride on were `BufferedInMemory` (verified at runtime: `isDurable=False`). Wolverine's outbox only persists envelopes bound for **durable** endpoints — so the "durable outbox" provided post-commit ordering only, and a crash between commit and dispatch would silently lose the event (and its cross-domain replication).

`opts.Policies.UseDurableLocalQueues()` restores the intended semantics: envelopes are written to `wolverine_incoming_envelopes` in the same transaction as the entity change and recovered by the durability agent after a crash. Delivery is genuinely at-least-once now — the replication handlers were reviewed and already carry the required idempotency guards (create no-ops if the row exists; update/activate/delete no-op if it doesn't), and Stage B's `DomainEventSerializationTests` already pin STJ round-trip serialization for the durable event types.

### Tests

- `MessagingControllerTests` (new, Docker) — counts, dead-letter list/detail (incl. body), 404, replay, discard against a real SQL container. Dead letters are seeded via Wolverine's own `Inbox.MoveToDeadLetterStorageAsync` with a fictional handler-less message type — no envelope-schema SQL, and replayed test envelopes can never dispatch into real handlers.
- `DurableEventRoutingTests` (2 new):
  - `DurableEventChains_RouteToDurableLocalQueues`: pins `Sender.IsDurable` for a representative event from every durable family. This regression is invisible to delivery-based tests (in-memory delivery also "arrives eventually"), so the queue mode is asserted directly.
  - `DurableEvent_WhoseHandlerFailsPersistently_LandsInDeadLetterStore`: a poisoned `TeamCreatedEvent` (name exceeds the projection's column length) rides the real 1s/5s/15s retry schedule and is asserted into the durable dead-letter store — proving the failure pipeline the dashboard monitors end-to-end.

Full integration suite 17/17 green (inline replication contract untouched), architecture tests green, frontend lint/typecheck/tests green (2492).

### Notes for reviewers

- The large `Internal/Generated/WolverineHandlers` diff (~324 files) is a one-line reorder of a service-locator local per file — deterministic codegen churn from adding new types to the compilation, behaviorally identical (same class of churn as the documented OTLP ordering effect). Verified reproducible: clean HEAD regen produces zero diff; this change set produces this exact diff every time. CI's freshness check will agree.
- `wayd-api.ts` / `specification.json` are NSwag regeneration.
- On a healthy system the dashboard reads all zeros — successful envelopes clear immediately (Handled is retained 5 minutes for idempotency, then purged). Non-zero tiles mean backlog, retries in cooldown, or dead letters; the tile tooltips spell this out.
