### PR TITLE
Feature/add storymap to mcp

### DIFF
--- a/Wayd.Web/src/Wayd.Mcp/.changeset/story-map-read-tools.md
+++ b/Wayd.Web/src/Wayd.Mcp/.changeset/story-map-read-tools.md
@@ -1,0 +1,23 @@
+---
+'@wayd/mcp': minor
+---
+
+Add MCP tools for reading, creating, and managing Story Maps.
+
+**Read tools:**
+
+- `StoryMaps_GetStoryMaps` — list story maps (id, key, name, description, status, owner), with an `includeArchived` option
+- `StoryMaps_GetStoryMap` — get a story map in full by ID or key: goals, each with ordered steps and tasks (including checklists, persona tags, and linked work item IDs), plus the map's swim lanes and personas
+
+**Management tools:**
+
+- Maps — `StoryMaps_CreateStoryMap`, `StoryMaps_UpdateStoryMap`, `StoryMaps_ChangeStoryMapOwner`, `StoryMaps_ArchiveStoryMap`, `StoryMaps_DeleteStoryMap`
+- Goals — `StoryMaps_AddGoal`, `StoryMaps_RenameGoal`, `StoryMaps_ReorderGoal`, `StoryMaps_DeleteGoal`, `StoryMaps_SetGoalPersonas`
+- Steps — `StoryMaps_AddStep`, `StoryMaps_RenameStep`, `StoryMaps_ReorderStep`, `StoryMaps_MoveStep`, `StoryMaps_DeleteStep`, `StoryMaps_SetStepPersonas`
+- Tasks — `StoryMaps_AddTask`, `StoryMaps_UpdateTask`, `StoryMaps_MoveTask`, `StoryMaps_DeleteTask`, `StoryMaps_SetTaskPersonas`
+- Checklists — `StoryMaps_AddChecklistItem`, `StoryMaps_RenameChecklistItem`, `StoryMaps_SetChecklistItemChecked`, `StoryMaps_RemoveChecklistItem`, `StoryMaps_PromoteChecklistItem`
+- Work item links — `StoryMaps_LinkWorkItem`, `StoryMaps_UnlinkWorkItem`
+- Swim lanes — `StoryMaps_AddSwimLane`, `StoryMaps_RenameSwimLane`, `StoryMaps_SetSwimLaneDates`, `StoryMaps_ReorderSwimLane`, `StoryMaps_RemoveSwimLane`
+- Personas — `StoryMaps_AddPersona`, `StoryMaps_UpdatePersona`, `StoryMaps_ReorderPersona`, `StoryMaps_DeletePersona`
+
+Also adds a `wayd-story-maps` agent skill covering story map analysis (scope per swim lane, persona coverage, checklist progress, work item traceability) and safe management workflows (UUID resolution, replace-set persona tagging, destructive-operation cautions).

--- a/Wayd.Web/src/Wayd.Mcp/README.md
+++ b/Wayd.Web/src/Wayd.Mcp/README.md
@@ -133,13 +133,14 @@ Then use `wayd-mcp` as the command instead of `npx -y @wayd/mcp` in any of the c
 
 Skills are prompt files that guide Claude on how to efficiently use the Wayd MCP tools — which tools to call in sequence, how to resolve IDs, and what the entity relationships look like. Without them, agents tend to make redundant calls or miss non-obvious patterns (e.g. project lifecycle transitions use separate action endpoints, not a status field).
 
-Five self-contained skills are available:
+Six self-contained skills are available:
 
 | Skill | Trigger |
 | --- | --- |
 | `wayd-ppm` | Portfolios, programs, projects — lookup, create, update, lifecycle |
 | `wayd-pi` | Planning intervals, iterations, objectives, health reports, risks |
 | `wayd-roadmaps` | Roadmap exploration — activities, timeboxes, milestones |
+| `wayd-story-maps` | Story maps — analyze, create, and manage goals, steps, tasks, swim lanes, personas |
 | `wayd-teams` | Team lookup — resolve a team name to an ID |
 | `wayd-users` | User lookup — resolve a user name to a UUID for assignees and project roles |
 
@@ -151,7 +152,7 @@ From your project root:
 npx skills add destacey/Wayd
 ```
 
-Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, `/wayd-roadmaps`, `/wayd-teams`, or `/wayd-users`.
+Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, `/wayd-roadmaps`, `/wayd-story-maps`, `/wayd-teams`, or `/wayd-users`.
 
 ## Available Tools
 
@@ -171,6 +172,7 @@ Once installed, activate a skill in Claude Code with `/wayd-ppm`, `/wayd-pi`, `/
 | --- | --- |
 | **Planning Intervals** | List, get details, calendar, predictability, teams, iterations, objectives, risks, objective health check history, get/create objective health check |
 | **Roadmaps** | List, get details, get items and activities |
