### PR TITLE
Feature/story map ux enhancements

### DIFF
--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-actions.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-actions.ts
@@ -20,7 +20,8 @@ export interface BoardActions {
   onDeleteGoal: (goalId: string) => void
   onRenameStep: (stepId: string, name: string) => void
   onDeleteStep: (stepId: string) => void
-  onAddTask: (stepId: string) => void
+  /** Omitting the lane adds to the default one; a task cell passes its own. */
+  onAddTask: (stepId: string, swimLaneId?: string) => void
   onRenameTask: (task: StoryMapTaskDto, title: string) => void
   onDeleteTask: (taskId: string) => void
   /** Link or unlink a single persona; the handler sends the resulting full list to the API. */

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-counts.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-counts.test.ts
@@ -229,7 +229,9 @@ describe('countTasksByLane', () => {
 
   it('omits a lane holding no tasks', () => {
     // Arrange
-    const details = map([goal('g1', [step('s1', [], [task('t1', [], 'lane-a')])])])
+    const details = map([
+      goal('g1', [step('s1', [], [task('t1', [], 'lane-a')])]),
+    ])
 
     // Act
     const counts = countTasksByLane(details, null)
@@ -266,7 +268,11 @@ describe('countTasksByLane', () => {
     // Arrange
     const details = map([
       goal('g1', [
-        step('s1', [], [task('t1', ['p1'], 'lane-a'), task('t2', [], 'lane-b')]),
+        step(
+          's1',
+          [],
+          [task('t1', ['p1'], 'lane-a'), task('t2', [], 'lane-b')],
+        ),
       ]),
     ])
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.test.ts
@@ -154,7 +154,10 @@ describe('resolveDrop', () => {
 
     it('ignores a goal dropped on a different kind of node', () => {
       // Arrange
-      const withSteps = map([goal('g1', 0, [step('s1', 'g1', 0)]), goal('g2', 1)])
+      const withSteps = map([
+        goal('g1', 0, [step('s1', 'g1', 0)]),
+        goal('g2', 1),
+      ])
 
       // Act / Assert — a goal has no meaning as a child of a step.
       expect(drop(withSteps, 'g1', 's1')).toBeNull()
@@ -663,7 +666,7 @@ describe('collapsed swim lanes', () => {
     [swimLane(open, 0, true), swimLane(folded, 1)],
   )
 
-  const layout = buildBoardLayout(details, new Set([folded]))
+  const layout = buildBoardLayout(details, { swimLaneIds: new Set([folded]) })
   const index = buildDragIndex(layout)
 
   it('does not index a task in a collapsed lane', () => {
@@ -707,7 +710,9 @@ describe('collapsed swim lanes', () => {
       [goal('g1', 0, [step('s1', 'g1', 0)])],
       [swimLane(open, 0, true), swimLane(folded, 1), swimLane('l2', 2)],
     )
-    const threeLaneLayout = buildBoardLayout(threeLanes, new Set([folded]))
+    const threeLaneLayout = buildBoardLayout(threeLanes, {
+      swimLaneIds: new Set([folded]),
+    })
 
     // Act — folding a lane away must not pin it in place.
     const result = resolveDrop(
@@ -724,5 +729,107 @@ describe('collapsed swim lanes', () => {
       swimLaneId: folded,
       newOrder: 2,
     })
+  })
+})
+
+describe('collapsed goals', () => {
+  const lane = 'lane-default'
+
+  const details = map([
+    goal('g1', 0, [step('s1', 'g1', 0, [task('t1', 's1', lane, 0)])]),
+    goal('g2', 1, [step('s2', 'g2', 0, [task('t2', 's2', lane, 0)])]),
+    goal('g3', 2, [step('s3', 'g3', 0)]),
+  ])
+
+  const layout = buildBoardLayout(details, { goalIds: new Set(['g2']) })
+  const index = buildDragIndex(layout)
+
+  it('does not index the steps or tasks of a collapsed goal', () => {
+    // Arrange / Act / Assert — neither renders a cell, so neither is a drag node.
+    expect(index.kindById.get('s2')).toBeUndefined()
+    expect(index.kindById.get('t2')).toBeUndefined()
+    expect(index.kindById.get('s1')).toBe('step')
+    expect(index.kindById.get('t1')).toBe('task')
+  })
+
+  it('rejects a collapsed goal’s step as a drop target', () => {
+    // Arrange / Act / Assert — dropping there would land the step out of sight.
+    expect(isValidDropTarget(index, 's1', 's2')).toBe(false)
+    expect(resolveDrop(layout, index, 's1', 's2', 'before')).toBeNull()
+  })
+
+  it('rejects a task dropped into a collapsed goal’s cell', () => {
+    // Arrange / Act / Assert
+    expect(isValidDropTarget(index, 't1', taskCellId('s2', lane))).toBe(false)
+  })
+
+  it('still allows the collapsed goal itself to be reordered', () => {
+    // Arrange / Act — folding a goal away must not pin it in place.
+    const result = resolveDrop(layout, index, 'g2', 'g1', 'before')
+
+    // Assert
+    expect(result).toEqual({ kind: 'goal', goalId: 'g2', newOrder: 0 })
+  })
+
+  it('still allows an expanded goal to reorder across a collapsed one', () => {
+    // Arrange / Act — g1 past g3, with the collapsed g2 in between.
+    const result = resolveDrop(layout, index, 'g1', 'g3', 'after')
+
+    // Assert — removing g1 first pulls g3 back to index 1, so the end is index 2.
+    expect(result).toEqual({ kind: 'goal', goalId: 'g1', newOrder: 2 })
+  })
+
+  it('still reorders steps among the goals that remain expanded', () => {
+    // Arrange / Act — s1 joins g3, across the collapsed g2 sitting between them on screen.
+    const result = resolveDrop(layout, index, 's1', 's3', 'after')
+
+    // Assert
+    expect(result).toEqual({
+      kind: 'step',
+      stepId: 's1',
+      targetGoalId: 'g3',
+      newOrder: 1,
+    })
+  })
+})
+
+/** A well-formed cell id can still name a cell no longer on the board once a collapse hides it. */
+describe('task cells that are not rendered', () => {
+  const details = map(
+    [
+      goal('g1', 0, [step('s1', 'g1', 0, [task('t1', 's1', 'l0', 0)])]),
+      goal('g2', 1, [step('s2', 'g2', 0)]),
+    ],
+    [swimLane('l0', 0, true), swimLane('l1', 1)],
+  )
+
+  const layout = buildBoardLayout(details, {
+    goalIds: new Set(['g2']),
+    swimLaneIds: new Set(['l1']),
+  })
+  const index = buildDragIndex(layout)
+
+  it('accepts a cell on a rendered step crossed with an expanded lane', () => {
+    // Arrange / Act / Assert — the control case: this cell really is on the board.
+    expect(isValidDropTarget(index, 't1', taskCellId('s1', 'l0'))).toBe(true)
+  })
+
+  it('rejects a well-formed cell id naming a collapsed lane', () => {
+    // Arrange / Act / Assert — s1 renders, but l1 owns no task row.
+    const hidden = taskCellId('s1', 'l1')
+    expect(isValidDropTarget(index, 't1', hidden)).toBe(false)
+    expect(resolveDrop(layout, index, 't1', hidden)).toBeNull()
+  })
+
+  it('rejects a well-formed cell id naming a collapsed goal’s step', () => {
+    // Arrange / Act / Assert — l0 is expanded, but s2 lives inside the collapsed g2.
+    const hidden = taskCellId('s2', 'l0')
+    expect(isValidDropTarget(index, 't1', hidden)).toBe(false)
+    expect(resolveDrop(layout, index, 't1', hidden)).toBeNull()
+  })
+
+  it('rejects a cell id for a step that does not exist at all', () => {
+    // Arrange / Act / Assert
+    expect(isValidDropTarget(index, 't1', taskCellId('nope', 'l0'))).toBe(false)
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.test.ts
@@ -646,3 +646,83 @@ describe('isValidDropTarget', () => {
     expect(isValid('g1', 'unknown')).toBe(false)
   })
 })
+
+describe('collapsed swim lanes', () => {
+  const open = 'lane-default'
+  const folded = 'l1'
+
+  const details = map(
+    [
+      goal('g1', 0, [
+        step('s1', 'g1', 0, [
+          task('t-open', 's1', open, 0),
+          task('t-folded', 's1', folded, 0),
+        ]),
+      ]),
+    ],
+    [swimLane(open, 0, true), swimLane(folded, 1)],
+  )
+
+  const layout = buildBoardLayout(details, new Set([folded]))
+  const index = buildDragIndex(layout)
+
+  it('does not index a task in a collapsed lane', () => {
+    // Arrange / Act / Assert — it renders no card, so it is not a draggable node.
+    expect(index.kindById.get('t-folded')).toBeUndefined()
+    expect(index.kindById.get('t-open')).toBe('task')
+  })
+
+  it('rejects a collapsed lane task as a drag source', () => {
+    // Arrange / Act / Assert
+    expect(isValidDropTarget(index, 't-folded', taskCellId('s1', open))).toBe(
+      false,
+    )
+  })
+
+  it('rejects a collapsed lane task as a drop target', () => {
+    // Arrange / Act / Assert — dropping onto a hidden card would land the task out of sight.
+    expect(isValidDropTarget(index, 't-open', 't-folded')).toBe(false)
+    expect(
+      resolveDrop(layout, index, 't-open', 't-folded', 'before'),
+    ).toBeNull()
+  })
+
+  it('appends to an empty cell without counting the collapsed lane task', () => {
+    // Arrange / Act — the open lane's own cell still resolves normally.
+    const result = resolveDrop(
+      layout,
+      index,
+      't-open',
+      taskCellId('s1', open),
+      'before',
+    )
+
+    // Assert — already the only (and last) task there, so appending changes nothing.
+    expect(result).toBeNull()
+  })
+
+  it('still allows a collapsed lane itself to be reordered', () => {
+    // Arrange — a third lane, so there is somewhere for the collapsed one to actually go.
+    const threeLanes = map(
+      [goal('g1', 0, [step('s1', 'g1', 0)])],
+      [swimLane(open, 0, true), swimLane(folded, 1), swimLane('l2', 2)],
+    )
+    const threeLaneLayout = buildBoardLayout(threeLanes, new Set([folded]))
+
+    // Act — folding a lane away must not pin it in place.
+    const result = resolveDrop(
+      threeLaneLayout,
+      buildDragIndex(threeLaneLayout),
+      folded,
+      'l2',
+      'after',
+    )
+
+    // Assert — removing l1 first pulls l2 back to index 1, so the end is index 2.
+    expect(result).toEqual({
+      kind: 'swimLane',
+      swimLaneId: folded,
+      newOrder: 2,
+    })
+  })
+})

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.test.ts
@@ -11,6 +11,9 @@ import {
   emptyStepSlotId,
   isValidDropTarget,
   resolveDrop,
+  resolveReceivingCellId,
+  resolveReceivingGoalId,
+  resolveStepSeam,
   taskCellId,
   type DropResult,
   type DropSide,
@@ -831,5 +834,214 @@ describe('task cells that are not rendered', () => {
   it('rejects a cell id for a step that does not exist at all', () => {
     // Arrange / Act / Assert
     expect(isValidDropTarget(index, 't1', taskCellId('nope', 'l0'))).toBe(false)
+  })
+})
+
+/**
+ * The drag preview. These share their inputs with `resolveDrop`, so what the board shows mid-drag
+ * and what the drop does cannot disagree.
+ */
+describe('resolveStepSeam', () => {
+  const lane = 'lane-default'
+  const details = map([
+    goal('g1', 0, [
+      step('s1', 'g1', 0),
+      step('s2', 'g1', 1),
+      step('s3', 'g1', 2),
+    ]),
+    goal('g2', 1, [step('s4', 'g2', 0)]),
+  ])
+
+  const layout = buildBoardLayout(details)
+  const index = buildDragIndex(layout)
+
+  const seam = (activeId: string, overId: string, side: DropSide) =>
+    resolveStepSeam(layout, index, activeId, overId, side)
+
+  it('draws on the hovered step when the pointer is on its leading half', () => {
+    // Arrange / Act / Assert
+    expect(seam('s3', 's1', 'before')).toEqual({
+      stepId: 's1',
+      edge: 'before',
+    })
+  })
+
+  it('hands a trailing-half hover to the next step as its leading edge', () => {
+    // Arrange / Act — "after s1" and "before s2" are the same gap.
+    const result = seam('s3', 's1', 'after')
+
+    // Assert — one seam, one line: s2 draws it, s1 does not.
+    expect(result).toEqual({ stepId: 's2', edge: 'before' })
+  })
+
+  it('gives one seam the same answer from either side', () => {
+    // Arrange / Act — the gap between s1 and s2, approached from both directions.
+    const fromLeft = seam('s3', 's1', 'after')
+    const fromRight = seam('s3', 's2', 'before')
+
+    // Assert — the flicker this prevents was these two disagreeing.
+    expect(fromLeft).toEqual(fromRight)
+  })
+
+  it('keeps a trailing edge on the last step of a goal', () => {
+    // Arrange / Act — s3 ends g1, and the next column belongs to g2.
+    const result = seam('s1', 's3', 'after')
+
+    // Assert — nothing follows it inside the goal to borrow a leading edge from.
+    expect(result).toEqual({ stepId: 's3', edge: 'after' })
+  })
+
+  it('does not hand a seam across a goal boundary', () => {
+    // Arrange / Act — s4 is the next column on the board, but belongs to another goal.
+    const result = seam('s1', 's3', 'after')
+
+    // Assert
+    expect(result).not.toEqual({ stepId: 's4', edge: 'before' })
+  })
+
+  it('ignores drags that are not steps', () => {
+    // Arrange
+    const withTask = map([
+      goal('g1', 0, [step('s1', 'g1', 0, [task('t1', 's1', lane, 0)])]),
+    ])
+    const taskLayout = buildBoardLayout(withTask)
+
+    // Act / Assert — a goal or task drag draws no step seam.
+    expect(
+      resolveStepSeam(
+        taskLayout,
+        buildDragIndex(taskLayout),
+        't1',
+        's1',
+        'before',
+      ),
+    ).toBeNull()
+    expect(seam('g1', 's1', 'before')).toBeNull()
+  })
+
+  it('returns null with no target', () => {
+    // Arrange / Act / Assert
+    expect(seam('s1', '', 'before')).toBeNull()
+    expect(resolveStepSeam(layout, index, null, 's1', 'before')).toBeNull()
+  })
+})
+
+describe('resolveReceivingGoalId', () => {
+  const details = map([
+    goal('g1', 0, [step('s1', 'g1', 0), step('s2', 'g1', 1)]),
+    goal('g2', 1, [step('s3', 'g2', 0)]),
+    goal('g3', 2),
+  ])
+
+  const index = buildDragIndex(buildBoardLayout(details))
+
+  it('names the goal a step is crossing into', () => {
+    // Arrange / Act / Assert
+    expect(resolveReceivingGoalId(index, 's1', 's3')).toBe('g2')
+  })
+
+  it('returns null for a reorder inside the same goal', () => {
+    // Arrange / Act / Assert — the parent is not in question, so nothing is marked.
+    expect(resolveReceivingGoalId(index, 's1', 's2')).toBeNull()
+  })
+
+  it('names the goal behind an empty step slot', () => {
+    // Arrange / Act / Assert — g3 has no steps, so its slot is the only way in.
+    expect(resolveReceivingGoalId(index, 's1', emptyStepSlotId('g3'))).toBe(
+      'g3',
+    )
+  })
+
+  it('ignores drags that are not steps', () => {
+    // Arrange / Act / Assert
+    expect(resolveReceivingGoalId(index, 'g1', 's3')).toBeNull()
+  })
+})
+
+describe('resolveReceivingCellId', () => {
+  const laneA = 'lane-default'
+  const laneB = 'l1'
+
+  const details = map(
+    [
+      goal('g1', 0, [
+        step('s1', 'g1', 0, [
+          task('t1', 's1', laneA, 0),
+          task('t2', 's1', laneB, 0),
+        ]),
+        step('s2', 'g1', 1, [task('t3', 's2', laneA, 0)]),
+      ]),
+    ],
+    [swimLane(laneA, 0, true), swimLane(laneB, 1)],
+  )
+
+  const index = buildDragIndex(buildBoardLayout(details))
+
+  it('names the cell when the step changes', () => {
+    // Arrange / Act / Assert — t1 dropped on a card in another step's column.
+    expect(resolveReceivingCellId(index, 't1', 't3')).toBe(
+      taskCellId('s2', laneA),
+    )
+  })
+
+  it('names the cell when only the lane changes', () => {
+    // Arrange / Act / Assert — same step, different lane is still a reparent.
+    expect(resolveReceivingCellId(index, 't1', 't2')).toBe(
+      taskCellId('s1', laneB),
+    )
+  })
+
+  it('names an empty cell targeted directly', () => {
+    // Arrange / Act / Assert
+    expect(resolveReceivingCellId(index, 't1', taskCellId('s2', laneB))).toBe(
+      taskCellId('s2', laneB),
+    )
+  })
+
+  it('returns null for a reorder inside the same cell', () => {
+    // Arrange — a second task in t1's own cell.
+    const sameCell = map(
+      [
+        goal('g1', 0, [
+          step('s1', 'g1', 0, [
+            task('t1', 's1', laneA, 0),
+            task('t2', 's1', laneA, 1),
+          ]),
+        ]),
+      ],
+      [swimLane(laneA, 0, true)],
+    )
+
+    // Act / Assert — the insertion line alone says where it lands.
+    expect(
+      resolveReceivingCellId(
+        buildDragIndex(buildBoardLayout(sameCell)),
+        't1',
+        't2',
+      ),
+    ).toBeNull()
+  })
+
+  it('returns null for a cell the board is not rendering', () => {
+    // Arrange — collapse the lane holding the target cell.
+    const collapsed = buildBoardLayout(details, {
+      swimLaneIds: new Set([laneB]),
+    })
+
+    // Act / Assert
+    expect(
+      resolveReceivingCellId(
+        buildDragIndex(collapsed),
+        't1',
+        taskCellId('s2', laneB),
+      ),
+    ).toBeNull()
+  })
+
+  it('ignores drags that are not tasks', () => {
+    // Arrange / Act / Assert
+    expect(
+      resolveReceivingCellId(index, 's1', taskCellId('s2', laneA)),
+    ).toBeNull()
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
@@ -84,15 +84,20 @@ export interface BoardDragIndex {
   kindById: Map<string, DragKind>
   goalIdByStepId: Map<string, string>
   cellByTaskId: Map<string, { stepId: string; swimLaneId: string }>
+  /**
+   * Every task-cell id the board renders — one per rendered step × expanded lane. Cell ids are
+   * structured strings, so a well-formed one can still name a cell a collapse has hidden; targets
+   * are checked against this set rather than by parsing.
+   */
+  renderedCellIds: Set<string>
 }
 
 /**
  * Index every draggable id once per drag, so drop resolution is plain lookups.
  *
- * Tasks in a collapsed swim lane are deliberately left out: they render no card and no cell, so they
- * are neither draggable nor droppable, and indexing them would let `resolveDrop` compute a landing
- * position among siblings the user cannot see. A collapsed lane's own banner stays draggable, so
- * lanes can still be reordered while collapsed.
+ * Anything a collapse hides is left out — indexing it would let `resolveDrop` compute a landing
+ * position among siblings the user cannot see. A collapsed node's own header stays draggable, so
+ * goals and lanes can still be reordered while collapsed.
  */
 export const buildDragIndex = (layout: BoardLayout): BoardDragIndex => {
   const kindById = new Map<string, DragKind>()
@@ -105,6 +110,12 @@ export const buildDragIndex = (layout: BoardLayout): BoardDragIndex => {
       .map(({ swimLane }) => swimLane.id),
   )
 
+  const expandedLaneIds = layout.swimLanes
+    .filter(({ isCollapsed }) => !isCollapsed)
+    .map(({ swimLane }) => swimLane.id)
+
+  const renderedCellIds = new Set<string>()
+
   for (const { goal } of layout.goals) kindById.set(goal.id, 'goal')
   for (const { swimLane } of layout.swimLanes) {
     kindById.set(swimLane.id, 'swimLane')
@@ -112,6 +123,11 @@ export const buildDragIndex = (layout: BoardLayout): BoardDragIndex => {
   for (const { step, goalId } of layout.steps) {
     kindById.set(step.id, 'step')
     goalIdByStepId.set(step.id, goalId)
+
+    for (const swimLaneId of expandedLaneIds) {
+      renderedCellIds.add(taskCellId(step.id, swimLaneId))
+    }
+
     for (const task of step.tasks) {
       if (collapsedLaneIds.has(task.swimLaneId)) continue
 
@@ -123,7 +139,7 @@ export const buildDragIndex = (layout: BoardLayout): BoardDragIndex => {
     }
   }
 
-  return { kindById, goalIdByStepId, cellByTaskId }
+  return { kindById, goalIdByStepId, cellByTaskId, renderedCellIds }
 }
 
 /**
@@ -180,9 +196,9 @@ export const isValidDropTarget = (
     // goals row itself is never a target.
     case 'step':
       return overKind === 'step' || parseEmptyStepSlotId(overId) !== null
-    // A task lands on another task, or on a (step × lane) cell — including an empty one.
+    // A task lands on another task, or on a rendered (step × lane) cell — including an empty one.
     case 'task':
-      return overKind === 'task' || parseTaskCellId(overId) !== null
+      return overKind === 'task' || index.renderedCellIds.has(overId)
   }
 }
 
@@ -265,8 +281,10 @@ export const resolveDrop = (
   if (!from) return null
 
   // Dropped on a cell rather than a card — the empty space below the last one, or an empty cell.
-  // Either way the task appends to the end.
-  const cell = parseTaskCellId(overId)
+  // Either way the task appends to the end. Parseable is not enough: a hidden cell parses fine.
+  const cell = index.renderedCellIds.has(overId)
+    ? parseTaskCellId(overId)
+    : null
   if (cell) {
     const existing =
       layout.tasksByCell.get(`${cell.stepId}:${cell.swimLaneId}`) ?? []
@@ -309,7 +327,6 @@ export const resolveDrop = (
     targetStepId: to.stepId,
     targetSwimLaneId: to.swimLaneId,
     newOrder,
-    changedCell:
-      to.stepId !== from.stepId || to.swimLaneId !== from.swimLaneId,
+    changedCell: to.stepId !== from.stepId || to.swimLaneId !== from.swimLaneId,
   }
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
@@ -331,3 +331,97 @@ export const resolveDrop = (
     changedCell: to.stepId !== from.stepId || to.swimLaneId !== from.swimLaneId,
   }
 }
+
+/**
+ * What a drag should show while it is in flight — the counterpart to {@link resolveDrop}, which says
+ * what the drop will do. Both read the same `(activeId, overId, side)`, so the preview and the
+ * outcome cannot disagree.
+ */
+
+/** The one cell drawing the insertion line for the current seam, and which of its edges. */
+export interface StepSeam {
+  stepId: string
+  edge: DropSide
+}
+
+/**
+ * Which step cell draws the insertion line.
+ *
+ * A seam has two names — "after step A" and "before step B" — that resolve to the same index, so
+ * letting each cell light its own hovered edge gives one landing position two appearances that swap
+ * as the pointer crosses a midpoint. This picks a single cell per seam: normally the step that
+ * follows it, drawing a leading edge. A goal's last step has no follower, so that seam alone keeps a
+ * trailing edge.
+ */
+export const resolveStepSeam = (
+  layout: BoardLayout,
+  index: BoardDragIndex,
+  activeId: string | null,
+  overId: string | null,
+  side: DropSide,
+): StepSeam | null => {
+  if (!activeId || index.kindById.get(activeId) !== 'step') return null
+  if (!overId || index.kindById.get(overId) !== 'step') return null
+
+  const hovered = layout.steps.find((s) => s.step.id === overId)
+  if (!hovered) return null
+
+  if (side === 'before') return { stepId: hovered.step.id, edge: 'before' }
+
+  const next = layout.steps.find(
+    (s) =>
+      s.goalId === hovered.goalId && s.indexInGoal === hovered.indexInGoal + 1,
+  )
+
+  return next
+    ? { stepId: next.step.id, edge: 'before' }
+    : { stepId: hovered.step.id, edge: 'after' }
+}
+
+/**
+ * The goal a dragged step would join, whose run of step columns is outlined as the destination.
+ * Null when the drag stays inside its current goal — a reorder needs no destination marker — and for
+ * a step-less goal, whose slot already marks itself as the target.
+ */
+export const resolveReceivingGoalId = (
+  index: BoardDragIndex,
+  activeId: string | null,
+  overId: string | null,
+): string | null => {
+  if (!activeId || !overId) return null
+  if (index.kindById.get(activeId) !== 'step') return null
+
+  const fromGoalId = index.goalIdByStepId.get(activeId)
+
+  // Either hovering a sibling step, or the empty slot of a goal with no steps of its own.
+  const toGoalId =
+    index.goalIdByStepId.get(overId) ?? parseEmptyStepSlotId(overId)
+
+  return toGoalId && toGoalId !== fromGoalId ? toGoalId : null
+}
+
+/**
+ * The cell a dragged task would land in, or null when that is the cell it already sits in. A task's
+ * parent is its step crossed with its swim lane, so either axis changing is a reparent.
+ */
+export const resolveReceivingCellId = (
+  index: BoardDragIndex,
+  activeId: string | null,
+  overId: string | null,
+): string | null => {
+  if (!activeId || !overId) return null
+  if (index.kindById.get(activeId) !== 'task') return null
+
+  const from = index.cellByTaskId.get(activeId)
+  if (!from) return null
+
+  // The target is either an empty cell, or a card — in which case the cell is the one it sits in.
+  const overCell = index.cellByTaskId.get(overId)
+  const to = overCell
+    ? taskCellId(overCell.stepId, overCell.swimLaneId)
+    : index.renderedCellIds.has(overId)
+      ? overId
+      : null
+
+  return to && to !== taskCellId(from.stepId, from.swimLaneId) ? to : null
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
@@ -43,7 +43,8 @@ export const EMPTY_STEP_SLOT_PREFIX = 'step-slot:'
 export const emptyStepSlotId = (goalId: string) =>
   `${EMPTY_STEP_SLOT_PREFIX}${goalId}`
 
-const parseEmptyStepSlotId = (id: string) =>
+/** The goal id behind an empty-slot target, or null when the id is not one. */
+export const parseEmptyStepSlotId = (id: string) =>
   id.startsWith(EMPTY_STEP_SLOT_PREFIX)
     ? id.slice(EMPTY_STEP_SLOT_PREFIX.length)
     : null

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-drag.ts
@@ -86,11 +86,24 @@ export interface BoardDragIndex {
   cellByTaskId: Map<string, { stepId: string; swimLaneId: string }>
 }
 
-/** Index every draggable id once per drag, so drop resolution is plain lookups. */
+/**
+ * Index every draggable id once per drag, so drop resolution is plain lookups.
+ *
+ * Tasks in a collapsed swim lane are deliberately left out: they render no card and no cell, so they
+ * are neither draggable nor droppable, and indexing them would let `resolveDrop` compute a landing
+ * position among siblings the user cannot see. A collapsed lane's own banner stays draggable, so
+ * lanes can still be reordered while collapsed.
+ */
 export const buildDragIndex = (layout: BoardLayout): BoardDragIndex => {
   const kindById = new Map<string, DragKind>()
   const goalIdByStepId = new Map<string, string>()
   const cellByTaskId = new Map<string, { stepId: string; swimLaneId: string }>()
+
+  const collapsedLaneIds = new Set(
+    layout.swimLanes
+      .filter(({ isCollapsed }) => isCollapsed)
+      .map(({ swimLane }) => swimLane.id),
+  )
 
   for (const { goal } of layout.goals) kindById.set(goal.id, 'goal')
   for (const { swimLane } of layout.swimLanes) {
@@ -100,6 +113,8 @@ export const buildDragIndex = (layout: BoardLayout): BoardDragIndex => {
     kindById.set(step.id, 'step')
     goalIdByStepId.set(step.id, goalId)
     for (const task of step.tasks) {
+      if (collapsedLaneIds.has(task.swimLaneId)) continue
+
       kindById.set(task.id, 'task')
       cellByTaskId.set(task.id, {
         stepId: step.id,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-export.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-export.test.ts
@@ -40,7 +40,14 @@ const step = (
   tasks: StoryMapTaskDto[] = [],
   personaIds: string[] = [],
 ): StoryMapStepDto =>
-  ({ id: name, goalId: 'g1', name, order, personaIds, tasks }) as StoryMapStepDto
+  ({
+    id: name,
+    goalId: 'g1',
+    name,
+    order,
+    personaIds,
+    tasks,
+  }) as StoryMapStepDto
 
 const goal = (
   name: string,
@@ -52,11 +59,7 @@ const goal = (
 const lane = (id: string, name: string, order: number): StoryMapSwimLaneDto =>
   ({ id, name, order, isDefault: order === 0 }) as StoryMapSwimLaneDto
 
-const persona = (
-  id: string,
-  name: string,
-  order: number,
-): StoryMapPersonaDto =>
+const persona = (id: string, name: string, order: number): StoryMapPersonaDto =>
   ({ id, name, order, color: '#fff' }) as StoryMapPersonaDto
 
 const map = (
@@ -95,7 +98,9 @@ describe('buildExportRows', () => {
 
   it('produces a row for every header column', () => {
     // Arrange
-    const details = map([goal('Goal A', 0, [step('Step 1', 0, [task('T', 0)])])])
+    const details = map([
+      goal('Goal A', 0, [step('Step 1', 0, [task('T', 0)])]),
+    ])
 
     // Act
     const rows = buildExportRows(details)
@@ -166,7 +171,7 @@ describe('buildExportRows', () => {
       ])
     })
 
-    it('groups a step\'s tasks by swim lane in board order', () => {
+    it("groups a step's tasks by swim lane in board order", () => {
       // Arrange
       const details = map(
         [
@@ -254,7 +259,11 @@ describe('buildExportRows', () => {
     it('joins linked persona names with a semicolon', () => {
       // Arrange
       const details = map(
-        [goal('Goal A', 0, [step('Step 1', 0, [task('T', 0, 'lane-1', ['p1', 'p2'])])])],
+        [
+          goal('Goal A', 0, [
+            step('Step 1', 0, [task('T', 0, 'lane-1', ['p1', 'p2'])]),
+          ]),
+        ],
         undefined,
         [persona('p1', 'Engineer', 0), persona('p2', 'Designer', 1)],
       )
@@ -266,10 +275,14 @@ describe('buildExportRows', () => {
       expect(rows[0][7]).toBe('Engineer; Designer')
     })
 
-    it('lists personas in the map\'s order, not the order they were linked', () => {
+    it("lists personas in the map's order, not the order they were linked", () => {
       // Arrange
       const details = map(
-        [goal('Goal A', 0, [step('Step 1', 0, [task('T', 0, 'lane-1', ['p2', 'p1'])])])],
+        [
+          goal('Goal A', 0, [
+            step('Step 1', 0, [task('T', 0, 'lane-1', ['p2', 'p1'])]),
+          ]),
+        ],
         undefined,
         [persona('p1', 'Engineer', 0), persona('p2', 'Designer', 1)],
       )
@@ -283,9 +296,11 @@ describe('buildExportRows', () => {
 
     it('leaves the column blank when nothing is linked', () => {
       // Arrange
-      const details = map([goal('Goal A', 0, [step('Step 1', 0, [task('T', 0)])])], undefined, [
-        persona('p1', 'Engineer', 0),
-      ])
+      const details = map(
+        [goal('Goal A', 0, [step('Step 1', 0, [task('T', 0)])])],
+        undefined,
+        [persona('p1', 'Engineer', 0)],
+      )
 
       // Act
       const rows = buildExportRows(details)
@@ -297,7 +312,11 @@ describe('buildExportRows', () => {
     it('ignores a persona id the map no longer has', () => {
       // Arrange — a stale link left by a deleted persona.
       const details = map(
-        [goal('Goal A', 0, [step('Step 1', 0, [task('T', 0, 'lane-1', ['gone', 'p1'])])])],
+        [
+          goal('Goal A', 0, [
+            step('Step 1', 0, [task('T', 0, 'lane-1', ['gone', 'p1'])]),
+          ]),
+        ],
         undefined,
         [persona('p1', 'Engineer', 0)],
       )
@@ -398,7 +417,11 @@ describe('buildExportRows', () => {
   it('still exports a task whose swim lane is missing from the map', () => {
     // Arrange
     const details = map(
-      [goal('Goal A', 0, [step('Step 1', 0, [task('Orphan', 0, 'lane-gone')])])],
+      [
+        goal('Goal A', 0, [
+          step('Step 1', 0, [task('Orphan', 0, 'lane-gone')]),
+        ]),
+      ],
       [lane('lane-1', 'Tasks', 0)],
     )
 
@@ -406,8 +429,6 @@ describe('buildExportRows', () => {
     const rows = buildExportRows(details)
 
     // Assert — kept, with the lane name blank rather than dropped from the file.
-    expect(rows).toEqual([
-      ['Goal A', 1, 'Step 1', 1, 'Orphan', 1, '', '', ''],
-    ])
+    expect(rows).toEqual([['Goal A', 1, 'Step 1', 1, 'Orphan', 1, '', '', '']])
   })
 })

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.test.ts
@@ -9,8 +9,15 @@ import { buildBoardLayout, cellKey } from './board-layout'
 
 /**
  * Two invariants are asserted throughout: a goal header spans exactly its own steps' tracks, and
- * `stepColumnCount` includes a placeholder track for every step-less goal.
+ * `stepColumnTracks` declares one track per step plus a placeholder for every step-less goal and a
+ * narrow spine for every collapsed one.
  */
+
+/** The flexible track every non-collapsed step column gets. */
+const FLEX_TRACK = 'minmax(var(--sm-col-min), 1fr)'
+
+/** The fixed narrow track a collapsed goal's spine gets. */
+const SPINE_TRACK = 'var(--sm-collapsed-col-width)'
 
 const task = (
   id: string,
@@ -85,7 +92,7 @@ describe('buildBoardLayout', () => {
       ])
 
       // Act
-      const { steps, lastColumn, stepColumnCount } = buildBoardLayout(details)
+      const { steps, lastColumn, stepColumnTracks } = buildBoardLayout(details)
 
       // Assert — column 1 is the label column, so steps start at 2.
       expect(steps.map((s) => [s.step.id, s.column])).toEqual([
@@ -94,7 +101,7 @@ describe('buildBoardLayout', () => {
         ['s3', 4],
       ])
       expect(lastColumn).toBe(4)
-      expect(stepColumnCount).toBe(3)
+      expect(stepColumnTracks).toEqual([FLEX_TRACK, FLEX_TRACK, FLEX_TRACK])
     })
 
     it('spans a goal header across exactly its own steps', () => {
@@ -160,11 +167,11 @@ describe('buildBoardLayout', () => {
       const details = map([goal('g1', 0), goal('g2', 1), goal('g3', 2)])
 
       // Act
-      const { goals, steps, stepColumnCount } = buildBoardLayout(details)
+      const { goals, steps, stepColumnTracks } = buildBoardLayout(details)
 
       // Assert — three tracks for three goals, despite there being no steps at all.
       expect(steps).toHaveLength(0)
-      expect(stepColumnCount).toBe(3)
+      expect(stepColumnTracks).toEqual([FLEX_TRACK, FLEX_TRACK, FLEX_TRACK])
       expect(
         goals.map((g) => [g.goal.id, g.columnStart, g.columnSpan]),
       ).toEqual([
@@ -197,7 +204,7 @@ describe('buildBoardLayout', () => {
       ])
 
       // Act
-      const { goals, steps, stepColumnCount } = buildBoardLayout(details)
+      const { goals, steps, stepColumnTracks } = buildBoardLayout(details)
 
       // Assert — g2 occupies column 4, so g3's step lands at 5.
       expect(
@@ -208,15 +215,153 @@ describe('buildBoardLayout', () => {
         ['g3', 5, 1],
       ])
       expect(steps.map((s) => s.column)).toEqual([2, 3, 5])
-      expect(stepColumnCount).toBe(4)
+      expect(stepColumnTracks).toHaveLength(4)
     })
 
     it('declares one track for a map with no goals at all', () => {
       // Arrange / Act
-      const { stepColumnCount } = buildBoardLayout(map([]))
+      const { stepColumnTracks } = buildBoardLayout(map([]))
 
       // Assert — the grid template still needs a track to name.
-      expect(stepColumnCount).toBe(1)
+      expect(stepColumnTracks).toEqual([FLEX_TRACK])
+    })
+  })
+
+  describe('collapsed goals', () => {
+    it('folds a collapsed goal to one narrow track and shuffles the rest left', () => {
+      // Arrange
+      const details = map([
+        goal('g1', 0, [step('s1', 'g1', 0), step('s2', 'g1', 1)]),
+        goal('g2', 1, [step('s3', 'g2', 0), step('s4', 'g2', 1)]),
+        goal('g3', 2, [step('s5', 'g3', 0)]),
+      ])
+
+      // Act
+      const { goals, stepColumnTracks, lastColumn } = buildBoardLayout(
+        details,
+        {
+          goalIds: new Set(['g2']),
+        },
+      )
+
+      // Assert — g2 spans one track instead of two, so g3 starts at 5 rather than 6.
+      expect(
+        goals.map((g) => [
+          g.goal.id,
+          g.columnStart,
+          g.columnSpan,
+          g.isCollapsed,
+        ]),
+      ).toEqual([
+        ['g1', 2, 2, false],
+        ['g2', 4, 1, true],
+        ['g3', 5, 1, false],
+      ])
+      expect(lastColumn).toBe(5)
+      expect(stepColumnTracks).toEqual([
+        FLEX_TRACK,
+        FLEX_TRACK,
+        SPINE_TRACK,
+        FLEX_TRACK,
+      ])
+    })
+
+    it('contributes no step placements for a collapsed goal', () => {
+      // Arrange
+      const details = map([
+        goal('g1', 0, [step('s1', 'g1', 0)]),
+        goal('g2', 1, [step('s2', 'g2', 0), step('s3', 'g2', 1)]),
+      ])
+
+      // Act
+      const { steps } = buildBoardLayout(details, { goalIds: new Set(['g2']) })
+
+      // Assert — a collapsed goal's steps render no cells, so they are not placed at all.
+      expect(steps.map((s) => s.step.id)).toEqual(['s1'])
+    })
+
+    it('leaves a collapsed goal’s tasks out of the task buckets', () => {
+      // Arrange
+      const details = map([
+        goal('g1', 0, [
+          step('s1', 'g1', 0, [task('t1', 's1', 'lane-default', 0)]),
+        ]),
+        goal('g2', 1, [
+          step('s2', 'g2', 0, [task('t2', 's2', 'lane-default', 0)]),
+        ]),
+      ])
+
+      // Act
+      const { tasksByCell } = buildBoardLayout(details, {
+        goalIds: new Set(['g2']),
+      })
+
+      // Assert — hidden cells must not be drop targets.
+      expect(tasksByCell.has(cellKey('s1', 'lane-default'))).toBe(true)
+      expect(tasksByCell.has(cellKey('s2', 'lane-default'))).toBe(false)
+    })
+
+    it('does not flag a collapsed goal as a placeholder column', () => {
+      // Arrange — both fold to one track, but only the placeholder accepts a dropped step.
+      const details = map([goal('g1', 0), goal('g2', 1)])
+
+      // Act
+      const { goals } = buildBoardLayout(details, { goalIds: new Set(['g2']) })
+
+      // Assert
+      expect(
+        goals.map((g) => [g.goal.id, g.isPlaceholderColumn, g.isCollapsed]),
+      ).toEqual([
+        ['g1', true, false],
+        ['g2', false, true],
+      ])
+    })
+
+    it('declares a spine for every collapsed goal when all are collapsed', () => {
+      // Arrange
+      const details = map([
+        goal('g1', 0, [step('s1', 'g1', 0)]),
+        goal('g2', 1, [step('s2', 'g2', 0)]),
+      ])
+
+      // Act
+      const {
+        steps,
+        stepColumnTracks,
+        collapsedColumnCount,
+        flexibleColumnCount,
+      } = buildBoardLayout(details, { goalIds: new Set(['g1', 'g2']) })
+
+      // Assert
+      expect(steps).toHaveLength(0)
+      expect(stepColumnTracks).toEqual([SPINE_TRACK, SPINE_TRACK])
+      expect(collapsedColumnCount).toBe(2)
+      expect(flexibleColumnCount).toBe(0)
+    })
+
+    it('collapses goals and swim lanes independently', () => {
+      // Arrange
+      const details = map(
+        [
+          goal('g1', 0, [step('s1', 'g1', 0, [task('t1', 's1', 'l0', 0)])]),
+          goal('g2', 1, [step('s2', 'g2', 0)]),
+        ],
+        [swimLane('l0', 0, true), swimLane('l1', 1)],
+      )
+
+      // Act
+      const { goals, swimLanes, steps } = buildBoardLayout(details, {
+        goalIds: new Set(['g2']),
+        swimLaneIds: new Set(['l1']),
+      })
+
+      // Assert — the two axes fold independently.
+      expect(goals.map((g) => g.isCollapsed)).toEqual([false, true])
+      expect(swimLanes.map((l) => [l.swimLane.id, l.row])).toEqual([
+        ['l0', 4],
+        ['l1', null],
+      ])
+      expect(steps.map((s) => s.step.id)).toEqual(['s1'])
     })
   })
 
@@ -232,12 +377,12 @@ describe('buildBoardLayout', () => {
       const { swimLanes } = buildBoardLayout(details)
 
       // Assert — rows 1 and 2 are goals and steps, so lanes start at 3.
-      expect(
-        swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row]),
-      ).toEqual([
-        ['l0', 3, 4],
-        ['l1', 5, 6],
-      ])
+      expect(swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row])).toEqual(
+        [
+          ['l0', 3, 4],
+          ['l1', 5, 6],
+        ],
+      )
     })
 
     it('orders lanes by their order field', () => {
@@ -264,11 +409,18 @@ describe('buildBoardLayout', () => {
       )
 
       // Act
-      const { swimLanes } = buildBoardLayout(details, new Set(['l1']))
+      const { swimLanes } = buildBoardLayout(details, {
+        swimLaneIds: new Set(['l1']),
+      })
 
       // Assert — l1 keeps only its banner (row 5), so l2 starts at 6 rather than 7.
       expect(
-        swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row, l.isCollapsed]),
+        swimLanes.map((l) => [
+          l.swimLane.id,
+          l.headerRow,
+          l.row,
+          l.isCollapsed,
+        ]),
       ).toEqual([
         ['l0', 3, 4, false],
         ['l1', 5, null, true],
@@ -291,12 +443,14 @@ describe('buildBoardLayout', () => {
       )
 
       // Act
-      const { tasksByCell } = buildBoardLayout(details, new Set(['l1']))
+      const { tasksByCell } = buildBoardLayout(details, {
+        swimLaneIds: new Set(['l1']),
+      })
 
       // Assert — a collapsed lane renders no cells, so its tasks are not drop siblings.
-      expect(
-        tasksByCell.get(cellKey('s1', 'l0'))?.map((t) => t.id),
-      ).toEqual(['t-open'])
+      expect(tasksByCell.get(cellKey('s1', 'l0'))?.map((t) => t.id)).toEqual([
+        't-open',
+      ])
       expect(tasksByCell.has(cellKey('s1', 'l1'))).toBe(false)
     })
 
@@ -308,13 +462,17 @@ describe('buildBoardLayout', () => {
       )
 
       // Act
-      const { swimLanes } = buildBoardLayout(details, new Set(['l0', 'l1']))
+      const { swimLanes } = buildBoardLayout(details, {
+        swimLaneIds: new Set(['l0', 'l1']),
+      })
 
       // Assert — consecutive banner rows, no task rows at all.
-      expect(swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row])).toEqual([
-        ['l0', 3, null],
-        ['l1', 4, null],
-      ])
+      expect(swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row])).toEqual(
+        [
+          ['l0', 3, null],
+          ['l1', 4, null],
+        ],
+      )
     })
 
     it('treats an unknown collapsed id as collapsing nothing', () => {
@@ -322,7 +480,9 @@ describe('buildBoardLayout', () => {
       const details = map([goal('g1', 0)], [swimLane('l0', 0, true)])
 
       // Act
-      const { swimLanes } = buildBoardLayout(details, new Set(['gone']))
+      const { swimLanes } = buildBoardLayout(details, {
+        swimLaneIds: new Set(['gone']),
+      })
 
       // Assert
       expect(swimLanes.map((l) => [l.swimLane.id, l.row])).toEqual([['l0', 4]])

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.test.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.test.ts
@@ -255,6 +255,80 @@ describe('buildBoardLayout', () => {
     })
   })
 
+  describe('collapsed swim lanes', () => {
+    it('gives a collapsed lane no task row and pulls the lanes below it up', () => {
+      // Arrange
+      const details = map(
+        [goal('g1', 0, [step('s1', 'g1', 0)])],
+        [swimLane('l0', 0, true), swimLane('l1', 1), swimLane('l2', 2)],
+      )
+
+      // Act
+      const { swimLanes } = buildBoardLayout(details, new Set(['l1']))
+
+      // Assert — l1 keeps only its banner (row 5), so l2 starts at 6 rather than 7.
+      expect(
+        swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row, l.isCollapsed]),
+      ).toEqual([
+        ['l0', 3, 4, false],
+        ['l1', 5, null, true],
+        ['l2', 6, 7, false],
+      ])
+    })
+
+    it('leaves a collapsed lane out of the task buckets', () => {
+      // Arrange — one task in each lane, on the same step.
+      const details = map(
+        [
+          goal('g1', 0, [
+            step('s1', 'g1', 0, [
+              task('t-open', 's1', 'l0', 0),
+              task('t-folded', 's1', 'l1', 0),
+            ]),
+          ]),
+        ],
+        [swimLane('l0', 0, true), swimLane('l1', 1)],
+      )
+
+      // Act
+      const { tasksByCell } = buildBoardLayout(details, new Set(['l1']))
+
+      // Assert — a collapsed lane renders no cells, so its tasks are not drop siblings.
+      expect(
+        tasksByCell.get(cellKey('s1', 'l0'))?.map((t) => t.id),
+      ).toEqual(['t-open'])
+      expect(tasksByCell.has(cellKey('s1', 'l1'))).toBe(false)
+    })
+
+    it('collapses every lane when all are collapsed', () => {
+      // Arrange
+      const details = map(
+        [goal('g1', 0)],
+        [swimLane('l0', 0, true), swimLane('l1', 1)],
+      )
+
+      // Act
+      const { swimLanes } = buildBoardLayout(details, new Set(['l0', 'l1']))
+
+      // Assert — consecutive banner rows, no task rows at all.
+      expect(swimLanes.map((l) => [l.swimLane.id, l.headerRow, l.row])).toEqual([
+        ['l0', 3, null],
+        ['l1', 4, null],
+      ])
+    })
+
+    it('treats an unknown collapsed id as collapsing nothing', () => {
+      // Arrange — a lane deleted by someone else can leave a stale id in the set.
+      const details = map([goal('g1', 0)], [swimLane('l0', 0, true)])
+
+      // Act
+      const { swimLanes } = buildBoardLayout(details, new Set(['gone']))
+
+      // Assert
+      expect(swimLanes.map((l) => [l.swimLane.id, l.row])).toEqual([['l0', 4]])
+    })
+  })
+
   describe('task bucketing', () => {
     it('groups tasks by step and swim lane, sorted by order', () => {
       // Arrange — supplied out of order to prove they are sorted.

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.ts
@@ -20,11 +20,13 @@ import {
 export const LABEL_COLUMN = 1
 const FIRST_STEP_COLUMN = 2
 
-/** Grid row lines: goals, then steps, then two rows per swim lane (its header, then its tasks). */
+/**
+ * Grid row lines: goals, then steps, then the swim lanes. An expanded lane takes two rows — its
+ * header banner, then its row of task cells — while a collapsed one takes only the banner.
+ */
 export const GOAL_ROW = 1
 export const STEP_ROW = 2
 const FIRST_SWIM_LANE_ROW = 3
-const ROWS_PER_SWIM_LANE = 2
 
 export interface StepPlacement {
   step: StoryMapStepDto
@@ -51,9 +53,14 @@ export interface SwimLanePlacement {
   swimLane: StoryMapSwimLaneDto
   /** 1-based grid row line of the lane's full-width header banner. */
   headerRow: number
-  /** 1-based grid row line this lane's task cells occupy, directly under the header. */
-  row: number
+  /**
+   * 1-based grid row line this lane's task cells occupy, directly under the header — or null when
+   * the lane is collapsed, in which case it claims no task row at all.
+   */
+  row: number | null
   index: number
+  /** Collapsed lanes render as the banner alone; their tasks are hidden, not filtered. */
+  isCollapsed: boolean
 }
 
 export interface BoardLayout {
@@ -82,8 +89,15 @@ const byOrder = <T extends { order: number }>(items: T[]): T[] =>
 /**
  * Walk the map in display order, assigning each step the next column and each goal a header span
  * covering its steps. A step-less goal still claims one column so its header stays reachable.
+ *
+ * `collapsedSwimLaneIds` is transient view state, so it changes geometry rather than data: a
+ * collapsed lane claims its banner row and nothing else, and the lanes below shuffle up. Row numbers
+ * are therefore accumulated, not derived from the lane's index.
  */
-export const buildBoardLayout = (map: StoryMapDetailsDto): BoardLayout => {
+export const buildBoardLayout = (
+  map: StoryMapDetailsDto,
+  collapsedSwimLaneIds: ReadonlySet<string> = new Set(),
+): BoardLayout => {
   const goals: GoalPlacement[] = []
   const steps: StepPlacement[] = []
 
@@ -106,17 +120,25 @@ export const buildBoardLayout = (map: StoryMapDetailsDto): BoardLayout => {
     goals.push({ goal, columnStart, columnSpan, index, isPlaceholderColumn })
   })
 
-  // Each lane occupies two rows: a full-width header banner, then the row of task cells under it.
-  const swimLanes = byOrder(map.swimLanes).map((swimLane, index) => ({
-    swimLane,
-    headerRow: FIRST_SWIM_LANE_ROW + index * ROWS_PER_SWIM_LANE,
-    row: FIRST_SWIM_LANE_ROW + index * ROWS_PER_SWIM_LANE + 1,
-    index,
-  }))
+  // An expanded lane occupies two rows — a full-width header banner, then the row of task cells
+  // under it — and a collapsed one just the banner, so rows are handed out as the walk proceeds.
+  let laneRow = FIRST_SWIM_LANE_ROW
+  const swimLanes = byOrder(map.swimLanes).map((swimLane, index) => {
+    const isCollapsed = collapsedSwimLaneIds.has(swimLane.id)
+    const headerRow = laneRow
+    const row = isCollapsed ? null : headerRow + 1
+    laneRow += isCollapsed ? 1 : 2
+
+    return { swimLane, headerRow, row, index, isCollapsed }
+  })
 
   const tasksByCell = new Map<string, StoryMapTaskDto[]>()
   for (const { step } of steps) {
     for (const task of step.tasks) {
+      // A collapsed lane renders no cells, so its tasks must not appear here either — this map is
+      // what drop resolution counts siblings in, and a hidden cell is not a legal landing place.
+      if (collapsedSwimLaneIds.has(task.swimLaneId)) continue
+
       const key = cellKey(step.id, task.swimLaneId)
       const list = tasksByCell.get(key)
       if (list) list.push(task)

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/board-layout.ts
@@ -20,6 +20,9 @@ import {
 export const LABEL_COLUMN = 1
 const FIRST_STEP_COLUMN = 2
 
+/** Shared empty set, so the default collapse state allocates nothing per call. */
+const EMPTY_IDS: ReadonlySet<string> = new Set()
+
 /**
  * Grid row lines: goals, then steps, then the swim lanes. An expanded lane takes two rows — its
  * header banner, then its row of task cells — while a collapsed one takes only the banner.
@@ -47,6 +50,8 @@ export interface GoalPlacement {
   index: number
   /** A step-less goal still claims one track, which needs blank filler cells in the rows below. */
   isPlaceholderColumn: boolean
+  /** Folds to a single narrow track its header runs down; contributes no step columns. */
+  isCollapsed: boolean
 }
 
 export interface SwimLanePlacement {
@@ -54,12 +59,12 @@ export interface SwimLanePlacement {
   /** 1-based grid row line of the lane's full-width header banner. */
   headerRow: number
   /**
-   * 1-based grid row line this lane's task cells occupy, directly under the header — or null when
-   * the lane is collapsed, in which case it claims no task row at all.
+   * 1-based grid row line this lane's task cells occupy, directly under the header — null when the
+   * lane is collapsed and claims no task row.
    */
   row: number | null
   index: number
-  /** Collapsed lanes render as the banner alone; their tasks are hidden, not filtered. */
+  /** Renders as the banner alone. */
   isCollapsed: boolean
 }
 
@@ -70,11 +75,15 @@ export interface BoardLayout {
   /** 1-based line number of the right-most column, used to spot outer-edge cells. */
   lastColumn: number
   /**
-   * Number of step tracks the grid template must declare. NOT `steps.length` — a step-less goal
-   * still claims a placeholder track, and declaring too few makes the browser size the overflow
-   * columns by content instead of `1fr`, so goals stop sharing width equally.
+   * One entry per step track, in column order, each the CSS width for that track. NOT derivable from
+   * `steps.length` — a step-less goal claims a placeholder track and a collapsed goal a narrow
+   * spine, and declaring too few tracks makes the browser size the overflow ones by content instead
+   * of `1fr`, so goals stop sharing width equally.
    */
-  stepColumnCount: number
+  stepColumnTracks: string[]
+  /** Track counts by kind, so the board can floor its width at the sum of the minimums. */
+  flexibleColumnCount: number
+  collapsedColumnCount: number
   /** Tasks keyed by `${stepId}:${swimLaneId}`, each list sorted by order. */
   tasksByCell: Map<string, StoryMapTaskDto[]>
 }
@@ -86,42 +95,65 @@ export const cellKey = (stepId: string, swimLaneId: string) =>
 const byOrder = <T extends { order: number }>(items: T[]): T[] =>
   [...items].sort((a, b) => a.order - b.order)
 
+/** What the viewer has folded away. Transient view state — see the note on `buildBoardLayout`. */
+export interface BoardCollapseState {
+  goalIds?: ReadonlySet<string>
+  swimLaneIds?: ReadonlySet<string>
+}
+
+const NO_COLLAPSE: BoardCollapseState = {}
+
 /**
  * Walk the map in display order, assigning each step the next column and each goal a header span
  * covering its steps. A step-less goal still claims one column so its header stays reachable.
  *
- * `collapsedSwimLaneIds` is transient view state, so it changes geometry rather than data: a
- * collapsed lane claims its banner row and nothing else, and the lanes below shuffle up. Row numbers
- * are therefore accumulated, not derived from the lane's index.
+ * A collapsed node renders no cells, so anything it hides is left out of `tasksByCell` — a cell that
+ * renders nothing must not be a drop target.
  */
 export const buildBoardLayout = (
   map: StoryMapDetailsDto,
-  collapsedSwimLaneIds: ReadonlySet<string> = new Set(),
+  collapsed: BoardCollapseState = NO_COLLAPSE,
 ): BoardLayout => {
+  const collapsedGoalIds = collapsed.goalIds ?? EMPTY_IDS
+  const collapsedSwimLaneIds = collapsed.swimLaneIds ?? EMPTY_IDS
+
   const goals: GoalPlacement[] = []
   const steps: StepPlacement[] = []
 
   let column = FIRST_STEP_COLUMN
 
+  const collapsedColumns = new Set<number>()
+
   byOrder(map.goals).forEach((goal, index) => {
     const goalSteps = byOrder(goal.steps)
+    const isCollapsed = collapsedGoalIds.has(goal.id)
     const columnStart = column
 
-    goalSteps.forEach((step, indexInGoal) => {
-      steps.push({ step, goalId: goal.id, column, indexInGoal })
-      column += 1
+    if (!isCollapsed) {
+      goalSteps.forEach((step, indexInGoal) => {
+        steps.push({ step, goalId: goal.id, column, indexInGoal })
+        column += 1
+      })
+    }
+
+    // Both fold to a single track, but the placeholder accepts a dropped step and the spine does not.
+    const isPlaceholderColumn = !isCollapsed && goalSteps.length === 0
+    const columnSpan = isCollapsed ? 1 : Math.max(goalSteps.length, 1)
+    if (isCollapsed) collapsedColumns.add(column)
+    if (isCollapsed || isPlaceholderColumn) column += 1
+
+    goals.push({
+      goal,
+      columnStart,
+      columnSpan,
+      index,
+      isPlaceholderColumn,
+      isCollapsed,
     })
-
-    // An empty goal still occupies a single placeholder column.
-    const isPlaceholderColumn = goalSteps.length === 0
-    const columnSpan = Math.max(goalSteps.length, 1)
-    if (isPlaceholderColumn) column += 1
-
-    goals.push({ goal, columnStart, columnSpan, index, isPlaceholderColumn })
   })
 
-  // An expanded lane occupies two rows — a full-width header banner, then the row of task cells
-  // under it — and a collapsed one just the banner, so rows are handed out as the walk proceeds.
+  // Rows are accumulated, not derived from the index: an expanded lane takes two (banner, tasks)
+  // and a collapsed one takes only its banner.
   let laneRow = FIRST_SWIM_LANE_ROW
   const swimLanes = byOrder(map.swimLanes).map((swimLane, index) => {
     const isCollapsed = collapsedSwimLaneIds.has(swimLane.id)
@@ -135,8 +167,9 @@ export const buildBoardLayout = (
   const tasksByCell = new Map<string, StoryMapTaskDto[]>()
   for (const { step } of steps) {
     for (const task of step.tasks) {
-      // A collapsed lane renders no cells, so its tasks must not appear here either — this map is
-      // what drop resolution counts siblings in, and a hidden cell is not a legal landing place.
+      // Drop resolution counts siblings in this map, so a hidden cell must not appear in it. A
+      // collapsed goal needs no equivalent check — it contributes no steps, so the loop above never
+      // reaches its tasks.
       if (collapsedSwimLaneIds.has(task.swimLaneId)) continue
 
       const key = cellKey(step.id, task.swimLaneId)
@@ -151,13 +184,23 @@ export const buildBoardLayout = (
 
   const lastColumn = column - 1
 
+  // Floored at 1 so a map with no goals still has a track for the grid template to declare.
+  const stepColumnCount = Math.max(lastColumn - LABEL_COLUMN, 1)
+
+  const stepColumnTracks = Array.from({ length: stepColumnCount }, (_, i) =>
+    collapsedColumns.has(FIRST_STEP_COLUMN + i)
+      ? 'var(--sm-collapsed-col-width)'
+      : 'minmax(var(--sm-col-min), 1fr)',
+  )
+
   return {
     goals,
     steps,
     swimLanes,
     lastColumn,
-    // Floored at 1 so a map with no goals still has a track for the grid template to declare.
-    stepColumnCount: Math.max(lastColumn - LABEL_COLUMN, 1),
+    stepColumnTracks,
+    collapsedColumnCount: collapsedColumns.size,
+    flexibleColumnCount: stepColumnCount - collapsedColumns.size,
     tasksByCell,
   }
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/empty-step-slot.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/empty-step-slot.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useDroppable } from '@dnd-kit/core'
+import { PlusOutlined } from '@ant-design/icons'
 import { CSSProperties, FC } from 'react'
 import { emptyStepSlotId } from './board-drag'
 import { STEP_ROW } from './board-layout'
@@ -12,17 +13,23 @@ export interface EmptyStepSlotProps {
   column: number
   canUpdate: boolean
   isLastColumn: boolean
+  onAddStep: (goalId: string) => void
 }
 
 /**
  * The empty slot in the steps row beneath a step-less goal. Fills the placeholder column so the grid
- * has no hole, and is the drop target for moving a step into that goal.
+ * has no hole, is the drop target for moving a step into that goal, and for editors is a ghost step
+ * that adds the goal's first one when clicked.
+ *
+ * A <button> only for editors — a viewer who cannot add gets no focusable element promising an
+ * action that would fail.
  */
 const EmptyStepSlot: FC<EmptyStepSlotProps> = ({
   goalId,
   column,
   canUpdate,
   isLastColumn,
+  onAddStep,
 }) => {
   const { setNodeRef, isOver } = useDroppable({
     id: emptyStepSlotId(goalId),
@@ -31,14 +38,31 @@ const EmptyStepSlot: FC<EmptyStepSlotProps> = ({
 
   const style: CSSProperties = { gridRow: STEP_ROW, gridColumn: column }
 
+  const className = `${styles.stepCell} ${styles.emptyStepSlot} ${
+    isLastColumn ? styles.lastColumn : ''
+  } ${isOver ? styles.stepCellOver : ''}`
+
+  if (!canUpdate) {
+    return <div ref={setNodeRef} className={className} style={style} />
+  }
+
   return (
-    <div
+    <button
       ref={setNodeRef}
-      className={`${styles.stepCell} ${isLastColumn ? styles.lastColumn : ''} ${
-        isOver ? styles.stepCellOver : ''
-      }`}
+      type="button"
+      className={`${className} ${styles.emptyStepSlotButton}`}
       style={style}
-    />
+      aria-label="Add the first step"
+      onClick={() => onAddStep(goalId)}
+    >
+      {/* The drop highlight is the message while a step is held over the slot. */}
+      {!isOver && (
+        <span className={styles.emptyStepSlotHint}>
+          <PlusOutlined />
+          Add step
+        </span>
+      )}
+    </button>
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/empty-step-slot.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/empty-step-slot.tsx
@@ -42,5 +42,4 @@ const EmptyStepSlot: FC<EmptyStepSlotProps> = ({
   )
 }
 
-
 export default EmptyStepSlot

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/goal-header-cell.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/goal-header-cell.tsx
@@ -1,7 +1,13 @@
 'use client'
 
-import { DeleteOutlined, PlusOutlined } from '@ant-design/icons'
+import {
+  DeleteOutlined,
+  DownOutlined,
+  PlusOutlined,
+  RightOutlined,
+} from '@ant-design/icons'
 import { Button, Popconfirm } from 'antd'
+import { WaydTooltip } from '@/src/components/common'
 import { CSSProperties, FC } from 'react'
 import { BoardActions } from './board-actions'
 import { DropSide } from './board-drag'
@@ -19,6 +25,12 @@ export interface GoalHeaderCellProps {
   isLastColumn: boolean
   /** Which edge of the hovered node a drop lands on, from the board's pointer tracking. */
   dropSide: DropSide
+  onToggleCollapsed: (goalId: string) => void
+  /**
+   * Grid row line just past the last swim-lane row. A collapsed goal's header spans down to it,
+   * since it renders nothing else and its column would otherwise be a hole.
+   */
+  bottomRow: number
 }
 
 /** A goal's header cell, spanning the column tracks of all its steps. */
@@ -29,8 +41,10 @@ const GoalHeaderCell: FC<GoalHeaderCellProps> = ({
   onAddStep,
   isLastColumn,
   dropSide,
+  onToggleCollapsed,
+  bottomRow,
 }) => {
-  const { goal, columnStart, columnSpan } = placement
+  const { goal, columnStart, columnSpan, isCollapsed } = placement
 
   const {
     attributes,
@@ -43,7 +57,7 @@ const GoalHeaderCell: FC<GoalHeaderCellProps> = ({
   } = useBoardSortable(goal.id, !actions.canUpdate, { dropSide })
 
   const style: CSSProperties = {
-    gridRow: GOAL_ROW,
+    gridRow: isCollapsed ? `${GOAL_ROW} / ${bottomRow}` : GOAL_ROW,
     gridColumn: `${columnStart} / span ${columnSpan}`,
     ...sortableStyle,
   }
@@ -78,8 +92,8 @@ const GoalHeaderCell: FC<GoalHeaderCellProps> = ({
       ref={setNodeRef}
       data-tour="goal-cell"
       className={`${styles.goalCell} ${dragClassName} ${muted ? styles.muted : ''} ${
-        isLastColumn ? styles.lastColumn : ''
-      } ${
+        isCollapsed ? styles.goalCellCollapsed : ''
+      } ${isLastColumn ? styles.lastColumn : ''} ${
         isDropTarget
           ? dropsAfter
             ? styles.stepCellDropAfter
@@ -90,17 +104,42 @@ const GoalHeaderCell: FC<GoalHeaderCellProps> = ({
       {...attributes}
       {...listeners}
     >
-      <InlineEditText
-        value={goal.name}
-        onSave={(name) => actions.onRenameGoal(goal.id, name)}
-        disabled={!actions.canUpdate}
-        autoEdit={actions.autoEditId === goal.id}
-        onEditEnd={actions.onAutoEditEnd}
-        ariaLabel="Rename goal"
-        className={styles.goalName}
-        display={(v) => <span className={styles.goalName}>{v}</span>}
-      />
-      {actions.canUpdate && (
+      <WaydTooltip title={isCollapsed ? 'Expand goal' : 'Collapse goal'}>
+        <Button
+          size="small"
+          type="text"
+          icon={isCollapsed ? <RightOutlined /> : <DownOutlined />}
+          className={styles.goalCollapseButton}
+          aria-expanded={!isCollapsed}
+          aria-label={
+            isCollapsed ? `Expand ${goal.name}` : `Collapse ${goal.name}`
+          }
+          onClick={() => onToggleCollapsed(goal.id)}
+        />
+      </WaydTooltip>
+
+      {/* Not editable while collapsed: a rotated box gives the inline editor nothing to size
+          against. Expanding restores it. */}
+      {isCollapsed ? (
+        <WaydTooltip title={goal.name}>
+          <span className={`${styles.goalName} ${styles.goalNameVertical}`}>
+            {goal.name}
+          </span>
+        </WaydTooltip>
+      ) : (
+        <InlineEditText
+          value={goal.name}
+          onSave={(name) => actions.onRenameGoal(goal.id, name)}
+          disabled={!actions.canUpdate}
+          autoEdit={actions.autoEditId === goal.id}
+          onEditEnd={actions.onAutoEditEnd}
+          ariaLabel="Rename goal"
+          className={styles.goalName}
+          display={(v) => <span className={styles.goalName}>{v}</span>}
+        />
+      )}
+
+      {actions.canUpdate && !isCollapsed && (
         <div className={styles.headerActions}>
           <Button
             size="small"

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/inline-edit-text.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/inline-edit-text.tsx
@@ -114,7 +114,9 @@ const InlineEditText: FC<InlineEditTextProps> = ({
 
     // Otherwise an auto-sizing textarea that matches the display text's box, so the caret lands
     // where the user clicked (including on a wrapped second line) and the layout does not jump.
-    return <TextArea ref={inputRef as Ref<TextAreaRef>} autoSize {...editorProps} />
+    return (
+      <TextArea ref={inputRef as Ref<TextAreaRef>} autoSize {...editorProps} />
+    )
   }
 
   return (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/manage-personas-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/manage-personas-form.tsx
@@ -13,11 +13,7 @@ import {
 } from '@/src/store/features/planning/story-maps-api'
 import { useMessage } from '@/src/components/contexts/messaging'
 import { nextUnusedPersonaColor, personaColorPalette } from '@/src/utils'
-import {
-  DeleteOutlined,
-  HolderOutlined,
-  PlusOutlined,
-} from '@ant-design/icons'
+import { DeleteOutlined, HolderOutlined, PlusOutlined } from '@ant-design/icons'
 import {
   Button,
   ColorPicker,
@@ -43,7 +39,14 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { CSSProperties, FC, KeyboardEvent, useMemo, useRef, useState } from 'react'
+import {
+  CSSProperties,
+  FC,
+  KeyboardEvent,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import styles from '../../_components/story-map.module.css'
 
 const { Text } = Typography
@@ -379,7 +382,13 @@ const ManagePersonasForm: FC<ManagePersonasFormProps> = ({
   }
 
   return (
-    <Modal title="Personas" open onCancel={onClose} footer={null} destroyOnHidden>
+    <Modal
+      title="Personas"
+      open
+      onCancel={onClose}
+      footer={null}
+      destroyOnHidden
+    >
       <Text type="secondary" className={styles.personaModalSubtitle}>
         Scoped to this map. Tag them on steps and tasks to filter.
       </Text>
@@ -442,10 +451,7 @@ const ManagePersonasForm: FC<ManagePersonasFormProps> = ({
                 name="description"
                 className={styles.personaEditorField}
               >
-                <Input
-                  placeholder="Who is this, in one line"
-                  maxLength={256}
-                />
+                <Input placeholder="Who is this, in one line" maxLength={256} />
               </Form.Item>
               <Flex gap={8} justify="flex-end">
                 <Button size="small" onClick={cancelAdd}>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/persona-filter-bar.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/persona-filter-bar.tsx
@@ -184,4 +184,3 @@ const PersonaFilterBar: FC<PersonaFilterBarProps> = ({
 }
 
 export default PersonaFilterBar
-

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/step-header-cell.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/step-header-cell.tsx
@@ -4,7 +4,6 @@ import { DeleteOutlined, PlusOutlined } from '@ant-design/icons'
 import { Button, Popconfirm } from 'antd'
 import { CSSProperties, FC } from 'react'
 import { BoardActions } from './board-actions'
-import { DropSide } from './board-drag'
 import { StepPlacement, STEP_ROW } from './board-layout'
 import InlineEditText from './inline-edit-text'
 import PersonaToggleDots from './persona-toggle-dots'
@@ -17,8 +16,17 @@ export interface StepHeaderCellProps {
   actions: BoardActions
   /** Cells in the right-most column drop the border that would double against the grid's own. */
   isLastColumn: boolean
-  /** Which edge of the hovered node a drop lands on, from the board's pointer tracking. */
-  dropSide: DropSide
+  /**
+   * The lit seam, decided by the board rather than by each cell's own `isOver`.
+   *
+   * "After this step" and "before the next" are the same gap and resolve to the same index, so a
+   * cell lighting its own trailing edge gave one landing position two appearances that swapped as
+   * the pointer crossed a midpoint. The board picks one cell per seam instead: the leading edge of
+   * whichever step follows it, falling back to a trailing edge for a goal's last step, which has no
+   * following step to borrow an edge from.
+   */
+  showsDropBefore: boolean
+  showsDropAfter: boolean
 }
 
 /** A step's header cell — one column track wide, above its own task cells. */
@@ -27,7 +35,8 @@ const StepHeaderCell: FC<StepHeaderCellProps> = ({
   selectedPersonaId,
   actions,
   isLastColumn,
-  dropSide,
+  showsDropBefore,
+  showsDropAfter,
 }) => {
   const { step, column } = placement
 
@@ -37,9 +46,7 @@ const StepHeaderCell: FC<StepHeaderCellProps> = ({
     setNodeRef,
     style: sortableStyle,
     dragClassName,
-    isDropTarget,
-    dropsAfter,
-  } = useBoardSortable(step.id, !actions.canUpdate, { dropSide })
+  } = useBoardSortable(step.id, !actions.canUpdate)
 
   const style: CSSProperties = {
     gridRow: STEP_ROW,
@@ -66,11 +73,11 @@ const StepHeaderCell: FC<StepHeaderCellProps> = ({
       className={`${styles.stepCell} ${dragClassName} ${muted ? styles.muted : ''} ${
         isLastColumn ? styles.lastColumn : ''
       } ${
-        isDropTarget
-          ? dropsAfter
+        showsDropBefore
+          ? styles.stepCellDropBefore
+          : showsDropAfter
             ? styles.stepCellDropAfter
-            : styles.stepCellDropBefore
-          : ''
+            : ''
       }`}
       style={style}
       {...attributes}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -8,6 +8,7 @@ import {
   CollisionDetection,
   DndContext,
   DragEndEvent,
+  DragMoveEvent,
   DragOverlay,
   DragStartEvent,
   PointerSensor,
@@ -23,6 +24,7 @@ import { countTasksByLane } from './board-counts'
 import {
   buildDragIndex,
   isValidDropTarget,
+  parseEmptyStepSlotId,
   resolveDrop,
   taskCellId,
   type DropSide,
@@ -194,26 +196,33 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
   )
 
   // onDragMove, not onDragOver: the side flips as the pointer crosses a target's midpoint, which is
-  // not a change of target. The setState is a no-op unless the side actually changed.
-  const handleDragMove = () => {
+  // not a change of target. Both setStates are no-ops unless the value actually changed.
+  const handleDragMove = (event: DragMoveEvent) => {
     setDropSide((current) =>
       current === dropSideRef.current ? current : dropSideRef.current,
     )
+
+    const next = event.over ? String(event.over.id) : null
+    setOverId((current) => (current === next ? current : next))
   }
 
   // The node being dragged, rendered into the DragOverlay. Board nodes are grid children, so
   // transforming the original in place would slide it across its neighbours instead.
   const [activeDragId, setActiveDragId] = useState<string | null>(null)
 
+  const [overId, setOverId] = useState<string | null>(null)
+
   const handleDragStart = (event: DragStartEvent) => {
     // Start neutral rather than inheriting the previous drag's side.
     dropSideRef.current = 'before'
     setDropSide('before')
+    setOverId(null)
     setActiveDragId(String(event.active.id))
   }
 
   const handleDragEnd = (event: DragEndEvent) => {
     setActiveDragId(null)
+    setOverId(null)
 
     const { active, over } = event
     if (!over) return
@@ -227,6 +236,25 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     )
     if (drop) actions.onDrop(drop)
   }
+
+  /**
+   * The goal a dragged step would join, or null when the drag stays inside its current goal — a
+   * reorder needs no destination marker, since the insertion line already says where it lands.
+   */
+  const receivingGoal = useMemo(() => {
+    if (!activeDragId || !overId) return null
+    if (dragIndex.kindById.get(activeDragId) !== 'step') return null
+
+    const fromGoalId = dragIndex.goalIdByStepId.get(activeDragId)
+
+    // Either hovering a sibling step, or the empty slot of a goal with no steps of its own.
+    const toGoalId =
+      dragIndex.goalIdByStepId.get(overId) ?? parseEmptyStepSlotId(overId)
+
+    if (!toGoalId || toGoalId === fromGoalId) return null
+
+    return goals.find((g) => g.goal.id === toGoalId) ?? null
+  }, [activeDragId, overId, dragIndex, goals])
 
   // What to show inside the overlay: the name of whatever kind is being dragged.
   const activeDragLabel = useMemo(() => {
@@ -267,7 +295,10 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
       onDragStart={handleDragStart}
       onDragMove={handleDragMove}
       onDragEnd={handleDragEnd}
-      onDragCancel={() => setActiveDragId(null)}
+      onDragCancel={() => {
+        setActiveDragId(null)
+        setOverId(null)
+      }}
     >
       <div
         ref={scrollRef}
@@ -321,6 +352,18 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
               />
             ))}
 
+            {/* Its own overlay rather than a class on the step cells: outlining each cell would
+                draw interior edges between them instead of one boundary round the run. */}
+            {receivingGoal && (
+              <div
+                className={styles.receivingStepBand}
+                style={{
+                  gridRow: STEP_ROW,
+                  gridColumn: `${receivingGoal.columnStart} / span ${receivingGoal.columnSpan}`,
+                }}
+              />
+            )}
+
             {/* ── Task band: per swim lane, a full-width header banner then a row of task cells ── */}
             {swimLanes.map(({ swimLane, headerRow, isCollapsed }) => (
               <SwimLaneHeader
@@ -371,6 +414,7 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
                     column={placement.columnStart}
                     canUpdate={actions.canUpdate}
                     isLastColumn={placement.columnStart === lastColumn}
+                    onAddStep={onAddStep}
                   />
                   {expandedSwimLanes.map(({ swimLane, row }) => (
                     <div

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -182,20 +182,23 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
 
       const top = resolved[0]
       const pointer = args.pointerCoordinates
-      if (top && pointer) {
-        const rect = args.droppableRects.get(top.id)
-        if (rect) {
-          // Tasks stack vertically; goals and steps read left to right.
-          dropSideRef.current =
-            dragIndex.kindById.get(activeId) === 'task'
-              ? pointer.y > rect.top + rect.height / 2
-                ? 'after'
-                : 'before'
-              : pointer.x > rect.left + rect.width / 2
-                ? 'after'
-                : 'before'
-          dropTargetRef.current = String(top.id)
-        }
+      const rect = top ? args.droppableRects.get(top.id) : undefined
+
+      if (top && pointer && rect) {
+        // Tasks stack vertically; goals and steps read left to right.
+        dropSideRef.current =
+          dragIndex.kindById.get(activeId) === 'task'
+            ? pointer.y > rect.top + rect.height / 2
+              ? 'after'
+              : 'before'
+            : pointer.x > rect.left + rect.width / 2
+              ? 'after'
+              : 'before'
+        dropTargetRef.current = String(top.id)
+      } else {
+        // Dragged clear of every valid target. Without this the ref keeps the last one, and its
+        // seam and destination highlights stay lit over a drop that would no longer happen.
+        dropTargetRef.current = null
       }
 
       return resolved
@@ -236,19 +239,16 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     setActiveDragId(null)
     setOverId(null)
 
-    const { active, over } = event
-    if (!over) return
-
-    // The side was measured against dropTargetRef, so pair them here too. Falling back to `over`
-    // keeps the drop working if the release lands without a fresh collision pass; mixing the two
-    // would resolve the side against a target it was never measured on.
-    const targetId =
-      dropTargetRef.current !== null ? dropTargetRef.current : String(over.id)
+    // The side is only meaningful against the target it was measured on, so the drop uses that same
+    // target rather than dnd-kit's `over` — the two can describe different frames. A null ref means
+    // the last pass found no valid target, which is a drop on nothing.
+    const targetId = dropTargetRef.current
+    if (!targetId) return
 
     const drop = resolveDrop(
       layout,
       dragIndex,
-      String(active.id),
+      String(event.active.id),
       targetId,
       dropSideRef.current,
     )

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -8,7 +8,6 @@ import {
   CollisionDetection,
   DndContext,
   DragEndEvent,
-  DragMoveEvent,
   DragOverlay,
   DragStartEvent,
   PointerSensor,
@@ -157,6 +156,12 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
   const dropSideRef = useRef<DropSide>('before')
   const [dropSide, setDropSide] = useState<DropSide>('before')
 
+  // The target the side above was measured against, captured in the same pass. `event.over` from
+  // onDragMove is not interchangeable with it: the two can describe different frames, and a side
+  // left over from the previous target sends the seam to the wrong cell for a frame — a visible
+  // flick to the far end of the neighbouring step.
+  const dropTargetRef = useRef<string | null>(null)
+
   // Restrict hit testing to legal targets, so an illegal one never highlights.
   const collisionDetection: CollisionDetection = useMemo(
     () => (args) => {
@@ -187,6 +192,7 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
               : pointer.x > rect.left + rect.width / 2
                 ? 'after'
                 : 'before'
+          dropTargetRef.current = String(top.id)
         }
       }
 
@@ -197,13 +203,16 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
 
   // onDragMove, not onDragOver: the side flips as the pointer crosses a target's midpoint, which is
   // not a change of target. Both setStates are no-ops unless the value actually changed.
-  const handleDragMove = (event: DragMoveEvent) => {
+  //
+  // Both values come from the refs, so the pair always describes one collision pass. Taking the
+  // target from `event.over` instead would let it run ahead of the side measured against it.
+  const handleDragMove = () => {
     setDropSide((current) =>
       current === dropSideRef.current ? current : dropSideRef.current,
     )
-
-    const next = event.over ? String(event.over.id) : null
-    setOverId((current) => (current === next ? current : next))
+    setOverId((current) =>
+      current === dropTargetRef.current ? current : dropTargetRef.current,
+    )
   }
 
   // The node being dragged, rendered into the DragOverlay. Board nodes are grid children, so
@@ -213,8 +222,9 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
   const [overId, setOverId] = useState<string | null>(null)
 
   const handleDragStart = (event: DragStartEvent) => {
-    // Start neutral rather than inheriting the previous drag's side.
+    // Start neutral rather than inheriting the previous drag's side and target.
     dropSideRef.current = 'before'
+    dropTargetRef.current = null
     setDropSide('before')
     setOverId(null)
     setActiveDragId(String(event.active.id))
@@ -227,19 +237,26 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     const { active, over } = event
     if (!over) return
 
+    // The side was measured against dropTargetRef, so pair them here too. Falling back to `over`
+    // keeps the drop working if the release lands without a fresh collision pass; mixing the two
+    // would resolve the side against a target it was never measured on.
+    const targetId =
+      dropTargetRef.current !== null ? dropTargetRef.current : String(over.id)
+
     const drop = resolveDrop(
       layout,
       dragIndex,
       String(active.id),
-      String(over.id),
+      targetId,
       dropSideRef.current,
     )
     if (drop) actions.onDrop(drop)
   }
 
   /**
-   * The goal a dragged step would join, or null when the drag stays inside its current goal — a
-   * reorder needs no destination marker, since the insertion line already says where it lands.
+   * The goal a dragged step would join, and whose step columns the band marks. Null when the drag
+   * stays inside its current goal — a reorder needs no destination marker, since the insertion line
+   * already says where it lands.
    */
   const receivingGoal = useMemo(() => {
     if (!activeDragId || !overId) return null
@@ -253,8 +270,45 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
 
     if (!toGoalId || toGoalId === fromGoalId) return null
 
-    return goals.find((g) => g.goal.id === toGoalId) ?? null
+    const placement = goals.find((g) => g.goal.id === toGoalId)
+
+    // A step-less goal's slot already marks itself as the drop target, and the band around a single
+    // cell would only ring it a second time.
+    return placement && !placement.isPlaceholderColumn ? placement : null
   }, [activeDragId, overId, dragIndex, goals])
+
+  /**
+   * Which step cell draws the insertion line, and on which edge.
+   *
+   * A seam has two names — "after step A" and "before step B" — that resolve to the same index, so
+   * letting each cell light its own hovered edge gave one landing position two appearances. This
+   * picks a single cell per seam: normally the step that follows it, drawing a leading edge. A
+   * goal's last step has no follower, so that one seam keeps a trailing edge.
+   */
+  const litStepSeam = useMemo(() => {
+    if (!activeDragId || dragIndex.kindById.get(activeDragId) !== 'step') {
+      return null
+    }
+    if (!overId || dragIndex.kindById.get(overId) !== 'step') return null
+
+    const hovered = steps.find((s) => s.step.id === overId)
+    if (!hovered) return null
+
+    if (dropSide === 'before') {
+      return { stepId: hovered.step.id, edge: 'before' as const }
+    }
+
+    // Hand the seam to the next step in the same goal, which draws it as its own leading edge.
+    const next = steps.find(
+      (s) =>
+        s.goalId === hovered.goalId &&
+        s.indexInGoal === hovered.indexInGoal + 1,
+    )
+
+    return next
+      ? { stepId: next.step.id, edge: 'before' as const }
+      : { stepId: hovered.step.id, edge: 'after' as const }
+  }, [activeDragId, overId, dropSide, dragIndex, steps])
 
   /**
    * The cell a dragged task would land in, or null when that is the cell it already sits in. A
@@ -370,7 +424,14 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
                 selectedPersonaId={selectedPersonaId}
                 actions={actions}
                 isLastColumn={placement.column === lastColumn}
-                dropSide={dropSide}
+                showsDropBefore={
+                  litStepSeam?.stepId === placement.step.id &&
+                  litStepSeam.edge === 'before'
+                }
+                showsDropAfter={
+                  litStepSeam?.stepId === placement.step.id &&
+                  litStepSeam.edge === 'after'
+                }
               />
             ))}
 
@@ -415,6 +476,8 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
                 <TaskCell
                   key={cellKey(step.id, swimLane.id)}
                   cellId={taskCellId(step.id, swimLane.id)}
+                  stepId={step.id}
+                  swimLaneId={swimLane.id}
                   tasks={tasksByCell.get(cellKey(step.id, swimLane.id)) ?? []}
                   column={column}
                   row={row}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -256,6 +256,28 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     return goals.find((g) => g.goal.id === toGoalId) ?? null
   }, [activeDragId, overId, dragIndex, goals])
 
+  /**
+   * The cell a dragged task would land in, or null when that is the cell it already sits in. A
+   * task's parent is the step crossed with the swim lane, so either axis changing is a reparent.
+   */
+  const receivingCellId = useMemo(() => {
+    if (!activeDragId || !overId) return null
+    if (dragIndex.kindById.get(activeDragId) !== 'task') return null
+
+    const from = dragIndex.cellByTaskId.get(activeDragId)
+    if (!from) return null
+
+    // The target is either an empty cell, or a card — in which case the cell is the one it sits in.
+    const overCell = dragIndex.cellByTaskId.get(overId)
+    const to = overCell
+      ? taskCellId(overCell.stepId, overCell.swimLaneId)
+      : dragIndex.renderedCellIds.has(overId)
+        ? overId
+        : null
+
+    return to && to !== taskCellId(from.stepId, from.swimLaneId) ? to : null
+  }, [activeDragId, overId, dragIndex])
+
   // What to show inside the overlay: the name of whatever kind is being dragged.
   const activeDragLabel = useMemo(() => {
     if (!activeDragId) return null
@@ -400,6 +422,9 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
                   actions={actions}
                   isLastColumn={column === lastColumn}
                   dropSide={dropSide}
+                  isReceiving={
+                    taskCellId(step.id, swimLane.id) === receivingCellId
+                  }
                 />
               )),
             )}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { StoryMapDetailsDto } from '@/src/services/wayd-api'
+import { useRemainingHeight } from '@/src/hooks'
 import { PlusOutlined } from '@ant-design/icons'
 import { Button } from 'antd'
 import {
@@ -38,6 +39,7 @@ import GoalHeaderCell from './goal-header-cell'
 import StepHeaderCell from './step-header-cell'
 import SwimLaneHeader from './swim-lane-header'
 import TaskCell from './task-cell'
+import { useGoalRowHeight } from './use-goal-row-height'
 import styles from '../../_components/story-map.module.css'
 
 export interface StoryMapBoardProps {
@@ -58,6 +60,8 @@ interface BoardGridCssVars extends CSSProperties {
   /** Counts of each track kind, so the CSS can floor the board's width at their minimums. */
   '--sm-flexible-col-count': number
   '--sm-collapsed-col-count': number
+  /** How far down the steps row pins, measured rather than assumed. */
+  '--sm-goal-row-height': string
 }
 
 /**
@@ -99,12 +103,19 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     collapsedColumnCount,
   } = layout
 
+  const [goalRowRef, goalRowHeight] = useGoalRowHeight()
+
+  // Sticky rows need a scrollport of their own to pin against, so the board takes the viewport
+  // height that is left below it rather than letting the page scroll.
+  const [scrollRef, scrollHeight] = useRemainingHeight()
+
   // An explicit track list rather than one repeat(): a collapsed goal's spine is a fixed width
   // while every other step column shares the leftover space equally.
   const gridStyle: BoardGridCssVars = {
     '--sm-step-columns': stepColumnTracks.join(' '),
     '--sm-flexible-col-count': flexibleColumnCount,
     '--sm-collapsed-col-count': collapsedColumnCount,
+    '--sm-goal-row-height': `${goalRowHeight}px`,
   }
 
   // Everything placed in a task row iterates this rather than every lane. The predicate is a type
@@ -258,11 +269,16 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveDragId(null)}
     >
-      <div className={styles.boardScroll}>
+      <div
+        ref={scrollRef}
+        className={styles.boardScroll}
+        style={{ height: scrollHeight }}
+      >
         <div className={styles.boardGrid} style={gridStyle} data-tour="board">
           <SortableContext items={sortableIds}>
             {/* ── Sticky label column ── */}
             <div
+              ref={goalRowRef}
               className={`${styles.labelCell} ${styles.labelCellGoals}`}
               style={{ gridRow: GOAL_ROW, gridColumn: LABEL_COLUMN }}
             >

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -46,14 +46,18 @@ export interface StoryMapBoardProps {
   actions: BoardActions
   onAddStep: (goalId: string) => void
   onAddSwimLane: () => void
-  /** Lane ids the viewer has folded away — a local view preference, not map data. */
+  /** Lane and goal ids the viewer has folded away — local view state, not map data. */
   collapsedSwimLaneIds: ReadonlySet<string>
   onToggleSwimLaneCollapsed: (swimLaneId: string) => void
+  collapsedGoalIds: ReadonlySet<string>
+  onToggleGoalCollapsed: (goalId: string) => void
 }
 
 interface BoardGridCssVars extends CSSProperties {
   '--sm-step-columns': string
-  '--sm-step-count': number
+  /** Counts of each track kind, so the CSS can floor the board's width at their minimums. */
+  '--sm-flexible-col-count': number
+  '--sm-collapsed-col-count': number
 }
 
 /**
@@ -73,28 +77,48 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
   onAddSwimLane,
   collapsedSwimLaneIds,
   onToggleSwimLaneCollapsed,
+  collapsedGoalIds,
+  onToggleGoalCollapsed,
 }) => {
   const layout = useMemo(
-    () => buildBoardLayout(map, collapsedSwimLaneIds),
-    [map, collapsedSwimLaneIds],
+    () =>
+      buildBoardLayout(map, {
+        goalIds: collapsedGoalIds,
+        swimLaneIds: collapsedSwimLaneIds,
+      }),
+    [map, collapsedGoalIds, collapsedSwimLaneIds],
   )
-  const { goals, steps, swimLanes, tasksByCell, lastColumn, stepColumnCount } =
-    layout
+  const {
+    goals,
+    steps,
+    swimLanes,
+    tasksByCell,
+    lastColumn,
+    stepColumnTracks,
+    flexibleColumnCount,
+    collapsedColumnCount,
+  } = layout
 
-  // Equal-width step columns. The count is published too, so the CSS can floor the board's width at
-  // the sum of the track minimums.
+  // An explicit track list rather than one repeat(): a collapsed goal's spine is a fixed width
+  // while every other step column shares the leftover space equally.
   const gridStyle: BoardGridCssVars = {
-    '--sm-step-columns': `repeat(${stepColumnCount}, minmax(var(--sm-col-min), 1fr))`,
-    '--sm-step-count': stepColumnCount,
+    '--sm-step-columns': stepColumnTracks.join(' '),
+    '--sm-flexible-col-count': flexibleColumnCount,
+    '--sm-collapsed-col-count': collapsedColumnCount,
   }
 
-  // Only expanded lanes own a task row, so everything placed in one — the cells, the label-column
-  // spacer, and a step-less goal's blank filler — iterates this rather than every lane. The
-  // predicate is a type guard so `row` narrows to a number for the inline gridRow.
+  // Everything placed in a task row iterates this rather than every lane. The predicate is a type
+  // guard so `row` narrows to a number for the inline gridRow.
   const expandedSwimLanes = swimLanes.filter(
     (placement): placement is typeof placement & { row: number } =>
       placement.row !== null,
   )
+
+  // The grid line just past the last lane row, which a collapsed goal's spine spans down to.
+  const bottomRow =
+    STEP_ROW +
+    1 +
+    swimLanes.reduce((rows, lane) => rows + (lane.isCollapsed ? 1 : 2), 0)
 
   // Deleting a lane moves its tasks to the default lane, so the confirmation says how many — every
   // task moves, not just the ones the filter leaves visible.
@@ -204,14 +228,13 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
         return steps.find((s) => s.step.id === activeDragId)?.step.name ?? null
       case 'swimLane':
         return (
-          swimLanes.find((l) => l.swimLane.id === activeDragId)?.swimLane.name ??
-          null
+          swimLanes.find((l) => l.swimLane.id === activeDragId)?.swimLane
+            .name ?? null
         )
       case 'task':
         return (
-          steps
-            .flatMap((s) => s.step.tasks)
-            .find((t) => t.id === activeDragId)?.title ?? null
+          steps.flatMap((s) => s.step.tasks).find((t) => t.id === activeDragId)
+            ?.title ?? null
         )
       default:
         return null
@@ -235,133 +258,143 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
       onDragEnd={handleDragEnd}
       onDragCancel={() => setActiveDragId(null)}
     >
-    <div className={styles.boardScroll}>
-      <div className={styles.boardGrid} style={gridStyle} data-tour="board">
-      <SortableContext items={sortableIds}>
-        {/* ── Sticky label column ── */}
-        <div
-          className={`${styles.labelCell} ${styles.labelCellGoals}`}
-          style={{ gridRow: GOAL_ROW, gridColumn: LABEL_COLUMN }}
-        >
-          Goals
-        </div>
-        <div
-          className={`${styles.labelCell} ${styles.labelCellSteps}`}
-          style={{ gridRow: STEP_ROW, gridColumn: LABEL_COLUMN }}
-        >
-          Steps
-        </div>
+      <div className={styles.boardScroll}>
+        <div className={styles.boardGrid} style={gridStyle} data-tour="board">
+          <SortableContext items={sortableIds}>
+            {/* ── Sticky label column ── */}
+            <div
+              className={`${styles.labelCell} ${styles.labelCellGoals}`}
+              style={{ gridRow: GOAL_ROW, gridColumn: LABEL_COLUMN }}
+            >
+              Goals
+            </div>
+            <div
+              className={`${styles.labelCell} ${styles.labelCellSteps}`}
+              style={{ gridRow: STEP_ROW, gridColumn: LABEL_COLUMN }}
+            >
+              Steps
+            </div>
 
-        {/* ── Goals row ── */}
-        {goals.map((placement) => (
-          <GoalHeaderCell
-            key={placement.goal.id}
-            placement={placement}
-            selectedPersonaId={selectedPersonaId}
-            actions={actions}
-            onAddStep={onAddStep}
-            isLastColumn={
-              placement.columnStart + placement.columnSpan - 1 === lastColumn
-            }
-            dropSide={dropSide}
-          />
-        ))}
-
-        {/* ── Steps row ── */}
-        {steps.map((placement) => (
-          <StepHeaderCell
-            key={placement.step.id}
-            placement={placement}
-            selectedPersonaId={selectedPersonaId}
-            actions={actions}
-            isLastColumn={placement.column === lastColumn}
-            dropSide={dropSide}
-          />
-        ))}
-
-        {/* ── Task band: per swim lane, a full-width header banner then a row of task cells ── */}
-        {swimLanes.map(({ swimLane, headerRow, isCollapsed }) => (
-          <SwimLaneHeader
-            key={`lane-header-${swimLane.id}`}
-            swimLane={swimLane}
-            row={headerRow}
-            taskCount={taskCountsByLane.get(swimLane.id) ?? 0}
-            visibleTaskCount={visibleCountsByLane.get(swimLane.id) ?? 0}
-            isCollapsed={isCollapsed}
-            onToggleCollapsed={onToggleSwimLaneCollapsed}
-            actions={actions}
-          />
-        ))}
-
-        {/* Empty filler beside each lane's task row, so the label column's right border continues
-            past the Steps row. The lane name itself lives in the banner above. A collapsed lane has
-            no task row to sit beside. */}
-        {expandedSwimLanes.map(({ swimLane, row }) => (
-          <div
-            key={`lane-spacer-${swimLane.id}`}
-            className={`${styles.labelCell} ${styles.labelCellSpacer}`}
-            style={{ gridRow: row, gridColumn: LABEL_COLUMN }}
-          />
-        ))}
-
-        {expandedSwimLanes.map(({ swimLane, row }) =>
-          steps.map(({ step, column }) => (
-            <TaskCell
-              key={cellKey(step.id, swimLane.id)}
-              cellId={taskCellId(step.id, swimLane.id)}
-              tasks={tasksByCell.get(cellKey(step.id, swimLane.id)) ?? []}
-              column={column}
-              row={row}
-              selectedPersonaId={selectedPersonaId}
-              actions={actions}
-              isLastColumn={column === lastColumn}
-              dropSide={dropSide}
-            />
-          )),
-        )}
-
-        {/* ── Blank cells filling a step-less goal's placeholder track ── */}
-        {goals
-          .filter((placement) => placement.isPlaceholderColumn)
-          .map((placement) => (
-            <Fragment key={`placeholder-${placement.goal.id}`}>
-              <EmptyStepSlot
-                goalId={placement.goal.id}
-                column={placement.columnStart}
-                canUpdate={actions.canUpdate}
-                isLastColumn={placement.columnStart === lastColumn}
+            {/* ── Goals row ── */}
+            {goals.map((placement) => (
+              <GoalHeaderCell
+                key={placement.goal.id}
+                placement={placement}
+                selectedPersonaId={selectedPersonaId}
+                actions={actions}
+                onAddStep={onAddStep}
+                isLastColumn={
+                  placement.columnStart + placement.columnSpan - 1 ===
+                  lastColumn
+                }
+                dropSide={dropSide}
+                onToggleCollapsed={onToggleGoalCollapsed}
+                bottomRow={bottomRow}
               />
-              {expandedSwimLanes.map(({ swimLane, row }) => (
-                <div
-                  key={`placeholder-${placement.goal.id}-${swimLane.id}`}
-                  className={`${styles.taskCell} ${
-                    placement.columnStart === lastColumn ? styles.lastColumn : ''
-                  }`}
-                  style={{ gridRow: row, gridColumn: placement.columnStart }}
-                />
-              ))}
-            </Fragment>
-          ))}
+            ))}
 
-        {/* ── Add swim lane: a full-width footer under the last lane row. Always rendered (empty
+            {/* ── Steps row ── */}
+            {steps.map((placement) => (
+              <StepHeaderCell
+                key={placement.step.id}
+                placement={placement}
+                selectedPersonaId={selectedPersonaId}
+                actions={actions}
+                isLastColumn={placement.column === lastColumn}
+                dropSide={dropSide}
+              />
+            ))}
+
+            {/* ── Task band: per swim lane, a full-width header banner then a row of task cells ── */}
+            {swimLanes.map(({ swimLane, headerRow, isCollapsed }) => (
+              <SwimLaneHeader
+                key={`lane-header-${swimLane.id}`}
+                swimLane={swimLane}
+                row={headerRow}
+                taskCount={taskCountsByLane.get(swimLane.id) ?? 0}
+                visibleTaskCount={visibleCountsByLane.get(swimLane.id) ?? 0}
+                isCollapsed={isCollapsed}
+                onToggleCollapsed={onToggleSwimLaneCollapsed}
+                actions={actions}
+              />
+            ))}
+
+            {/* Empty filler beside each lane's task row, so the label column's right border continues
+            past the Steps row. The lane name itself lives in the banner above. */}
+            {expandedSwimLanes.map(({ swimLane, row }) => (
+              <div
+                key={`lane-spacer-${swimLane.id}`}
+                className={`${styles.labelCell} ${styles.labelCellSpacer}`}
+                style={{ gridRow: row, gridColumn: LABEL_COLUMN }}
+              />
+            ))}
+
+            {expandedSwimLanes.map(({ swimLane, row }) =>
+              steps.map(({ step, column }) => (
+                <TaskCell
+                  key={cellKey(step.id, swimLane.id)}
+                  cellId={taskCellId(step.id, swimLane.id)}
+                  tasks={tasksByCell.get(cellKey(step.id, swimLane.id)) ?? []}
+                  column={column}
+                  row={row}
+                  selectedPersonaId={selectedPersonaId}
+                  actions={actions}
+                  isLastColumn={column === lastColumn}
+                  dropSide={dropSide}
+                />
+              )),
+            )}
+
+            {/* ── Blank cells filling a step-less goal's placeholder track ── */}
+            {goals
+              .filter((placement) => placement.isPlaceholderColumn)
+              .map((placement) => (
+                <Fragment key={`placeholder-${placement.goal.id}`}>
+                  <EmptyStepSlot
+                    goalId={placement.goal.id}
+                    column={placement.columnStart}
+                    canUpdate={actions.canUpdate}
+                    isLastColumn={placement.columnStart === lastColumn}
+                  />
+                  {expandedSwimLanes.map(({ swimLane, row }) => (
+                    <div
+                      key={`placeholder-${placement.goal.id}-${swimLane.id}`}
+                      className={`${styles.taskCell} ${
+                        placement.columnStart === lastColumn
+                          ? styles.lastColumn
+                          : ''
+                      }`}
+                      style={{
+                        gridRow: row,
+                        gridColumn: placement.columnStart,
+                      }}
+                    />
+                  ))}
+                </Fragment>
+              ))}
+
+            {/* ── Add swim lane: a full-width footer under the last lane row. Always rendered (empty
             when the user cannot edit) so it forms the grid's bottom edge and the lane cells above
             keep their own bottom border. ── */}
-        <div className={styles.addSwimLaneCell} style={{ gridColumn: '1 / -1' }}>
-          {actions.canUpdate && (
-            <Button
-              type="text"
-              size="small"
-              icon={<PlusOutlined />}
-              data-tour="add-swim-lane"
-              onClick={onAddSwimLane}
+            <div
+              className={styles.addSwimLaneCell}
+              style={{ gridColumn: '1 / -1' }}
             >
-              Add swim lane
-            </Button>
-          )}
+              {actions.canUpdate && (
+                <Button
+                  type="text"
+                  size="small"
+                  icon={<PlusOutlined />}
+                  data-tour="add-swim-lane"
+                  onClick={onAddSwimLane}
+                >
+                  Add swim lane
+                </Button>
+              )}
+            </div>
+          </SortableContext>
         </div>
-      </SortableContext>
       </div>
-    </div>
 
       {/* The floating copy that follows the cursor. A plain labelled chip rather than a clone of the
           card: the real cells are sized by their grid track, which does not exist outside the grid,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -46,6 +46,9 @@ export interface StoryMapBoardProps {
   actions: BoardActions
   onAddStep: (goalId: string) => void
   onAddSwimLane: () => void
+  /** Lane ids the viewer has folded away — a local view preference, not map data. */
+  collapsedSwimLaneIds: ReadonlySet<string>
+  onToggleSwimLaneCollapsed: (swimLaneId: string) => void
 }
 
 interface BoardGridCssVars extends CSSProperties {
@@ -68,8 +71,13 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
   actions,
   onAddStep,
   onAddSwimLane,
+  collapsedSwimLaneIds,
+  onToggleSwimLaneCollapsed,
 }) => {
-  const layout = useMemo(() => buildBoardLayout(map), [map])
+  const layout = useMemo(
+    () => buildBoardLayout(map, collapsedSwimLaneIds),
+    [map, collapsedSwimLaneIds],
+  )
   const { goals, steps, swimLanes, tasksByCell, lastColumn, stepColumnCount } =
     layout
 
@@ -79,6 +87,14 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     '--sm-step-columns': `repeat(${stepColumnCount}, minmax(var(--sm-col-min), 1fr))`,
     '--sm-step-count': stepColumnCount,
   }
+
+  // Only expanded lanes own a task row, so everything placed in one — the cells, the label-column
+  // spacer, and a step-less goal's blank filler — iterates this rather than every lane. The
+  // predicate is a type guard so `row` narrows to a number for the inline gridRow.
+  const expandedSwimLanes = swimLanes.filter(
+    (placement): placement is typeof placement & { row: number } =>
+      placement.row !== null,
+  )
 
   // Deleting a lane moves its tasks to the default lane, so the confirmation says how many — every
   // task moves, not just the ones the filter leaves visible.
@@ -264,20 +280,23 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
         ))}
 
         {/* ── Task band: per swim lane, a full-width header banner then a row of task cells ── */}
-        {swimLanes.map(({ swimLane, headerRow }) => (
+        {swimLanes.map(({ swimLane, headerRow, isCollapsed }) => (
           <SwimLaneHeader
             key={`lane-header-${swimLane.id}`}
             swimLane={swimLane}
             row={headerRow}
             taskCount={taskCountsByLane.get(swimLane.id) ?? 0}
             visibleTaskCount={visibleCountsByLane.get(swimLane.id) ?? 0}
+            isCollapsed={isCollapsed}
+            onToggleCollapsed={onToggleSwimLaneCollapsed}
             actions={actions}
           />
         ))}
 
         {/* Empty filler beside each lane's task row, so the label column's right border continues
-            past the Steps row. The lane name itself lives in the banner above. */}
-        {swimLanes.map(({ swimLane, row }) => (
+            past the Steps row. The lane name itself lives in the banner above. A collapsed lane has
+            no task row to sit beside. */}
+        {expandedSwimLanes.map(({ swimLane, row }) => (
           <div
             key={`lane-spacer-${swimLane.id}`}
             className={`${styles.labelCell} ${styles.labelCellSpacer}`}
@@ -285,7 +304,7 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
           />
         ))}
 
-        {swimLanes.map(({ swimLane, row }) =>
+        {expandedSwimLanes.map(({ swimLane, row }) =>
           steps.map(({ step, column }) => (
             <TaskCell
               key={cellKey(step.id, swimLane.id)}
@@ -312,7 +331,7 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
                 canUpdate={actions.canUpdate}
                 isLastColumn={placement.columnStart === lastColumn}
               />
-              {swimLanes.map(({ swimLane, row }) => (
+              {expandedSwimLanes.map(({ swimLane, row }) => (
                 <div
                   key={`placeholder-${placement.goal.id}-${swimLane.id}`}
                   className={`${styles.taskCell} ${

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/story-map-board.tsx
@@ -23,8 +23,10 @@ import { countTasksByLane } from './board-counts'
 import {
   buildDragIndex,
   isValidDropTarget,
-  parseEmptyStepSlotId,
   resolveDrop,
+  resolveReceivingCellId,
+  resolveReceivingGoalId,
+  resolveStepSeam,
   taskCellId,
   type DropSide,
 } from './board-drag'
@@ -253,84 +255,26 @@ const StoryMapBoard: FC<StoryMapBoardProps> = ({
     if (drop) actions.onDrop(drop)
   }
 
-  /**
-   * The goal a dragged step would join, and whose step columns the band marks. Null when the drag
-   * stays inside its current goal — a reorder needs no destination marker, since the insertion line
-   * already says where it lands.
-   */
+  // A step-less goal's slot already marks itself as the drop target, so the band would only ring it
+  // a second time.
   const receivingGoal = useMemo(() => {
-    if (!activeDragId || !overId) return null
-    if (dragIndex.kindById.get(activeDragId) !== 'step') return null
+    const goalId = resolveReceivingGoalId(dragIndex, activeDragId, overId)
+    const placement = goalId
+      ? goals.find((g) => g.goal.id === goalId)
+      : undefined
 
-    const fromGoalId = dragIndex.goalIdByStepId.get(activeDragId)
-
-    // Either hovering a sibling step, or the empty slot of a goal with no steps of its own.
-    const toGoalId =
-      dragIndex.goalIdByStepId.get(overId) ?? parseEmptyStepSlotId(overId)
-
-    if (!toGoalId || toGoalId === fromGoalId) return null
-
-    const placement = goals.find((g) => g.goal.id === toGoalId)
-
-    // A step-less goal's slot already marks itself as the drop target, and the band around a single
-    // cell would only ring it a second time.
     return placement && !placement.isPlaceholderColumn ? placement : null
   }, [activeDragId, overId, dragIndex, goals])
 
-  /**
-   * Which step cell draws the insertion line, and on which edge.
-   *
-   * A seam has two names — "after step A" and "before step B" — that resolve to the same index, so
-   * letting each cell light its own hovered edge gave one landing position two appearances. This
-   * picks a single cell per seam: normally the step that follows it, drawing a leading edge. A
-   * goal's last step has no follower, so that one seam keeps a trailing edge.
-   */
-  const litStepSeam = useMemo(() => {
-    if (!activeDragId || dragIndex.kindById.get(activeDragId) !== 'step') {
-      return null
-    }
-    if (!overId || dragIndex.kindById.get(overId) !== 'step') return null
+  const litStepSeam = useMemo(
+    () => resolveStepSeam(layout, dragIndex, activeDragId, overId, dropSide),
+    [layout, dragIndex, activeDragId, overId, dropSide],
+  )
 
-    const hovered = steps.find((s) => s.step.id === overId)
-    if (!hovered) return null
-
-    if (dropSide === 'before') {
-      return { stepId: hovered.step.id, edge: 'before' as const }
-    }
-
-    // Hand the seam to the next step in the same goal, which draws it as its own leading edge.
-    const next = steps.find(
-      (s) =>
-        s.goalId === hovered.goalId &&
-        s.indexInGoal === hovered.indexInGoal + 1,
-    )
-
-    return next
-      ? { stepId: next.step.id, edge: 'before' as const }
-      : { stepId: hovered.step.id, edge: 'after' as const }
-  }, [activeDragId, overId, dropSide, dragIndex, steps])
-
-  /**
-   * The cell a dragged task would land in, or null when that is the cell it already sits in. A
-   * task's parent is the step crossed with the swim lane, so either axis changing is a reparent.
-   */
-  const receivingCellId = useMemo(() => {
-    if (!activeDragId || !overId) return null
-    if (dragIndex.kindById.get(activeDragId) !== 'task') return null
-
-    const from = dragIndex.cellByTaskId.get(activeDragId)
-    if (!from) return null
-
-    // The target is either an empty cell, or a card — in which case the cell is the one it sits in.
-    const overCell = dragIndex.cellByTaskId.get(overId)
-    const to = overCell
-      ? taskCellId(overCell.stepId, overCell.swimLaneId)
-      : dragIndex.renderedCellIds.has(overId)
-        ? overId
-        : null
-
-    return to && to !== taskCellId(from.stepId, from.swimLaneId) ? to : null
-  }, [activeDragId, overId, dragIndex])
+  const receivingCellId = useMemo(
+    () => resolveReceivingCellId(dragIndex, activeDragId, overId),
+    [dragIndex, activeDragId, overId],
+  )
 
   // What to show inside the overlay: the name of whatever kind is being dragged.
   const activeDragLabel = useMemo(() => {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/swim-lane-header.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/swim-lane-header.tsx
@@ -48,7 +48,7 @@ export interface SwimLaneHeaderProps {
   taskCount: number
   /** Tasks left after the persona filter — what the banner reports. */
   visibleTaskCount: number
-  /** Collapsed lanes hide their task row; the banner stays, as the way back. */
+  /** Collapsed lanes hide their task row; the banner stays. */
   isCollapsed: boolean
   onToggleCollapsed: (swimLaneId: string) => void
   actions: BoardActions
@@ -80,9 +80,7 @@ const SwimLaneHeader: FC<SwimLaneHeaderProps> = ({
 
   const dateLabel = formatRange(swimLane.startDate, swimLane.endDate)
 
-  const handleDatesChange = (
-    dates: [Dayjs | null, Dayjs | null] | null,
-  ) => {
+  const handleDatesChange = (dates: [Dayjs | null, Dayjs | null] | null) => {
     // Clearing the whole control yields null; clearing one side yields a null in that slot.
     actions.onSetSwimLaneDates(
       swimLane.id,
@@ -109,7 +107,9 @@ const SwimLaneHeader: FC<SwimLaneHeaderProps> = ({
           format={DISPLAY_FORMAT}
           value={[toDayjs(swimLane.startDate), toDayjs(swimLane.endDate)]}
           onChange={handleDatesChange}
-          getPopupContainer={(trigger) => trigger.parentElement ?? document.body}
+          getPopupContainer={(trigger) =>
+            trigger.parentElement ?? document.body
+          }
         />
       }
     >
@@ -142,8 +142,7 @@ const SwimLaneHeader: FC<SwimLaneHeaderProps> = ({
       {...listeners}
     >
       <div className={styles.swimLaneHeaderSticky}>
-        {/* Every lane collapses, the default one included — it is usually the fullest, so it is the
-            one most worth folding away. */}
+        {/* The default lane collapses too — it is usually the fullest. */}
         <WaydTooltip title={isCollapsed ? 'Expand lane' : 'Collapse lane'}>
           <Button
             size="small"
@@ -179,13 +178,11 @@ const SwimLaneHeader: FC<SwimLaneHeaderProps> = ({
         {/* Both dates are optional and independent — a lane can have just a start, just an end,
             neither, or both. The picker's own range semantics stop an end before a start. */}
         {!isFixed &&
-          (actions.canUpdate ? (
-            datesControl
-          ) : (
-            dateLabel && (
-              <span className={styles.swimLaneDatesText}>{dateLabel}</span>
-            )
-          ))}
+          (actions.canUpdate
+            ? datesControl
+            : dateLabel && (
+                <span className={styles.swimLaneDatesText}>{dateLabel}</span>
+              ))}
 
         {actions.canUpdate && !isFixed && (
           <div className={styles.footerActions}>

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/swim-lane-header.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/swim-lane-header.tsx
@@ -2,7 +2,12 @@
 
 import { StoryMapSwimLaneDto } from '@/src/services/wayd-api'
 import { WaydTooltip } from '@/src/components/common'
-import { CalendarOutlined, DeleteOutlined } from '@ant-design/icons'
+import {
+  CalendarOutlined,
+  DeleteOutlined,
+  DownOutlined,
+  RightOutlined,
+} from '@ant-design/icons'
 import { Button, DatePicker, Popconfirm, Popover } from 'antd'
 import dayjs, { Dayjs } from 'dayjs'
 import { FC, useState } from 'react'
@@ -43,6 +48,9 @@ export interface SwimLaneHeaderProps {
   taskCount: number
   /** Tasks left after the persona filter — what the banner reports. */
   visibleTaskCount: number
+  /** Collapsed lanes hide their task row; the banner stays, as the way back. */
+  isCollapsed: boolean
+  onToggleCollapsed: (swimLaneId: string) => void
   actions: BoardActions
 }
 
@@ -55,6 +63,8 @@ const SwimLaneHeader: FC<SwimLaneHeaderProps> = ({
   row,
   taskCount,
   visibleTaskCount,
+  isCollapsed,
+  onToggleCollapsed,
   actions,
 }) => {
   const isFixed = swimLane.isDefault
@@ -132,6 +142,24 @@ const SwimLaneHeader: FC<SwimLaneHeaderProps> = ({
       {...listeners}
     >
       <div className={styles.swimLaneHeaderSticky}>
+        {/* Every lane collapses, the default one included — it is usually the fullest, so it is the
+            one most worth folding away. */}
+        <WaydTooltip title={isCollapsed ? 'Expand lane' : 'Collapse lane'}>
+          <Button
+            size="small"
+            type="text"
+            icon={isCollapsed ? <RightOutlined /> : <DownOutlined />}
+            className={styles.swimLaneCollapseButton}
+            aria-expanded={!isCollapsed}
+            aria-label={
+              isCollapsed
+                ? `Expand ${swimLane.name}`
+                : `Collapse ${swimLane.name}`
+            }
+            onClick={() => onToggleCollapsed(swimLane.id)}
+          />
+        </WaydTooltip>
+
         {isFixed ? (
           <span className={styles.swimLaneName}>{swimLane.name}</span>
         ) : (

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-card.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-card.tsx
@@ -45,65 +45,67 @@ const TaskCard: FC<TaskCardProps> = ({
   const lineBelow = forceDropAfter || dropsAfter
 
   return (
-  <div
-    ref={setNodeRef}
-    style={style}
-    data-tour="task-card"
-    className={`${styles.taskCard} ${dragClassName} ${muted ? styles.muted : ''} ${
-      showLine
-        ? lineBelow
-          ? styles.taskCardDropBelow
-          : styles.taskCardDropAbove
-        : ''
-    }`}
-    {...attributes}
-    {...listeners}
-  >
-    <InlineEditText
-      value={task.title}
-      onSave={(title) => actions.onRenameTask(task, title)}
-      disabled={!actions.canUpdate}
-      autoEdit={actions.autoEditId === task.id}
-      onEditEnd={actions.onAutoEditEnd}
-      ariaLabel="Rename task"
-      className={styles.taskTitle}
-      display={(v) => <span className={styles.taskTitle}>{v}</span>}
-    />
-
-    {/* Footer: persona toggles on the left, hover-revealed delete on the right. */}
-    <div className={styles.cellFooter}>
-      <PersonaToggleDots
-        personas={actions.personas}
-        linkedPersonaIds={task.personaIds}
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-tour="task-card"
+      className={`${styles.taskCard} ${dragClassName} ${muted ? styles.muted : ''} ${
+        showLine
+          ? lineBelow
+            ? styles.taskCardDropBelow
+            : styles.taskCardDropAbove
+          : ''
+      }`}
+      {...attributes}
+      {...listeners}
+    >
+      <InlineEditText
+        value={task.title}
+        onSave={(title) => actions.onRenameTask(task, title)}
         disabled={!actions.canUpdate}
-        onToggle={(personaId) => actions.onToggleTaskPersona(task.id, personaId)}
+        autoEdit={actions.autoEditId === task.id}
+        onEditEnd={actions.onAutoEditEnd}
+        ariaLabel="Rename task"
+        className={styles.taskTitle}
+        display={(v) => <span className={styles.taskTitle}>{v}</span>}
       />
-      <div className={styles.footerTrailing}>
-        {task.checklistTotalCount > 0 && (
-          <span className={styles.checklistCount}>
-            {task.checklistCompletedCount}/{task.checklistTotalCount}
-          </span>
-        )}
-        {actions.canUpdate && (
-          <div className={styles.footerActions}>
-            <Popconfirm
-              title="Delete this task?"
-              okText="Delete"
-              okButtonProps={{ danger: true }}
-              onConfirm={() => actions.onDeleteTask(task.id)}
-            >
-              <Button
-                size="small"
-                type="text"
-                icon={<DeleteOutlined />}
-                aria-label="Delete task"
-              />
-            </Popconfirm>
-          </div>
-        )}
+
+      {/* Footer: persona toggles on the left, hover-revealed delete on the right. */}
+      <div className={styles.cellFooter}>
+        <PersonaToggleDots
+          personas={actions.personas}
+          linkedPersonaIds={task.personaIds}
+          disabled={!actions.canUpdate}
+          onToggle={(personaId) =>
+            actions.onToggleTaskPersona(task.id, personaId)
+          }
+        />
+        <div className={styles.footerTrailing}>
+          {task.checklistTotalCount > 0 && (
+            <span className={styles.checklistCount}>
+              {task.checklistCompletedCount}/{task.checklistTotalCount}
+            </span>
+          )}
+          {actions.canUpdate && (
+            <div className={styles.footerActions}>
+              <Popconfirm
+                title="Delete this task?"
+                okText="Delete"
+                okButtonProps={{ danger: true }}
+                onConfirm={() => actions.onDeleteTask(task.id)}
+              >
+                <Button
+                  size="small"
+                  type="text"
+                  icon={<DeleteOutlined />}
+                  aria-label="Delete task"
+                />
+              </Popconfirm>
+            </div>
+          )}
+        </div>
       </div>
     </div>
-  </div>
   )
 }
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-cell.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-cell.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { StoryMapTaskDto } from '@/src/services/wayd-api'
+import { PlusOutlined } from '@ant-design/icons'
 import { useDroppable } from '@dnd-kit/core'
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSSProperties, FC } from 'react'
@@ -13,6 +14,9 @@ export interface TaskCellProps {
   tasks: StoryMapTaskDto[]
   /** Identifies this (step × swim lane) cell as a drop target. */
   cellId: string
+  /** The cell's own coordinates, so a task added here lands in this lane rather than the default. */
+  stepId: string
+  swimLaneId: string
   /** 1-based grid column of the owning step. */
   column: number
   /** 1-based grid row of the owning swim lane. */
@@ -34,6 +38,8 @@ export interface TaskCellProps {
 const TaskCell: FC<TaskCellProps> = ({
   tasks,
   cellId,
+  stepId,
+  swimLaneId,
   column,
   row,
   selectedPersonaId,
@@ -87,6 +93,20 @@ const TaskCell: FC<TaskCellProps> = ({
           />
         ))}
       </SortableContext>
+
+      {/* Hidden mid-drag: the cell is a drop target then, and a button inside it would offer a
+          second meaning for the same space. */}
+      {actions.canUpdate && !isOver && (
+        <button
+          type="button"
+          className={styles.ghostTask}
+          aria-label="Add task"
+          onClick={() => actions.onAddTask(stepId, swimLaneId)}
+        >
+          <PlusOutlined />
+          Task
+        </button>
+      )}
     </div>
   )
 }

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-cell.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-cell.tsx
@@ -23,6 +23,8 @@ export interface TaskCellProps {
   isLastColumn: boolean
   /** Which edge of the hovered node a drop lands on, from the board's pointer tracking. */
   dropSide: DropSide
+  /** A task from another cell would land here, so this cell is the destination. */
+  isReceiving: boolean
 }
 
 /**
@@ -38,6 +40,7 @@ const TaskCell: FC<TaskCellProps> = ({
   actions,
   isLastColumn,
   dropSide,
+  isReceiving,
 }) => {
   // The cell itself is a drop target, not just its cards — an empty cell has no sortable items to
   // aim at. dnd-kit reports isOver on the innermost target only, so a cell and one of its cards
@@ -57,9 +60,13 @@ const TaskCell: FC<TaskCellProps> = ({
   return (
     <div
       ref={setNodeRef}
+      // The receiving outline marks the destination cell; .taskCellOver is the append-here glow an
+      // empty cell gets under the pointer. Both can apply at once — an empty cell in another step
+      // is both — and .taskCellOver's own outline wins, which is the louder and more specific of
+      // the two signals.
       className={`${styles.taskCell} ${isLastColumn ? styles.lastColumn : ''} ${
-        isOver && !appendsToEnd ? styles.taskCellOver : ''
-      }`}
+        isReceiving ? styles.taskCellReceiving : ''
+      } ${isOver && !appendsToEnd ? styles.taskCellOver : ''}`}
       style={style}
     >
       <SortableContext

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-cell.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/task-cell.tsx
@@ -2,10 +2,7 @@
 
 import { StoryMapTaskDto } from '@/src/services/wayd-api'
 import { useDroppable } from '@dnd-kit/core'
-import {
-  SortableContext,
-  verticalListSortingStrategy,
-} from '@dnd-kit/sortable'
+import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { CSSProperties, FC } from 'react'
 import { BoardActions } from './board-actions'
 import { DropSide } from './board-drag'

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-goal-row-height.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-goal-row-height.ts
@@ -3,13 +3,12 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
- * Measures the pinned goals row, so the steps row beneath it knows how far down to pin.
+ * Measures the pinned goals row, so the steps row beneath it knows how far down to pin. A stale
+ * offset either overlaps the two rows or leaves a strip of scrolled content between them.
  *
- * The offset cannot be a constant: the goals row is as tall as its longest wrapped goal name, which
- * changes with the name, the column width, and the viewport. Measuring keeps the two pinned rows
- * flush — a stale offset either overlaps them or leaves a strip of scrolled content between.
- *
- * Returns a callback ref for any cell in the goals row, plus its measured height.
+ * Attach the ref to the row's LABEL cell, not a goal cell: any one goal may be shorter than the
+ * row, while `align-items: stretch` sizes the label to the tallest. Giving that cell its own height
+ * or `align-self` would silently break this.
  */
 export const useGoalRowHeight = (): [
   ref: (node: HTMLElement | null) => void,

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-goal-row-height.ts
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-goal-row-height.ts
@@ -1,0 +1,45 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+/**
+ * Measures the pinned goals row, so the steps row beneath it knows how far down to pin.
+ *
+ * The offset cannot be a constant: the goals row is as tall as its longest wrapped goal name, which
+ * changes with the name, the column width, and the viewport. Measuring keeps the two pinned rows
+ * flush — a stale offset either overlaps them or leaves a strip of scrolled content between.
+ *
+ * Returns a callback ref for any cell in the goals row, plus its measured height.
+ */
+export const useGoalRowHeight = (): [
+  ref: (node: HTMLElement | null) => void,
+  height: number,
+] => {
+  const [height, setHeight] = useState(0)
+  const observerRef = useRef<ResizeObserver | null>(null)
+
+  const measure = useCallback((node: HTMLElement) => {
+    setHeight(node.getBoundingClientRect().height)
+  }, [])
+
+  const callbackRef = useCallback(
+    (node: HTMLElement | null) => {
+      observerRef.current?.disconnect()
+      observerRef.current = null
+
+      if (!node) return
+
+      measure(node)
+
+      // The row reflows whenever a name wraps differently — on resize, on rename, and when
+      // collapsing a goal changes every column's width.
+      observerRef.current = new ResizeObserver(() => measure(node))
+      observerRef.current.observe(node)
+    },
+    [measure],
+  )
+
+  useEffect(() => () => observerRef.current?.disconnect(), [])
+
+  return [callbackRef, height]
+}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-story-map-tour.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-story-map-tour.tsx
@@ -287,7 +287,9 @@ export const useStoryMapTour = (
   // ── Build mode: create along with the tour ──────────────────────────────────
 
   const buildSteps: TourProps['steps'] = [
-    welcomeStep('Let’s build yours together — the tour waits for you at each step.'),
+    welcomeStep(
+      'Let’s build yours together — the tour waits for you at each step.',
+    ),
     {
       title: 'Create your first goal',
       description:

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-story-map-tour.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/_components/use-story-map-tour.tsx
@@ -235,7 +235,7 @@ export const useStoryMapTour = (
   const moveStep = {
     title: 'Move things around',
     description:
-      'Everything drags. Reorder goals and steps by dragging them along their row — a step can even move to another goal — and drag tasks between cells and swim lanes.',
+      'Everything drags. Reorder goals and steps by dragging them along their row — a step can even move to another goal — and drag tasks between cells and swim lanes. A blue line shows where it will land, and moving something to a new parent outlines the destination.',
     target: anchor('board'),
     style: stepStyle,
   }
@@ -269,7 +269,7 @@ export const useStoryMapTour = (
   const swimLaneStep = {
     title: 'Slice releases with swim lanes',
     description:
-      'Swim lanes split tasks into releases or phases — each can carry a date range. Click Add swim lane to create one, then drag tasks into it.',
+      'Swim lanes split tasks into releases or phases — each can carry a date range. Click Add swim lane to create one, then drag tasks into it. A lane’s caret collapses it, which keeps a finished release out of the way.',
     target: anchor('add-swim-lane'),
     mask: false,
     placement: 'top' as const,
@@ -309,7 +309,7 @@ export const useStoryMapTour = (
     {
       title: 'Break it into steps',
       description:
-        'Steps are the actions a user takes toward the goal, read left to right. Click the + in your goal’s header to add the first step.',
+        'Steps are the actions a user takes toward the goal, read left to right. Click the + in your goal’s header — or the Add step placeholder below it — to add the first one.',
       target: anchor('add-step'),
       mask: false,
       style: stepStyle,
@@ -317,7 +317,7 @@ export const useStoryMapTour = (
     {
       title: 'Add a task',
       description:
-        'Tasks are the concrete work under each step. Click the + in your step’s footer to add one — it lands in the swim lane below.',
+        'Tasks are the concrete work under each step. Click the + in your step’s footer to add one, or the + Task placeholder in any cell to add it straight to that swim lane.',
       target: anchor('add-task'),
       mask: false,
       style: stepStyle,
@@ -336,7 +336,7 @@ export const useStoryMapTour = (
     {
       title: 'Goals',
       description:
-        'Goals are what your users are trying to accomplish; each spans the steps beneath it. Click a name to rename it, use the + in its header to add steps, and add more goals with + Goal in the page header.',
+        'Goals are what your users are trying to accomplish; each spans the steps beneath it. Click a name to rename it, use the + in its header to add steps, and add more goals with + Goal in the page header. The caret beside the name folds the goal away when you want it out of the way.',
       target: anchor('goal-cell'),
       style: stepStyle,
     },
@@ -350,7 +350,7 @@ export const useStoryMapTour = (
     {
       title: 'Tasks',
       description:
-        'Tasks are the concrete work under each step, sorted into the swim lanes below. Click a title to edit it.',
+        'Tasks are the concrete work under each step, sorted into the swim lanes below. Click a title to edit it, or use the + Task placeholder at the bottom of any cell to add one there.',
       target: anchor('task-card'),
       style: stepStyle,
     },

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/loading.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/loading.tsx
@@ -11,4 +11,3 @@ export default function StoryMapDetailsLoading() {
     </>
   )
 }
-

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
@@ -139,6 +139,21 @@ const StoryMapDetailPage: FC = () => {
     null,
   )
   const [openManagePersonas, setOpenManagePersonas] = useState(false)
+  // Lanes the viewer has folded away while working. Deliberately transient and local: it is a way to
+  // get a finished lane out of the way while filling the next one, not a property of the map — so it
+  // is never sent to the server and never broadcast to the others editing alongside you.
+  const [collapsedSwimLaneIds, setCollapsedSwimLaneIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set())
+
+  const handleToggleSwimLaneCollapsed = useCallback((swimLaneId: string) => {
+    setCollapsedSwimLaneIds((current) => {
+      const next = new Set(current)
+      if (!next.delete(swimLaneId)) next.add(swimLaneId)
+      return next
+    })
+  }, [])
+
   // The id of an item just created inline, so its name field opens in edit mode.
   const [autoEditId, setAutoEditId] = useState<string | null>(null)
 
@@ -655,6 +670,8 @@ const StoryMapDetailPage: FC = () => {
           actions={actions}
           onAddStep={handleAddStep}
           onAddSwimLane={handleAddSwimLane}
+          collapsedSwimLaneIds={collapsedSwimLaneIds}
+          onToggleSwimLaneCollapsed={handleToggleSwimLaneCollapsed}
         />
       )}
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
@@ -233,7 +233,9 @@ const StoryMapDetailPage: FC = () => {
     }
   }
 
-  const handleAddTask = async (stepId: string) => {
+  // The lane is optional: the step header's add button has no cell in mind and falls back to the
+  // default lane, while a cell's own ghost row names the lane it sits in.
+  const handleAddTask = async (stepId: string, swimLaneId?: string) => {
     if (!map) return
     try {
       const task = await addTask({
@@ -241,7 +243,7 @@ const StoryMapDetailPage: FC = () => {
         request: {
           stepId,
           title: DEFAULT_TASK_TITLE,
-          swimLaneId: map.swimLanes.find((l) => l.isDefault)?.id,
+          swimLaneId: swimLaneId ?? map.swimLanes.find((l) => l.isDefault)?.id,
         },
       }).unwrap()
       setAutoEditId(task.id)

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
@@ -139,17 +139,28 @@ const StoryMapDetailPage: FC = () => {
     null,
   )
   const [openManagePersonas, setOpenManagePersonas] = useState(false)
-  // Lanes the viewer has folded away while working. Deliberately transient and local: it is a way to
-  // get a finished lane out of the way while filling the next one, not a property of the map — so it
-  // is never sent to the server and never broadcast to the others editing alongside you.
+  // Lanes and goals the viewer has folded away. Transient and local — never sent to the server, so
+  // collapsing does not affect anyone else editing the same map.
   const [collapsedSwimLaneIds, setCollapsedSwimLaneIds] = useState<
     ReadonlySet<string>
   >(() => new Set())
+
+  const [collapsedGoalIds, setCollapsedGoalIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  )
 
   const handleToggleSwimLaneCollapsed = useCallback((swimLaneId: string) => {
     setCollapsedSwimLaneIds((current) => {
       const next = new Set(current)
       if (!next.delete(swimLaneId)) next.add(swimLaneId)
+      return next
+    })
+  }, [])
+
+  const handleToggleGoalCollapsed = useCallback((goalId: string) => {
+    setCollapsedGoalIds((current) => {
+      const next = new Set(current)
+      if (!next.delete(goalId)) next.add(goalId)
       return next
     })
   }, [])
@@ -194,7 +205,6 @@ const StoryMapDetailPage: FC = () => {
     () => [...(map?.personas ?? [])].sort((a, b) => a.order - b.order),
     [map],
   )
-
 
   const handleAddGoal = async () => {
     if (!map) return
@@ -384,7 +394,11 @@ const StoryMapDetailPage: FC = () => {
   const handleDeleteGoal = async (goalId: string) => {
     if (!map) return
     try {
-      await deleteGoal({ storyMapId: map.id, storyMapKey: key, goalId }).unwrap()
+      await deleteGoal({
+        storyMapId: map.id,
+        storyMapKey: key,
+        goalId,
+      }).unwrap()
     } catch {
       messageApi.error('Failed to delete goal.')
     }
@@ -407,7 +421,11 @@ const StoryMapDetailPage: FC = () => {
   const handleDeleteStep = async (stepId: string) => {
     if (!map) return
     try {
-      await deleteStep({ storyMapId: map.id, storyMapKey: key, stepId }).unwrap()
+      await deleteStep({
+        storyMapId: map.id,
+        storyMapKey: key,
+        stepId,
+      }).unwrap()
     } catch {
       messageApi.error('Failed to delete step.')
     }
@@ -430,7 +448,11 @@ const StoryMapDetailPage: FC = () => {
   const handleDeleteTask = async (taskId: string) => {
     if (!map) return
     try {
-      await deleteTask({ storyMapId: map.id, storyMapKey: key, taskId }).unwrap()
+      await deleteTask({
+        storyMapId: map.id,
+        storyMapKey: key,
+        taskId,
+      }).unwrap()
     } catch {
       messageApi.error('Failed to delete task.')
     }
@@ -672,6 +694,8 @@ const StoryMapDetailPage: FC = () => {
           onAddSwimLane={handleAddSwimLane}
           collapsedSwimLaneIds={collapsedSwimLaneIds}
           onToggleSwimLaneCollapsed={handleToggleSwimLaneCollapsed}
+          collapsedGoalIds={collapsedGoalIds}
+          onToggleGoalCollapsed={handleToggleGoalCollapsed}
         />
       )}
 

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
@@ -100,7 +100,6 @@ const StoryMapDetailPage: FC = () => {
   const pathname = usePathname()
   const router = useRouter()
   const dispatch = useAppDispatch()
-  useDocumentTitle(`Story Map ${key}`)
 
   const { token } = useTheme()
   const { hasPermissionClaim } = useAuth()
@@ -108,6 +107,8 @@ const StoryMapDetailPage: FC = () => {
   const canDelete = hasPermissionClaim('Permissions.StoryMaps.Delete')
 
   const { data: map, isLoading } = useGetStoryMapQuery(key)
+
+  useDocumentTitle(`${map?.name ?? key} - Story Map Details`)
 
   const [presence, setPresence] = useState<PresenceParticipant[]>([])
 
@@ -560,12 +561,9 @@ const StoryMapDetailPage: FC = () => {
           },
         ]
       : []),
-    // Only separate the export once something sits above it — a viewer with neither permission sees
-    // export alone, and a leading divider would hang off the top of the menu.
     ...(canEdit || canDelete
       ? [{ key: 'export-divider', type: 'divider' as const }]
       : []),
-    // Viewing is enough to export — it reads nothing the page is not already showing.
     {
       key: 'export',
       label: 'Export CSV',
@@ -726,7 +724,6 @@ const StoryMapDetailPage: FC = () => {
           onFormComplete={() => {
             deletedHereRef.current = true
             setOpenDeleteMap(false)
-            // The map no longer exists — return to the list.
             router.push('/planning/story-maps')
           }}
           onFormCancel={() => setOpenDeleteMap(false)}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/[key]/page.tsx
@@ -33,7 +33,7 @@ import {
   useSetTaskPersonasMutation,
 } from '@/src/store/features/planning/story-maps-api'
 import { useMessage } from '@/src/components/contexts/messaging'
-import { Avatar, Button, Divider, Dropdown, Flex, Tag, Tour } from 'antd'
+import { Avatar, Button, Dropdown, Flex, Tag, Tour } from 'antd'
 import { ItemType } from 'antd/es/menu/interface'
 import { WaydTooltip } from '@/src/components/common'
 import {
@@ -648,8 +648,6 @@ const StoryMapDetailPage: FC = () => {
         tags={pageTitleTags}
         actions={pageTitleActions}
       />
-
-      <Divider className={styles.headerDivider} />
 
       <PersonaFilterBar
         storyMapId={map.id}

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/create-story-map-form.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/create-story-map-form.tsx
@@ -102,4 +102,3 @@ const CreateStoryMapForm = ({
 }
 
 export default CreateStoryMapForm
-

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -114,6 +114,22 @@
   width: 220px;
 }
 
+/* The collapse caret. Always visible rather than hover-revealed: once a lane is folded away the
+   banner is all that is left of it, so the way back must never be hidden behind a hover. */
+.swimLaneCollapseButton {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  padding: 0;
+  font-size: 10px;
+  color: var(--sm-text-secondary);
+  /* The banner is itself the lane's drag surface; the caret is a control on top of it, so it opts
+     back out of `touch-action: none` the way the other inline controls do. */
+  touch-action: auto;
+  cursor: pointer;
+}
+
 /* Calendar icon alone on an undated lane; icon plus the range as text once set. */
 .swimLaneDatesButton {
   flex: none;

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -428,6 +428,42 @@
   background-color: var(--sm-bg);
 }
 
+/* Ghost row at the foot of every task cell. One appears in every cell on the board, so at rest it
+   is invisible and only surfaces on hover of its own cell — a permanent dashed box in each would
+   read as clutter at board scale. Kept in the flow (not absolute) so it never overlaps a card.
+
+   `margin-top: auto` is deliberately absent: the row sits directly under the last card rather than
+   at the foot of a tall cell, so it reads as "add after this one". */
+.ghostTask {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border: 1px dashed var(--sm-border);
+  border-radius: var(--sm-radius);
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  color: var(--sm-muted);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity 0.15s;
+  /* Sits inside the cell's drop target; the sensor's activation distance separates click from drag. */
+  touch-action: auto;
+}
+
+.taskCell:hover .ghostTask,
+.ghostTask:focus-visible {
+  opacity: 1;
+}
+
+.ghostTask:hover,
+.ghostTask:focus-visible {
+  border-color: var(--ant-color-primary);
+  color: var(--ant-color-primary);
+}
+
 .taskTitle {
   font-size: 13px;
   color: var(--sm-text);
@@ -567,35 +603,14 @@
   z-index: 1;
 }
 
-/* The leading dot matches the task indicator, so both axes read as the same marker. */
-.stepCellDropBefore::after,
-.stepCellDropAfter::after {
-  content: '';
-  position: absolute;
-  top: -3px;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background-color: var(--ant-color-primary);
-  z-index: 1;
-}
-
 /* Centred on the 1px border between cells, so the line reads as the seam rather than as an outline
    of either neighbour. */
 .stepCellDropBefore::before {
   left: -1px;
 }
 
-.stepCellDropBefore::after {
-  left: -4px;
-}
-
 .stepCellDropAfter::before {
   right: -1px;
-}
-
-.stepCellDropAfter::after {
-  right: -4px;
 }
 
 /* The step columns of the goal a dragged step is crossing into. Outline rather than fill — the

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -17,18 +17,24 @@
    so every cell aligns across goals instead of nesting inside them. Cells place themselves via
    inline gridRow/gridColumn from the layout model; only the track template lives here. */
 .boardGrid {
-  /* Step tracks share leftover space equally, floored at this width. */
-  --sm-col-min: 160px;
+  /* Step tracks share leftover space equally, floored at this width. The floor covers the goal
+     row's fixed furniture — padding, the collapse caret, the action pair, and the gaps between
+     them — and leaves ~97px for the name itself. */
+  --sm-col-min: 186px;
   --sm-label-width: 80px;
+  /* A collapsed goal's spine: wide enough for the caret button plus the rotated name beneath it. */
+  --sm-collapsed-col-width: 40px;
   display: grid;
   grid-template-columns: var(--sm-label-width) var(--sm-step-columns);
   align-items: stretch;
   /* Sized against the container, never intrinsically: `max-content` would resolve each track to its
      longest unwrapped title, so columns would ignore the viewport and 1fr would never bind. The
-     min-width floors the board at every track's minimum so it scrolls rather than crushing them. */
+     min-width floors the board at every track's minimum so it scrolls rather than crushing them —
+     the flexible tracks at --sm-col-min each, plus the fixed-width collapsed spines. */
   width: 100%;
   min-width: calc(
-    var(--sm-label-width) + (var(--sm-step-count) * var(--sm-col-min))
+    var(--sm-label-width) + (var(--sm-flexible-col-count) * var(--sm-col-min)) +
+      (var(--sm-collapsed-col-count) * var(--sm-collapsed-col-width))
   );
   border: 1px solid var(--sm-border);
   border-radius: var(--sm-radius-lg);
@@ -114,8 +120,8 @@
   width: 220px;
 }
 
-/* The collapse caret. Always visible rather than hover-revealed: once a lane is folded away the
-   banner is all that is left of it, so the way back must never be hidden behind a hover. */
+/* Always visible, not hover-revealed: once a lane is folded the banner is all that is left of it,
+   so the way back must stay on show. */
 .swimLaneCollapseButton {
   flex: none;
   width: 18px;
@@ -124,6 +130,8 @@
   padding: 0;
   font-size: 10px;
   color: var(--sm-text-secondary);
+  /* Closes the same visual gap the goal caret does — see .goalCollapseButton. */
+  margin-right: -5px;
   /* The banner is itself the lane's drag surface; the caret is a control on top of it, so it opts
      back out of `touch-action: none` the way the other inline controls do. */
   touch-action: auto;
@@ -190,7 +198,9 @@
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 12px;
+  /* Less inset on the left than the right: the leading caret is a small glyph centred in a larger
+     hit target, so it already carries its own visual margin. */
+  padding: 8px 12px 8px 6px;
   border-right: 1px solid var(--sm-border);
   border-bottom: 1px solid var(--sm-border);
   background-color: var(--sm-bg);
@@ -200,6 +210,53 @@
   font-size: 15px;
   font-weight: 600;
   color: var(--sm-text);
+}
+
+/* Always visible, not hover-revealed: once a goal is folded the spine is all that is left of it, so
+   the way back must stay on show. */
+.goalCollapseButton {
+  flex: none;
+  width: 18px;
+  height: 18px;
+  min-width: 18px;
+  padding: 0;
+  font-size: 10px;
+  color: var(--sm-text-secondary);
+  /* Pulls the name in past the glyph's own bearing: the caret is drawn well inside its 18px hit
+     target, so .goalCell's 8px gap reads as ~13px of empty space against it. The button keeps its
+     full width, so only the visual gap closes. */
+  margin-right: -5px;
+  /* The goal cell is itself the drag surface; the caret is a control on top of it, so it opts back
+     out of `touch-action: none` the way the other inline controls do. */
+  touch-action: auto;
+  cursor: pointer;
+}
+
+/* A collapsed goal: one narrow track running the full height of the board, the caret above its
+   rotated name. `justify-content` overrides .goalCell's space-between, which would push the name to
+   the far end of a board-height cell. */
+.goalCellCollapsed {
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 8px 4px;
+  background-color: var(--sm-bg-elevated);
+  overflow: hidden;
+}
+
+/* `writing-mode` rather than a transform: a rotated element still occupies its unrotated box, so a
+   transform would make a long name claim its full horizontal width and blow the track open.
+   writing-mode changes the box itself, so the text flows within the spine and clips. The full name
+   is on the tooltip. */
+.goalNameVertical {
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-height: 0;
+  font-size: 13px;
 }
 
 /* Column layout so the footer's `margin-top: auto` pins it to the bottom, keeping footers aligned

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -529,6 +529,15 @@
   overflow-wrap: anywhere;
 }
 
+/* The cell a dragged task is crossing into, from a different step or lane. Marks the destination
+   while the insertion line marks the position within it. Declared before .taskCellOver so that
+   rule's louder treatment wins when a cell is both. */
+.taskCellReceiving {
+  outline: 2px solid var(--ant-color-primary);
+  outline-offset: -2px;
+  border-radius: var(--sm-radius);
+}
+
 /* A task cell under the pointer — including an empty one, the only way to reach a cell with no
    cards. Lights up only when the drop would append; hovering a card shows an insertion line there. */
 .taskCellOver {

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -6,10 +6,13 @@
   gap: 16px;
 }
 
+/* The scroll container both axes of stickiness pin against: the label column sticks left, the goals
+   and steps rows stick top. Its height is set inline from useRemainingHeight so the board fills the
+   viewport — a sticky row needs its own scrollport, and if the page scrolled instead there would be
+   nothing for `top` to resolve against. */
 .boardScroll {
-  overflow-x: auto;
+  overflow: auto;
   padding-bottom: 8px;
-  /* Establishes the scroll container the sticky label column pins against. */
   position: relative;
 }
 
@@ -24,6 +27,14 @@
   --sm-label-width: 80px;
   /* A collapsed goal's spine: wide enough for the caret button plus the rotated name beneath it. */
   --sm-collapsed-col-width: 40px;
+  /* Stacking order for everything that pins, lowest first. Cells that stick on one axis must sit
+     above ordinary content; those that stick on two must sit above the one-axis cells, or they are
+     punched through at the intersection where both are pinned at once. */
+  --sm-z-lifted: 1;
+  --sm-z-sticky-column: 2;
+  --sm-z-sticky-lane: 3;
+  --sm-z-sticky-row: 4;
+  --sm-z-sticky-corner: 5;
   display: grid;
   grid-template-columns: var(--sm-label-width) var(--sm-step-columns);
   align-items: stretch;
@@ -62,12 +73,42 @@
   );
   position: sticky;
   left: 0;
-  z-index: 2;
+  z-index: var(--sm-z-sticky-column);
 }
 
+/* The two corner cells: sticky on both axes at once, so they must outrank everything that sticks on
+   only one — otherwise the goal and step cells slide underneath them. */
 .labelCellGoals,
 .labelCellSteps {
   align-items: center;
+  z-index: var(--sm-z-sticky-corner);
+}
+
+.labelCellGoals {
+  top: 0;
+}
+
+/* Offset by the goals row's measured height, published by the board — the row's height depends on
+   how far its longest goal name wraps, so it cannot be a constant. */
+.labelCellSteps {
+  top: var(--sm-goal-row-height);
+}
+
+/* ─── Pinned header rows ──────────────────────────────────────────────────── */
+
+/* Goals and steps stay in view while the task rows scroll under them. Both need an opaque fill for
+   the same reason the label column does: the default cell backgrounds let scrolled content ghost
+   through. */
+.goalCell {
+  position: sticky;
+  top: 0;
+  z-index: var(--sm-z-sticky-row);
+}
+
+.stepCell {
+  position: sticky;
+  top: var(--sm-goal-row-height);
+  z-index: var(--sm-z-sticky-row);
 }
 
 /* Empty filler beside a lane's task row — it exists only to continue the label column's right
@@ -93,10 +134,11 @@
     var(--sm-bg-elevated),
     var(--sm-bg-elevated)
   );
-  /* The banner crosses the label column, whose cells are sticky at z-index 2. Match that so the
-     banner is not punched through by the sticky column as the board scrolls under it. */
+  /* The banner crosses the sticky label column, so it must outrank it or the column punches through
+     as the board scrolls under. It stays below the pinned goals and steps rows, which it scrolls
+     beneath. */
   position: relative;
-  z-index: 2;
+  z-index: var(--sm-z-sticky-lane);
 }
 
 /* The banner's contents stick as one shrink-to-fit unit. Sticking each child independently fails:
@@ -243,6 +285,10 @@
   padding: 8px 4px;
   background-color: var(--sm-bg-elevated);
   overflow: hidden;
+  /* The spine already spans every row, so it is on screen throughout the scroll and has nothing to
+     pin against — sticking it would shunt its content down as the board scrolls. Its caret and name
+     stay put at the top instead, which is where the pinned header rows are. */
+  position: static;
 }
 
 /* `writing-mode` rather than a transform: a rotated element still occupies its unrotated box, so a
@@ -268,7 +314,14 @@
   padding: 8px 12px;
   border-right: 1px solid var(--sm-border);
   border-bottom: 1px solid var(--sm-border);
-  background-color: var(--sm-bg-elevated);
+  /* Pinned, so the fill must be fully opaque — --sm-bg-elevated is a translucent fill and would let
+     the task cards scrolling under it ghost through. Layering it over the opaque container colour
+     keeps the tint. Same treatment as .labelCell. */
+  background-color: var(--sm-bg);
+  background-image: linear-gradient(
+    var(--sm-bg-elevated),
+    var(--sm-bg-elevated)
+  );
 }
 
 .stepName {
@@ -383,14 +436,19 @@
 .goalCell.draggable:hover,
 .stepCell.draggable:hover,
 .taskCard.draggable:hover {
-  /* Grid cells sit flush against their neighbours, which are painted later in DOM order — without
-     a stacking context the lifted cell's shadow vanishes under them. */
-  position: relative;
-  z-index: 1;
   transform: translateY(-2px);
   /* The same shadow as the floating drag-overlay chip, so hover and mid-drag read as one
      "picked up" state. */
   box-shadow: var(--ant-box-shadow-secondary);
+}
+
+/* Grid cells sit flush against their neighbours, which are painted later in DOM order — without a
+   stacking context the lifted cell's shadow vanishes under them. Only the task card needs this:
+   goal and step cells are already positioned (sticky) with a z-index of their own, and forcing
+   `relative` here would unpin the header rows for as long as the pointer rested on them. */
+.taskCard.draggable:hover {
+  position: relative;
+  z-index: var(--sm-z-lifted);
 }
 
 /* Controls inside a cell are not drag surfaces. The sensor's 4px activation distance separates a

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -77,7 +77,11 @@
 }
 
 /* The two corner cells: sticky on both axes at once, so they must outrank everything that sticks on
-   only one — otherwise the goal and step cells slide underneath them. */
+   only one — otherwise the goal and step cells slide underneath them.
+ *
+ * Do not give either an explicit height or an `align-self`. The grid's `align-items: stretch` sizes
+ * them to their row, which is what lets the goals label be measured as the row height (see
+ * use-goal-row-height.ts) — overriding that would leave the steps row pinning at a stale offset. */
 .labelCellGoals,
 .labelCellSteps {
   align-items: center;
@@ -88,17 +92,14 @@
   top: 0;
 }
 
-/* Offset by the goals row's measured height, published by the board — the row's height depends on
-   how far its longest goal name wraps, so it cannot be a constant. */
+/* Measured, not constant: the row is as tall as its longest wrapped goal name. */
 .labelCellSteps {
   top: var(--sm-goal-row-height);
 }
 
 /* ─── Pinned header rows ──────────────────────────────────────────────────── */
 
-/* Goals and steps stay in view while the task rows scroll under them. Both need an opaque fill for
-   the same reason the label column does: the default cell backgrounds let scrolled content ghost
-   through. */
+/* Goals and steps stay in view while the task rows scroll under them. */
 .goalCell {
   position: sticky;
   top: 0;
@@ -264,9 +265,8 @@
   padding: 0;
   font-size: 10px;
   color: var(--sm-text-secondary);
-  /* Pulls the name in past the glyph's own bearing: the caret is drawn well inside its 18px hit
-     target, so .goalCell's 8px gap reads as ~13px of empty space against it. The button keeps its
-     full width, so only the visual gap closes. */
+  /* The caret is drawn well inside its 18px hit target, so the 8px flex gap reads as ~13px. Closes
+     the visual gap without shrinking the target. */
   margin-right: -5px;
   /* The goal cell is itself the drag surface; the caret is a control on top of it, so it opts back
      out of `touch-action: none` the way the other inline controls do. */
@@ -291,10 +291,8 @@
   position: static;
 }
 
-/* `writing-mode` rather than a transform: a rotated element still occupies its unrotated box, so a
-   transform would make a long name claim its full horizontal width and blow the track open.
-   writing-mode changes the box itself, so the text flows within the spine and clips. The full name
-   is on the tooltip. */
+/* `writing-mode` rather than a transform: a rotated element keeps its unrotated box, so a long name
+   would claim its full horizontal width and blow the track open. The full name is on the tooltip. */
 .goalNameVertical {
   writing-mode: vertical-rl;
   transform: rotate(180deg);
@@ -322,6 +320,53 @@
     var(--sm-bg-elevated),
     var(--sm-bg-elevated)
   );
+}
+
+/* The ghost step under a step-less goal — a vacancy to fill, not a blank real step. */
+.emptyStepSlot {
+  align-items: center;
+  justify-content: center;
+  /* Inset so the dash sits inside the cell's own borders instead of doubling them. */
+  outline: 1px dashed var(--sm-border);
+  outline-offset: -5px;
+  background-image: none;
+}
+
+/* Carries .stepCell, so it must shed the browser's button defaults. */
+.emptyStepSlotButton {
+  border: none;
+  border-right: 1px solid var(--sm-border);
+  border-bottom: 1px solid var(--sm-border);
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  /* The slot is a drop target, so a touch drag onto it must not be stolen by page scrolling. */
+  touch-action: none;
+}
+
+/* The border-right reset above re-adds what .lastColumn exists to remove, and both carry one class
+   worth of specificity — so the outer-edge case needs restating here to win on source order. */
+.emptyStepSlotButton.lastColumn {
+  border-right: none;
+}
+
+.emptyStepSlotButton:hover,
+.emptyStepSlotButton:focus-visible {
+  outline-color: var(--ant-color-primary);
+}
+
+.emptyStepSlotButton:hover .emptyStepSlotHint,
+.emptyStepSlotButton:focus-visible .emptyStepSlotHint {
+  color: var(--ant-color-primary);
+}
+
+/* Muted until hovered — a step-less goal is a normal state mid-mapping. */
+.emptyStepSlotHint {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--sm-muted);
 }
 
 .stepName {
@@ -493,11 +538,12 @@
 }
 
 /* Insertion line for the horizontal rows (goals and steps): a vertical rule on the target's leading
-   or trailing edge, marking the seam the dragged node will land on. */
-.stepCellDropBefore,
-.stepCellDropAfter {
-  position: relative;
-}
+   or trailing edge, marking the seam the dragged node will land on.
+ *
+ * These pseudo-elements need a positioned ancestor, and the cells already are one — goal and step
+ * cells are `sticky` so the header rows pin while the board scrolls. Declaring `position: relative`
+ * here would override that (same specificity, later in the file) and unpin the drop target for the
+ * duration of the drag, dropping it out of the header row. */
 
 .stepCellDropBefore::before,
 .stepCellDropAfter::before {
@@ -541,6 +587,18 @@
 
 .stepCellDropAfter::after {
   right: -4px;
+}
+
+/* The step columns of the goal a dragged step is crossing into. Outline rather than fill — the
+   cells beneath carry the step names and the insertion line, which a tint would fight. */
+.receivingStepBand {
+  pointer-events: none;
+  outline: 2px solid var(--ant-color-primary);
+  outline-offset: -2px;
+  border-radius: var(--sm-radius);
+  /* Above the step cells it covers — they are sticky with a z-index of their own. */
+  position: relative;
+  z-index: var(--sm-z-sticky-row);
 }
 
 /* The empty steps slot under a step-less goal, while a step is held over it. Same treatment as an

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/_components/story-map.module.css
@@ -285,10 +285,20 @@
   padding: 8px 4px;
   background-color: var(--sm-bg-elevated);
   overflow: hidden;
-  /* The spine already spans every row, so it is on screen throughout the scroll and has nothing to
-     pin against — sticking it would shunt its content down as the board scrolls. Its caret and name
-     stay put at the top instead, which is where the pinned header rows are. */
+  /* Not sticky, unlike the goal cells beside it: the spine spans every row, and a sticky element
+     moves only within its own grid area, so pinning it would slide its content down the spine as
+     the board scrolls. The caret inside it sticks instead — see .goalCellCollapsed .goalCollapseButton. */
   position: static;
+}
+
+/* Keeps the expand control on screen while a tall board scrolls. The spine itself cannot pin, so
+   without this the only way back out of a collapsed goal scrolls away with the top of the board.
+   Offset past the pinned goals row it would otherwise slide under, plus the spine's own top padding
+   so it rests exactly where it sits unscrolled. */
+.goalCellCollapsed .goalCollapseButton {
+  position: sticky;
+  top: calc(var(--sm-goal-row-height) + 8px);
+  z-index: var(--sm-z-sticky-row);
 }
 
 /* `writing-mode` rather than a transform: a rotated element keeps its unrotated box, so a long name

--- a/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/page.tsx
+++ b/Wayd.Web/src/wayd.web.reactclient/src/app/planning/story-maps/page.tsx
@@ -141,4 +141,3 @@ const StoryMapsPageWithAuthorization = requireFeatureFlag(
 )
 
 export default StoryMapsPageWithAuthorization
-

--- a/docs/user-guide/planning/story-maps.mdx
+++ b/docs/user-guide/planning/story-maps.mdx
@@ -69,9 +69,22 @@ The detail page renders the whole map as one aligned grid:
 └────────┴────────────┴───────────┴──────────┴───────────┘
 ```
 
-Every step gets one column, and a goal header spans the columns of its own steps. The label column on the left stays fixed while the board scrolls sideways, so you never lose track of which row you are reading. Columns share the available width evenly and stop shrinking at a minimum, so a wide map scrolls rather than squeezing its cards into unreadable slivers.
+Every step gets one column, and a goal header spans the columns of its own steps. Columns share the available width evenly and stop shrinking at a minimum, so a wide map scrolls rather than squeezing its cards into unreadable slivers.
 
 Each swim lane is a full-width banner followed by a row of cells. A task's position is the intersection of its step's column and its lane's row.
+
+The board keeps its headers in view as you scroll: the label column on the left stays fixed while the board scrolls sideways, and the Goals and Steps rows stay pinned to the top while the task rows scroll underneath. On a tall or wide map you never lose track of which goal and step a card belongs to.
+
+### Collapsing
+
+Goals and swim lanes each have a **caret** beside their name that folds them away — a way to set a finished part of the board aside while you work on the next.
+
+- A collapsed **swim lane** keeps its banner and hides its row of cards.
+- A collapsed **goal** folds to a narrow vertical strip showing its name, hiding its steps and their tasks.
+
+Collapsing only changes your own view. Nothing is deleted, nothing is sent to the server, and other people looking at the same map are unaffected. Expanding brings everything straight back. Because collapsing is a view setting rather than a saved one, the board opens fully expanded each visit.
+
+A collapsed goal or lane can still be dragged to reorder it, but its hidden steps and tasks cannot be dropped on until you expand it again.
 
 ## Personas
 
@@ -121,6 +134,8 @@ Click any goal, step, task, or lane name to edit it in place. **Enter** saves, *
 
 Add buttons appear on hover: **+** on a goal cell adds a step, **+** on a step cell adds a task, and **Add swim lane** sits at the bottom of the board. New items are created with a placeholder name and open straight into edit mode, so you can add a goal and type its real name without a second click.
 
+Two placeholders offer the same thing in place. A goal with no steps yet shows a dashed **+ Add step** slot in the Steps row, and every task cell shows a dashed **+ Task** row at the foot of its cards when you hover it. Adding through a cell's own placeholder puts the task in that cell — the step column you clicked, in that swim lane — rather than in the default lane.
+
 Delete buttons appear on hover in the same places. Deleting a goal deletes its steps and their tasks; deleting a step deletes its tasks. Both warn you first.
 
 ## Rearranging
@@ -134,11 +149,20 @@ Everything on the board can be dragged. There is no grab handle — drag the car
 | **Task** | Reordered within its cell, moved to another step, or moved to another swim lane |
 | **Swim Lane** | Reordered, except the default lane, which stays first |
 
-While dragging, a **blue insertion line** shows exactly where the item will land — a vertical line for goals and steps, a horizontal one for tasks. The line sits inside the target's own box rather than on the seam between two items, so the last position in one goal and the first in the next are never ambiguous. An empty cell highlights instead, since it has no card to draw a line against.
+While dragging, a **blue insertion line** shows exactly where the item will land — a vertical line for goals and steps, a horizontal one for tasks. Each gap between two items has a single line, so one landing position never shows two possible marks. An empty cell highlights instead, since it has no card to draw a line against.
+
+When a drag would move an item to a **different parent**, that parent is outlined as well, so the insertion line answers "where" while the outline answers "into what":
+
+| Dragging | Outlined |
+|---|---|
+| A step into another goal | That goal's whole run of step columns |
+| A task into another step or lane | The destination cell |
+
+Reordering within the same parent draws no outline — the parent is not in question there.
 
 Illegal targets never highlight: a step dragged over the goals row shows nothing, because a step cannot become a goal.
 
-To move a step into a goal that has no steps yet, drop it on the empty area beneath that goal.
+To move a step into a goal that has no steps yet, drop it on the **+ Add step** placeholder beneath that goal.
 
 ## Real-time Collaboration
 


### PR DESCRIPTION
## Story map board: collapsing, pinned headers, and clearer drag affordances

A batch of UX work on the story map board, aimed at making large maps navigable and drag-and-drop legible.

### Collapsing

**Swim lanes** and **goals** can now be folded away while working — a way to get a finished part of the board out of the way while filling in the next.

- A collapsed lane keeps its banner and drops its task row; the lanes below shuffle up.
- A collapsed goal folds to a narrow vertical spine with a rotated name, contributing no step columns, so the goals to its right shuffle left.

Collapse state is **transient and local** — held in component state, never sent to the server. Two people on the same map can collapse different things without affecting each other.

Anything a collapse hides is excluded from the drag model (`tasksByCell`, `buildDragIndex`), so a hidden cell can never become a drop target. The collapsed node's own header stays draggable, so goals and lanes still reorder while collapsed.

### Pinned header rows

The Goals and Steps rows now stay in view while task rows scroll under them. The board owns its vertical scroll (via `useRemainingHeight`) rather than letting the page scroll, since a sticky row needs its own scrollport.

The Steps row's offset is **measured at runtime**, not hardcoded — the Goals row is as tall as its longest wrapped goal name, which varies with the name, column width, and viewport.

This required replacing ad-hoc z-index values with a named scale (`--sm-z-lifted` → `sticky-column` → `sticky-lane` → `sticky-row` → `sticky-corner`), since cells that stick on both axes must outrank those sticking on one.

### Add affordances

- **Ghost "+ Add step"** on a goal with no steps — previously a blank cell that was a silent drop target. Renders as a `<button>` for editors and an inert `<div>` for viewers.
- **Ghost "+ Task"** at the foot of every task cell, revealed on hover of its own cell. `onAddTask` gained an optional `swimLaneId` so a cell adds into *its own* lane; previously every add went to the default lane regardless of where you clicked.

### Drag legibility

- **Cross-goal step drags** outline the receiving goal's whole run of step columns — the boundary the step lands in, while the insertion line marks position within it. Suppressed for a step-less goal, whose slot already marks itself.
- **Cross-cell task drags** outline the destination cell. This also covers a case that previously had *no* destination signal: moving a task into an already-occupied cell in another step.
- **One seam, one line.** "After step A" and "before step B" are the same gap and resolve to the same index, but each cell used to light its own hovered edge, giving one landing position two appearances that swapped across a midpoint. The board now picks a single cell per seam.
- Dropped the insertion-line dot on goal/step cells, which protruded into the row above once the Steps row became sticky.

### Fixes

- **Drag state desync.** The drop side and drop target were read from different sources (`dropSideRef` vs `event.over`), so a frame landing mid-transition could pair a stale side with a fresh target and flick the insertion line to the wrong cell. Both now come from refs written in the same collision pass. The same mismatch existed in `handleDragEnd`, where it affected the actual drop rather than the preview.
- **`position: relative` unpinning sticky cells.** `.stepCellDropBefore`/`.stepCellDropAfter` restated `position: relative`, overriding the new `sticky` at equal specificity and dropping the drop target out of the header row mid-drag. Same bug fixed in the hover-lift rule.

### Testing

162 tests in the story map suites (up from 137). New coverage for collapsed-lane and collapsed-goal row/column geometry, task-bucket exclusion, and drag-target rejection for hidden cells.

`buildDragIndex` now validates task-cell targets against a `renderedCellIds` set rather than by parsing the id — a well-formed cell id can name a cell a collapse has hidden, which collapse turns from impossible into routine.
