### PR TITLE
Feature/azdo integration improvements

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -47,6 +47,7 @@
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
     <PackageVersion Include="Microsoft.FeatureManagement.AspNetCore" Version="4.6.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.7.0" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />

--- a/Wayd.Common/src/Wayd.Common.Application/Interfaces/IAzureDevOpsService.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Interfaces/IAzureDevOpsService.cs
@@ -1,19 +1,20 @@
-﻿using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Models;
 
 namespace Wayd.Common.Application.Interfaces;
 
 public interface IAzureDevOpsService
 {
-    Task<Result<string>> GetSystemId(string organizationUrl, string token, CancellationToken cancellationToken);
-    Task<Result<List<IExternalWorkProcess>>> GetWorkProcesses(string organizationUrl, string token, CancellationToken cancellationToken);
-    Task<Result<IExternalWorkProcessConfiguration>> GetWorkProcess(string organizationUrl, string token, Guid processId, CancellationToken cancellationToken);
-    Task<Result<IExternalWorkspaceConfiguration>> GetWorkspace(string organizationUrl, string token, Guid workspaceId, CancellationToken cancellationToken);
-    Task<Result<List<IExternalWorkspace>>> GetWorkspaces(string organizationUrl, string token, CancellationToken cancellationToken);
-    Task<Result<List<IExternalTeam>>> GetTeams(string organizationUrl, string token, Guid[] projectIds, CancellationToken cancellationToken);
-    Task<Result<List<IExternalIteration<AzdoIterationMetadata>>>> GetIterations(string organizationUrl, string token, string projectName, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken);
-    Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken);
-    Task<Result<List<IExternalWorkItemLink>>> GetParentLinkChanges(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
-    Task<Result<List<IExternalWorkItemLink>>> GetDependencyLinkChanges(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
-    Task<Result<int[]>> GetDeletedWorkItemIds(string organizationUrl, string token, string projectName, DateTime lastChangedDate, CancellationToken cancellationToken);
-    Task<Result> TestConnection(string organizationUrl, string token);
+    Task<Result<string>> GetSystemId(AzureDevOpsConnectionContext connection, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkProcess>>> GetWorkProcesses(AzureDevOpsConnectionContext connection, CancellationToken cancellationToken);
+    Task<Result<IExternalWorkProcessConfiguration>> GetWorkProcess(AzureDevOpsConnectionContext connection, Guid processId, CancellationToken cancellationToken);
+    Task<Result<IExternalWorkspaceConfiguration>> GetWorkspace(AzureDevOpsConnectionContext connection, Guid workspaceId, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkspace>>> GetWorkspaces(AzureDevOpsConnectionContext connection, CancellationToken cancellationToken);
+    Task<Result<List<IExternalTeam>>> GetTeams(AzureDevOpsConnectionContext connection, Guid[] projectIds, CancellationToken cancellationToken);
+    Task<Result<List<IExternalIteration<AzdoIterationMetadata>>>> GetIterations(AzureDevOpsConnectionContext connection, string projectName, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkItem>>> GetWorkItems(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkItemLink>>> GetParentLinkChanges(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
+    Task<Result<List<IExternalWorkItemLink>>> GetDependencyLinkChanges(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
+    Task<Result<int[]>> GetDeletedWorkItemIds(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken);
+    Task<Result> TestConnection(AzureDevOpsConnectionContext connection);
 }

--- a/Wayd.Common/src/Wayd.Common.Application/Models/AzureDevOpsConnectionContext.cs
+++ b/Wayd.Common/src/Wayd.Common.Application/Models/AzureDevOpsConnectionContext.cs
@@ -1,0 +1,7 @@
+namespace Wayd.Common.Application.Models;
+
+/// <summary>
+/// Endpoint and credentials for a single Azure DevOps connection, passed as one unit so an
+/// organization URL and its personal access token can never be crossed between connections.
+/// </summary>
+public sealed record AzureDevOpsConnectionContext(string OrganizationUrl, string PersonalAccessToken);

--- a/Wayd.Infrastructure/src/Wayd.Infrastructure/ConnectorModules/AzureDevOpsConnectorModule.cs
+++ b/Wayd.Infrastructure/src/Wayd.Infrastructure/ConnectorModules/AzureDevOpsConnectorModule.cs
@@ -14,6 +14,15 @@ public sealed class AzureDevOpsConnectorModule : IConnectorModule
 
     public void Register(IServiceCollection services)
     {
+        // Named client shared by all Azure DevOps REST calls. The host's default resilience
+        // pipeline (ConfigureHttpClientDefaults in ConfigureServices) applies: retry honoring
+        // Retry-After — which is how Azure DevOps signals throttling — 90s per-attempt timeout,
+        // 5min total, circuit breaker. HttpClient.Timeout is disabled so the pipeline's total
+        // timeout is the single outer bound; the factory's 100s default would otherwise abort
+        // a slow-but-retrying request mid-pipeline.
+        services.AddHttpClient(AzureDevOpsHttpClient.Name,
+            client => client.Timeout = Timeout.InfiniteTimeSpan);
+
         services.AddTransient<IAzureDevOpsService, AzureDevOpsService>();
         services.AddKeyedTransient<IWorkItemSource, AzureDevOpsWorkItemSource>(Connector.AzureDevOps);
         services.AddScoped<ISyncableConnectionDescriptorBuilder, AzureDevOpsConnectionDescriptorBuilder>();

--- a/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/ConnectorModules/ConnectorModulesTests.cs
+++ b/Wayd.Infrastructure/tests/Wayd.Infrastructure.Tests/Sut/ConnectorModules/ConnectorModulesTests.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 using Wayd.Infrastructure.ConnectorModules;
 using Wayd.Integrations.Abstractions;
+using Wayd.Integrations.AzureDevOps;
 
 namespace Wayd.Infrastructure.Tests.Sut.ConnectorModules;
 
@@ -83,5 +84,26 @@ public sealed class ConnectorModulesTests
         services.Count(d => d.ServiceType == typeof(ISyncableConnectionDescriptorBuilder))
             .Should().Be(syncCapableCount,
                 "every sync-capable connector registers exactly one descriptor builder");
+    }
+
+    [Fact]
+    public void AddConnectorModules_RegistersTheNamedAzureDevOpsHttpClient()
+    {
+        // Arrange
+        var services = new ServiceCollection();
+
+        // Act
+        services.AddConnectorModules();
+
+        // Assert - AzureDevOpsService resolves this client by name via IHttpClientFactory; if the
+        // registration is ever renamed or dropped, every AzDO sync fails at runtime with no signal
+        // until then. IHttpClientFactory registers named options, not a directly-queryable service
+        // entry, so build the provider and confirm the factory actually produces a client for the name.
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IHttpClientFactory>();
+
+        var act = () => factory.CreateClient(AzureDevOpsHttpClient.Name);
+
+        act.Should().NotThrow();
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/AzureDevOpsHttpClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/AzureDevOpsHttpClient.cs
@@ -1,0 +1,11 @@
+namespace Wayd.Integrations.AzureDevOps;
+
+/// <summary>
+/// The <see cref="System.Net.Http.IHttpClientFactory"/> named client used for all Azure DevOps REST calls.
+/// Registered by the Azure DevOps connector module; the host's default resilience pipeline
+/// (retry honoring Retry-After, per-attempt/total timeouts, circuit breaker) applies to it.
+/// </summary>
+public static class AzureDevOpsHttpClient
+{
+    public const string Name = "azure-devops";
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/AzureDevOpsService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/AzureDevOpsService.cs
@@ -1,4 +1,3 @@
-﻿using Ardalis.GuardClauses;
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
@@ -12,22 +11,30 @@ using Wayd.Integrations.AzureDevOps.Utils;
 
 namespace Wayd.Integrations.AzureDevOps;
 
-public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProvider serviceProvider, IDateTimeProvider dateTimeProvider, IMemoryCache memoryCache) : IAzureDevOpsService
+public class AzureDevOpsService(
+    ILogger<AzureDevOpsService> logger,
+    ILoggerFactory loggerFactory,
+    IHttpClientFactory httpClientFactory,
+    IDateTimeProvider dateTimeProvider,
+    IMemoryCache memoryCache) : IAzureDevOpsService
 {
     // https://learn.microsoft.com/en-us/azure/devops/integrate/concepts/rest-api-versioning?view=azure-devops#supported-versions
-    private readonly string _apiVersion = "7.0";
+    // 7.1 requires Azure DevOps Services (or Server 2025+). Wayd only connects to the hosted
+    // service — if on-prem Server support ever enters scope, 7.0 is the floor Server 2022 speaks.
+    private readonly string _apiVersion = "7.1";
 
     private readonly ILogger<AzureDevOpsService> _logger = logger;
-    private readonly IServiceProvider _serviceProvider = serviceProvider;
+    private readonly ILoggerFactory _loggerFactory = loggerFactory;
+    private readonly IHttpClientFactory _httpClientFactory = httpClientFactory;
     private readonly IDateTimeProvider _dateTimeProvider = dateTimeProvider;
     private readonly IMemoryCache _memoryCache = memoryCache;
 
-    public async Task<Result> TestConnection(string organizationUrl, string token)
+    public async Task<Result> TestConnection(AzureDevOpsConnectionContext connection)
     {
         try
         {
             // use the GetInstanceId method to test the connection
-            var result = await GetSystemId(organizationUrl, token, CancellationToken.None).ConfigureAwait(false);
+            var result = await GetSystemId(connection, CancellationToken.None).ConfigureAwait(false);
 
             return result.IsSuccess
                 ? Result.Success()
@@ -40,9 +47,9 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
         }
     }
 
-    public async Task<Result<string>> GetSystemId(string organizationUrl, string token, CancellationToken cancellationToken)
+    public async Task<Result<string>> GetSystemId(AzureDevOpsConnectionContext connection, CancellationToken cancellationToken)
     {
-        var generalService = GetService<GeneralService>(organizationUrl, token);
+        var generalService = CreateGeneralService(connection);
 
         var result = await generalService.GetConnectionData(cancellationToken).ConfigureAwait(false);
         if (result.IsFailure)
@@ -53,9 +60,9 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<string>("No systemId returned.");
     }
 
-    public async Task<Result<List<IExternalWorkProcess>>> GetWorkProcesses(string organizationUrl, string token, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalWorkProcess>>> GetWorkProcesses(AzureDevOpsConnectionContext connection, CancellationToken cancellationToken)
     {
-        var processService = GetService<ProcessService>(organizationUrl, token);
+        var processService = CreateProcessService(connection);
 
         var result = await processService.GetProcesses(cancellationToken).ConfigureAwait(false);
 
@@ -64,9 +71,9 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<List<IExternalWorkProcess>>(result.Error);
     }
 
-    public async Task<Result<IExternalWorkProcessConfiguration>> GetWorkProcess(string organizationUrl, string token, Guid processId, CancellationToken cancellationToken)
+    public async Task<Result<IExternalWorkProcessConfiguration>> GetWorkProcess(AzureDevOpsConnectionContext connection, Guid processId, CancellationToken cancellationToken)
     {
-        var processService = GetService<ProcessService>(organizationUrl, token);
+        var processService = CreateProcessService(connection);
 
         var result = await processService.GetProcess(processId, cancellationToken).ConfigureAwait(false);
 
@@ -75,9 +82,9 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<IExternalWorkProcessConfiguration>(result.Error);
     }
 
-    public async Task<Result<IExternalWorkspaceConfiguration>> GetWorkspace(string organizationUrl, string token, Guid workspaceId, CancellationToken cancellationToken)
+    public async Task<Result<IExternalWorkspaceConfiguration>> GetWorkspace(AzureDevOpsConnectionContext connection, Guid workspaceId, CancellationToken cancellationToken)
     {
-        var result = await GetProject(organizationUrl, token, workspaceId.ToString(), cancellationToken).ConfigureAwait(false);
+        var result = await GetProject(connection, workspaceId.ToString(), cancellationToken).ConfigureAwait(false);
 
         if (result.IsFailure)
             return Result.Failure<IExternalWorkspaceConfiguration>(result.Error);
@@ -88,9 +95,9 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
         return result.Value.ToAzdoWorkspaceConfiguration();
     }
 
-    public async Task<Result<List<IExternalWorkspace>>> GetWorkspaces(string organizationUrl, string token, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalWorkspace>>> GetWorkspaces(AzureDevOpsConnectionContext connection, CancellationToken cancellationToken)
     {
-        var projectService = GetService<ProjectService>(organizationUrl, token);
+        var projectService = CreateProjectService(connection);
 
         var result = await projectService.GetProjects(cancellationToken).ConfigureAwait(false);
 
@@ -99,53 +106,53 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<List<IExternalWorkspace>>(result.Error);
     }
 
-    public async Task<Result<List<IExternalTeam>>> GetTeams(string organizationUrl, string token, Guid[] projectIds, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalTeam>>> GetTeams(AzureDevOpsConnectionContext connection, Guid[] projectIds, CancellationToken cancellationToken)
     {
-        var projectService = GetService<ProjectService>(organizationUrl, token);
+        var projectService = CreateProjectService(connection);
 
         var result = await projectService.GetTeams(projectIds, cancellationToken).ConfigureAwait(false);
         if (result.IsFailure)
             return Result.Failure<List<IExternalTeam>>(result.Error);
 
         if (_logger.IsEnabled(LogLevel.Debug))
-            _logger.LogDebug("{TeamCount} teams found for organization {organizationUrl}.", result.Value.Count, organizationUrl);
+            _logger.LogDebug("{TeamCount} teams found for organization {organizationUrl}.", result.Value.Count, connection.OrganizationUrl);
 
         return result.Value;
     }
 
-    public async Task<Result<List<IExternalIteration<AzdoIterationMetadata>>>> GetIterations(string organizationUrl, string token, string projectName, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalIteration<AzdoIterationMetadata>>>> GetIterations(AzureDevOpsConnectionContext connection, string projectName, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken)
     {
-        var projectResult = await GetProject(organizationUrl, token, projectName, cancellationToken).ConfigureAwait(false);
+        var projectResult = await GetProject(connection, projectName, cancellationToken).ConfigureAwait(false);
         if (projectResult.IsFailure)
             return Result.Failure<List<IExternalIteration<AzdoIterationMetadata>>>($"Unable to get details for project {projectName}");
 
-        var iterationsResult = await GetOrFetchIterationsAsync(organizationUrl, token, projectName, teamSettings, cancellationToken).ConfigureAwait(false);
+        var iterationsResult = await GetOrFetchIterationsAsync(connection, projectName, teamSettings, cancellationToken).ConfigureAwait(false);
 
         return iterationsResult.IsSuccess
             ? iterationsResult.Value.ToIExternalIterations(_dateTimeProvider.Now, projectResult.Value.Id)
             : Result.Failure<List<IExternalIteration<AzdoIterationMetadata>>>(iterationsResult.Error);
     }
 
-    public async Task<Result<List<IExternalWorkItem>>> GetWorkItems(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalWorkItem>>> GetWorkItems(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, Dictionary<Guid, Guid?> teamSettings, CancellationToken cancellationToken)
     {
-        var iterationsResult = await GetOrFetchIterationsAsync(organizationUrl, token, projectName, teamSettings, cancellationToken).ConfigureAwait(false);
+        var iterationsResult = await GetOrFetchIterationsAsync(connection, projectName, teamSettings, cancellationToken).ConfigureAwait(false);
         if (iterationsResult.IsFailure)
             return Result.Failure<List<IExternalWorkItem>>(iterationsResult.Error);
 
         var cachedIterations = iterationsResult.Value;
 
-        var workItemService = GetService<WorkItemService>(organizationUrl, token);
+        var workItemService = CreateWorkItemService(connection);
 
         var result = await workItemService.GetWorkItems(projectName, lastChangedDate, workItemTypes, cancellationToken).ConfigureAwait(false);
 
         return result.IsSuccess
-            ? result.Value.ToIExternalWorkItems(cachedIterations)
+            ? result.Value.ToIExternalWorkItems(cachedIterations, _logger)
             : Result.Failure<List<IExternalWorkItem>>(result.Error);
     }
 
-    public async Task<Result<List<IExternalWorkItemLink>>> GetParentLinkChanges(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalWorkItemLink>>> GetParentLinkChanges(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
     {
-        var workItemService = GetService<WorkItemService>(organizationUrl, token);
+        var workItemService = CreateWorkItemService(connection);
 
         var result = await workItemService.GetParentLinkChanges(projectName, lastChangedDate, workItemTypes, cancellationToken).ConfigureAwait(false);
 
@@ -154,9 +161,9 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<List<IExternalWorkItemLink>>(result.Error);
     }
 
-    public async Task<Result<List<IExternalWorkItemLink>>> GetDependencyLinkChanges(string organizationUrl, string token, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
+    public async Task<Result<List<IExternalWorkItemLink>>> GetDependencyLinkChanges(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
     {
-        var workItemService = GetService<WorkItemService>(organizationUrl, token);
+        var workItemService = CreateWorkItemService(connection);
 
         var result = await workItemService.GetDependencyLinkChanges(projectName, lastChangedDate, workItemTypes, cancellationToken).ConfigureAwait(false);
 
@@ -165,27 +172,27 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             : Result.Failure<List<IExternalWorkItemLink>>(result.Error);
     }
 
-    public async Task<Result<int[]>> GetDeletedWorkItemIds(string organizationUrl, string token, string projectName, DateTime lastChangedDate, CancellationToken cancellationToken)
+    public async Task<Result<int[]>> GetDeletedWorkItemIds(AzureDevOpsConnectionContext connection, string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
     {
-        var workItemService = GetService<WorkItemService>(organizationUrl, token);
+        var workItemService = CreateWorkItemService(connection);
 
-        var result = await workItemService.GetDeletedWorkItemIds(projectName, lastChangedDate, cancellationToken).ConfigureAwait(false);
+        var result = await workItemService.GetDeletedWorkItemIds(projectName, lastChangedDate, workItemTypes, cancellationToken).ConfigureAwait(false);
 
         return result.IsSuccess
             ? result.Value
             : Result.Failure<int[]>(result.Error);
     }
 
-    private async Task<Result<ProjectDetailsDto>> GetProject(string organizationUrl, string token, string projectIdOrName, CancellationToken cancellationToken)
+    private async Task<Result<ProjectDetailsDto>> GetProject(AzureDevOpsConnectionContext connection, string projectIdOrName, CancellationToken cancellationToken)
     {
-        var projectService = GetService<ProjectService>(organizationUrl, token);
+        var projectService = CreateProjectService(connection);
 
         return await projectService.GetProject(projectIdOrName, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<Result<List<IterationDto>>> GetOrFetchIterationsAsync(string organizationUrl, string token, string projectName, Dictionary<Guid, Guid?>? teamSettings, CancellationToken cancellationToken, bool forceRefresh = false)
+    private async Task<Result<List<IterationDto>>> GetOrFetchIterationsAsync(AzureDevOpsConnectionContext connection, string projectName, Dictionary<Guid, Guid?>? teamSettings, CancellationToken cancellationToken, bool forceRefresh = false)
     {
-        var cacheKey = CacheKeyGenerator.GetCacheKey("azdo-iterations", organizationUrl, projectName, teamSettings);
+        var cacheKey = CacheKeyGenerator.GetCacheKey("azdo-iterations", connection.OrganizationUrl, projectName, teamSettings);
 
         if (!forceRefresh && _memoryCache.TryGetValue(cacheKey, out List<IterationDto>? cached) && cached is not null)
         {
@@ -195,7 +202,7 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
             return Result.Success(cached);
         }
 
-        var projectService = GetService<ProjectService>(organizationUrl, token);
+        var projectService = CreateProjectService(connection);
         var result = await projectService.GetIterations(projectName, teamSettings, cancellationToken).ConfigureAwait(false);
         if (result.IsFailure)
             return Result.Failure<List<IterationDto>>(result.Error);
@@ -213,20 +220,19 @@ public class AzureDevOpsService(ILogger<AzureDevOpsService> logger, IServiceProv
         return Result.Success(toCache);
     }
 
-    private TService GetService<TService>(string organizationUrl, string token)
-    {
-        Guard.Against.NullOrWhiteSpace(organizationUrl, nameof(organizationUrl));
-        Guard.Against.NullOrWhiteSpace(token, nameof(token));
-        var logger = _serviceProvider.GetService(typeof(ILogger<TService>)) as ILogger<TService>;
-        Guard.Against.Null(logger);
+    // Each service gets a fresh HttpClient from the factory: instances are cheap wrappers over the
+    // factory's pooled handler chain, which also carries the host's resilience pipeline.
+    private HttpClient CreateHttpClient() => _httpClientFactory.CreateClient(AzureDevOpsHttpClient.Name);
 
-        return typeof(TService) switch
-        {
-            Type type when type == typeof(ProcessService) => (TService)Activator.CreateInstance(typeof(ProcessService), organizationUrl, token, _apiVersion, logger)!,
-            Type type when type == typeof(ProjectService) => (TService)Activator.CreateInstance(typeof(ProjectService), organizationUrl, token, _apiVersion, logger)!,
-            Type type when type == typeof(WorkItemService) => (TService)Activator.CreateInstance(typeof(WorkItemService), organizationUrl, token, _apiVersion, logger)!,
-            Type type when type == typeof(GeneralService) => (TService)Activator.CreateInstance(typeof(GeneralService), organizationUrl, token, _apiVersion, logger)!,
-            _ => throw new NotImplementedException(),
-        };
-    }
+    private GeneralService CreateGeneralService(AzureDevOpsConnectionContext connection) =>
+        new(CreateHttpClient(), connection.OrganizationUrl, connection.PersonalAccessToken, _apiVersion, _loggerFactory.CreateLogger<GeneralService>());
+
+    private ProcessService CreateProcessService(AzureDevOpsConnectionContext connection) =>
+        new(CreateHttpClient(), connection.OrganizationUrl, connection.PersonalAccessToken, _apiVersion, _loggerFactory.CreateLogger<ProcessService>());
+
+    private ProjectService CreateProjectService(AzureDevOpsConnectionContext connection) =>
+        new(CreateHttpClient(), connection.OrganizationUrl, connection.PersonalAccessToken, _apiVersion, _loggerFactory.CreateLogger<ProjectService>());
+
+    private WorkItemService CreateWorkItemService(AzureDevOpsConnectionContext connection) =>
+        new(CreateHttpClient(), connection.OrganizationUrl, connection.PersonalAccessToken, _apiVersion, _loggerFactory.CreateLogger<WorkItemService>());
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/BaseClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/BaseClient.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Ardalis.GuardClauses;
 using Wayd.Integrations.AzureDevOps.Extensions;
 using Wayd.Integrations.AzureDevOps.Models.Converters;
@@ -7,15 +7,25 @@ using RestSharp.Serializers.Json;
 
 namespace Wayd.Integrations.AzureDevOps.Clients;
 
-internal abstract class BaseClient : IDisposable
+internal abstract class BaseClient
 {
     protected readonly RestClient _client;
     protected readonly string _token;
     protected readonly string _apiVersion;
 
-    // TODO: add retry logic (with Polly?)
-    internal BaseClient(string organizationUrl, string token, string apiVersion)
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
     {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new ReportingWorkItemLinkResponseConverter() }
+    };
+
+    // The HttpClient must come from IHttpClientFactory (the AzureDevOpsHttpClient.Name named client):
+    // the factory owns handler pooling/lifetime and applies the host's resilience pipeline
+    // (retry honoring Retry-After, timeouts, circuit breaker). RestClient here is a thin per-request
+    // wrapper over that shared handler chain and intentionally does not own or dispose the HttpClient.
+    internal BaseClient(HttpClient httpClient, string organizationUrl, string token, string apiVersion)
+    {
+        Guard.Against.Null(httpClient, nameof(httpClient));
         Guard.Against.NullOrWhiteSpace(organizationUrl, nameof(organizationUrl));
         Guard.Against.NullOrWhiteSpace(token, nameof(token));
         Guard.Against.NullOrWhiteSpace(apiVersion, nameof(apiVersion));
@@ -23,18 +33,9 @@ internal abstract class BaseClient : IDisposable
         _token = token;
         _apiVersion = apiVersion;
 
-        var options = new RestClientOptions(organizationUrl)
-        {
-            Timeout = TimeSpan.FromSeconds(300),
-        };
+        var options = new RestClientOptions(organizationUrl);
 
-        var jsonSerializerOptions = new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            Converters = { new ReportingWorkItemLinkResponseConverter() }
-        };
-
-        _client = new RestClient(options, configureSerialization: s => s.UseSystemTextJson(jsonSerializerOptions));
+        _client = new RestClient(httpClient, options, configureSerialization: s => s.UseSystemTextJson(_jsonSerializerOptions));
     }
 
     protected void SetupRequest(RestRequest request, bool includePreviewTag = false)
@@ -43,9 +44,20 @@ internal abstract class BaseClient : IDisposable
         request.AddAuthorizationHeaderForPersonalAccessToken(_token);
     }
 
-    public void Dispose()
+    // RestSharp's ExecuteAsync never throws for a failed request — including a genuine
+    // cancellation of the caller's token mid-request, which it catches internally and reports as
+    // an unsuccessful response with ErrorException set to the OperationCanceledException, rather
+    // than letting it propagate. Left unchecked, that makes a cancelled sync run indistinguishable
+    // from an ordinary HTTP failure to every caller up the stack (the AzDO services' own
+    // `catch (OperationCanceledException) { throw; }` guards only catch cancellation thrown
+    // directly in their own frame — not one already absorbed a layer down, inside RestSharp).
+    // Re-throwing it here, once, restores real propagation for every client call site.
+    protected async Task<RestResponse<T>> ExecuteAsync<T>(RestRequest request, CancellationToken cancellationToken)
     {
-        _client?.Dispose();
-        GC.SuppressFinalize(this);
+        var response = await _client.ExecuteAsync<T>(request, cancellationToken).ConfigureAwait(false);
+        if (response.ErrorException is OperationCanceledException operationCanceledException)
+            throw operationCanceledException;
+
+        return response;
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/GeneralClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/GeneralClient.cs
@@ -1,12 +1,12 @@
-﻿using Wayd.Integrations.AzureDevOps.Models;
+using Wayd.Integrations.AzureDevOps.Models;
 using RestSharp;
 
 namespace Wayd.Integrations.AzureDevOps.Clients;
 
 internal sealed class GeneralClient : BaseClient
 {
-    internal GeneralClient(string organizationUrl, string token, string apiVersion)
-        : base(organizationUrl, token, apiVersion)
+    internal GeneralClient(HttpClient httpClient, string organizationUrl, string token, string apiVersion)
+        : base(httpClient, organizationUrl, token, apiVersion)
     { }
 
     internal async Task<RestResponse<ConnectionDataResponse>> GetConnectionData(CancellationToken cancellationToken)
@@ -14,7 +14,7 @@ internal sealed class GeneralClient : BaseClient
         var request = new RestRequest("/_apis/connectionData", Method.Get);
         SetupRequest(request, true);  // still in preview only
 
-        return await _client.ExecuteAsync<ConnectionDataResponse>(request, cancellationToken)
+        return await ExecuteAsync<ConnectionDataResponse>(request, cancellationToken)
             .ConfigureAwait(false);
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/ProcessClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/ProcessClient.cs
@@ -1,4 +1,4 @@
-﻿using Wayd.Integrations.AzureDevOps.Models.Contracts;
+using Wayd.Integrations.AzureDevOps.Models.Contracts;
 using Wayd.Integrations.AzureDevOps.Models.Processes;
 using RestSharp;
 
@@ -6,8 +6,8 @@ namespace Wayd.Integrations.AzureDevOps.Clients;
 
 internal sealed class ProcessClient : BaseClient
 {
-    internal ProcessClient(string organizationUrl, string token, string apiVersion)
-        : base(organizationUrl, token, apiVersion)
+    internal ProcessClient(HttpClient httpClient, string organizationUrl, string token, string apiVersion)
+        : base(httpClient, organizationUrl, token, apiVersion)
     { }
 
     internal async Task<RestResponse<AzdoListResponse<ProcessDto>>> GetProcesses(CancellationToken cancellationToken)
@@ -16,7 +16,7 @@ internal sealed class ProcessClient : BaseClient
         SetupRequest(request);
         request.AddParameter("$expand", "projects");
 
-        return await _client.ExecuteAsync<AzdoListResponse<ProcessDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<AzdoListResponse<ProcessDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task<RestResponse<ProcessDto>> GetProcess(Guid processId, CancellationToken cancellationToken)
@@ -25,7 +25,7 @@ internal sealed class ProcessClient : BaseClient
         SetupRequest(request);
         request.AddParameter("$expand", "projects");
 
-        return await _client.ExecuteAsync<ProcessDto>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<ProcessDto>(request, cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task<RestResponse<AzdoListResponse<ProcessWorkItemTypeDto>>> GetWorkItemTypes(Guid processId, CancellationToken cancellationToken)
@@ -36,7 +36,7 @@ internal sealed class ProcessClient : BaseClient
 
         // there seems to be a bug in the API when including states that duplicates hidden states
 
-        return await _client.ExecuteAsync<AzdoListResponse<ProcessWorkItemTypeDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<AzdoListResponse<ProcessWorkItemTypeDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task<RestResponse<AzdoListResponse<ProcessWorkItemStateDto>>> GetWorkItemTypeStates(Guid processId, string workItemTypeReferenceName, CancellationToken cancellationToken)
@@ -44,7 +44,7 @@ internal sealed class ProcessClient : BaseClient
         var request = new RestRequest($"/_apis/work/processes/{processId}/workitemtypes/{workItemTypeReferenceName}/states", Method.Get);
         SetupRequest(request);
 
-        return await _client.ExecuteAsync<AzdoListResponse<ProcessWorkItemStateDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<AzdoListResponse<ProcessWorkItemStateDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task<RestResponse<AzdoListResponse<BehaviorDto>>> GetBehaviors(Guid processId, CancellationToken cancellationToken)
@@ -52,6 +52,6 @@ internal sealed class ProcessClient : BaseClient
         var request = new RestRequest($"/_apis/work/processes/{processId}/behaviors", Method.Get);
         SetupRequest(request);
 
-        return await _client.ExecuteAsync<AzdoListResponse<BehaviorDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<AzdoListResponse<BehaviorDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/ProjectClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/ProjectClient.cs
@@ -1,4 +1,4 @@
-﻿using Wayd.Integrations.AzureDevOps.Models;
+using Wayd.Integrations.AzureDevOps.Models;
 using Wayd.Integrations.AzureDevOps.Models.Contracts;
 using Wayd.Integrations.AzureDevOps.Models.Projects;
 using RestSharp;
@@ -7,8 +7,8 @@ namespace Wayd.Integrations.AzureDevOps.Clients;
 
 internal sealed class ProjectClient : BaseClient
 {
-    internal ProjectClient(string organizationUrl, string token, string apiVersion)
-        : base(organizationUrl, token, apiVersion)
+    internal ProjectClient(HttpClient httpClient, string organizationUrl, string token, string apiVersion)
+        : base(httpClient, organizationUrl, token, apiVersion)
     { }
 
     internal async Task<RestResponse<AzdoListResponse<ProjectDto>>> GetProjects(int top, int skip, CancellationToken cancellationToken)
@@ -18,7 +18,7 @@ internal sealed class ProjectClient : BaseClient
         request.AddParameter("$top", top);
         request.AddParameter("$skip", skip);
 
-        return await _client.ExecuteAsync<AzdoListResponse<ProjectDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<AzdoListResponse<ProjectDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task<RestResponse<ProjectDto>> GetProject(string projectIdOrName, CancellationToken cancellationToken)
@@ -26,7 +26,7 @@ internal sealed class ProjectClient : BaseClient
         var request = new RestRequest($"/_apis/projects/{projectIdOrName}", Method.Get);
         SetupRequest(request);
 
-        return await _client.ExecuteAsync<ProjectDto>(request, cancellationToken);
+        return await ExecuteAsync<ProjectDto>(request, cancellationToken).ConfigureAwait(false);
     }
 
     internal async Task<RestResponse<ListResponse<PropertyDto>>> GetProjectProperties(Guid projectId, CancellationToken cancellationToken)
@@ -35,15 +35,17 @@ internal sealed class ProjectClient : BaseClient
         SetupRequest(request, true);
         request.AddParameter("keys", "System.ProcessTemplateType");
 
-        return await _client.ExecuteAsync<ListResponse<PropertyDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<ListResponse<PropertyDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 
-    internal async Task<RestResponse<ListResponse<TeamDto>>> GetProjectTeams(Guid projectId, CancellationToken cancellationToken)
+    internal async Task<RestResponse<ListResponse<TeamDto>>> GetProjectTeams(Guid projectId, int top, int skip, CancellationToken cancellationToken)
     {
         var request = new RestRequest($"/_apis/projects/{projectId}/teams", Method.Get);
         SetupRequest(request);
+        request.AddParameter("$top", top);
+        request.AddParameter("$skip", skip);
 
-        return await _client.ExecuteAsync<ListResponse<TeamDto>>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<ListResponse<TeamDto>>(request, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -58,7 +60,7 @@ internal sealed class ProjectClient : BaseClient
         var request = new RestRequest($"/{projectId}/{teamId}/_apis/work/teamsettings", Method.Get);
         SetupRequest(request);
 
-        return await _client.ExecuteAsync<TeamSettingsResponse>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<TeamSettingsResponse>(request, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -73,7 +75,7 @@ internal sealed class ProjectClient : BaseClient
         SetupRequest(request);
         request.AddParameter("$depth", 100); // TODO: make this configurable
 
-        return await _client.ExecuteAsync<ClassificationNodeResponse>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<ClassificationNodeResponse>(request, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -88,6 +90,6 @@ internal sealed class ProjectClient : BaseClient
         SetupRequest(request);
         request.AddParameter("$depth", 100); // TODO: make this configurable
 
-        return await _client.ExecuteAsync<IterationNodeResponse>(request, cancellationToken).ConfigureAwait(false);
+        return await ExecuteAsync<IterationNodeResponse>(request, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/WorkItemClient.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Clients/WorkItemClient.cs
@@ -1,5 +1,6 @@
 ﻿using Ardalis.GuardClauses;
 using Wayd.Common.Extensions;
+using Wayd.Integrations.AzureDevOps.Extensions;
 using Wayd.Integrations.AzureDevOps.Models;
 using Wayd.Integrations.AzureDevOps.Models.WorkItems;
 using RestSharp;
@@ -8,11 +9,11 @@ namespace Wayd.Integrations.AzureDevOps.Clients;
 
 internal sealed class WorkItemClient : BaseClient
 {
-    internal WorkItemClient(string organizationUrl, string token, string apiVersion)
-        : base(organizationUrl, token, apiVersion)
+    internal WorkItemClient(HttpClient httpClient, string organizationUrl, string token, string apiVersion)
+        : base(httpClient, organizationUrl, token, apiVersion)
     { }
 
-    internal async Task<int[]> GetWorkItemIds(string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
+    internal async Task<int[]> GetWorkItemIds(string projectName, DateTime lastChangedDate, string[] workItemTypes, bool excludeWorkItemTypes, CancellationToken cancellationToken)
     {
         Guard.Against.NullOrWhiteSpace(projectName, nameof(projectName));
 
@@ -27,14 +28,14 @@ internal sealed class WorkItemClient : BaseClient
         List<int> workItemIds = [];
         while (true)
         {
-            var wiql = CreateWiqlQueryForSync(projectName, lastChangedDate, workItemTypes, startingId);
+            var wiql = CreateWiqlQueryForSync(projectName, lastChangedDate, workItemTypes, startingId, excludeWorkItemTypes);
 
             request.AddJsonBody(wiql);
 
-            var response = await _client.ExecuteAsync<WiqlResponse>(request, cancellationToken).ConfigureAwait(false);
+            var response = await ExecuteAsync<WiqlResponse>(request, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessful)
             {
-                throw new Exception($"Error getting work item ids for project {projectName} from Azure DevOps: {response.ErrorMessage}");
+                throw new Exception($"Error getting work item ids for project {projectName} from Azure DevOps: {response.GetErrorText()}");
             }
             else if (response.Data?.WorkItems is null || response.Data.WorkItems.Count == 0)
             {
@@ -74,16 +75,18 @@ internal sealed class WorkItemClient : BaseClient
         foreach (var batch in batches)
         {
             request.AddJsonBody(WorkItemsBatchRequest.Create(batch, fields));
-            var response = await _client.ExecuteAsync<ListResponse<WorkItemResponse>>(request, cancellationToken).ConfigureAwait(false);
+            var response = await ExecuteAsync<ListResponse<WorkItemResponse>>(request, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessful)
             {
-                throw new Exception($"Error getting work items for project {projectName} from Azure DevOps: {response.ErrorMessage}");
+                throw new Exception($"Error getting work items for project {projectName} from Azure DevOps: {response.GetErrorText()}");
             }
-            else if (response.Data is null || response.Data.Count == 0)
+            else if (response.Data is null)
             {
-                throw new Exception($"Successful response, but no work items returned for project {projectName} from Azure DevOps");
+                throw new Exception($"Successful response, but no work item data returned for project {projectName} from Azure DevOps");
             }
 
+            // An empty batch is legitimate under errorPolicy=omit: every id in it was deleted
+            // between the WIQL query and this fetch.
             workItems.AddRange(response.Data.Value);
 
             var bodyParameter = request.Parameters.OfType<BodyParameter>().Single();
@@ -128,11 +131,11 @@ internal sealed class WorkItemClient : BaseClient
                 request.AddQueryParameter("continuationToken", continuationToken);
             }
 
-            var response = await _client.ExecuteAsync<BatchResponse<ReportingWorkItemLinkResponse>>(request, cancellationToken).ConfigureAwait(false);
+            var response = await ExecuteAsync<BatchResponse<ReportingWorkItemLinkResponse>>(request, cancellationToken).ConfigureAwait(false);
 
             if (!response.IsSuccessful)
             {
-                throw new Exception($"Error getting work item link changes for project {projectName} from Azure DevOps: {response.ErrorMessage}");
+                throw new Exception($"Error getting work item link changes for project {projectName} from Azure DevOps: {response.GetErrorText()}");
             }
             else if (response.Data?.Values is null)
             {
@@ -146,8 +149,15 @@ internal sealed class WorkItemClient : BaseClient
                 break;
             }
 
-            // TODO: does this value change after each continuation?
-            continuationToken = response.Data?.ContinuationToken;
+            // A non-final batch must advance the watermark token; re-issuing the same request
+            // would loop forever on the same page, so treat a stalled token as a protocol error.
+            var nextContinuationToken = response.Data.ContinuationToken;
+            if (string.IsNullOrEmpty(nextContinuationToken) || nextContinuationToken == continuationToken)
+            {
+                throw new Exception($"Error getting work item link changes for project {projectName} from Azure DevOps: continuation token did not advance (token: '{nextContinuationToken}').");
+            }
+
+            continuationToken = nextContinuationToken;
         }
 
         return workItemLinks;
@@ -160,23 +170,27 @@ internal sealed class WorkItemClient : BaseClient
         var request = new RestRequest($"/{projectName}/_apis/wit/recyclebin", Method.Get);
         SetupRequest(request);
 
-        var response = await _client.ExecuteAsync<ListResponse<WiqlWorkItemResponse>>(request, cancellationToken).ConfigureAwait(false);
+        var response = await ExecuteAsync<ListResponse<WiqlWorkItemResponse>>(request, cancellationToken).ConfigureAwait(false);
 
         return response.IsSuccessful
             ? response.Data?.Value.Select(w => w.Id).ToArray() ?? []
-            : throw new Exception($"Error getting deleted work item ids for project {projectName} from Azure DevOps: {response.ErrorMessage}");
+            : throw new Exception($"Error getting deleted work item ids for project {projectName} from Azure DevOps: {response.GetErrorText()}");
     }
 
-    private static WiqlRequest CreateWiqlQueryForSync(string project, DateTime dateTime, string[] workItemTypes, int startingId)
+    private static WiqlRequest CreateWiqlQueryForSync(string project, DateTime dateTime, string[] workItemTypes, int startingId, bool excludeWorkItemTypes)
     {
         var workItemTypesFilter = "";
         if (workItemTypes.Length > 0)
         {
-            workItemTypesFilter = $"AND [System.WorkItemType] IN ({string.Join(",", workItemTypes.Select(t => $"\'{t}\'"))})";
+            var typeOperator = excludeWorkItemTypes ? "NOT IN" : "IN";
+            workItemTypesFilter = $"AND [System.WorkItemType] {typeOperator} ({string.Join(",", workItemTypes.Select(t => $"'{EscapeWiqlLiteral(t)}'"))})";
         }
         return new()
         {
-            Query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{project}' AND [System.Id] > {startingId} AND [System.ChangedDate] > '{dateTime:yyyy-MM-ddTHH:mm:ssZ}' {workItemTypesFilter} ORDER BY [System.Id] Asc"
+            Query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{EscapeWiqlLiteral(project)}' AND [System.Id] > {startingId} AND [System.ChangedDate] > '{dateTime:yyyy-MM-ddTHH:mm:ssZ}' {workItemTypesFilter} ORDER BY [System.Id] Asc"
         };
     }
+
+    // WIQL string literals escape embedded single quotes by doubling them.
+    private static string EscapeWiqlLiteral(string value) => value.Replace("'", "''");
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Extensions/RestResponseExtensions.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Extensions/RestResponseExtensions.cs
@@ -1,0 +1,33 @@
+using RestSharp;
+
+namespace Wayd.Integrations.AzureDevOps.Extensions;
+
+internal static class RestResponseExtensions
+{
+    private const int MaxContentLength = 500;
+
+    /// <summary>
+    /// Builds a diagnostic error string from a failed response. RestSharp only populates
+    /// <see cref="RestResponseBase.ErrorMessage"/> for transport-level exceptions; for HTTP-level
+    /// failures the useful detail (status code and the Azure DevOps error body) lives in
+    /// StatusCode/Content, so include all three when present.
+    /// </summary>
+    internal static string GetErrorText(this RestResponse response)
+    {
+        var parts = new List<string>(3)
+        {
+            response.StatusCode == 0 ? "Connection Error" : $"{(int)response.StatusCode} {response.StatusDescription}"
+        };
+
+        if (!string.IsNullOrWhiteSpace(response.ErrorMessage))
+            parts.Add(response.ErrorMessage);
+
+        if (!string.IsNullOrWhiteSpace(response.Content))
+        {
+            var content = response.Content.Trim();
+            parts.Add(content.Length <= MaxContentLength ? content : content[..MaxContentLength] + "…");
+        }
+
+        return string.Join(" - ", parts);
+    }
+}

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
 using Wayd.Common.Application.Interfaces.ExternalWork;
 using Wayd.Integrations.AzureDevOps.Models.Contracts;
 using Wayd.Integrations.AzureDevOps.Models.Projects;
@@ -22,7 +23,7 @@ internal static class WorkItemResponseExtensions
 {
     private static readonly double _defaultStackRank = 999_999_999_999D;
 
-    public static AzdoWorkItem ToAzdoWorkItem(this WorkItemResponse workItem, IterationDto iteration)
+    public static AzdoWorkItem ToAzdoWorkItem(this WorkItemResponse workItem, IterationDto? iteration)
     {
         var created = Instant.FromDateTimeOffset(workItem.Fields.CreatedDate);
         Instant? activated = workItem.Fields.ActivatedDate.HasValue ? Instant.FromDateTimeUtc(workItem.Fields.ActivatedDate.Value) : null;
@@ -52,9 +53,9 @@ internal static class WorkItemResponseExtensions
             DoneTimestamp = closed.HasValue
                 ? closed < created ? created : closed
                 : null,
-            TeamId = iteration.TeamId,
-            ExternalTeamIdentifier = iteration.Identifier.ToString(),
-            IterationId = workItem.Fields.IterationId,
+            TeamId = iteration?.TeamId,
+            ExternalTeamIdentifier = iteration?.Identifier.ToString(),
+            IterationId = iteration is not null ? workItem.Fields.IterationId : null,
             StoryPoints = storyPoints,
             Tags = string.IsNullOrWhiteSpace(workItem.Fields.Tags)
                 ? []
@@ -62,13 +63,21 @@ internal static class WorkItemResponseExtensions
         };
     }
 
-    public static List<IExternalWorkItem> ToIExternalWorkItems(this List<WorkItemResponse> workItems, List<IterationDto> iterations)
+    public static List<IExternalWorkItem> ToIExternalWorkItems(this List<WorkItemResponse> workItems, List<IterationDto> iterations, ILogger logger)
     {
         var iterationsDictionary = iterations.ToDictionary(x => x.Id, x => x);
         var result = new List<IExternalWorkItem>(workItems.Count);
         foreach (var workItem in workItems)
         {
-            var iteration = iterationsDictionary[workItem.Fields.IterationId];
+            // System.IterationId is 0 (its default) when Azure DevOps has no iteration assigned to
+            // the work item, and any id can fall outside the iteration tree if it's added after the
+            // iteration cache snapshot within the same sync. Either way, sync the item with a null
+            // iteration/team rather than aborting the whole workspace sync over one work item.
+            if (!iterationsDictionary.TryGetValue(workItem.Fields.IterationId, out var iteration))
+            {
+                logger.LogWarning("Work item {WorkItemId} references iteration {IterationId}, which was not found in the synced iteration set. Syncing without an iteration/team assignment.", workItem.Id, workItem.Fields.IterationId);
+            }
+
             result.Add(workItem.ToAzdoWorkItem(iteration));
         }
         return result;

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemResponse.cs
@@ -70,10 +70,13 @@ internal static class WorkItemResponseExtensions
         foreach (var workItem in workItems)
         {
             // System.IterationId is 0 (its default) when Azure DevOps has no iteration assigned to
-            // the work item, and any id can fall outside the iteration tree if it's added after the
-            // iteration cache snapshot within the same sync. Either way, sync the item with a null
-            // iteration/team rather than aborting the whole workspace sync over one work item.
-            if (!iterationsDictionary.TryGetValue(workItem.Fields.IterationId, out var iteration))
+            // the work item — a routine, high-volume condition for backlog items, not worth a log
+            // line per occurrence. A non-zero id missing from the cache is different: it means an
+            // iteration the work item genuinely references wasn't in the synced set (e.g. added
+            // after the iteration cache snapshot within the same sync), which is worth surfacing.
+            // Either way, sync the item with a null iteration/team rather than aborting the whole
+            // workspace sync over one work item.
+            if (!iterationsDictionary.TryGetValue(workItem.Fields.IterationId, out var iteration) && workItem.Fields.IterationId != 0)
             {
                 logger.LogWarning("Work item {WorkItemId} references iteration {IterationId}, which was not found in the synced iteration set. Syncing without an iteration/team assignment.", workItem.Id, workItem.Fields.IterationId);
             }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemsBatchRequest.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Models/WorkItems/WorkItemsBatchRequest.cs
@@ -11,6 +11,13 @@ internal sealed record WorkItemsBatchRequest
     [DataMember]
     public int[] Ids { get; set; } = [];
 
+    // The API's default error policy is "fail", which rejects the ENTIRE batch when any requested
+    // id no longer exists — a real race during sync, since ids come from an earlier WIQL query and
+    // work items can be deleted in between. "omit" returns the survivors and skips the rest;
+    // deletions are reconciled separately via GetDeletedWorkItemIds.
+    [DataMember]
+    public string ErrorPolicy { get; set; } = "omit";
+
     public static WorkItemsBatchRequest Create(IEnumerable<int> ids, IEnumerable<string> fields)
     {
         return new WorkItemsBatchRequest

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/GeneralService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/GeneralService.cs
@@ -1,13 +1,14 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 using Wayd.Integrations.AzureDevOps.Clients;
+using Wayd.Integrations.AzureDevOps.Extensions;
 using Wayd.Integrations.AzureDevOps.Models;
 
 namespace Wayd.Integrations.AzureDevOps.Services;
 
-internal sealed class GeneralService(string organizationUrl, string token, string apiVersion, ILogger<GeneralService> logger)
+internal sealed class GeneralService(HttpClient httpClient, string organizationUrl, string token, string apiVersion, ILogger<GeneralService> logger)
 {
-    private readonly GeneralClient _generalClient = new(organizationUrl, token, apiVersion);
+    private readonly GeneralClient _generalClient = new(httpClient, organizationUrl, token, apiVersion);
     private readonly ILogger<GeneralService> _logger = logger;
 
     public async Task<Result<ConnectionDataResponse?>> GetConnectionData(CancellationToken cancellationToken)
@@ -17,8 +18,8 @@ internal sealed class GeneralService(string organizationUrl, string token, strin
             var response = await _generalClient.GetConnectionData(cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessful)
             {
-                _logger.LogError("Error getting connection data from Azure DevOps: {ErrorMessage}.", response.ErrorMessage);
-                return Result.Failure<ConnectionDataResponse?>(response.ErrorMessage);
+                _logger.LogError("Error getting connection data from Azure DevOps: {ErrorMessage}.", response.GetErrorText());
+                return Result.Failure<ConnectionDataResponse?>(response.GetErrorText());
             }
             else if (response.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
             {
@@ -31,10 +32,17 @@ internal sealed class GeneralService(string organizationUrl, string token, strin
 
             return response.Data;
         }
+        catch (OperationCanceledException)
+        {
+            // A genuine cancellation (caller's token fired) is not a sync failure — let it
+            // propagate so the caller's cancellation handling (e.g. marking a sync run
+            // cancelled rather than partially failed) actually runs.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting connection data from Azure DevOps.");
-            return Result.Failure<ConnectionDataResponse?>(ex.ToString());
+            return Result.Failure<ConnectionDataResponse?>(ex.Message);
         }
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/ProcessService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/ProcessService.cs
@@ -2,14 +2,15 @@
 using CSharpFunctionalExtensions;
 using Microsoft.Extensions.Logging;
 using Wayd.Integrations.AzureDevOps.Clients;
+using Wayd.Integrations.AzureDevOps.Extensions;
 using Wayd.Integrations.AzureDevOps.Models.Contracts;
 using Wayd.Integrations.AzureDevOps.Models.Processes;
 
 namespace Wayd.Integrations.AzureDevOps.Services;
 
-internal sealed class ProcessService(string organizationUrl, string token, string apiVersion, ILogger<ProcessService> logger)
+internal sealed class ProcessService(HttpClient httpClient, string organizationUrl, string token, string apiVersion, ILogger<ProcessService> logger)
 {
-    private readonly ProcessClient _processClient = new(organizationUrl, token, apiVersion);
+    private readonly ProcessClient _processClient = new(httpClient, organizationUrl, token, apiVersion);
     private readonly ILogger<ProcessService> _logger = logger;
 
     public async Task<Result<List<AzdoWorkProcess>>> GetProcesses(CancellationToken cancellationToken)
@@ -19,8 +20,8 @@ internal sealed class ProcessService(string organizationUrl, string token, strin
             var response = await _processClient.GetProcesses(cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessful)
             {
-                _logger.LogError("Error getting processes from Azure DevOps: {ErrorMessage}.", response.ErrorMessage);
-                return Result.Failure<List<AzdoWorkProcess>>(response.ErrorMessage);
+                _logger.LogError("Error getting processes from Azure DevOps: {ErrorMessage}.", response.GetErrorText());
+                return Result.Failure<List<AzdoWorkProcess>>(response.GetErrorText());
             }
             else if (response.StatusCode == System.Net.HttpStatusCode.NonAuthoritativeInformation)
             {
@@ -35,10 +36,17 @@ internal sealed class ProcessService(string organizationUrl, string token, strin
 
             return Result.Success(processes);
         }
+        catch (OperationCanceledException)
+        {
+            // A genuine cancellation (caller's token fired) is not a sync failure — let it
+            // propagate so the caller's cancellation handling (e.g. marking a sync run
+            // cancelled rather than partially failed) actually runs.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting processes from Azure DevOps.");
-            return Result.Failure<List<AzdoWorkProcess>>(ex.ToString());
+            return Result.Failure<List<AzdoWorkProcess>>(ex.Message);
         }
     }
 
@@ -60,10 +68,14 @@ internal sealed class ProcessService(string organizationUrl, string token, strin
 
             return Result.Success(processResult.Value.ToAzdoWorkProcessDetails(behaviorsResult.Value, workTypesResult.Value));
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting process {ProcessId} from Azure DevOps.", processId);
-            return Result.Failure<AzdoWorkProcessConfiguration>(ex.ToString());
+            return Result.Failure<AzdoWorkProcessConfiguration>(ex.Message);
         }
     }
 
@@ -95,8 +107,8 @@ internal sealed class ProcessService(string organizationUrl, string token, strin
         var response = await _processClient.GetBehaviors(processId, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessful)
         {
-            _logger.LogError("Error getting behaviors for process {ProcessId} from Azure DevOps: {ErrorMessage}.", processId, response.ErrorMessage);
-            return Result.Failure<List<BehaviorDto>>(response.ErrorMessage);
+            _logger.LogError("Error getting behaviors for process {ProcessId} from Azure DevOps: {ErrorMessage}.", processId, response.GetErrorText());
+            return Result.Failure<List<BehaviorDto>>(response.GetErrorText());
         }
 
         if (_logger.IsEnabled(LogLevel.Debug))
@@ -110,8 +122,8 @@ internal sealed class ProcessService(string organizationUrl, string token, strin
         var response = await _processClient.GetWorkItemTypes(processId, cancellationToken).ConfigureAwait(false);
         if (!response.IsSuccessful)
         {
-            _logger.LogError("Error getting work item types for process {ProcessId} from Azure DevOps: {ErrorMessage}.", processId, response.ErrorMessage);
-            return Result.Failure<List<ProcessWorkItemTypeDto>>(response.ErrorMessage);
+            _logger.LogError("Error getting work item types for process {ProcessId} from Azure DevOps: {ErrorMessage}.", processId, response.GetErrorText());
+            return Result.Failure<List<ProcessWorkItemTypeDto>>(response.GetErrorText());
         }
 
         if (_logger.IsEnabled(LogLevel.Debug))

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/ProjectService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/ProjectService.cs
@@ -5,16 +5,21 @@ using Wayd.Common.Application.Interfaces.ExternalWork;
 using Wayd.Common.Application.Logging;
 using Wayd.Common.Extensions;
 using Wayd.Integrations.AzureDevOps.Clients;
+using Wayd.Integrations.AzureDevOps.Extensions;
 using Wayd.Integrations.AzureDevOps.Models;
 using Wayd.Integrations.AzureDevOps.Models.Projects;
 
 namespace Wayd.Integrations.AzureDevOps.Services;
 
-internal sealed class ProjectService(string organizationUrl, string token, string apiVersion, ILogger<ProjectService> logger)
+internal sealed class ProjectService(HttpClient httpClient, string organizationUrl, string token, string apiVersion, ILogger<ProjectService> logger)
 {
-    private readonly ProjectClient _projectClient = new(organizationUrl, token, apiVersion);
+    private readonly ProjectClient _projectClient = new(httpClient, organizationUrl, token, apiVersion);
     private readonly ILogger<ProjectService> _logger = logger;
     private readonly int _maxBatchSize = 100;
+
+    // Deliberately small: enough to collapse the per-team settings N+1 without bursting against
+    // Azure DevOps throttling or competing with interactive traffic on the API host.
+    private readonly int _teamSettingsMaxConcurrency = 4;
 
     /// <summary>
     /// Retrieves a list of projects from Azure DevOps in batches.
@@ -36,8 +41,8 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
                 var batch = await _projectClient.GetProjects(top: _maxBatchSize, skip: projects.Count, cancellationToken).ConfigureAwait(false);
                 if (!batch.IsSuccessful)
                 {
-                    _logger.LogError("Error getting projects from Azure DevOps: {ErrorMessage}.", batch.ErrorMessage);
-                    return Result.Failure<List<ProjectDto>>(batch.ErrorMessage);
+                    _logger.LogError("Error getting projects from Azure DevOps: {ErrorMessage}.", batch.GetErrorText());
+                    return Result.Failure<List<ProjectDto>>(batch.GetErrorText());
                 }
 
                 if (batch.Data is null)
@@ -54,10 +59,17 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
 
             return projects;
         }
+        catch (OperationCanceledException)
+        {
+            // A genuine cancellation (caller's token fired) is not a sync failure — let it
+            // propagate so the caller's cancellation handling (e.g. marking a sync run
+            // cancelled rather than partially failed) actually runs.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting projects from Azure DevOps");
-            return Result.Failure<List<ProjectDto>>(ex.ToString());
+            return Result.Failure<List<ProjectDto>>(ex.Message);
         }
     }
 
@@ -107,10 +119,14 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
 
             return ProjectDetailsDto.Create(projectResponse.Data, [.. propertiesResponse.Data.Value]);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting project {ProjectId} from Azure DevOps", projectIdOrName);
-            return Result.Failure<ProjectDetailsDto>(ex.ToString());
+            return Result.Failure<ProjectDetailsDto>(ex.Message);
         }
     }
 
@@ -138,47 +154,85 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
             foreach (var id in projectIds)
             {
                 currentProjectId = id;
-                var response = await _projectClient.GetProjectTeams(id, cancellationToken).ConfigureAwait(false);
-                if (!response.IsSuccessful)
+
+                // The teams endpoint caps results (default 100), so page like GetProjects does.
+                List<TeamDto> projectTeams = [];
+                while (true)
                 {
-                    _logger.LogError("Error getting teams for project {ProjectId} from Azure DevOps: {ErrorMessage}.", id, response.ErrorMessage);
-                    return Result.Failure<List<IExternalTeam>>($"Error getting teams for project {id} from Azure DevOps"); // each project should have at least one team
+                    var response = await _projectClient.GetProjectTeams(id, top: _maxBatchSize, skip: projectTeams.Count, cancellationToken).ConfigureAwait(false);
+                    if (!response.IsSuccessful)
+                    {
+                        _logger.LogError("Error getting teams for project {ProjectId} from Azure DevOps: {ErrorMessage}.", id, response.GetErrorText());
+                        return Result.Failure<List<IExternalTeam>>($"Error getting teams for project {id} from Azure DevOps"); // each project should have at least one team
+                    }
+
+                    if (response.Data is null)
+                        break;
+
+                    projectTeams.AddRange(response.Data.Value);
+
+                    if (response.Data.Value.Count < _maxBatchSize)
+                        break;
                 }
-                if (response.Data is null)
+
+                if (projectTeams.Count == 0)
                 {
                     if (_logger.IsEnabled(LogLevel.Debug))
                         _logger.LogDebug("No teams found for project {ProjectId}.", id);
                     return Result.Failure<List<IExternalTeam>>($"Error getting teams for project {id} from Azure DevOps"); // each project should have at least one team
                 }
 
-                // set team settings: boardId
-                foreach (var team in response.Data.Value)
+                // Fetch team settings (backlog iteration → boardId) with bounded concurrency. The calls
+                // are independent I/O-bound lookups, so the parallelism costs no thread-pool capacity
+                // while awaiting; the small degree keeps the burst polite to both Azure DevOps
+                // throttling and the API host serving interactive traffic. Results land in a slot per
+                // team to keep the output order deterministic; a failed settings lookup skips just
+                // that team, matching the previous sequential behavior.
+                var teamSlots = new IExternalTeam?[projectTeams.Count];
+                var parallelOptions = new ParallelOptions
                 {
-                    var teamSettingsResponse = await _projectClient.GetProjectTeamsSettings(id, team.Id, cancellationToken).ConfigureAwait(false);
+                    MaxDegreeOfParallelism = _teamSettingsMaxConcurrency,
+                    CancellationToken = cancellationToken
+                };
+
+                await Parallel.ForEachAsync(Enumerable.Range(0, projectTeams.Count), parallelOptions, async (index, ct) =>
+                {
+                    var team = projectTeams[index];
+                    var teamSettingsResponse = await _projectClient.GetProjectTeamsSettings(id, team.Id, ct).ConfigureAwait(false);
                     if (!teamSettingsResponse.IsSuccessful)
                     {
-                        _logger.LogError("Error getting team settings for team {TeamId} in project {ProjectId} from Azure DevOps: {ErrorMessage}.", team.Id, id, teamSettingsResponse.ErrorMessage);
-                        continue;
+                        _logger.LogError("Error getting team settings for team {TeamId} in project {ProjectId} from Azure DevOps: {ErrorMessage}.", team.Id, id, teamSettingsResponse.GetErrorText());
+                        return;
                     }
                     if (teamSettingsResponse.Data is null)
                     {
                         _logger.LogWarning("No team settings found for team {TeamId} in project {ProjectId}.", team.Id, id);
-                        continue;
+                        return;
                     }
 
-                    teams.Add(team.ToAzdoTeam(id, teamSettingsResponse.Data.BacklogIteration?.Id));
+                    teamSlots[index] = team.ToAzdoTeam(id, teamSettingsResponse.Data.BacklogIteration?.Id);
+                }).ConfigureAwait(false);
+
+                foreach (var team in teamSlots)
+                {
+                    if (team is not null)
+                        teams.Add(team);
                 }
 
                 if (_logger.IsEnabled(LogLevel.Debug))
-                    _logger.LogDebug("{TeamCount} teams found for project {ProjectId}.", response.Data.Value.Count, id);
+                    _logger.LogDebug("{TeamCount} teams found for project {ProjectId}.", projectTeams.Count, id);
             }
 
             return teams;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting teams for project {ProjectId} from Azure DevOps", currentProjectId);
-            return Result.Failure<List<IExternalTeam>>(ex.ToString());
+            return Result.Failure<List<IExternalTeam>>(ex.Message);
         }
     }
 
@@ -200,8 +254,8 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
             var response = await _projectClient.GetAreaPaths(projectName, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessful)
             {
-                _logger.LogError("Error getting areas for project {ProjectId} from Azure DevOps: {ErrorMessage}.", projectName, response.ErrorMessage);
-                return Result.Failure<List<ClassificationNodeResponse>>(response.ErrorMessage);
+                _logger.LogError("Error getting areas for project {ProjectId} from Azure DevOps: {ErrorMessage}.", projectName, response.GetErrorText());
+                return Result.Failure<List<ClassificationNodeResponse>>(response.GetErrorText());
             }
             if (response.Data is null)
             {
@@ -216,10 +270,14 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
 
             return areaPaths;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting areas for project {ProjectId} from Azure DevOps", projectName);
-            return Result.Failure<List<ClassificationNodeResponse>>(ex.ToString());
+            return Result.Failure<List<ClassificationNodeResponse>>(ex.Message);
         }
     }
 
@@ -243,8 +301,8 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
             var response = await _projectClient.GetIterationPaths(projectName, cancellationToken).ConfigureAwait(false);
             if (!response.IsSuccessful)
             {
-                _logger.LogError("Error getting iterations for project {ProjectId} from Azure DevOps: {ErrorMessage}.", projectName, response.ErrorMessage);
-                return Result.Failure<List<IterationDto>>(response.ErrorMessage);
+                _logger.LogError("Error getting iterations for project {ProjectId} from Azure DevOps: {ErrorMessage}.", projectName, response.GetErrorText());
+                return Result.Failure<List<IterationDto>>(response.GetErrorText());
             }
             if (response.Data is null)
             {
@@ -261,10 +319,14 @@ internal sealed class ProjectService(string organizationUrl, string token, strin
 
             return iterations;
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting iterations for project {ProjectId} from Azure DevOps", projectName);
-            return Result.Failure<List<IterationDto>>(ex.ToString());
+            return Result.Failure<List<IterationDto>>(ex.Message);
         }
     }
 

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/WorkItemService.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Services/WorkItemService.cs
@@ -5,16 +5,16 @@ using Wayd.Integrations.AzureDevOps.Models.WorkItems;
 
 namespace Wayd.Integrations.AzureDevOps.Services;
 
-internal sealed class WorkItemService(string organizationUrl, string token, string apiVersion, ILogger<WorkItemService> logger)
+internal sealed class WorkItemService(HttpClient httpClient, string organizationUrl, string token, string apiVersion, ILogger<WorkItemService> logger)
 {
-    private readonly WorkItemClient _workItemClient = new(organizationUrl, token, apiVersion);
+    private readonly WorkItemClient _workItemClient = new(httpClient, organizationUrl, token, apiVersion);
     private readonly ILogger<WorkItemService> _logger = logger;
 
     public async Task<Result<List<WorkItemResponse>>> GetWorkItems(string projectName, DateTime lastChangedDate, string[] workItemTypes, CancellationToken cancellationToken)
     {
         try
         {
-            var workItemIds = await _workItemClient.GetWorkItemIds(projectName, lastChangedDate, workItemTypes, cancellationToken).ConfigureAwait(false);
+            var workItemIds = await _workItemClient.GetWorkItemIds(projectName, lastChangedDate, workItemTypes, excludeWorkItemTypes: false, cancellationToken).ConfigureAwait(false);
 
             if (_logger.IsEnabled(LogLevel.Debug))
                 _logger.LogDebug("{WorkItemIdCount} work item ids found for project {Project}", workItemIds.Length, projectName);
@@ -56,10 +56,17 @@ internal sealed class WorkItemService(string organizationUrl, string token, stri
 
             return Result.Success(workitems);
         }
+        catch (OperationCanceledException)
+        {
+            // A genuine cancellation (caller's token fired) is not a sync failure — let it
+            // propagate so the caller's cancellation handling (e.g. marking a sync run
+            // cancelled rather than partially failed) actually runs.
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting work items for project {Project} from Azure DevOps", projectName);
-            return Result.Failure<List<WorkItemResponse>>(ex.ToString());
+            return Result.Failure<List<WorkItemResponse>>(ex.Message);
         }
     }
 
@@ -76,10 +83,14 @@ internal sealed class WorkItemService(string organizationUrl, string token, stri
 
             return Result.Success(links);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting parent link changes for project {Project} from Azure DevOps", projectName);
-            return Result.Failure<List<ReportingWorkItemLinkResponse>>(ex.ToString());
+            return Result.Failure<List<ReportingWorkItemLinkResponse>>(ex.Message);
         }
     }
 
@@ -96,37 +107,47 @@ internal sealed class WorkItemService(string organizationUrl, string token, stri
 
             return Result.Success(links);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Exception thrown getting parent link changes for project {Project} from Azure DevOps", projectName);
-            return Result.Failure<List<ReportingWorkItemLinkResponse>>(ex.ToString());
+            _logger.LogError(ex, "Exception thrown getting dependency link changes for project {Project} from Azure DevOps", projectName);
+            return Result.Failure<List<ReportingWorkItemLinkResponse>>(ex.Message);
         }
     }
 
-    public async Task<Result<int[]>> GetDeletedWorkItemIds(string projectName, DateTime lastChangedDate, CancellationToken cancellationToken)
+    public async Task<Result<int[]>> GetDeletedWorkItemIds(string projectName, DateTime lastChangedDate, string[] syncedWorkItemTypes, CancellationToken cancellationToken)
     {
         try
         {
-            int[] workItemIds = await _workItemClient.GetDeletedWorkItemIds(projectName, cancellationToken).ConfigureAwait(false);
+            int[] recycleBinIds = await _workItemClient.GetDeletedWorkItemIds(projectName, cancellationToken).ConfigureAwait(false);
 
-            // TODO: make this configurable and better.
-            // We are trying to solve for the scenario where a work item is synced, but then later
-            // changes to a work item type that is not being synced.
-            int[] noneSyncedIds = await _workItemClient.GetWorkItemIds(projectName, lastChangedDate, ["Task", "Issue"], cancellationToken).ConfigureAwait(false);
+            // A work item that changed to a type outside the synced set looks "deleted" from the
+            // workspace's perspective. Querying NOT IN over the synced types catches every other
+            // type — including custom types in inherited processes — without maintaining a list of
+            // non-synced type names. With no type filter every type is synced, so only the recycle
+            // bin applies.
+            int[] typeChangedIds = syncedWorkItemTypes.Length > 0
+                ? await _workItemClient.GetWorkItemIds(projectName, lastChangedDate, syncedWorkItemTypes, excludeWorkItemTypes: true, cancellationToken).ConfigureAwait(false)
+                : [];
 
-            int[] deletedWorkItemIds = new int[workItemIds.Length + noneSyncedIds.Length];
-            Array.Copy(workItemIds, 0, deletedWorkItemIds, 0, workItemIds.Length);
-            Array.Copy(noneSyncedIds, 0, deletedWorkItemIds, workItemIds.Length, noneSyncedIds.Length);
+            int[] deletedWorkItemIds = [.. recycleBinIds.Concat(typeChangedIds).Distinct()];
 
             if (_logger.IsEnabled(LogLevel.Debug))
                 _logger.LogDebug("{WorkItemIdCount} deleted work item ids found for project {Project}", deletedWorkItemIds.Length, projectName);
 
             return Result.Success(deletedWorkItemIds);
         }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Exception thrown getting deleted work item ids for project {Project} from Azure DevOps", projectName);
-            return Result.Failure<int[]>(ex.ToString());
+            return Result.Failure<int[]>(ex.Message);
         }
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Utils/CacheKeyGenerator.cs
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Utils/CacheKeyGenerator.cs
@@ -1,18 +1,13 @@
-﻿using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 
 namespace Wayd.Integrations.AzureDevOps.Utils;
 
 /// <summary>
-/// Generates cache keys for Azure DevOps resources with optimized performance.
-/// Uses an internal cache to avoid repeated SHA256 computations for the same inputs.
+/// Generates deterministic cache keys for Azure DevOps resources.
 /// </summary>
 internal static class CacheKeyGenerator
 {
-    // Cache for the computed cache keys to avoid repeated SHA256 computations
-    private static readonly ConcurrentDictionary<string, string> _cacheKeyCache = new();
-
     /// <summary>
     /// Generates a cache key for Azure DevOps resources.
     /// </summary>
@@ -29,10 +24,12 @@ internal static class CacheKeyGenerator
         Dictionary<Guid, Guid?>? teamSettings,
         string? extra = null)
     {
-        // Normalize organization host (avoid duplicate keys for URL variants)
-        var orgHost = Uri.TryCreate(organizationUrl, UriKind.Absolute, out var uri)
-            ? uri.Host.ToLowerInvariant()
-            : organizationUrl.ToLowerInvariant();
+        // Normalize the organization URL to authority + path (avoid duplicate keys for URL variants).
+        // The path segment MUST be included: on dev.azure.com the organization lives in the path
+        // (https://dev.azure.com/{org}), so a host-only key would collide across organizations.
+        var orgKey = Uri.TryCreate(organizationUrl, UriKind.Absolute, out var uri)
+            ? $"{uri.Authority}{uri.AbsolutePath.TrimEnd('/')}".ToLowerInvariant()
+            : organizationUrl.Trim().TrimEnd('/').ToLowerInvariant();
 
         // Deterministic teamSettings representation
         var teamPart = teamSettings is null || teamSettings.Count == 0
@@ -40,18 +37,11 @@ internal static class CacheKeyGenerator
             : string.Join("|", teamSettings.OrderBy(kvp => kvp.Key)
                                           .Select(kvp => $"{kvp.Key}:{(kvp.Value.HasValue ? kvp.Value.Value.ToString("D") : "null")}"));
 
-        // Build a simple key for the cache key lookup to avoid recomputing the same hash
-        var lookupKey = $"{resourceType}::{orgHost}::{projectIdOrName}::{teamPart}{(extra is null ? string.Empty : "::" + extra)}";
+        // Compact fingerprint for teamSettings + extra params
+        var fingerprintSource = teamPart + (extra is null ? string.Empty : "|" + extra);
+        var fingerprint = ComputeSha256Hex(fingerprintSource);
 
-        // Use GetOrAdd to avoid repeated SHA256 computations for the same inputs
-        return _cacheKeyCache.GetOrAdd(lookupKey, key =>
-        {
-            // Build a compact fingerprint for teamSettings + extra params
-            var fingerprintSource = teamPart + (extra is null ? string.Empty : "|" + extra);
-            var fingerprint = ComputeSha256Hex(fingerprintSource);
-
-            return $"{resourceType}::{orgHost}::{projectIdOrName}::{fingerprint}";
-        });
+        return $"{resourceType}::{orgKey}::{projectIdOrName}::{fingerprint}";
     }
 
     /// <summary>
@@ -59,18 +49,9 @@ internal static class CacheKeyGenerator
     /// </summary>
     private static string ComputeSha256Hex(string input)
     {
-        // Encode once, compute hash via the static API
         var bytes = Encoding.UTF8.GetBytes(input);
         var hash = SHA256.HashData(bytes);
 
         return Convert.ToHexString(hash).ToLowerInvariant();
-    }
-
-    /// <summary>
-    /// Clears the internal cache. Useful for testing or to free memory.
-    /// </summary>
-    internal static void ClearCache()
-    {
-        _cacheKeyCache.Clear();
     }
 }

--- a/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Wayd.Integrations.AzureDevOps.csproj
+++ b/Wayd.Integrations/src/Wayd.Integrations.AzureDevOps/Wayd.Integrations.AzureDevOps.csproj
@@ -4,6 +4,7 @@
         <PackageReference Include="Ardalis.GuardClauses" />
         <PackageReference Include="CSharpFunctionalExtensions" />
         <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
         <PackageReference Include="RestSharp" />
     </ItemGroup>

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.IntegrationTests/Sut/Services/ProcessServiceTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.IntegrationTests/Sut/Services/ProcessServiceTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Wayd.Integrations.AzureDevOps.IntegrationTests.Models;
 using Wayd.Integrations.AzureDevOps.Services;
 using Moq;
@@ -29,6 +29,7 @@ public class ProcessServiceTests
         var expectedLogMessage = $"{expectedCount} processes found.";
 
         var service = new ProcessService(
+            new HttpClient(),
             _azdoOrganizationOptions.OrganizationUrl,
             _azdoOrganizationOptions.PersonalAccessToken,
             _azdoOrganizationOptions.ApiVersion,
@@ -54,6 +55,7 @@ public class ProcessServiceTests
         var expectedBacklogLevelsCount = _processServiceData.GetProcessBacklogLevelsCount;
 
         var service = new ProcessService(
+            new HttpClient(),
             _azdoOrganizationOptions.OrganizationUrl,
             _azdoOrganizationOptions.PersonalAccessToken,
             _azdoOrganizationOptions.ApiVersion,
@@ -80,6 +82,7 @@ public class ProcessServiceTests
         var expectedLogMessage = $"Error getting process {processId} from Azure DevOps: Not Found.";
 
         var service = new ProcessService(
+            new HttpClient(),
             _azdoOrganizationOptions.OrganizationUrl,
             _azdoOrganizationOptions.PersonalAccessToken,
             _azdoOrganizationOptions.ApiVersion,
@@ -116,6 +119,7 @@ public class ProcessServiceTests
         var expectedErrorMessage4 = "Connection Error - The remote certificate is invalid according to the validation procedure: RemoteCertificateNameMismatch";
 
         var service = new ProcessService(
+            new HttpClient(),
             organizationUrl,
             _azdoOrganizationOptions.PersonalAccessToken,
             _azdoOrganizationOptions.ApiVersion,
@@ -150,6 +154,7 @@ public class ProcessServiceTests
         var expectedLogMessage = $"Error getting process {processId} from Azure DevOps: Unauthorized.";
 
         var service = new ProcessService(
+            new HttpClient(),
             _azdoOrganizationOptions.OrganizationUrl,
             personalAccessToken,
             _azdoOrganizationOptions.ApiVersion,

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/FakeHttpClientFactory.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/FakeHttpClientFactory.cs
@@ -1,0 +1,19 @@
+namespace Wayd.Integrations.AzureDevOps.Tests.Support;
+
+/// <summary>
+/// Test double for <see cref="IHttpClientFactory"/> that hands out a new <see cref="HttpClient"/>
+/// per call — mirroring the real factory — all wired to the same <see cref="StubHttpMessageHandler"/>
+/// so tests can assert on every request the service under test issues, however many clients it creates.
+/// </summary>
+public sealed class FakeHttpClientFactory(StubHttpMessageHandler handler) : IHttpClientFactory
+{
+    public int CreateClientCallCount { get; private set; }
+
+    public HttpClient CreateClient(string name)
+    {
+        CreateClientCallCount++;
+        // disposeHandler: false — the shared handler must outlive any one HttpClient, same as the
+        // real factory's pooled handler behind named clients.
+        return new HttpClient(handler, disposeHandler: false);
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/FakeLogger.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/FakeLogger.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Logging;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Support;
+
+/// <summary>
+/// Minimal <see cref="ILogger"/> double that records each logged entry's level and rendered
+/// message, for tests that assert on whether (and at what level) something was logged.
+/// </summary>
+public sealed class FakeLogger : ILogger
+{
+    public List<(LogLevel Level, string Message)> Entries { get; } = [];
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+    {
+        Entries.Add((logLevel, formatter(state, exception)));
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/FakeMemoryCache.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/FakeMemoryCache.cs
@@ -1,0 +1,64 @@
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Support;
+
+/// <summary>
+/// Minimal in-memory <see cref="IMemoryCache"/> double: enough of the real semantics (get/set,
+/// absolute expiration) to test <see cref="AzureDevOpsService"/>'s iteration cache without pulling
+/// in the concrete Microsoft.Extensions.Caching.Memory package as a test dependency.
+/// </summary>
+public sealed class FakeMemoryCache : IMemoryCache
+{
+    private sealed record Entry(object? Value, DateTimeOffset? AbsoluteExpiration);
+
+    private readonly Dictionary<object, Entry> _entries = [];
+
+    public int SetCallCount { get; private set; }
+
+    public ICacheEntry CreateEntry(object key) => new FakeCacheEntry(this, key);
+
+    public void Remove(object key) => _entries.Remove(key);
+
+    public bool TryGetValue(object key, out object? value)
+    {
+        if (_entries.TryGetValue(key, out var entry) &&
+            (entry.AbsoluteExpiration is null || entry.AbsoluteExpiration > DateTimeOffset.UtcNow))
+        {
+            value = entry.Value;
+            return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    public void Dispose() { }
+
+    private void Store(object key, object? value, DateTimeOffset? absoluteExpiration)
+    {
+        SetCallCount++;
+        _entries[key] = new Entry(value, absoluteExpiration);
+    }
+
+    private sealed class FakeCacheEntry(FakeMemoryCache cache, object key) : ICacheEntry
+    {
+        public object Key { get; } = key;
+        public object? Value { get; set; }
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
+        public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+        public TimeSpan? SlidingExpiration { get; set; }
+        public IList<IChangeToken> ExpirationTokens { get; } = [];
+        public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; } = [];
+        public CacheItemPriority Priority { get; set; }
+        public long? Size { get; set; }
+
+        public void Dispose()
+        {
+            var absolute = AbsoluteExpiration ?? (AbsoluteExpirationRelativeToNow.HasValue
+                ? DateTimeOffset.UtcNow + AbsoluteExpirationRelativeToNow.Value
+                : null);
+            cache.Store(Key, Value, absolute);
+        }
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/StubHttpMessageHandler.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Support/StubHttpMessageHandler.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Text;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Support;
+
+/// <summary>
+/// Test double for <see cref="HttpMessageHandler"/> that records outgoing requests (with buffered
+/// bodies) and replays enqueued JSON responses in order. Thread-safe so tests can exercise code
+/// paths that issue concurrent requests (e.g. bounded-parallel team-settings lookups).
+/// </summary>
+public sealed class StubHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Lock _lock = new();
+    private readonly Queue<(HttpStatusCode StatusCode, string Json)> _responses = new();
+
+    public List<CapturedRequest> Requests { get; } = [];
+
+    /// <summary>When true, the next SendAsync call throws OperationCanceledException instead of
+    /// returning a response — simulates the caller's token firing mid-request.</summary>
+    public bool ThrowOperationCanceledOnNextSend { get; set; }
+
+    public void EnqueueResponse(HttpStatusCode statusCode, string json)
+    {
+        lock (_lock)
+        {
+            _responses.Enqueue((statusCode, json));
+        }
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (ThrowOperationCanceledOnNextSend)
+        {
+            ThrowOperationCanceledOnNextSend = false;
+            throw new OperationCanceledException("Simulated cancellation mid-request.");
+        }
+
+        var body = request.Content is null ? null : await request.Content.ReadAsStringAsync(cancellationToken);
+
+        HttpStatusCode statusCode;
+        string json;
+        lock (_lock)
+        {
+            Requests.Add(new CapturedRequest(request.Method, request.RequestUri, body));
+
+            if (_responses.Count == 0)
+                throw new InvalidOperationException($"No stub response enqueued for request {request.Method} {request.RequestUri}.");
+
+            (statusCode, json) = _responses.Dequeue();
+        }
+
+        return new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+    }
+
+    public sealed record CapturedRequest(HttpMethod Method, Uri? Uri, string? Body);
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/AzureDevOpsServiceTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/AzureDevOpsServiceTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using NodaTime;
+using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Models;
+using Wayd.Integrations.AzureDevOps.Tests.Support;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Sut;
+
+public class AzureDevOpsServiceTests
+{
+    private const string OrganizationUrl = "https://dev.azure.com/acme";
+    private const string Token = "test-pat-token";
+
+    private static readonly AzureDevOpsConnectionContext _connection = new(OrganizationUrl, Token);
+
+    private readonly StubHttpMessageHandler _handler = new();
+    private readonly FakeHttpClientFactory _httpClientFactory;
+    private readonly FakeMemoryCache _memoryCache = new();
+    private readonly AzureDevOpsService _sut;
+
+    public AzureDevOpsServiceTests()
+    {
+        _httpClientFactory = new FakeHttpClientFactory(_handler);
+        _sut = new AzureDevOpsService(
+            NullLogger<AzureDevOpsService>.Instance,
+            NullLoggerFactory.Instance,
+            _httpClientFactory,
+            new FixedDateTimeProvider(),
+            _memoryCache);
+    }
+
+    [Fact]
+    public async Task GetIterations_SecondCallWithinCacheWindow_DoesNotReissueIterationsRequest()
+    {
+        // Arrange - GetIterations calls GetProject (1 request) + GetOrFetchIterationsAsync (2 requests:
+        // project details + iteration tree). A second call for the same project/team-settings should
+        // reuse the cached iteration tree instead of hitting the iterations endpoint again.
+        var projectId = Guid.NewGuid();
+        _handler.EnqueueResponse(HttpStatusCode.OK, ProjectJson(projectId));
+        _handler.EnqueueResponse(HttpStatusCode.OK, PropertiesJson());
+        _handler.EnqueueResponse(HttpStatusCode.OK, IterationTreeJson());
+        _handler.EnqueueResponse(HttpStatusCode.OK, ProjectJson(projectId));
+        _handler.EnqueueResponse(HttpStatusCode.OK, PropertiesJson());
+
+        // Act
+        var first = await _sut.GetIterations(_connection, "Atlas", [], TestContext.Current.CancellationToken);
+        var second = await _sut.GetIterations(_connection, "Atlas", [], TestContext.Current.CancellationToken);
+
+        // Assert
+        first.IsSuccess.Should().BeTrue();
+        second.IsSuccess.Should().BeTrue();
+        second.Value.Should().BeEquivalentTo(first.Value);
+        _handler.Requests.Should().HaveCount(5); // not 6 — the iteration tree fetch was skipped the second time
+        _memoryCache.SetCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetWorkspace_WithoutProcessTemplateTypeProperty_ReturnsFailure()
+    {
+        // Arrange - a project with no System.ProcessTemplateType property can't be mapped to a workspace configuration
+        var projectId = Guid.NewGuid();
+        _handler.EnqueueResponse(HttpStatusCode.OK, ProjectJson(projectId));
+        _handler.EnqueueResponse(HttpStatusCode.OK, """{"count":0,"value":[]}""");
+
+        // Act
+        var result = await _sut.GetWorkspace(_connection, projectId, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("process template type");
+    }
+
+    [Fact]
+    public async Task TestConnection_WhenUnderlyingCallFails_ReturnsFailureInsteadOfThrowing()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.Unauthorized, """{"message":"access denied"}""");
+
+        // Act
+        var result = await _sut.TestConnection(_connection);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task TestConnection_WhenConnectionDataHasNoInstanceIdMatch_Succeeds()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.OK, """{"instanceId":"6ff2ee2f-9d9b-40b1-9502-e4c00a318c00"}""");
+
+        // Act
+        var result = await _sut.TestConnection(_connection);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task EachServiceCall_RequestsAFreshHttpClientFromTheFactory()
+    {
+        // Arrange - AzureDevOpsService must not cache/reuse a client across calls; each Create*Service
+        // call pulls a new one from the factory, which owns pooling/lifetime.
+        _handler.EnqueueResponse(HttpStatusCode.OK, """{"instanceId":"6ff2ee2f-9d9b-40b1-9502-e4c00a318c00"}""");
+        _handler.EnqueueResponse(HttpStatusCode.OK, """{"instanceId":"6ff2ee2f-9d9b-40b1-9502-e4c00a318c00"}""");
+
+        // Act
+        await _sut.GetSystemId(_connection, TestContext.Current.CancellationToken);
+        await _sut.GetSystemId(_connection, TestContext.Current.CancellationToken);
+
+        // Assert
+        _httpClientFactory.CreateClientCallCount.Should().Be(2);
+    }
+
+    private static string ProjectJson(Guid id)
+    {
+        return $$"""{"id":"{{id}}","name":"Atlas","description":"Test project"}""";
+    }
+
+    private static string PropertiesJson()
+    {
+        return """{"count":1,"value":[{"name":"System.ProcessTemplateType","value":"adcc42ab-9882-485e-a3fe-04140420fbb1"}]}""";
+    }
+
+    private static string IterationTreeJson()
+    {
+        return """
+            {
+                "id": 1,
+                "identifier": "68429463-523f-4c69-8c16-4321543db2e4",
+                "name": "Atlas",
+                "path": "\\Atlas\\Iteration",
+                "children": []
+            }
+            """;
+    }
+
+    private sealed class FixedDateTimeProvider : IDateTimeProvider
+    {
+        public Instant Now => Instant.FromUtc(2026, 1, 1, 0, 0);
+        public LocalDate Today => new(2026, 1, 1);
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Clients/WorkItemClientTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Clients/WorkItemClientTests.cs
@@ -1,0 +1,235 @@
+using System.Net;
+using System.Text.Json;
+using Wayd.Integrations.AzureDevOps.Clients;
+using Wayd.Integrations.AzureDevOps.Tests.Support;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Sut.Clients;
+
+public class WorkItemClientTests
+{
+    private const string OrganizationUrl = "https://dev.azure.com/acme";
+    private const string Token = "test-pat-token";
+    private const string ApiVersion = "7.0";
+    private const string ProjectName = "Atlas";
+
+    private readonly StubHttpMessageHandler _handler = new();
+    private readonly WorkItemClient _sut;
+
+    public WorkItemClientTests()
+    {
+        _sut = new WorkItemClient(new HttpClient(_handler), OrganizationUrl, Token, ApiVersion);
+    }
+
+    [Fact]
+    public async Task GetWorkItems_SendsOmitErrorPolicyInBatchRequest()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.OK, WorkItemsJson(101));
+
+        // Act
+        await _sut.GetWorkItems(ProjectName, [101], ["System.Title"], TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = _handler.Requests.Should().ContainSingle().Subject;
+        request.Body.Should().NotBeNull();
+        using var body = JsonDocument.Parse(request.Body!);
+        body.RootElement.GetProperty("errorPolicy").GetString().Should().Be("omit");
+    }
+
+    [Fact]
+    public async Task GetWorkItems_WithEmptyBatchResponse_ReturnsEmptyList()
+    {
+        // Arrange - errorPolicy=omit returns an empty batch when every requested id was deleted
+        _handler.EnqueueResponse(HttpStatusCode.OK, """{"count":0,"value":[]}""");
+
+        // Act
+        var result = await _sut.GetWorkItems(ProjectName, [101, 102], ["System.Title"], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetWorkItems_WithMoreThanBatchSizeIds_SplitsIntoBatchedRequests()
+    {
+        // Arrange - 250 distinct ids should produce two batches (200 + 50)
+        var workItemIds = Enumerable.Range(1, 250).ToArray();
+        _handler.EnqueueResponse(HttpStatusCode.OK, WorkItemsJson(1));
+        _handler.EnqueueResponse(HttpStatusCode.OK, WorkItemsJson(201));
+
+        // Act
+        var result = await _sut.GetWorkItems(ProjectName, workItemIds, ["System.Title"], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().HaveCount(2);
+        _handler.Requests.Should().HaveCount(2);
+        CountIdsInBody(_handler.Requests[0].Body!).Should().Be(200);
+        CountIdsInBody(_handler.Requests[1].Body!).Should().Be(50);
+    }
+
+    [Fact]
+    public async Task GetWorkItems_WithFailedResponse_ThrowsWithStatusAndBodyDetail()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.BadRequest, """{"message":"bad request"}""");
+
+        // Act
+        var act = () => _sut.GetWorkItems(ProjectName, [101], ["System.Title"], TestContext.Current.CancellationToken);
+
+        // Assert - RestSharp leaves ErrorMessage null on HTTP failures; the status code and the
+        // response body must still surface in the thrown message
+        await act.Should().ThrowAsync<Exception>()
+            .WithMessage($"*{ProjectName}*400*bad request*");
+    }
+
+    [Fact]
+    public async Task GetWorkItemIds_EscapesSingleQuotesInWiqlLiterals()
+    {
+        // Arrange
+        var quotedProject = "O'Brien Project";
+        _handler.EnqueueResponse(HttpStatusCode.OK, """{"queryType":"flat","queryResultType":"workItem","workItems":[]}""");
+
+        // Act
+        await _sut.GetWorkItemIds(quotedProject, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), ["Bug's Type"], excludeWorkItemTypes: false, TestContext.Current.CancellationToken);
+
+        // Assert
+        var request = _handler.Requests.Should().ContainSingle().Subject;
+        using var body = JsonDocument.Parse(request.Body!);
+        var query = body.RootElement.GetProperty("query").GetString()!;
+        query.Should().Contain("[System.TeamProject] = 'O''Brien Project'");
+        query.Should().Contain("[System.WorkItemType] IN ('Bug''s Type')");
+    }
+
+    [Fact]
+    public async Task GetWorkItems_WithNoIds_ReturnsEmptyListWithoutRequest()
+    {
+        // Arrange
+
+        // Act
+        var result = await _sut.GetWorkItems(ProjectName, [], ["System.Title"], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().BeEmpty();
+        _handler.Requests.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetWorkItemIds_WithFullPage_PagesFromLastIdUntilShortPage()
+    {
+        // Arrange - a page of exactly 10,000 ids (the client's page size) forces a second query
+        var firstPageIds = Enumerable.Range(1, 10_000).ToArray();
+        _handler.EnqueueResponse(HttpStatusCode.OK, WiqlIdsJson(firstPageIds));
+        _handler.EnqueueResponse(HttpStatusCode.OK, WiqlIdsJson([10_001, 10_002]));
+
+        // Act
+        var result = await _sut.GetWorkItemIds(ProjectName, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), [], excludeWorkItemTypes: false, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().HaveCount(10_002);
+        _handler.Requests.Should().HaveCount(2);
+        GetWiqlQuery(_handler.Requests[0].Body!).Should().Contain("[System.Id] > 0");
+        GetWiqlQuery(_handler.Requests[1].Body!).Should().Contain("[System.Id] > 10000");
+    }
+
+    [Fact]
+    public async Task GetWorkItemLinkChanges_FollowsContinuationTokenUntilLastBatch()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.OK, LinkBatchJson(sourceId: 1, isLastBatch: false, continuationToken: "watermark-1"));
+        _handler.EnqueueResponse(HttpStatusCode.OK, LinkBatchJson(sourceId: 2, isLastBatch: true, continuationToken: "watermark-2"));
+
+        // Act
+        var result = await _sut.GetWorkItemLinkChanges(ProjectName, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), ["System.LinkTypes.Hierarchy"], [], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().HaveCount(2);
+        _handler.Requests.Should().HaveCount(2);
+        _handler.Requests[0].Uri!.Query.Should().NotContain("continuationToken");
+        _handler.Requests[1].Uri!.Query.Should().Contain("continuationToken=watermark-1");
+    }
+
+    [Fact]
+    public async Task GetWorkItemLinkChanges_WithStalledContinuationToken_ThrowsInsteadOfLooping()
+    {
+        // Arrange - a non-final batch that repeats the same token would otherwise page forever
+        _handler.EnqueueResponse(HttpStatusCode.OK, LinkBatchJson(sourceId: 1, isLastBatch: false, continuationToken: "watermark-1"));
+        _handler.EnqueueResponse(HttpStatusCode.OK, LinkBatchJson(sourceId: 2, isLastBatch: false, continuationToken: "watermark-1"));
+
+        // Act
+        var act = () => _sut.GetWorkItemLinkChanges(ProjectName, new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc), ["System.LinkTypes.Hierarchy"], [], TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<Exception>().WithMessage("*continuation token did not advance*");
+        _handler.Requests.Should().HaveCount(2);
+    }
+
+    private static int CountIdsInBody(string body)
+    {
+        using var document = JsonDocument.Parse(body);
+        return document.RootElement.GetProperty("ids").GetArrayLength();
+    }
+
+    private static string GetWiqlQuery(string requestBody)
+    {
+        using var document = JsonDocument.Parse(requestBody);
+        return document.RootElement.GetProperty("query").GetString()!;
+    }
+
+    private static string WiqlIdsJson(int[] ids)
+    {
+        var items = string.Join(",", ids.Select(id => $$"""{"id":{{id}}}"""));
+        return $$"""{"queryType":"flat","queryResultType":"workItem","workItems":[{{items}}]}""";
+    }
+
+    private static string LinkBatchJson(int sourceId, bool isLastBatch, string continuationToken)
+    {
+        return $$"""
+            {
+                "values": [
+                    {
+                        "rel": "System.LinkTypes.Hierarchy",
+                        "attributes": {
+                            "sourceId": {{sourceId}},
+                            "targetId": {{sourceId + 100}},
+                            "isActive": true,
+                            "changedDate": "2026-01-02T10:00:00Z",
+                            "changedBy": { "uniqueName": "dev@acme.example" },
+                            "comment": null,
+                            "changedOperation": "create",
+                            "sourceProjectId": "6ff2ee2f-9d9b-40b1-9502-e4c00a318c00",
+                            "targetProjectId": "6ff2ee2f-9d9b-40b1-9502-e4c00a318c00"
+                        }
+                    }
+                ],
+                "isLastBatch": {{(isLastBatch ? "true" : "false")}},
+                "continuationToken": "{{continuationToken}}",
+                "nextLink": "https://dev.azure.com/acme/next"
+            }
+            """;
+    }
+
+    private static string WorkItemsJson(int id)
+    {
+        return $$"""
+            {
+                "count": 1,
+                "value": [
+                    {
+                        "id": {{id}},
+                        "rev": 1,
+                        "fields": {
+                            "System.Title": "Sample work item",
+                            "System.WorkItemType": "User Story",
+                            "System.State": "Active",
+                            "System.CreatedDate": "2026-01-05T10:00:00Z",
+                            "System.CreatedBy": { "uniqueName": "dev@acme.example" },
+                            "System.ChangedDate": "2026-01-06T10:00:00Z",
+                            "System.ChangedBy": { "uniqueName": "dev@acme.example" },
+                            "System.IterationId": 5
+                        }
+                    }
+                ]
+            }
+            """;
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Models/WorkItems/WorkItemResponseTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Models/WorkItems/WorkItemResponseTests.cs
@@ -1,6 +1,8 @@
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Wayd.Integrations.AzureDevOps.Models.Projects;
 using Wayd.Integrations.AzureDevOps.Models.WorkItems;
+using Wayd.Integrations.AzureDevOps.Tests.Support;
 
 namespace Wayd.Integrations.AzureDevOps.Tests.Sut.Models.WorkItems;
 
@@ -42,6 +44,38 @@ public class WorkItemResponseTests
         mapped.IterationId.Should().BeNull();
         mapped.TeamId.Should().BeNull();
         mapped.ExternalTeamIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToIExternalWorkItems_WithNoIterationAssigned_DoesNotLogWarning()
+    {
+        // Arrange - IterationId == 0 is the routine "no iteration assigned" case (common for
+        // backlog items) and would flood the logs at Warning level on a large sync if it logged
+        // per occurrence; it must stay silent.
+        var workItem = MakeWorkItem(id: 103, iterationId: 0);
+        var logger = new FakeLogger();
+
+        // Act
+        new List<WorkItemResponse> { workItem }.ToIExternalWorkItems([], logger);
+
+        // Assert
+        logger.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToIExternalWorkItems_WithNonZeroIterationIdMissingFromSyncedSet_LogsWarning()
+    {
+        // Arrange - a non-zero iteration id genuinely referenced by the work item but absent from
+        // the synced set (e.g. added after the iteration cache snapshot) is a real gap worth a
+        // warning, unlike the routine "no iteration assigned" (IterationId == 0) case.
+        var workItem = MakeWorkItem(id: 104, iterationId: 999);
+        var logger = new FakeLogger();
+
+        // Act
+        new List<WorkItemResponse> { workItem }.ToIExternalWorkItems([], logger);
+
+        // Assert
+        logger.Entries.Should().ContainSingle(e => e.Level == LogLevel.Warning && e.Message.Contains("104") && e.Message.Contains("999"));
     }
 
     [Fact]

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Models/WorkItems/WorkItemResponseTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Models/WorkItems/WorkItemResponseTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Integrations.AzureDevOps.Models.Projects;
+using Wayd.Integrations.AzureDevOps.Models.WorkItems;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Sut.Models.WorkItems;
+
+public class WorkItemResponseTests
+{
+    [Fact]
+    public void ToIExternalWorkItems_WithKnownIteration_MapsTeamAndIterationFields()
+    {
+        // Arrange
+        var teamId = Guid.NewGuid();
+        var identifier = Guid.NewGuid();
+        var iteration = MakeIteration(id: 5, identifier, teamId);
+        var workItem = MakeWorkItem(id: 101, iterationId: 5);
+
+        // Act
+        var result = new List<WorkItemResponse> { workItem }.ToIExternalWorkItems([iteration], NullLogger.Instance);
+
+        // Assert
+        var mapped = result.Should().ContainSingle().Subject;
+        mapped.IterationId.Should().Be(5);
+        mapped.TeamId.Should().Be(teamId);
+        mapped.ExternalTeamIdentifier.Should().Be(identifier.ToString());
+    }
+
+    [Fact]
+    public void ToIExternalWorkItems_WithIterationIdNotInSyncedSet_SyncsItemWithNullIterationAndTeam()
+    {
+        // Arrange - System.IterationId defaults to 0 when Azure DevOps has no iteration assigned;
+        // it can also reference an iteration outside the cached tree. Either way the item must
+        // still sync rather than throw KeyNotFoundException.
+        var workItem = MakeWorkItem(id: 102, iterationId: 0);
+
+        // Act
+        var act = () => new List<WorkItemResponse> { workItem }.ToIExternalWorkItems([], NullLogger.Instance);
+
+        // Assert
+        var result = act.Should().NotThrow().Subject;
+        var mapped = result.Should().ContainSingle().Subject;
+        mapped.IterationId.Should().BeNull();
+        mapped.TeamId.Should().BeNull();
+        mapped.ExternalTeamIdentifier.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToIExternalWorkItems_WithMixOfKnownAndUnknownIterations_MapsEachIndependently()
+    {
+        // Arrange
+        var teamId = Guid.NewGuid();
+        var identifier = Guid.NewGuid();
+        var iteration = MakeIteration(id: 5, identifier, teamId);
+        var knownItem = MakeWorkItem(id: 201, iterationId: 5);
+        var unknownItem = MakeWorkItem(id: 202, iterationId: 999);
+
+        // Act
+        var result = new List<WorkItemResponse> { knownItem, unknownItem }.ToIExternalWorkItems([iteration], NullLogger.Instance);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Single(w => w.Id == 201).TeamId.Should().Be(teamId);
+        result.Single(w => w.Id == 202).TeamId.Should().BeNull();
+    }
+
+    private static WorkItemResponse MakeWorkItem(int id, int iterationId)
+    {
+        return new WorkItemResponse
+        {
+            Id = id,
+            Fields = new WorkItemFieldsResponse
+            {
+                Title = "Sample work item",
+                WorkItemType = "User Story",
+                State = "Active",
+                CreatedDate = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+                CreatedBy = new() { UniqueName = "dev@acme.example" },
+                ChangedDate = new DateTime(2026, 1, 2, 0, 0, 0, DateTimeKind.Utc),
+                ChangedBy = new() { UniqueName = "dev@acme.example" },
+                IterationId = iterationId
+            }
+        };
+    }
+
+    private static IterationDto MakeIteration(int id, Guid identifier, Guid teamId)
+    {
+        return new IterationDto
+        {
+            Id = id,
+            Identifier = identifier,
+            Name = "Sprint 1",
+            Path = "\\Atlas\\Sprint 1",
+            TeamId = teamId
+        };
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Services/ProjectServiceTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Services/ProjectServiceTests.cs
@@ -1,12 +1,171 @@
-﻿using System.Text.Json;
+﻿using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
 using Wayd.Integrations.AzureDevOps.Models.Projects;
+using Wayd.Integrations.AzureDevOps.Services;
 using Wayd.Integrations.AzureDevOps.Tests.Models;
+using Wayd.Integrations.AzureDevOps.Tests.Support;
 using Wayd.Integrations.AzureDevOps.Utils;
 
 namespace Wayd.Integrations.AzureDevOps.Tests.Sut.Services;
 
 public class ProjectServiceTests : CommonResponseOptions
 {
+    private const string OrganizationUrl = "https://dev.azure.com/acme";
+    private const string Token = "test-pat-token";
+    private const string ApiVersion = "7.0";
+
+    [Fact]
+    public async Task GetTeams_PagesThroughAllTeamsAndFetchesSettingsForEach()
+    {
+        // Arrange - 105 teams: a full page of 100 forces a second page request
+        var handler = new StubHttpMessageHandler();
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+        var projectId = Guid.NewGuid();
+
+        handler.EnqueueResponse(HttpStatusCode.OK, TeamsPageJson(teamCount: 100));
+        handler.EnqueueResponse(HttpStatusCode.OK, TeamsPageJson(teamCount: 5));
+        for (var i = 0; i < 105; i++)
+        {
+            handler.EnqueueResponse(HttpStatusCode.OK, TeamSettingsJson());
+        }
+
+        // Act
+        var result = await service.GetTeams([projectId], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(105);
+        handler.Requests.Should().HaveCount(107); // 2 team pages + 105 settings lookups
+        handler.Requests[1].Uri!.Query.Should().Contain("skip=100");
+    }
+
+    [Fact]
+    public async Task GetTeams_WhenTeamsPageRequestIsCancelled_PropagatesCancellationInsteadOfReturningFailure()
+    {
+        // Arrange - a genuine cancellation must not be laundered into an ordinary Result.Failure
+        var handler = new StubHttpMessageHandler { ThrowOperationCanceledOnNextSend = true };
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+        var projectId = Guid.NewGuid();
+
+        // Act
+        var act = () => service.GetTeams([projectId], TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetTeams_WhenTeamSettingsLookupIsCancelled_PropagatesCancellationInsteadOfReturningFailure()
+    {
+        // Arrange - the settings lookups run inside Parallel.ForEachAsync; a cancellation there
+        // must still propagate out of GetTeams rather than being folded into a per-team skip.
+        var handler = new StubHttpMessageHandler();
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+        var projectId = Guid.NewGuid();
+
+        handler.EnqueueResponse(HttpStatusCode.OK, TeamsPageJson(teamCount: 1));
+        handler.ThrowOperationCanceledOnNextSend = true;
+
+        // Act
+        var act = () => service.GetTeams([projectId], TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetTeams_WhenTeamSettingsLookupFails_SkipsThatTeamAndContinues()
+    {
+        // Arrange - one of the two settings lookups fails; only that team is dropped
+        var handler = new StubHttpMessageHandler();
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+        var projectId = Guid.NewGuid();
+
+        handler.EnqueueResponse(HttpStatusCode.OK, TeamsPageJson(teamCount: 2));
+        handler.EnqueueResponse(HttpStatusCode.InternalServerError, """{"message":"server error"}""");
+        handler.EnqueueResponse(HttpStatusCode.OK, TeamSettingsJson());
+
+        // Act
+        var result = await service.GetTeams([projectId], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetAreaPaths_WhenRequestFailsWithLongErrorBody_ReturnsTruncatedErrorText()
+    {
+        // Arrange - GetErrorText caps the response body at 500 chars so a large error page (e.g. an
+        // HTML error document from a misconfigured proxy) doesn't blow up log lines or Result errors.
+        // GetAreaPaths surfaces GetErrorText() directly in its Result, unlike GetTeams's fixed message,
+        // making it the clearest place to pin the formatting contract end-to-end.
+        var handler = new StubHttpMessageHandler();
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+        var longBody = new string('x', 1000);
+
+        handler.EnqueueResponse(HttpStatusCode.InternalServerError, longBody);
+
+        // Act
+        var result = await service.GetAreaPaths("Atlas", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().StartWith("500");
+        result.Error.Length.Should().BeLessThan(longBody.Length);
+        result.Error.Should().EndWith("…");
+    }
+
+    [Fact]
+    public async Task GetAreaPaths_WhenRequestFailsWithShortErrorBody_IncludesFullBodyUntruncated()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler();
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+
+        handler.EnqueueResponse(HttpStatusCode.Unauthorized, """{"message":"TF400813: resource not authorized"}""");
+
+        // Act
+        var result = await service.GetAreaPaths("Atlas", TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("401");
+        result.Error.Should().Contain("TF400813: resource not authorized");
+        result.Error.Should().NotContain("…");
+    }
+
+    [Fact]
+    public async Task GetTeams_WhenTeamsRequestFails_ReturnsFailure()
+    {
+        // Arrange
+        var handler = new StubHttpMessageHandler();
+        var service = new ProjectService(new HttpClient(handler), OrganizationUrl, Token, ApiVersion, NullLogger<ProjectService>.Instance);
+        var projectId = Guid.NewGuid();
+
+        handler.EnqueueResponse(HttpStatusCode.Unauthorized, """{"message":"access denied"}""");
+
+        // Act
+        var result = await service.GetTeams([projectId], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain(projectId.ToString());
+    }
+
+    private static string TeamsPageJson(int teamCount)
+    {
+        var teams = string.Join(",", Enumerable.Range(1, teamCount)
+            .Select(i => $$"""{"id":"{{Guid.NewGuid()}}","name":"Team {{i}}"}"""));
+        return $$"""{"count":{{teamCount}},"value":[{{teams}}]}""";
+    }
+
+    private static string TeamSettingsJson()
+    {
+        return "{\"backlogIteration\":{\"id\":\"" + Guid.NewGuid() + "\"}}";
+    }
+
     [Fact]
     public void FlattenIterationNode_WithSimpleStructure_ReturnsAllNodes()
     {

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Services/WorkItemServiceTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Services/WorkItemServiceTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using Wayd.Integrations.AzureDevOps.Services;
+using Wayd.Integrations.AzureDevOps.Tests.Support;
+
+namespace Wayd.Integrations.AzureDevOps.Tests.Sut.Services;
+
+public class WorkItemServiceTests
+{
+    private const string OrganizationUrl = "https://dev.azure.com/acme";
+    private const string Token = "test-pat-token";
+    private const string ApiVersion = "7.0";
+    private const string ProjectName = "Atlas";
+
+    private static readonly DateTime _lastChangedDate = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    private readonly StubHttpMessageHandler _handler = new();
+    private readonly WorkItemService _sut;
+
+    public WorkItemServiceTests()
+    {
+        _sut = new WorkItemService(new HttpClient(_handler), OrganizationUrl, Token, ApiVersion, NullLogger<WorkItemService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetDeletedWorkItemIds_CombinesRecycleBinAndTypeChangedIdsDistinct()
+    {
+        // Arrange - id 11 appears in both the recycle bin and the type-changed query
+        _handler.EnqueueResponse(HttpStatusCode.OK, RecycleBinJson(10, 11));
+        _handler.EnqueueResponse(HttpStatusCode.OK, WiqlIdsJson(11, 12));
+
+        // Act
+        var result = await _sut.GetDeletedWorkItemIds(ProjectName, _lastChangedDate, ["Epic", "Feature"], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new[] { 10, 11, 12 });
+    }
+
+    [Fact]
+    public async Task GetDeletedWorkItemIds_QueriesTypeChangesWithNotInOverSyncedTypes()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.OK, RecycleBinJson());
+        _handler.EnqueueResponse(HttpStatusCode.OK, WiqlIdsJson());
+
+        // Act
+        await _sut.GetDeletedWorkItemIds(ProjectName, _lastChangedDate, ["Epic", "Feature"], TestContext.Current.CancellationToken);
+
+        // Assert
+        _handler.Requests.Should().HaveCount(2);
+        var wiqlQuery = GetWiqlQuery(_handler.Requests[1].Body!);
+        wiqlQuery.Should().Contain("[System.WorkItemType] NOT IN ('Epic','Feature')");
+    }
+
+    [Fact]
+    public async Task GetDeletedWorkItemIds_WithNoSyncedTypes_OnlyQueriesRecycleBin()
+    {
+        // Arrange - with no type filter every type is synced, so no type-changed query applies
+        _handler.EnqueueResponse(HttpStatusCode.OK, RecycleBinJson(10));
+
+        // Act
+        var result = await _sut.GetDeletedWorkItemIds(ProjectName, _lastChangedDate, [], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().BeEquivalentTo(new[] { 10 });
+        _handler.Requests.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task GetWorkItems_WhenUnderlyingCallIsCancelled_PropagatesCancellationInsteadOfReturningFailure()
+    {
+        // Arrange - a genuine cancellation (caller's token fired) must not be laundered into an
+        // ordinary Result.Failure; the caller's own cancellation handling depends on the exception
+        // actually reaching it.
+        _handler.ThrowOperationCanceledOnNextSend = true;
+
+        // Act
+        var act = () => _sut.GetWorkItems(ProjectName, _lastChangedDate, [], TestContext.Current.CancellationToken);
+
+        // Assert
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task GetDeletedWorkItemIds_WhenRecycleBinFails_ReturnsFailureWithStatusDetail()
+    {
+        // Arrange
+        _handler.EnqueueResponse(HttpStatusCode.Unauthorized, """{"message":"access denied"}""");
+
+        // Act
+        var result = await _sut.GetDeletedWorkItemIds(ProjectName, _lastChangedDate, ["Epic"], TestContext.Current.CancellationToken);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error.Should().Contain("401");
+    }
+
+    private static string GetWiqlQuery(string requestBody)
+    {
+        using var document = JsonDocument.Parse(requestBody);
+        return document.RootElement.GetProperty("query").GetString()!;
+    }
+
+    private static string RecycleBinJson(params int[] ids)
+    {
+        var items = string.Join(",", ids.Select(id => $$"""{"id":{{id}}}"""));
+        return $$"""{"count":{{ids.Length}},"value":[{{items}}]}""";
+    }
+
+    private static string WiqlIdsJson(params int[] ids)
+    {
+        var items = string.Join(",", ids.Select(id => $$"""{"id":{{id}}}"""));
+        return $$"""{"queryType":"flat","queryResultType":"workItem","workItems":[{{items}}]}""";
+    }
+}

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Utils/CacheKeyGeneratorTests.cs
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Sut/Utils/CacheKeyGeneratorTests.cs
@@ -130,6 +130,44 @@ public class CacheKeyGeneratorTests
     }
 
     [Fact]
+    public void GetCacheKey_WithDifferentOrganizationsOnSameHost_ReturnsDifferentKeys()
+    {
+        // Arrange - dev.azure.com puts the organization in the URL path, not the host
+        var resourceType = "azdo-iterations";
+        var projectName = "MyProject";
+        var teamSettings = new Dictionary<Guid, Guid?>
+        {
+            { Guid.Parse("11111111-1111-1111-1111-111111111111"), Guid.Parse("22222222-2222-2222-2222-222222222222") }
+        };
+
+        // Act
+        var key1 = InvokeGetCacheKey(resourceType, "https://dev.azure.com/org-one", projectName, teamSettings);
+        var key2 = InvokeGetCacheKey(resourceType, "https://dev.azure.com/org-two", projectName, teamSettings);
+
+        // Assert
+        key1.Should().NotBe(key2);
+    }
+
+    [Fact]
+    public void GetCacheKey_WithTrailingSlashVariant_ReturnsSameKey()
+    {
+        // Arrange
+        var resourceType = "azdo-iterations";
+        var projectName = "MyProject";
+        var teamSettings = new Dictionary<Guid, Guid?>
+        {
+            { Guid.Parse("11111111-1111-1111-1111-111111111111"), Guid.Parse("22222222-2222-2222-2222-222222222222") }
+        };
+
+        // Act
+        var key1 = InvokeGetCacheKey(resourceType, "https://dev.azure.com/org-one", projectName, teamSettings);
+        var key2 = InvokeGetCacheKey(resourceType, "https://dev.azure.com/org-one/", projectName, teamSettings);
+
+        // Assert - URL variants of the same organization should share a key
+        key1.Should().Be(key2);
+    }
+
+    [Fact]
     public void GetCacheKey_WithTeamSettingOrderChanged_ReturnsSameKey()
     {
         // Arrange - Team settings should be order-independent due to OrderBy in implementation

--- a/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Wayd.Integrations.AzureDevOps.Tests.csproj
+++ b/Wayd.Integrations/tests/Wayd.Integrations.AzureDevOps.Tests/Wayd.Integrations.AzureDevOps.Tests.csproj
@@ -20,6 +20,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+        <PackageReference Include="Microsoft.Extensions.Http" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\..\Wayd.Common\src\Wayd.Common.Application\Wayd.Common.Application.csproj" />
       <ProjectReference Include="..\..\..\Wayd.Common\src\Wayd.Common.Domain\Wayd.Common.Domain.csproj" />
       <ProjectReference Include="..\..\..\Wayd.Common\src\Wayd.Common\Wayd.Common.csproj" />
       <ProjectReference Include="..\..\src\Wayd.Integrations.AzureDevOps\Wayd.Integrations.AzureDevOps.csproj" />

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/CreateAzureDevOpsConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/CreateAzureDevOpsConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.Common.Application.Models;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 using NodaTime;
@@ -79,9 +80,10 @@ public sealed class CreateAzureDevOpsConnectionCommandHandler(IAppIntegrationDbC
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
 
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/CreateAzureDevOpsConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/CreateAzureDevOpsConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 using NodaTime;
 
@@ -61,7 +62,7 @@ public sealed class CreateAzureDevOpsConnectionCommandHandler(IAppIntegrationDbC
             Instant timestamp = _dateTimeProvider.Now;
             var config = new AzureDevOpsBoardsConnectionConfiguration(request.Organization, request.PersonalAccessToken);
 
-            var systemIdResult = await _azureDevOpsService.GetSystemId(config.OrganizationUrl, config.PersonalAccessToken, cancellationToken);
+            var systemIdResult = await _azureDevOpsService.GetSystemId(new AzureDevOpsConnectionContext(config.OrganizationUrl, config.PersonalAccessToken), cancellationToken);
             if (systemIdResult.IsFailure)
             {
                 _logger.LogWarning("Unable to get system id for Azure DevOps connection for organization {Organization}. {Error}", request.Organization, systemIdResult.Error);

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/SyncAzureDevOpsConnectionConfigurationCommand.cs
@@ -1,4 +1,5 @@
 ﻿using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
 using Wayd.Common.Domain.Models;
 
@@ -167,7 +168,7 @@ public sealed class SyncAzureDevOpsConnectionConfigurationCommandHandler(IAppInt
     {
         var config = new AzureDevOpsBoardsConnectionConfiguration(connection.Configuration.Organization, connection.Configuration.PersonalAccessToken);
 
-        var systemIdResult = await _azureDevOpsService.GetSystemId(config.OrganizationUrl, config.PersonalAccessToken, cancellationToken);
+        var systemIdResult = await _azureDevOpsService.GetSystemId(new AzureDevOpsConnectionContext(config.OrganizationUrl, config.PersonalAccessToken), cancellationToken);
         if (systemIdResult.IsFailure)
         {
             _logger.LogError("Unable to get system id for Azure DevOps connection {ConnectionId}. {Error}", connection.Id, systemIdResult.Error);

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/UpdateAzureDevOpsConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/UpdateAzureDevOpsConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 
 namespace Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
@@ -71,7 +72,7 @@ public sealed class UpdateAzureDevOpsConnectionCommandHandler(IAppIntegrationDbC
 
             var config = new AzureDevOpsBoardsConnectionConfiguration(request.Organization, pat);
 
-            var systemIdAndTestResult = await _azureDevOpsService.GetSystemId(config.OrganizationUrl, config.PersonalAccessToken, cancellationToken);
+            var systemIdAndTestResult = await _azureDevOpsService.GetSystemId(new AzureDevOpsConnectionContext(config.OrganizationUrl, config.PersonalAccessToken), cancellationToken);
             if (systemIdAndTestResult.IsFailure)
             {
                 _logger.LogWarning("Unable to get system id for Azure DevOps connection for organization {Organization}. {Error}", request.Organization, systemIdAndTestResult.Error);

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/UpdateAzureDevOpsConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureDevOps/UpdateAzureDevOpsConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.Common.Application.Models;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 
@@ -95,7 +96,7 @@ public sealed class UpdateAzureDevOpsConnectionCommandHandler(IAppIntegrationDbC
                 await _appIntegrationDbContext.Entry(connection).ReloadAsync(cancellationToken);
                 connection.ClearDomainEvents();
 
-                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request.Redact(), updateResult.Error);
                 return Result.Failure<Guid>(updateResult.Error);
             }
 
@@ -105,9 +106,10 @@ public sealed class UpdateAzureDevOpsConnectionCommandHandler(IAppIntegrationDbC
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
 
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureOpenAI/CreateAzureOpenAIConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureOpenAI/CreateAzureOpenAIConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.AppIntegration.Domain.Models.AzureOpenAI;
 using NodaTime;
 
@@ -80,9 +81,10 @@ public sealed class CreateAzureOpenAIConnectionCommandHandler(IAppIntegrationDbC
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
 
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureOpenAI/UpdateAzureOpenAIConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/AzureOpenAI/UpdateAzureOpenAIConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.AppIntegration.Domain.Models.AzureOpenAI;
 
 namespace Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI;
@@ -82,7 +83,7 @@ public sealed class UpdateAzureOpenAIConnectionCommandHandler(IAppIntegrationDbC
                 await _appIntegrationDbContext.Entry(connection).ReloadAsync(cancellationToken);
                 connection.ClearDomainEvents();
 
-                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request.Redact(), updateResult.Error);
                 return Result.Failure<Guid>(updateResult.Error);
             }
 
@@ -92,9 +93,10 @@ public sealed class UpdateAzureOpenAIConnectionCommandHandler(IAppIntegrationDbC
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
 
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Entra/CreateEntraConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Entra/CreateEntraConnectionCommand.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.AppIntegration.Domain.Models.Entra;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 using NodaTime;
@@ -86,8 +87,9 @@ public sealed class CreateEntraConnectionCommandHandler(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Entra/UpdateEntraConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Entra/UpdateEntraConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.AppIntegration.Domain.Models.Entra;
 using Wayd.Common.Domain.Enums.AppIntegrations;
 
@@ -99,7 +100,7 @@ public sealed class UpdateEntraConnectionCommandHandler(
             {
                 await _appIntegrationDbContext.Entry(connection).ReloadAsync(cancellationToken);
                 connection.ClearDomainEvents();
-                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request.Redact(), updateResult.Error);
                 return Result.Failure<Guid>(updateResult.Error);
             }
 
@@ -109,8 +110,9 @@ public sealed class UpdateEntraConnectionCommandHandler(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/CreateWorkdayConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/CreateWorkdayConnectionCommand.cs
@@ -1,4 +1,5 @@
 ﻿using FluentValidation;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.AppIntegration.Domain.Models.Workday;
 using Wayd.Common.Application.Interfaces.ExternalPeople;
 using Wayd.Common.Domain.Enums.AppIntegrations;
@@ -104,8 +105,9 @@ public sealed class CreateWorkdayConnectionCommandHandler(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/UpdateWorkdayConnectionCommand.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Commands/Workday/UpdateWorkdayConnectionCommand.cs
@@ -1,5 +1,6 @@
 ﻿using FluentValidation;
 using Microsoft.EntityFrameworkCore;
+using Wayd.AppIntegration.Application.Logging;
 using Wayd.AppIntegration.Domain.Models.Workday;
 using Wayd.Common.Application.Interfaces.ExternalPeople;
 using Wayd.Common.Domain.Enums.AppIntegrations;
@@ -104,7 +105,7 @@ public sealed class UpdateWorkdayConnectionCommandHandler(
             {
                 await _appIntegrationDbContext.Entry(connection).ReloadAsync(cancellationToken);
                 connection.ClearDomainEvents();
-                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request, updateResult.Error);
+                _logger.LogError("Wayd Request: Failure for Request {Name} {@Request}.  Error message: {Error}", AppRequestName, request.Redact(), updateResult.Error);
                 return Result.Failure<Guid>(updateResult.Error);
             }
 
@@ -118,8 +119,9 @@ public sealed class UpdateWorkdayConnectionCommandHandler(
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, request);
-            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {request}");
+            var redactedRequest = request.Redact();
+            _logger.LogError(ex, "Wayd Request: Exception for Request {Name} {@Request}", AppRequestName, redactedRequest);
+            return Result.Failure<Guid>($"Wayd Request: Exception for Request {AppRequestName} {redactedRequest}");
         }
     }
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsInitManager.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsInitManager.cs
@@ -5,6 +5,7 @@ using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
 using Wayd.AppIntegration.Application.Interfaces;
 using Wayd.AppIntegration.Application.Logging;
 using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
 using Wayd.Common.Application.Requests.WorkManagement.Dtos;
 using Wayd.Common.Application.Requests.WorkManagement.Queries;
@@ -40,10 +41,9 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                     return Result.Failure($"The configuration for connection {connectionId} is not valid.");
                 }
 
-                var organizationUrl = connection.Configuration.OrganizationUrl;
-                var personalAccessToken = connection.Configuration.PersonalAccessToken;
+                var azdoConnection = new AzureDevOpsConnectionContext(connection.Configuration.OrganizationUrl, connection.Configuration.PersonalAccessToken);
 
-                var testConnectionResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_TestConnection", () => _azureDevOpsService.TestConnection(organizationUrl, personalAccessToken), syncId);
+                var testConnectionResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_TestConnection", () => _azureDevOpsService.TestConnection(azdoConnection), syncId);
                 if (testConnectionResult.IsFailure)
                 {
                     _logger.LogError("Unable to connect to Azure DevOps for connection {ConnectionId}. {Error}", connectionId, testConnectionResult.Error);
@@ -51,7 +51,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 }
 
                 // Load Processes
-                var workProcessesResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_GetWorkProcesses", () => _azureDevOpsService.GetWorkProcesses(organizationUrl, personalAccessToken, cancellationToken), syncId);
+                var workProcessesResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_GetWorkProcesses", () => _azureDevOpsService.GetWorkProcesses(azdoConnection, cancellationToken), syncId);
                 if (workProcessesResult.IsFailure)
                     return workProcessesResult;
 
@@ -63,7 +63,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 }
 
                 // Load Workspaces
-                var workspacesResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_GetWorkspaces", () => _azureDevOpsService.GetWorkspaces(organizationUrl, personalAccessToken, cancellationToken), syncId);
+                var workspacesResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_GetWorkspaces", () => _azureDevOpsService.GetWorkspaces(azdoConnection, cancellationToken), syncId);
                 if (workspacesResult.IsFailure)
                     return workspacesResult;
 
@@ -92,7 +92,7 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 if (workspaces.Count != 0)
                 {
                     var projectIds = workspaces.Select(w => w.ExternalId).ToArray();
-                    var teamsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_GetTeams", () => _azureDevOpsService.GetTeams(organizationUrl, personalAccessToken, projectIds, cancellationToken), syncId);
+                    var teamsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_SyncOrganizationConfiguration_GetTeams", () => _azureDevOpsService.GetTeams(azdoConnection, projectIds, cancellationToken), syncId);
                     if (teamsResult.IsFailure)
                         return teamsResult;
 
@@ -161,10 +161,9 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                 if (connectionResult.IsFailure)
                     return connectionResult.ConvertFailure<Guid>();
 
-                var organizationUrl = connectionResult.Value.Configuration.OrganizationUrl;
-                var personalAccessToken = connectionResult.Value.Configuration.PersonalAccessToken;
+                var azdoConnection = new AzureDevOpsConnectionContext(connectionResult.Value.Configuration.OrganizationUrl, connectionResult.Value.Configuration.PersonalAccessToken);
 
-                var processResult = await ExternalCallMeasure.MeasureAsync(_logger, "InitWorkProcessIntegration_GetWorkProcess", () => _azureDevOpsService.GetWorkProcess(organizationUrl, personalAccessToken, workProcessExternalId, cancellationToken));
+                var processResult = await ExternalCallMeasure.MeasureAsync(_logger, "InitWorkProcessIntegration_GetWorkProcess", () => _azureDevOpsService.GetWorkProcess(azdoConnection, workProcessExternalId, cancellationToken));
                 if (processResult.IsFailure)
                     return processResult.ConvertFailure<Guid>();
 
@@ -259,10 +258,9 @@ public sealed class AzureDevOpsInitManager(ILogger<AzureDevOpsInitManager> logge
                     return Result.Failure<Guid>("The connection is missing systemId. Please re-sync your connection and try again.");
                 }
 
-                var organizationUrl = connectionResult.Value.Configuration.OrganizationUrl;
-                var personalAccessToken = connectionResult.Value.Configuration.PersonalAccessToken;
+                var azdoConnection = new AzureDevOpsConnectionContext(connectionResult.Value.Configuration.OrganizationUrl, connectionResult.Value.Configuration.PersonalAccessToken);
 
-                var workspaceResult = await ExternalCallMeasure.MeasureAsync(_logger, "InitWorkspaceIntegration_GetWorkspace", () => _azureDevOpsService.GetWorkspace(organizationUrl, personalAccessToken, workspaceExternalId, cancellationToken));
+                var workspaceResult = await ExternalCallMeasure.MeasureAsync(_logger, "InitWorkspaceIntegration_GetWorkspace", () => _azureDevOpsService.GetWorkspace(azdoConnection, workspaceExternalId, cancellationToken));
                 if (workspaceResult.IsFailure)
                     return workspaceResult.ConvertFailure<Guid>();
 

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Connections/Managers/AzureDevOpsWorkItemSource.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using Ardalis.GuardClauses;
 using NodaTime;
 using Wayd.AppIntegration.Application.Connections.Dtos.AzureDevOps;
@@ -6,6 +6,7 @@ using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
 using Wayd.AppIntegration.Application.Interfaces;
 using Wayd.AppIntegration.Application.Logging;
 using Wayd.Common.Application.Enums;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.Planning.Iterations;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
 using Wayd.Common.Application.Requests.WorkManagement.Dtos;
@@ -65,13 +66,13 @@ public sealed class AzureDevOpsWorkItemSource(
     public Task<Result> TestConnection(CancellationToken cancellationToken)
     {
         var ctx = RequireBound();
-        return _azureDevOpsService.TestConnection(ctx.OrganizationUrl, ctx.PersonalAccessToken);
+        return _azureDevOpsService.TestConnection(ctx.Connection);
     }
 
     public Task<Result<string>> GetSystemId(CancellationToken cancellationToken)
     {
         var ctx = RequireBound();
-        return _azureDevOpsService.GetSystemId(ctx.OrganizationUrl, ctx.PersonalAccessToken, cancellationToken);
+        return _azureDevOpsService.GetSystemId(ctx.Connection, cancellationToken);
     }
 
     public Task<Result> RefreshOrganizationConfiguration(Guid syncId, CancellationToken cancellationToken)
@@ -153,7 +154,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
         // Workspace metadata refresh.
         var workspaceResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetWorkspace",
-            () => _azureDevOpsService.GetWorkspace(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.ExternalWorkspaceId, cancellationToken), syncId);
+            () => _azureDevOpsService.GetWorkspace(ctx.Connection, target.ExternalWorkspaceId, cancellationToken), syncId);
         if (workspaceResult.IsFailure)
             return workspaceResult.ConvertFailure();
 
@@ -167,7 +168,7 @@ public sealed class AzureDevOpsWorkItemSource(
         var (teamSettings, teamMappings) = DeserializeTeamMaps(target);
 
         var iterationsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetIterations",
-            () => _azureDevOpsService.GetIterations(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, teamSettings, cancellationToken), syncId);
+            () => _azureDevOpsService.GetIterations(ctx.Connection, target.WorkspaceName, teamSettings, cancellationToken), syncId);
         if (iterationsResult.IsFailure)
             return iterationsResult.ConvertFailure();
 
@@ -198,7 +199,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
         // Work items
         var workItemsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetWorkItems",
-            () => _azureDevOpsService.GetWorkItems(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, workTypeNames, teamSettings, cancellationToken), syncId);
+            () => _azureDevOpsService.GetWorkItems(ctx.Connection, target.WorkspaceName, lastChangedDate, workTypeNames, teamSettings, cancellationToken), syncId);
         if (workItemsResult.IsFailure)
         {
             _logger.LogError("Failed to retrieve work items for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, workItemsResult.Error);
@@ -224,7 +225,7 @@ public sealed class AzureDevOpsWorkItemSource(
         if (syncType == SyncType.Differential)
         {
             var parentsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetParentLinkChanges",
-                () => _azureDevOpsService.GetParentLinkChanges(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
+                () => _azureDevOpsService.GetParentLinkChanges(ctx.Connection, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
             if (parentsResult.IsFailure)
             {
                 _logger.LogError("Failed to retrieve parent link changes for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, parentsResult.Error);
@@ -248,7 +249,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
         // Dependency link changes
         var depsResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetDependencyLinkChanges",
-            () => _azureDevOpsService.GetDependencyLinkChanges(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
+            () => _azureDevOpsService.GetDependencyLinkChanges(ctx.Connection, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
         if (depsResult.IsFailure)
         {
             _logger.LogError("Failed to retrieve dependency link changes for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, depsResult.Error);
@@ -271,7 +272,7 @@ public sealed class AzureDevOpsWorkItemSource(
 
         // Deleted work items
         var deletedResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetDeletedWorkItemIds",
-            () => _azureDevOpsService.GetDeletedWorkItemIds(ctx.OrganizationUrl, ctx.PersonalAccessToken, target.WorkspaceName, lastChangedDate, cancellationToken), syncId);
+            () => _azureDevOpsService.GetDeletedWorkItemIds(ctx.Connection, target.WorkspaceName, lastChangedDate, workTypeNames, cancellationToken), syncId);
         if (deletedResult.IsFailure)
         {
             _logger.LogError("Failed to retrieve deleted work item ids for workspace {WorkspaceId}. Error: {Error}", target.InternalWorkspaceId, deletedResult.Error);
@@ -310,7 +311,7 @@ public sealed class AzureDevOpsWorkItemSource(
     {
         if (_descriptor is null || _cfg is null)
             throw new InvalidOperationException("AzureDevOpsWorkItemSource has not been bound. Call Bind(descriptor) before invoking sync methods.");
-        return new SyncContext(_cfg.OrganizationUrl, _cfg.PersonalAccessToken, _descriptor.SystemId ?? string.Empty);
+        return new SyncContext(new AzureDevOpsConnectionContext(_cfg.OrganizationUrl, _cfg.PersonalAccessToken), _descriptor.SystemId ?? string.Empty);
     }
 
     private SyncableConnectionDescriptor RequireDescriptor()
@@ -326,7 +327,7 @@ public sealed class AzureDevOpsWorkItemSource(
         Guard.Against.Default(workProcessInternalId, nameof(workProcessInternalId));
 
         var processResult = await ExternalCallMeasure.MeasureAsync(_logger, "Azdo_Sync_GetWorkProcess",
-            () => _azureDevOpsService.GetWorkProcess(ctx.OrganizationUrl, ctx.PersonalAccessToken, workProcessExternalId, cancellationToken), syncId);
+            () => _azureDevOpsService.GetWorkProcess(ctx.Connection, workProcessExternalId, cancellationToken), syncId);
         if (processResult.IsFailure)
             return processResult.ConvertFailure();
 
@@ -486,5 +487,5 @@ public sealed class AzureDevOpsWorkItemSource(
         }
     }
 
-    private sealed record SyncContext(string OrganizationUrl, string PersonalAccessToken, string SystemId);
+    private sealed record SyncContext(AzureDevOpsConnectionContext Connection, string SystemId);
 }

--- a/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Logging/RequestRedaction.cs
+++ b/Wayd.Services/Wayd.AppIntegration/src/Wayd.AppIntegration.Application/Logging/RequestRedaction.cs
@@ -1,0 +1,44 @@
+using Wayd.AppIntegration.Application.Connections.Commands;
+using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
+using Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI;
+using Wayd.AppIntegration.Application.Connections.Commands.Entra;
+using Wayd.AppIntegration.Application.Connections.Commands.Workday;
+
+namespace Wayd.AppIntegration.Application.Logging;
+
+/// <summary>
+/// Produces a loggable/error-string-safe representation of a connection Create/Update command by
+/// blanking its one secret property (PAT, password, client secret, API key). These commands are
+/// otherwise logged/echoed whole (via structured "{@Request}" destructuring or plain string
+/// interpolation, both of which call ToString()/serialize every property) whenever the handler's
+/// catch block fires — this exists so that path never puts the raw secret in a log sink or in a
+/// Result.Failure string that can flow back to the API/UI.
+/// </summary>
+public static class RequestRedaction
+{
+    private const string Redacted = "[redacted]";
+
+    public static object Redact(this CreateAzureDevOpsConnectionCommand request) =>
+        request with { PersonalAccessToken = Redacted };
+
+    public static object Redact(this UpdateAzureDevOpsConnectionCommand request) =>
+        request with { PersonalAccessToken = Redacted };
+
+    public static object Redact(this CreateWorkdayConnectionCommand request) =>
+        request with { IsuPassword = Redacted };
+
+    public static object Redact(this UpdateWorkdayConnectionCommand request) =>
+        request with { IsuPassword = Redacted };
+
+    public static object Redact(this CreateEntraConnectionCommand request) =>
+        request with { ClientSecret = Redacted };
+
+    public static object Redact(this UpdateEntraConnectionCommand request) =>
+        request with { ClientSecret = Redacted };
+
+    public static object Redact(this CreateAzureOpenAIConnectionCommand request) =>
+        request with { ApiKey = Redacted };
+
+    public static object Redact(this UpdateAzureOpenAIConnectionCommand request) =>
+        request with { ApiKey = Redacted };
+}

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsInitManagerTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsInitManagerTests.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Wayd.AppIntegration.Application.Connections.Commands;
@@ -9,6 +9,7 @@ using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
 using Wayd.Common.Application.Dtos;
 using Wayd.Common.Application.Interfaces;
 using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
 using Wayd.Common.Application.Requests.WorkManagement.Queries;
 using Wayd.Common.Domain.Enums.AppIntegrations;
@@ -115,7 +116,7 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Failure("Connection refused"));
 
         // Act
@@ -135,11 +136,11 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure<List<IExternalWorkProcess>>("Failed to get processes"));
 
         // Act
@@ -158,15 +159,15 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess>()));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure<List<IExternalWorkspace>>("Failed to get workspaces"));
 
         // Act
@@ -185,7 +186,7 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
 
         var mockProcess = new Mock<IExternalWorkProcess>();
@@ -194,7 +195,7 @@ public class AzureDevOpsInitManagerTests
         mockProcess.Setup(p => p.WorkspaceIds).Returns([Guid.CreateVersion7()]);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess> { mockProcess.Object }));
 
         var wsId = mockProcess.Object.WorkspaceIds.First();
@@ -203,7 +204,7 @@ public class AzureDevOpsInitManagerTests
         mockWorkspace.Setup(w => w.Name).Returns("TestProject");
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace> { mockWorkspace.Object }));
 
         _mocker.GetMock<IDispatcher>()
@@ -211,7 +212,7 @@ public class AzureDevOpsInitManagerTests
             .ReturnsAsync(new List<IntegrationRegistration<Guid, Guid>>());
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetTeams(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid[]>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetTeams(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure<List<IExternalTeam>>("Failed to get teams"));
 
         // Act
@@ -230,15 +231,15 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess>()));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
 
         _mocker.GetMock<IDispatcher>()
@@ -267,15 +268,15 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess>()));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
 
         _mocker.GetMock<IDispatcher>()
@@ -292,7 +293,7 @@ public class AzureDevOpsInitManagerTests
         // Assert
         result.IsSuccess.Should().BeTrue();
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetTeams(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid[]>(), It.IsAny<CancellationToken>()), Times.Never);
+            .Verify(s => s.GetTeams(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid[]>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
@@ -304,7 +305,7 @@ public class AzureDevOpsInitManagerTests
         SetupConnectionQuery(connectionId, details);
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ThrowsAsync(new InvalidOperationException("Unexpected error"));
 
         // Act
@@ -438,7 +439,7 @@ public class AzureDevOpsInitManagerTests
 
         // Should NOT call Azure DevOps to get the process details (no need to sync types/statuses/workflows)
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+            .Verify(s => s.GetWorkProcess(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
 
         // Should link this connection to the existing work process
         _mocker.GetMock<IDispatcher>()
@@ -465,13 +466,13 @@ public class AzureDevOpsInitManagerTests
 
         // SyncOrganizationConfiguration dependencies (called internally)
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess>()));
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
         _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
@@ -486,7 +487,7 @@ public class AzureDevOpsInitManagerTests
         mockWpConfig.Setup(p => p.WorkTypes).Returns(new List<IExternalWorkTypeWorkflow>());
         mockWpConfig.Setup(p => p.WorkStatuses).Returns(new List<IExternalWorkStatus>());
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), wpExternalId, It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcess(It.IsAny<AzureDevOpsConnectionContext>(), wpExternalId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(mockWpConfig.Object));
 
         // CreateExternalWorkProcessCommand
@@ -617,13 +618,13 @@ public class AzureDevOpsInitManagerTests
 
         // SyncOrganizationConfiguration dependencies
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess>()));
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
         _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
@@ -660,13 +661,13 @@ public class AzureDevOpsInitManagerTests
 
         // SyncOrganizationConfiguration dependencies
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.TestConnection(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(s => s.TestConnection(It.IsAny<AzureDevOpsConnectionContext>()))
             .ReturnsAsync(Result.Success());
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcesses(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcesses(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkProcess>()));
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspaces(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspaces(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkspace>()));
         _mocker.GetMock<IDispatcher>()
             .Setup(s => s.Send(It.IsAny<GetIntegrationRegistrationsForWorkProcessesQuery>(), It.IsAny<CancellationToken>()))
@@ -678,7 +679,7 @@ public class AzureDevOpsInitManagerTests
         // GetWorkspace (external)
         var mockWsConfig = new Mock<IExternalWorkspaceConfiguration>();
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspace(It.IsAny<string>(), It.IsAny<string>(), wsExternalId, It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspace(It.IsAny<AzureDevOpsConnectionContext>(), wsExternalId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(mockWsConfig.Object));
 
         // CreateExternalWorkspaceCommand

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Connections/Managers/AzureDevOpsWorkItemSourceTests.cs
@@ -1,4 +1,4 @@
-﻿using CSharpFunctionalExtensions;
+using CSharpFunctionalExtensions;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -14,6 +14,7 @@ using Wayd.Common.Application.Dtos;
 using Wayd.Common.Application.Enums;
 using Wayd.Common.Application.Interfaces;
 using Wayd.Common.Application.Interfaces.ExternalWork;
+using Wayd.Common.Application.Models;
 using Wayd.Common.Application.Requests.Planning.Iterations;
 using Wayd.Common.Application.Requests.WorkManagement.Commands;
 using Wayd.Common.Application.Requests.WorkManagement.Interfaces;
@@ -113,7 +114,7 @@ public class AzureDevOpsWorkItemSourceTests
         workProcessConfig.Setup(p => p.WorkStatuses).Returns(new List<IExternalWorkStatus>());
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkProcess(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(workProcessConfig.Object));
 
         _mocker.GetMock<IDispatcher>()
@@ -126,7 +127,7 @@ public class AzureDevOpsWorkItemSourceTests
 
         // SyncWorkspace
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkspace(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkspace(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new Mock<IExternalWorkspaceConfiguration>().Object));
 
         _mocker.GetMock<IDispatcher>()
@@ -145,19 +146,19 @@ public class AzureDevOpsWorkItemSourceTests
             .ReturnsAsync(Result.Success<Instant?>(null));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkItems(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<Dictionary<Guid, Guid?>>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkItems(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<Dictionary<Guid, Guid?>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkItem>()));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetParentLinkChanges(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkItemLink>()));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetDependencyLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetDependencyLinkChanges(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new List<IExternalWorkItemLink>()));
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(Array.Empty<int>()));
     }
 
@@ -372,10 +373,10 @@ public class AzureDevOpsWorkItemSourceTests
 
         // Same process across both workspaces: GetWorkProcess should only fire once.
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
+            .Verify(s => s.GetWorkProcess(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Once);
         // GetWorkspace is per-workspace.
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetWorkspace(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            .Verify(s => s.GetWorkspace(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     [Fact]
@@ -406,7 +407,7 @@ public class AzureDevOpsWorkItemSourceTests
 
         // Each Bind cycle should re-sync the work process once.
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetWorkProcess(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            .Verify(s => s.GetWorkProcess(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
     }
 
     // -------- SyncWorkItems: SyncType branching --------
@@ -425,7 +426,7 @@ public class AzureDevOpsWorkItemSourceTests
 
         result.IsSuccess.Should().BeTrue();
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
+            .Verify(s => s.GetParentLinkChanges(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
@@ -442,7 +443,7 @@ public class AzureDevOpsWorkItemSourceTests
 
         result.IsSuccess.Should().BeTrue();
         _mocker.GetMock<IAzureDevOpsService>()
-            .Verify(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
+            .Verify(s => s.GetParentLinkChanges(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // -------- SyncWorkItems: partial-failure semantics --------
@@ -456,7 +457,7 @@ public class AzureDevOpsWorkItemSourceTests
 
         // Override only the deletes call to fail.
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Failure<int[]>("AzDO returned 500"));
 
         var target = new WorkspaceSyncTarget(
@@ -493,16 +494,16 @@ public class AzureDevOpsWorkItemSourceTests
         var oneDepChange = new List<IExternalWorkItemLink> { Mock.Of<IExternalWorkItemLink>() };
 
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetWorkItems(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<Dictionary<Guid, Guid?>>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetWorkItems(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<Dictionary<Guid, Guid?>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(threeItems));
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetParentLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetParentLinkChanges(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(twoParentChanges));
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetDependencyLinkChanges(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetDependencyLinkChanges(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(oneDepChange));
         _mocker.GetMock<IAzureDevOpsService>()
-            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.GetDeletedWorkItemIds(It.IsAny<AzureDevOpsConnectionContext>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<string[]>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(Result.Success(new[] { 1, 2, 3, 4 }));
 
         _mocker.GetMock<IDispatcher>()

--- a/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Logging/RequestRedactionTests.cs
+++ b/Wayd.Services/Wayd.AppIntegration/tests/Wayd.AppIntegration.Application.Tests/Sut/Logging/RequestRedactionTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using Wayd.AppIntegration.Application.Connections.Commands;
+using Wayd.AppIntegration.Application.Connections.Commands.AzureDevOps;
+using Wayd.AppIntegration.Application.Connections.Commands.AzureOpenAI;
+using Wayd.AppIntegration.Application.Connections.Commands.Entra;
+using Wayd.AppIntegration.Application.Connections.Commands.Workday;
+using Wayd.AppIntegration.Application.Logging;
+using Wayd.Common.Domain.Enums.AppIntegrations;
+using Xunit;
+
+namespace Wayd.AppIntegration.Application.Tests.Sut.Logging;
+
+public class RequestRedactionTests
+{
+    [Fact]
+    public void Redact_CreateAzureDevOpsConnectionCommand_BlanksPersonalAccessToken()
+    {
+        // Arrange
+        var request = new CreateAzureDevOpsConnectionCommand("Acme Connection", null, "acme", "super-secret-pat");
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-pat");
+        redacted.ToString().Should().Contain("[redacted]");
+    }
+
+    [Fact]
+    public void Redact_UpdateAzureDevOpsConnectionCommand_BlanksPersonalAccessToken()
+    {
+        // Arrange
+        var request = new UpdateAzureDevOpsConnectionCommand(Guid.NewGuid(), "Acme Connection", null, "acme", "super-secret-pat");
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-pat");
+    }
+
+    [Fact]
+    public void Redact_CreateWorkdayConnectionCommand_BlanksIsuPassword()
+    {
+        // Arrange
+        var request = new CreateWorkdayConnectionCommand(
+            "Acme Workday", null, "https://wd.example/wsdl", "isu-user", "super-secret-password",
+            WorkdayWorkerKey.EmployeeId, false, EmployeeMatchProperty.Email, false, false, false, null, null);
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-password");
+    }
+
+    [Fact]
+    public void Redact_UpdateWorkdayConnectionCommand_BlanksIsuPassword()
+    {
+        // Arrange
+        var request = new UpdateWorkdayConnectionCommand(
+            Guid.NewGuid(), "Acme Workday", null, "https://wd.example/wsdl", "isu-user", "super-secret-password",
+            WorkdayWorkerKey.EmployeeId, false, EmployeeMatchProperty.Email, false, false, false, null, null);
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-password");
+    }
+
+    [Fact]
+    public void Redact_CreateEntraConnectionCommand_BlanksClientSecret()
+    {
+        // Arrange
+        var request = new CreateEntraConnectionCommand("Acme Entra", null, "tenant-id", "client-id", "super-secret-client-secret", null, false, EmployeeMatchProperty.Email, false);
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-client-secret");
+    }
+
+    [Fact]
+    public void Redact_UpdateEntraConnectionCommand_BlanksClientSecret()
+    {
+        // Arrange
+        var request = new UpdateEntraConnectionCommand(Guid.NewGuid(), "Acme Entra", null, "tenant-id", "client-id", "super-secret-client-secret", null, false, EmployeeMatchProperty.Email, false);
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-client-secret");
+    }
+
+    [Fact]
+    public void Redact_CreateAzureOpenAIConnectionCommand_BlanksApiKey()
+    {
+        // Arrange
+        var request = new CreateAzureOpenAIConnectionCommand("Acme OpenAI", null, "super-secret-api-key", "gpt-4o", "https://acme.openai.azure.com");
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-api-key");
+    }
+
+    [Fact]
+    public void Redact_UpdateAzureOpenAIConnectionCommand_BlanksApiKey()
+    {
+        // Arrange
+        var request = new UpdateAzureOpenAIConnectionCommand(Guid.NewGuid(), "Acme OpenAI", "https://acme.openai.azure.com", null, "gpt-4o", "super-secret-api-key");
+
+        // Act
+        var redacted = request.Redact();
+
+        // Assert
+        redacted.ToString().Should().NotContain("super-secret-api-key");
+    }
+}

--- a/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/AzureDevOpsConnectionsController.cs
+++ b/Wayd.Web/src/Wayd.Web.Api/Controllers/AppIntegrations/AzureDevOpsConnectionsController.cs
@@ -4,6 +4,7 @@ using Wayd.AppIntegration.Application.Connections.Queries.AzureDevOps;
 using Wayd.AppIntegration.Application.Interfaces;
 using Wayd.AppIntegration.Domain.Models;
 using Wayd.Common.Application.Interfaces;
+using Wayd.Common.Application.Models;
 using Wayd.Organization.Application.BaseTeams.Queries;
 using Wayd.Web.Api.Extensions;
 using Wayd.Web.Api.Models.AppIntegrations.Connections;
@@ -114,7 +115,7 @@ public class AzureDevOpsConnectionsController(IDispatcher dispatcher) : Controll
             return BadRequest(ProblemDetailsExtensions.ForBadRequest("Organization and PAT required.", HttpContext));
 
         var config = new AzureDevOpsBoardsConnectionConfiguration(request.Organization, request.PersonalAccessToken);
-        var result = await azureDevOpsService.TestConnection(config.OrganizationUrl, config.PersonalAccessToken);
+        var result = await azureDevOpsService.TestConnection(new AzureDevOpsConnectionContext(config.OrganizationUrl, config.PersonalAccessToken));
 
         return result.IsSuccess ? NoContent() : BadRequest(result.ToBadRequestObject(HttpContext));
     }


### PR DESCRIPTION
## Summary

Hardens the Azure DevOps integration's HTTP layer and fixes several correctness issues found while reviewing and load-testing it, plus a secret-logging leak found along the way that turned out to affect every connector, not just Azure DevOps.

### Azure DevOps: HTTP plumbing, resilience, and sync correctness

- Moved all Azure DevOps HTTP calls onto `IHttpClientFactory` (named client `"azure-devops"`) instead of constructing a new `RestClient` per call, so the host's standard resilience pipeline (retry honoring `Retry-After`, timeouts, circuit breaker) actually applies.
- Added `AzureDevOpsConnectionContext(OrganizationUrl, PersonalAccessToken)` to replace `(url, token)` parameter pairs across `IAzureDevOpsService`, so a connection's endpoint and credentials always travel together.
- **Fixed cancellation propagation**: RestSharp absorbs a cancelled request into an unsuccessful response instead of throwing, so a cancelled sync was silently reported as an ordinary partial failure rather than as cancelled. `BaseClient.ExecuteAsync` now detects this and re-throws; paired with explicit cancellation guards in each AzDO service.
- **Fixed a workspace-sync crash**: a work item with no iteration assigned (`System.IterationId` defaults to `0` -- a normal condition) threw `KeyNotFoundException` and aborted the entire workspace sync. It now logs a warning and syncs the item with a null iteration/team instead. Verified against a real 25,260-item sync with zero errors.
- Fixed a cache-key collision across `dev.azure.com` organizations that share a host (`CacheKeyGenerator` now keys on authority+path).
- `workitemsbatch` requests set `errorPolicy=omit` and tolerate an empty batch (ids can be deleted between the WIQL query and the fetch).
- Deleted-item detection now derives its "non-synced type" exclusion list from the workspace's actual synced work types instead of a hardcoded `["Task","Issue"]`.
- `GetTeams` paginates the teams endpoint and fetches per-team settings with bounded parallelism instead of unpaginated + sequential.
- WIQL literals escape embedded single quotes; a stalled/empty continuation token in link-change paging now errors instead of looping forever.
- Error messages now include status code and response body (RestSharp leaves `ErrorMessage` null on non-2xx failures); `Result` failures no longer leak full stack traces via `ex.ToString()`.
- API version bumped 7.0 -> 7.1 (Wayd only connects to Azure DevOps Services, never on-prem Server).

### Secret redaction (all connectors)

Found while working on the Azure DevOps fixes: Create/Update connection handlers logged the entire request record -- including the raw secret (PAT, password, client secret, or API key) -- via `{@Request}` destructuring on exception, and also embedded it directly in the returned `Result.Failure` string. Same pattern existed in Workday, Entra, and Azure OpenAI's Create/Update commands, not just Azure DevOps. Added a `Redact()` extension per command type that blanks the secret before it's logged or returned.

## Test plan

- [x] Full solution builds clean (`dotnet build Wayd.slnx`)
- [x] `Wayd.Integrations.AzureDevOps.Tests` -- 82 passing (new: HTTP client factory wiring, cache-key collision regression, cancellation propagation, missing-iteration handling, WIQL escaping/paging, teams pagination)
- [x] `Wayd.AppIntegration.Application.Tests` -- 96 passing (new: redaction coverage for all 4 connectors' Create/Update commands)
- [x] `Wayd.Infrastructure.Tests` -- 217 passing (new: DI registration check for the named Azure DevOps `HttpClient`)
- [x] `Wayd.Integrations.AzureDevOps.IntegrationTests` -- 5 passing against a live org
- [x] Manually verified against two real Azure DevOps organizations: both Full Syncs completed successfully (29 items and 25,260 items respectively), confirming the missing-iteration crash fix holds under real data at scale
- [x] Both commits independently build and pass their full test suites
- [ ] Secret redaction verified by unit test + code review only -- could not force the actual exception path live without an artificial fault injection (a bad org/PAT resolves to a graceful `Result.Failure`, not a thrown exception, so it never reaches the redaction code path); noting this as a known gap in live coverage