+| **Story Maps** | List, get full map. Create, update, archive, delete maps. Manage goals, steps, tasks, checklists, swim lanes, personas, and work item links |
 
 ### Organization
 

--- a/Wayd.Web/src/Wayd.Mcp/package-lock.json
+++ b/Wayd.Web/src/Wayd.Mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@wayd/mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@wayd/mcp",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.10.0",
@@ -1351,7 +1351,6 @@
       "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1391,7 +1390,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -1622,7 +1620,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2240,7 +2237,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2624,7 +2620,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -3143,7 +3138,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -4582,7 +4576,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4678,7 +4671,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4805,7 +4797,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/Wayd.Web/src/Wayd.Mcp/src/tools/index.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/tools/index.ts
@@ -7,6 +7,7 @@ import { definitions as projectHealthChecks } from './project-health-checks.js';
 import { definitions as roadmaps } from './roadmaps.js';
 import { definitions as planningIntervals } from './planning-intervals.js';
 import { definitions as objectiveHealthChecks } from './objective-health-checks.js';
+import { definitions as storyMaps } from './story-maps.js';
 import { definitions as tasks } from './tasks.js';
 import { definitions as teams } from './teams.js';
 import { definitions as users } from './users.js';
@@ -20,6 +21,7 @@ export const toolDefinitionMap: Map<string, McpToolDefinition> = new Map([
   ...roadmaps,
   ...planningIntervals,
   ...objectiveHealthChecks,
+  ...storyMaps,
   ...tasks,
   ...teams,
   ...users,

--- a/Wayd.Web/src/Wayd.Mcp/src/tools/story-maps.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/tools/story-maps.ts
@@ -422,7 +422,7 @@ export const definitions: [string, McpToolDefinition][] = [
   ['StoryMaps_AddPersona', {
     name: 'StoryMaps_AddPersona',
     description: `Define a persona on the map.`,
-    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":256},"color":{"type":"string","description":"Hex color, e.g. #1677ff."}},"required":["name","color"]}},"required":["storyMapId","requestBody"]},
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":256},"color":{"type":"string","pattern":"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$","description":"Hex color (#RGB or #RRGGBB), e.g. #1677ff."}},"required":["name","color"]}},"required":["storyMapId","requestBody"]},
     method: 'post',
     pathTemplate: '/api/planning/story-maps/{storyMapId}/personas',
     executionParameters: [{"name":"storyMapId","in":"path"}],
@@ -433,7 +433,7 @@ export const definitions: [string, McpToolDefinition][] = [
   ['StoryMaps_UpdatePersona', {
     name: 'StoryMaps_UpdatePersona',
     description: `Update a persona's name, description, and color.`,
-    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"personaId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":256},"color":{"type":"string","description":"Hex color, e.g. #1677ff."}},"required":["name","color"]}},"required":["storyMapId","personaId","requestBody"]},
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"personaId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":256},"color":{"type":"string","pattern":"^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$","description":"Hex color (#RGB or #RRGGBB), e.g. #1677ff."}},"required":["name","color"]}},"required":["storyMapId","personaId","requestBody"]},
     method: 'put',
     pathTemplate: '/api/planning/story-maps/{storyMapId}/personas/{personaId}',
     executionParameters: [{"name":"storyMapId","in":"path"},{"name":"personaId","in":"path"}],

