### PR TITLE
Bug/azure signalr hub cors connection

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/hooks/use-poker-session-connection.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/hooks/use-poker-session-connection.ts
@@ -71,6 +71,12 @@ export function usePokerSessionConnection(
             // running sessions. getFreshAuthToken shares the single-flight
             // refresh with the axios interceptor — no duplicate refresh calls.
             accessTokenFactory: async () => (await getFreshAuthToken()) ?? '',
+            // In prod the negotiate redirects the browser to Azure SignalR
+            // Service, which does not support credentialed CORS — with the
+            // signalr default (withCredentials: true) its preflight response
+            // has no Access-Control-Allow-Origin and the connect fails. Auth
+            // is Bearer-only (accessTokenFactory above), no cookies needed.
+            withCredentials: false,
           })
           .withAutomaticReconnect()
           .configureLogging(LogLevel.Warning)

--- a/Wayd.Web/src/wayd.web.reactclient/src/hooks/use-story-map-connection.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/hooks/use-story-map-connection.ts
@@ -74,6 +74,12 @@ export function useStoryMapConnection(
             // token expiry; getFreshAuthToken shares the single-flight refresh
             // with the axios interceptor.
             accessTokenFactory: async () => (await getFreshAuthToken()) ?? '',
+            // In prod the negotiate redirects the browser to Azure SignalR
+            // Service, which does not support credentialed CORS — with the
+            // signalr default (withCredentials: true) its preflight response
+            // has no Access-Control-Allow-Origin and the connect fails. Auth
+            // is Bearer-only (accessTokenFactory above), no cookies needed.
+            withCredentials: false,
           })
           .withAutomaticReconnect()
           .configureLogging(LogLevel.Warning)


### PR DESCRIPTION
- Set withCredentials to false for Azure SignalR connections to resolve CORS issues