--- a/Wayd.Web/src/Wayd.Mcp/src/tools/story-maps.ts
+++ b/Wayd.Web/src/Wayd.Mcp/src/tools/story-maps.ts
@@ -1,0 +1,466 @@
+import type { McpToolDefinition } from '../types.js';
+
+export const definitions: [string, McpToolDefinition][] = [
+
+  // -------------------------------------------------------------------------------------------
+  // Story maps
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_GetStoryMaps', {
+    name: 'StoryMaps_GetStoryMaps',
+    description: `Get a list of story maps (id, key, name, description, status, owner).`,
+    inputSchema: {"type":"object","properties":{"includeArchived":{"type":["boolean","null"],"description":"Include archived story maps. Defaults to false."}}},
+    method: 'get',
+    pathTemplate: '/api/planning/story-maps',
+    executionParameters: [{"name":"includeArchived","in":"query"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_GetStoryMap', {
+    name: 'StoryMaps_GetStoryMap',
+    description: `Get a story map in full: goals, each with ordered steps and tasks (including checklists, persona tags, and linked work item IDs), plus the map's swim lanes and personas.`,
+    inputSchema: {"type":"object","properties":{"idOrKey":{"type":"string"}},"required":["idOrKey"]},
+    method: 'get',
+    pathTemplate: '/api/planning/story-maps/{idOrKey}',
+    executionParameters: [{"name":"idOrKey","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_CreateStoryMap', {
+    name: 'StoryMaps_CreateStoryMap',
+    description: `Create a story map. Returns the new map's ID and key.`,
+    inputSchema: {"type":"object","properties":{"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":2048}},"required":["name"]}},"required":["requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps',
+    executionParameters: [],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_UpdateStoryMap', {
+    name: 'StoryMaps_UpdateStoryMap',
+    description: `Update a story map's name and description.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":2048}},"required":["name"]}},"required":["id","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{id}',
+    executionParameters: [{"name":"id","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_ChangeStoryMapOwner', {
+    name: 'StoryMaps_ChangeStoryMapOwner',
+    description: `Change the owner of a story map.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"ownerId":{"type":"string","description":"User ID of the new owner. Use Users_GetUsers to resolve a name to an ID."}},"required":["ownerId"]}},"required":["id","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{id}/owner',
+    executionParameters: [{"name":"id","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_ArchiveStoryMap', {
+    name: 'StoryMaps_ArchiveStoryMap',
+    description: `Archive a story map.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid"}},"required":["id"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{id}/archive',
+    executionParameters: [{"name":"id","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_DeleteStoryMap', {
+    name: 'StoryMaps_DeleteStoryMap',
+    description: `Delete a story map and everything on it. This is permanent — prefer StoryMaps_ArchiveStoryMap unless deletion is explicitly intended.`,
+    inputSchema: {"type":"object","properties":{"id":{"type":"string","format":"uuid"}},"required":["id"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{id}',
+    executionParameters: [{"name":"id","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Goals
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_AddGoal', {
+    name: 'StoryMaps_AddGoal',
+    description: `Add a goal to a story map. The goal is created with one step already in it.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/goals',
+    executionParameters: [{"name":"storyMapId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_RenameGoal', {
+    name: 'StoryMaps_RenameGoal',
+    description: `Rename a goal.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"goalId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","goalId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/goals/{goalId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"goalId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_ReorderGoal', {
+    name: 'StoryMaps_ReorderGoal',
+    description: `Reorder a goal within the map.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"goalId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"newOrder":{"type":"number","format":"int32","description":"Zero-based target position."}},"required":["newOrder"]}},"required":["storyMapId","goalId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/goals/{goalId}/order',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"goalId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_DeleteGoal', {
+    name: 'StoryMaps_DeleteGoal',
+    description: `Delete a goal, along with its steps and their tasks.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"goalId":{"type":"string","format":"uuid"}},"required":["storyMapId","goalId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/goals/{goalId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"goalId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_SetGoalPersonas', {
+    name: 'StoryMaps_SetGoalPersonas',
+    description: `Set the personas tagged on a goal. Replaces the full set — pass every persona ID that should remain tagged.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"goalId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"personaIds":{"type":"array","items":{"type":"string","format":"uuid"}}},"required":["personaIds"]}},"required":["storyMapId","goalId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/goals/{goalId}/personas',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"goalId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Steps
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_AddStep', {
+    name: 'StoryMaps_AddStep',
+    description: `Add a step to a goal.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"goalId":{"type":"string","format":"uuid"},"name":{"type":"string","maxLength":128}},"required":["goalId","name"]}},"required":["storyMapId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/steps',
+    executionParameters: [{"name":"storyMapId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_RenameStep', {
+    name: 'StoryMaps_RenameStep',
+    description: `Rename a step.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"stepId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","stepId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/steps/{stepId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"stepId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_ReorderStep', {
+    name: 'StoryMaps_ReorderStep',
+    description: `Reorder a step within its goal.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"stepId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"newOrder":{"type":"number","format":"int32","description":"Zero-based target position within the goal."}},"required":["newOrder"]}},"required":["storyMapId","stepId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/steps/{stepId}/order',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"stepId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_MoveStep', {
+    name: 'StoryMaps_MoveStep',
+    description: `Move a step into a different goal.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"stepId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"targetGoalId":{"type":"string","format":"uuid"},"newOrder":{"type":"number","format":"int32","description":"Zero-based target position within the target goal."}},"required":["targetGoalId","newOrder"]}},"required":["storyMapId","stepId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/steps/{stepId}/move',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"stepId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_DeleteStep', {
+    name: 'StoryMaps_DeleteStep',
+    description: `Delete a step and its tasks.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"stepId":{"type":"string","format":"uuid"}},"required":["storyMapId","stepId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/steps/{stepId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"stepId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_SetStepPersonas', {
+    name: 'StoryMaps_SetStepPersonas',
+    description: `Set the personas tagged on a step. Replaces the full set — pass every persona ID that should remain tagged.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"stepId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"personaIds":{"type":"array","items":{"type":"string","format":"uuid"}}},"required":["personaIds"]}},"required":["storyMapId","stepId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/steps/{stepId}/personas',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"stepId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Tasks
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_AddTask', {
+    name: 'StoryMaps_AddTask',
+    description: `Add a task (story card) to a step. Without a swimLaneId, it lands in the default swim lane.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"stepId":{"type":"string","format":"uuid"},"title":{"type":"string","maxLength":128},"swimLaneId":{"type":["string","null"],"format":"uuid"}},"required":["stepId","title"]}},"required":["storyMapId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks',
+    executionParameters: [{"name":"storyMapId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_UpdateTask', {
+    name: 'StoryMaps_UpdateTask',
+    description: `Update a task's title and description.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"title":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":2048}},"required":["title"]}},"required":["storyMapId","taskId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_MoveTask', {
+    name: 'StoryMaps_MoveTask',
+    description: `Move a task to a step and swim lane.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"targetStepId":{"type":"string","format":"uuid"},"targetSwimLaneId":{"type":"string","format":"uuid"},"newOrder":{"type":"number","format":"int32","description":"Zero-based target position within the step/lane cell."}},"required":["targetStepId","targetSwimLaneId","newOrder"]}},"required":["storyMapId","taskId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/move',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_DeleteTask', {
+    name: 'StoryMaps_DeleteTask',
+    description: `Delete a task.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"}},"required":["storyMapId","taskId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_SetTaskPersonas', {
+    name: 'StoryMaps_SetTaskPersonas',
+    description: `Set the personas tagged on a task. Replaces the full set — pass every persona ID that should remain tagged.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"personaIds":{"type":"array","items":{"type":"string","format":"uuid"}}},"required":["personaIds"]}},"required":["storyMapId","taskId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/personas',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Checklist
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_AddChecklistItem', {
+    name: 'StoryMaps_AddChecklistItem',
+    description: `Add a checklist item to a task. Returns the updated task.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","taskId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/checklist',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_RenameChecklistItem', {
+    name: 'StoryMaps_RenameChecklistItem',
+    description: `Rename a checklist item.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"itemId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","taskId","itemId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/checklist/{itemId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"},{"name":"itemId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_SetChecklistItemChecked', {
+    name: 'StoryMaps_SetChecklistItemChecked',
+    description: `Check or uncheck a checklist item.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"itemId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"isChecked":{"type":"boolean"}},"required":["isChecked"]}},"required":["storyMapId","taskId","itemId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/checklist/{itemId}/checked',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"},{"name":"itemId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_RemoveChecklistItem', {
+    name: 'StoryMaps_RemoveChecklistItem',
+    description: `Remove a checklist item from a task.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"itemId":{"type":"string","format":"uuid"}},"required":["storyMapId","taskId","itemId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/checklist/{itemId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"},{"name":"itemId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_PromoteChecklistItem', {
+    name: 'StoryMaps_PromoteChecklistItem',
+    description: `Promote a checklist item into its own task in the same step. Returns the new task.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"itemId":{"type":"string","format":"uuid"}},"required":["storyMapId","taskId","itemId"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/checklist/{itemId}/promote',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"},{"name":"itemId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Work item links
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_LinkWorkItem', {
+    name: 'StoryMaps_LinkWorkItem',
+    description: `Link a task to an existing work item. A work item can be linked to at most one task per map.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"workItemId":{"type":"number","format":"int32","description":"The work item's integer ID."}},"required":["workItemId"]}},"required":["storyMapId","taskId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/work-item-link',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_UnlinkWorkItem', {
+    name: 'StoryMaps_UnlinkWorkItem',
+    description: `Unlink a task from its work item.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"taskId":{"type":"string","format":"uuid"}},"required":["storyMapId","taskId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/tasks/{taskId}/work-item-link',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"taskId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Swim lanes
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_AddSwimLane', {
+    name: 'StoryMaps_AddSwimLane',
+    description: `Add a swim lane, appended below the existing ones.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/swim-lanes',
+    executionParameters: [{"name":"storyMapId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_RenameSwimLane', {
+    name: 'StoryMaps_RenameSwimLane',
+    description: `Rename a swim lane. The default swim lane cannot be renamed.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"swimLaneId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128}},"required":["name"]}},"required":["storyMapId","swimLaneId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/swim-lanes/{swimLaneId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"swimLaneId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_SetSwimLaneDates', {
+    name: 'StoryMaps_SetSwimLaneDates',
+    description: `Set a swim lane's descriptive start and end dates. Pass null to clear a date.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"swimLaneId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"startDate":{"type":["string","null"],"format":"date","description":"ISO date string (YYYY-MM-DD)."},"endDate":{"type":["string","null"],"format":"date","description":"ISO date string (YYYY-MM-DD)."}}}},"required":["storyMapId","swimLaneId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/swim-lanes/{swimLaneId}/dates',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"swimLaneId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_ReorderSwimLane', {
+    name: 'StoryMaps_ReorderSwimLane',
+    description: `Reorder a swim lane. The default swim lane cannot be reordered.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"swimLaneId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"newOrder":{"type":"number","format":"int32","description":"Zero-based target position."}},"required":["newOrder"]}},"required":["storyMapId","swimLaneId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/swim-lanes/{swimLaneId}/order',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"swimLaneId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_RemoveSwimLane', {
+    name: 'StoryMaps_RemoveSwimLane',
+    description: `Remove a swim lane. Its tasks return to the default swim lane; the response is the number of tasks moved.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"swimLaneId":{"type":"string","format":"uuid"}},"required":["storyMapId","swimLaneId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/swim-lanes/{swimLaneId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"swimLaneId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  // -------------------------------------------------------------------------------------------
+  // Personas
+  // -------------------------------------------------------------------------------------------
+
+  ['StoryMaps_AddPersona', {
+    name: 'StoryMaps_AddPersona',
+    description: `Define a persona on the map.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":256},"color":{"type":"string","description":"Hex color, e.g. #1677ff."}},"required":["name","color"]}},"required":["storyMapId","requestBody"]},
+    method: 'post',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/personas',
+    executionParameters: [{"name":"storyMapId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_UpdatePersona', {
+    name: 'StoryMaps_UpdatePersona',
+    description: `Update a persona's name, description, and color.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"personaId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"name":{"type":"string","maxLength":128},"description":{"type":["string","null"],"maxLength":256},"color":{"type":"string","description":"Hex color, e.g. #1677ff."}},"required":["name","color"]}},"required":["storyMapId","personaId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/personas/{personaId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"personaId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_ReorderPersona', {
+    name: 'StoryMaps_ReorderPersona',
+    description: `Reorder a persona within the map's persona list.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"personaId":{"type":"string","format":"uuid"},"requestBody":{"type":"object","properties":{"newOrder":{"type":"number","format":"int32","description":"Zero-based target position."}},"required":["newOrder"]}},"required":["storyMapId","personaId","requestBody"]},
+    method: 'put',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/personas/{personaId}/order',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"personaId","in":"path"}],
+    requestBodyContentType: 'application/json',
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+  ['StoryMaps_DeletePersona', {
+    name: 'StoryMaps_DeletePersona',
+    description: `Delete a persona and strip its tag from every goal, step, and task. The response is the number of nodes untagged.`,
+    inputSchema: {"type":"object","properties":{"storyMapId":{"type":"string","format":"uuid"},"personaId":{"type":"string","format":"uuid"}},"required":["storyMapId","personaId"]},
+    method: 'delete',
+    pathTemplate: '/api/planning/story-maps/{storyMapId}/personas/{personaId}',
+    executionParameters: [{"name":"storyMapId","in":"path"},{"name":"personaId","in":"path"}],
+    requestBodyContentType: undefined,
+    securityRequirements: [{"ApiKey":[]}],
+  }],
+
+];

--- a/Wayd.Web/src/Wayd.Mcp/tsconfig.json
+++ b/Wayd.Web/src/Wayd.Mcp/tsconfig.json
@@ -12,6 +12,7 @@
     "module": "Node16",
     "moduleResolution": "Node16",
     "noEmit": false,
+    "rootDir": "./src",
     "outDir": "./build",
     "declaration": true,
     "sourceMap": true,

--- a/docs/getting-started/mcp-server.mdx
+++ b/docs/getting-started/mcp-server.mdx
@@ -13,13 +13,14 @@ Wayd provides an [MCP (Model Context Protocol)](https://modelcontextprotocol.io)
 
 ## What Can It Do?
 
-The MCP server exposes 50+ tools across Wayd's core modules:
+The MCP server exposes 80+ tools across Wayd's core modules:
 
 | Module | Capabilities |
 |--------|-------------|
 | **[PPM](../user-guide/ppm/index.mdx)** | List/view portfolios, programs, projects, phases, tasks. Create and update tasks. View project plan tree and summary metrics. Get critical path. Manage task dependencies. Review and log project health checks. |
 | **[Planning](../user-guide/planning/index.mdx)** | List/view planning intervals, iterations, objectives, risks. Get PI predictability and health reports. Review and log objective health checks. View calendars. |
 | **[Roadmaps](../user-guide/planning/roadmaps.mdx)** | List/view roadmaps and their items (activities, milestones, timeboxes). |
+| **[Story Maps](../user-guide/planning/story-maps.mdx)** | List story maps and read a full map — goals, steps, tasks (with checklists, personas, and work item links), swim lanes, and personas. Create and manage maps: build out goals/steps/tasks, reorder and move cards, manage swim lanes, personas, checklists, and work item links. |
 | **[Organizations](../user-guide/organizations/index.mdx)** | List/view teams and users. |
 
 ## Prerequisites
@@ -124,11 +125,12 @@ CLI arguments take precedence over environment variables.
 
 ## Agent Skills
 
-For Claude Code users, five pre-built skills provide guided workflows:
+For Claude Code users, six pre-built skills provide guided workflows:
 
 - **`/wayd-ppm`** — Portfolio, program, and project operations
 - **`/wayd-pi`** — Planning intervals, iterations, objectives, and risks
 - **`/wayd-roadmaps`** — Roadmap exploration with activities and milestones
+- **`/wayd-story-maps`** — Story map analysis and management with goals, steps, tasks, swim lanes, and personas
 - **`/wayd-teams`** — Team lookup and resolving team names to IDs
 - **`/wayd-users`** — User lookup and resolving names to UUIDs for assignees and project roles
 
@@ -194,6 +196,30 @@ npx skills add destacey/wayd
 | `Roadmaps_GetRoadmaps` | List all roadmaps |
 | `Roadmaps_GetRoadmap` | Get roadmap details |
 | `Roadmaps_GetItems` | Get all roadmap items |
+
+### Story Maps
+
+| Tool | Description |
+|------|-------------|
+| `StoryMaps_GetStoryMaps` | List story maps (optionally including archived) |
+| `StoryMaps_GetStoryMap` | Get a full story map — goals, steps, tasks, swim lanes, personas |
+| `StoryMaps_CreateStoryMap` | Create a story map |
+| `StoryMaps_UpdateStoryMap` | Update a map's name and description |
+| `StoryMaps_ChangeStoryMapOwner` | Change the map's owner |
+| `StoryMaps_ArchiveStoryMap` | Archive a story map |
+| `StoryMaps_DeleteStoryMap` | Permanently delete a story map |
+| `StoryMaps_AddGoal` | Add a goal (created with one step) |
+| `StoryMaps_RenameGoal` / `StoryMaps_ReorderGoal` / `StoryMaps_DeleteGoal` | Manage goals |
+| `StoryMaps_AddStep` | Add a step to a goal |
+| `StoryMaps_RenameStep` / `StoryMaps_ReorderStep` / `StoryMaps_MoveStep` / `StoryMaps_DeleteStep` | Manage steps |
+| `StoryMaps_AddTask` | Add a task to a step (defaults to the default swim lane) |
+| `StoryMaps_UpdateTask` / `StoryMaps_MoveTask` / `StoryMaps_DeleteTask` | Manage tasks |
+| `StoryMaps_AddChecklistItem` / `StoryMaps_RenameChecklistItem` / `StoryMaps_SetChecklistItemChecked` / `StoryMaps_RemoveChecklistItem` | Manage a task's checklist |
+| `StoryMaps_PromoteChecklistItem` | Promote a checklist item into a task |
+| `StoryMaps_LinkWorkItem` / `StoryMaps_UnlinkWorkItem` | Link/unlink a task to a work item |
+| `StoryMaps_AddSwimLane` / `StoryMaps_RenameSwimLane` / `StoryMaps_SetSwimLaneDates` / `StoryMaps_ReorderSwimLane` / `StoryMaps_RemoveSwimLane` | Manage swim lanes |
+| `StoryMaps_AddPersona` / `StoryMaps_UpdatePersona` / `StoryMaps_ReorderPersona` / `StoryMaps_DeletePersona` | Manage personas |
+| `StoryMaps_SetGoalPersonas` / `StoryMaps_SetStepPersonas` / `StoryMaps_SetTaskPersonas` | Set persona tags on a node |
 
 ### Organization
 

--- a/skills/wayd-story-maps/SKILL.md
+++ b/skills/wayd-story-maps/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: wayd-story-maps
+description: Guides agents working with Wayd Story Maps — reading, analyzing, creating, and managing a map's goals, steps, tasks, swim lanes, and personas.
+---
+
+# Wayd Story Maps
+
+## When to use
+
+- Finding or listing story maps
+- Reading a story map's full structure (goals, steps, tasks)
+- Analyzing scope, slicing, or completeness of a story map
+- Checking persona coverage or work item linkage across a map
+- Creating a story map or building out its goals, steps, and tasks
+- Reorganizing a map — reordering, moving cards between steps and lanes
+- Managing swim lanes, personas, checklists, and work item links
+
+---
+
+## Entity context
+
+### Structure
+
+A story map is a single document with a fixed hierarchy:
+
+| Level | Description |
+|---|---|
+| **Goal** | A top-level user goal (backbone column group), ordered left to right |
+| **Step** | A step within a goal (backbone column), ordered within its goal |
+| **Task** | A story card under a step, placed in exactly one swim lane |
+
+Two cross-cutting concepts:
+
+- **Swim lanes** — horizontal release/iteration slices. Every map has a default lane (`isDefault: true`); lanes may carry descriptive `startDate`/`endDate`. A task's `swimLaneId` says which slice it belongs to.
+- **Personas** — user types defined on the map. Goals, steps, and tasks each carry a `personaIds` list of tagged personas.
+
+Tasks may also have:
+
+- A **checklist** (`checklist` items with `isChecked` state, plus `checklistCompletedCount` / `checklistTotalCount` rollups)
+- A **linked work item** (`linkedWorkItemId`, the integer work item ID) — at most one task per map may link a given work item
+
+### Common patterns
+
+- **`idOrKey`** — `StoryMaps_GetStoryMap` accepts either the UUID `id` or the integer `key`. All mutation tools require UUIDs — call `StoryMaps_GetStoryMap` first to resolve them.
+- **One call gets everything** — `StoryMaps_GetStoryMap` returns the entire map (goals → steps → tasks, swim lanes, personas). Never loop over sub-entities; there are no per-goal/per-step read endpoints.
+- **Archived maps** — the list excludes archived maps unless `includeArchived: true`
+- **Feature flag** — story maps are gated by the `StoryMaps` feature flag; if the instance has it disabled the endpoints return 404
+- **Ordering** — `newOrder` values are zero-based positions among siblings
+- **Persona sets replace** — `SetGoalPersonas` / `SetStepPersonas` / `SetTaskPersonas` replace the full tag set; include every persona ID that should remain
+
+## Instructions
+
+### Navigating story maps
+
+1. List story maps: `StoryMaps_GetStoryMaps` (pass `includeArchived: true` to include archived ones)
+2. Get the full map: `StoryMaps_GetStoryMap` with `idOrKey`
+
+### Analyzing a map
+
+All analysis works off the single `StoryMaps_GetStoryMap` response:
+
+- **Scope per slice** — group tasks by `swimLaneId` and join to `swimLanes` for lane names, order, and dates
+- **Persona coverage** — resolve `personaIds` on goals/steps/tasks against the map's `personas` list; nodes with an empty list are untagged
+- **Progress signals** — use `checklistCompletedCount` vs `checklistTotalCount` per task
+- **Traceability** — tasks with `linkedWorkItemId` are tied to work items; a null value means the task is unlinked
+- **Ordering** — goals, steps, tasks, swim lanes, and personas all carry an `order` field; sort by it when presenting the map
+
+### Building a map
+
+1. Create the map: `StoryMaps_CreateStoryMap` (`name`, optional `description`) — returns the new `id` and `key`
+2. Add goals: `StoryMaps_AddGoal` — **each new goal already contains one step**; rename it with `StoryMaps_RenameStep` instead of adding a duplicate
+3. Add further steps: `StoryMaps_AddStep` (`goalId`, `name`)
+4. Add tasks: `StoryMaps_AddTask` (`stepId`, `title`, optional `swimLaneId` — omit for the default lane)
+5. Optionally add swim lanes (`StoryMaps_AddSwimLane`) and personas (`StoryMaps_AddPersona` — requires a hex `color`)
+
+### Managing a map
+
+- **Rename/describe** — `StoryMaps_UpdateStoryMap`, `StoryMaps_RenameGoal`, `StoryMaps_RenameStep`, `StoryMaps_UpdateTask`
+- **Reorder** — `StoryMaps_ReorderGoal`, `StoryMaps_ReorderStep`, `StoryMaps_ReorderSwimLane`, `StoryMaps_ReorderPersona` (zero-based `newOrder`)
+- **Move** — `StoryMaps_MoveStep` (to another goal), `StoryMaps_MoveTask` (to a step + swim lane)
+- **Checklists** — `StoryMaps_AddChecklistItem`, `StoryMaps_RenameChecklistItem`, `StoryMaps_SetChecklistItemChecked`, `StoryMaps_RemoveChecklistItem`; `StoryMaps_PromoteChecklistItem` turns an item into a task in the same step
+- **Work items** — `StoryMaps_LinkWorkItem` (integer `workItemId`), `StoryMaps_UnlinkWorkItem`
+- **Ownership** — `StoryMaps_ChangeStoryMapOwner` (resolve the user ID with `Users_GetUsers`)
+
+### Destructive operations — confirm before calling
+
+- `StoryMaps_DeleteStoryMap` deletes the whole map permanently; prefer `StoryMaps_ArchiveStoryMap`
+- `StoryMaps_DeleteGoal` removes its steps and their tasks; `StoryMaps_DeleteStep` removes its tasks
+- `StoryMaps_RemoveSwimLane` keeps the tasks (they return to the default lane); the default lane can't be renamed, reordered, or removed
+- `StoryMaps_DeletePersona` strips the tag from every node on the map


### PR DESCRIPTION
## Add Story Maps to the MCP server

### Summary

Extends the `@wayd/mcp` server with full Story Map support — 36 new tools mirroring the `StoryMapsController` API — so AI agents can read story maps for analysis and create/manage them end to end. Also ships a new `wayd-story-maps` agent skill that teaches agents the map structure and safe usage patterns.

### New tools (`src/tools/story-maps.ts`)

**Read**
- `StoryMaps_GetStoryMaps` — list maps (id, key, name, description, status, owner), with an `includeArchived` option
- `StoryMaps_GetStoryMap` — the full map document in one call: goals → steps → tasks (checklists, persona tags, linked work item IDs), plus swim lanes and personas; accepts UUID or integer key

**Manage**
- **Maps** — create, update, change owner, archive, delete
- **Goals** — add, rename, reorder, delete, set personas
- **Steps** — add, rename, reorder, move between goals, delete, set personas
- **Tasks** — add, update, move (step + swim lane), delete, set personas
- **Checklists** — add, rename, check/uncheck, remove, promote item to task
- **Work item links** — link, unlink
- **Swim lanes** — add, rename, set dates, reorder, remove
- **Personas** — add, update, reorder, delete

Tool schemas carry the real API constraints (name/title ≤ 128 chars, descriptions ≤ 2048, hex persona colors) and encode behavioral quirks in their descriptions: new goals arrive with one step pre-created, removing a swim lane returns its tasks to the default lane, deleting a persona untags every node, and the delete-map tool steers agents toward archiving instead.

### New agent skill (`skills/wayd-story-maps/SKILL.md`)

Covers the goal → step → task hierarchy, swim lanes as release slices, and personas; analysis recipes (scope per lane, persona coverage, checklist progress, work item traceability); build/manage workflows; and key gotchas — mutation tools require UUIDs (resolve via `GetStoryMap`), persona-set tools replace the full tag set, endpoints 404 when the `StoryMaps` feature flag is disabled, and destructive operations warrant confirmation.

### Other changes

- Registered the new tool file in `src/tools/index.ts`
- Updated the MCP README and `docs/getting-started/mcp-server.mdx` (module table, skills list, new Story Maps tools section, tool count)
- Added a minor-version changeset for the `@wayd/mcp` release
- `tsconfig.json`: set `rootDir: "./src"` explicitly — TS 6 deprecates inferred `rootDir`, and relying on inference would break the `build/index.js` bin layout under TS 7

### Verification

- `npm run build` — Zod schema codegen (106 schemas, up from 70) and `tsc` compile cleanly; clean rebuild confirms output layout unchanged
- `npm run lint` — passes
